### PR TITLE
Typo fix on wallet page

### DIFF
--- a/pages/wallet.js
+++ b/pages/wallet.js
@@ -105,7 +105,7 @@ export function FundForm () {
             setShowAlert(false)
           }}
         >
-          Your can also fund your account via lightning address with <strong>{`${me.name}@stacker.news`}</strong>
+          You can also fund your account via lightning address with <strong>{`${me.name}@stacker.news`}</strong>
         </Alert>}
       <Form
         initial={{


### PR DESCRIPTION
I noticed a typo the word 'Your' should say 'You':

![image](https://user-images.githubusercontent.com/85003930/158867434-1437a15b-863f-4120-acca-10c26b7ca0c9.png)
