### PR TITLE
Add "\" after boost in comments

### DIFF
--- a/components/comment.js
+++ b/components/comment.js
@@ -75,6 +75,7 @@ export default function Comment ({
               {item.boost > 0 &&
                 <>
                   <span>{item.boost} boost</span>
+                  <span> \ </span>
                 </>}
               <Link href={`/items/${item.id}`} passHref>
                 <a onClick={e => e.stopPropagation()} className='text-reset'>{item.ncomments} replies</a>


### PR DESCRIPTION
Currently there's a space or "\" missing, e.g. https://stacker.news/items/5747 .
This PR also aligns this with https://github.com/stackernews/stacker.news/blob/master/components/item.js