### PR TITLE
Implements rss feed

### DIFF
--- a/lib/rss.js
+++ b/lib/rss.js
@@ -1,0 +1,31 @@
+const SITE_URL = 'https://stacker.news'
+const SITE_TITLE = 'Stacker News'
+const SITE_SUBTITLE = 'Like Hacker News, but with sats'
+
+const generateRssItem = (item) => {
+  return `
+    <item>
+      <guid>${SITE_URL}/items/${item.id}</guid>
+      <title>${item.title}</title>
+      <link>${SITE_URL}/items/${item.id}</link>
+      <pubDate>${new Date(item.createdAt).toUTCString()}</pubDate>
+    </item>
+  `
+}
+
+export default function generateRssFeed (items) {
+  const itemsList = items.map(generateRssItem)
+  return `
+    <rss xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
+      <channel>
+        <title>${SITE_TITLE}</title>
+        <link>${SITE_URL}</link>
+        <description>${SITE_SUBTITLE}</description>
+        <language>en</language>
+        <lastBuildDate>${new Date().toUTCString()}</lastBuildDate>
+        <atom:link href="${SITE_URL}" rel="self" type="application/rss+xml"/>
+        ${itemsList.join('')}
+      </channel>
+    </rss>
+  `
+}

--- a/pages/rss.js
+++ b/pages/rss.js
@@ -1,0 +1,31 @@
+
+import ApolloClient from '../api/client'
+import { gql } from '@apollo/client'
+import generateRssFeed from '../lib/rss'
+
+export default function RssFeed () {
+  return null
+}
+
+export async function getServerSideProps({ req, res }) {
+  const emptyProps = { props: {} } // to avoid server side warnings
+  const { error, data } = await (await ApolloClient(req)).query({
+    query: gql`
+      query Items {
+        items {
+          createdAt
+          id
+          title
+        }
+      }
+    `,
+  })
+
+  if (!data.items || error) return emptyProps
+
+  res.setHeader("Content-Type", "text/xml")
+  res.write(generateRssFeed(data.items))
+  res.end()
+
+  return emptyProps
+}


### PR DESCRIPTION
Related to https://github.com/stackernews/stacker.news/issues/16

A SSR solution for a RSS feed:
+ feed has latest items (live)
- each request impacts server (load)

It's also possible to use a SSG solution (ex: /public/rss.xml file):
+ static file, no load on the server (faster)
- xml file is only created on build time (delay)

Note, I was not able to properly test the query.