### PR TITLE
Validate URL against regexp

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -4,3 +4,9 @@ export function ensureProtocol (value) {
   }
   return value
 }
+
+export function isURL (value) {
+  // https://www.w3resource.com/javascript-exercises/javascript-regexp-exercise-9.php
+  const regexp =  /^(?:(?:https?|ftp):\/\/)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:[1-9]\d?|1\d\d|2[01]\d|22[0-3])(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/\S*)?$/;
+  return Boolean(regexp.test(value))
+}

--- a/pages/post.js
+++ b/pages/post.js
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import * as Yup from 'yup'
 import { gql, useMutation } from '@apollo/client'
 import LayoutCenter from '../components/layout-center'
-import { ensureProtocol } from '../lib/url'
+import { isURL } from '../lib/url'
 import { useMe } from '../components/me'
 import ActionTooltip from '../components/action-tooltip'
 import TextareaAutosize from 'react-textarea-autosize'
@@ -63,15 +63,7 @@ export const LinkSchema = Yup.object({
   title: Yup.string().required('required').trim(),
   url: Yup.string().test({
     name: 'url',
-    test: (value) => {
-      try {
-        value = ensureProtocol(value)
-        const valid = new URL(value)
-        return Boolean(valid)
-      } catch {
-        return false
-      }
-    },
+    test: (value) => isURL(value),
     message: 'invalid url'
   }).required('required')
 })


### PR DESCRIPTION
Previous method (via URL constructor) is prone to errors (allow spaces)

Closes https://github.com/stackernews/stacker.news/issues/14