### PR TITLE
Turn notifications box into a link

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -75,9 +75,12 @@ export default function Header ({ sub }) {
               <NavDropdown.Item onClick={() => signOut({ callbackUrl: '/' })}>logout</NavDropdown.Item>
             </NavDropdown>
             {me?.hasNewNotes &&
-              <span className='position-absolute p-1 bg-danger' style={{ top: '5px', right: '0px' }}>
-                <span className='invisible'>{' '}</span>
-              </span>}
+              <Link href='/notifications' passHref>
+                <span className='position-absolute p-1 bg-danger' style={{ top: '5px', right: '0px' }}>
+                  <span className='invisible'>{' '}</span>
+                </span>
+              </Link>
+            }
             {me && !me.bio &&
               <span className='position-absolute p-1 bg-secondary' style={{ bottom: '5px', right: '0px' }}>
                 <span className='invisible'>{' '}</span>


### PR DESCRIPTION
As mentioned in issue #87, I turned the red notifications box into a link that takes you to the notifications page. This allows the users to access notifications in only 1 click instead of 2 if they choose to.

Note I have not tested this locally yet because I am still working on getting login working in my dev environment. Its a small change and it should work, but if you could please test that would be great. I did test adding it to the dom in devtools and it does work as expected there.

![image](https://user-images.githubusercontent.com/85003930/161366223-e9aee38a-f3ec-4b7b-8529-775e375fa2ef.png)

Thanks!