### PR TITLE
Add footer links to error pages

### DIFF
--- a/components/layout-center.js
+++ b/components/layout-center.js
@@ -1,14 +1,18 @@
-import Layout from './layout'
-import styles from './layout-center.module.css'
+import Layout from "./layout";
+import styles from "./layout-center.module.css";
 
-export default function LayoutCenter ({ children, ...props }) {
+export default function LayoutCenter({ children, noFooterLinks, ...props }) {
   return (
     <div className={styles.page}>
-      <Layout noContain noFooterLinks {...props}>
-        <div className={styles.content}>
-          {children}
-        </div>
-      </Layout>
+      {noFooterLinks ? (
+        <Layout noContain noFooterLinks {...props}>
+          <div className={styles.content}>{children}</div>
+        </Layout>
+      ) : (
+        <Layout noContain {...props}>
+          <div className={styles.content}>{children}</div>
+        </Layout>
+      )}
     </div>
-  )
+  );
 }

--- a/pages/invoices/[id].js
+++ b/pages/invoices/[id].js
@@ -7,7 +7,7 @@ import { INVOICE } from '../../fragments/wallet'
 
 export default function FullInvoice () {
   return (
-    <LayoutCenter>
+    <LayoutCenter noFooterLinks>
       <LoadInvoice />
     </LayoutCenter>
   )

--- a/pages/items/[id]/edit.js
+++ b/pages/items/[id]/edit.js
@@ -11,7 +11,7 @@ export default function PostEdit ({ data: { item } }) {
   const editThreshold = new Date(item.createdAt).getTime() + 10 * 60000
 
   return (
-    <LayoutCenter sub={item.sub?.name}>
+    <LayoutCenter sub={item.sub?.name} noFooterLinks>
       {item.maxBid
         ? <JobForm item={item} sub={item.sub} />
         : (item.url

--- a/pages/post.js
+++ b/pages/post.js
@@ -36,7 +36,7 @@ export function PostForm () {
 
 export default function Post () {
   return (
-    <LayoutCenter>
+    <LayoutCenter noFooterLinks>
       <PostForm />
     </LayoutCenter>
   )

--- a/pages/settings.js
+++ b/pages/settings.js
@@ -22,7 +22,7 @@ export default function Settings () {
   )
 
   return (
-    <LayoutCenter>
+    <LayoutCenter noFooterLinks>
       <h2 className='mb-5 text-left'>settings</h2>
       <Form
         initial={{

--- a/pages/wallet.js
+++ b/pages/wallet.js
@@ -16,7 +16,7 @@ import { CREATE_WITHDRAWL, SEND_TO_LNADDR } from '../fragments/wallet'
 
 export default function Wallet () {
   return (
-    <LayoutCenter>
+    <LayoutCenter noFooterLinks>
       <WalletForm />
     </LayoutCenter>
   )

--- a/pages/withdrawals/[id].js
+++ b/pages/withdrawals/[id].js
@@ -9,7 +9,7 @@ import Link from 'next/link'
 
 export default function Withdrawl () {
   return (
-    <LayoutCenter>
+    <LayoutCenter noFooterLinks>
       <LoadWithdrawl />
     </LayoutCenter>
   )

--- a/pages/~/[sub]/post.js
+++ b/pages/~/[sub]/post.js
@@ -8,7 +8,7 @@ export const getServerSideProps = getGetServerSideProps(SUB, null, 'sub')
 // need to recent list items
 export default function Post ({ data: { sub } }) {
   return (
-    <LayoutCenter sub={sub.name}>
+    <LayoutCenter sub={sub.name} noFooterLinks>
       <JobForm sub={sub} />
     </LayoutCenter>
   )


### PR DESCRIPTION
Requested in issue #113, I have added the footer links back into the 404 and 500 status message pages.

![image](https://user-images.githubusercontent.com/85003930/161366753-4fc6be38-ef16-4d0d-a035-f76c061215e7.png)
