### PR TITLE
change drop down scroll to auto

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -217,7 +217,7 @@ a:hover {
   background-color: var(--theme-inputBg);
   border: 1px solid var(--theme-borderColor);
   max-width: 90vw;
-  overflow: scroll;
+  overflow: auto;
 }
 
 .dropdown-item {


### PR DESCRIPTION
I changed the overflow to `auto` so that it's not always showing the scroll when it's not needed.

@huumn we discussed the issue here: https://stacker.news/items/73723

![image](https://user-images.githubusercontent.com/43693074/193134276-97285f63-a921-43ae-b41a-c6066750812d.png)
