### PR TITLE
Use Array.from(value).length for title length validation

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -924,7 +924,7 @@ export const updateItem = async (parent, { id, data: { title, url, text, boost, 
     throw new UserInputError(`boost must be at least ${BOOST_MIN}`, { argumentName: 'boost' })
   }
 
-  if (!old.parentId && title.length > MAX_TITLE_LENGTH) {
+  if (!old.parentId && Array.from(title ?? '').length > MAX_TITLE_LENGTH) {
     throw new UserInputError('title too long')
   }
 
@@ -955,7 +955,7 @@ const createItem = async (parent, { title, url, text, boost, forward, parentId }
     throw new UserInputError(`boost must be at least ${BOOST_MIN}`, { argumentName: 'boost' })
   }
 
-  if (!parentId && title.length > MAX_TITLE_LENGTH) {
+  if (!parentId && Array.from(title ?? '').length > MAX_TITLE_LENGTH) {
     throw new UserInputError('title too long')
   }
 

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -1,6 +1,6 @@
 import { Form, Input, MarkdownInput, SubmitButton } from '../components/form'
 import { useRouter } from 'next/router'
-import * as Yup from 'yup'
+import Yup from './yup'
 import { gql, useApolloClient, useMutation } from '@apollo/client'
 import TextareaAutosize from 'react-textarea-autosize'
 import Countdown from './countdown'
@@ -27,7 +27,7 @@ export function DiscussionForm ({
 
   const DiscussionSchema = Yup.object({
     title: Yup.string().required('required').trim()
-      .max(MAX_TITLE_LENGTH,
+      .maxStrLen(MAX_TITLE_LENGTH,
         ({ max, value }) => `${Math.abs(max - value.length)} too many`),
     ...AdvPostSchema(client)
   })

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -1,6 +1,6 @@
 import { Form, Input, SubmitButton } from '../components/form'
 import { useRouter } from 'next/router'
-import * as Yup from 'yup'
+import Yup from './yup'
 import { gql, useApolloClient, useLazyQuery, useMutation } from '@apollo/client'
 import Countdown from './countdown'
 import AdvPostForm, { AdvPostInitial, AdvPostSchema } from './adv-post-form'
@@ -44,7 +44,7 @@ export function LinkForm ({ item, editThreshold }) {
 
   const LinkSchema = Yup.object({
     title: Yup.string().required('required').trim()
-      .max(MAX_TITLE_LENGTH,
+      .maxStrLen(MAX_TITLE_LENGTH,
         ({ max, value }) => `${Math.abs(max - value.length)} too many`),
     url: Yup.string().matches(URL, 'invalid url').required('required'),
     ...AdvPostSchema(client)

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -1,6 +1,6 @@
 import { Form, Input, MarkdownInput, SubmitButton, VariableInput } from '../components/form'
 import { useRouter } from 'next/router'
-import * as Yup from 'yup'
+import Yup from './yup'
 import { gql, useApolloClient, useMutation } from '@apollo/client'
 import Countdown from './countdown'
 import AdvPostForm, { AdvPostInitial, AdvPostSchema } from './adv-post-form'
@@ -25,7 +25,7 @@ export function PollForm ({ item, editThreshold }) {
 
   const PollSchema = Yup.object({
     title: Yup.string().required('required').trim()
-      .max(MAX_TITLE_LENGTH,
+      .maxStrLen(MAX_TITLE_LENGTH,
         ({ max, value }) => `${Math.abs(max - value.length)} too many`),
     options: Yup.array().of(
       Yup.string().trim().test('my-test', 'required', function (value) {

--- a/components/yup.js
+++ b/components/yup.js
@@ -1,0 +1,11 @@
+import * as Yup from 'yup';
+
+Yup.addMethod(Yup.string, 'maxStrLen', function maxStrLen(max, errorMessage) {
+  return this.test(`test-max-str-len`, (value, { createError, path }) => {
+    const length = Array.from(value ?? '').length;
+    const valid = length <= max;
+    return valid ? true : createError({ message: errorMessage({ max, value: { length } }), path });
+  });
+});
+
+export default Yup;


### PR DESCRIPTION
I created a custom validation function to use a different length than `str.length` during validation to fix #204.

I also used a hacky way to still access the `length` property used during validation for the error message by passing in an object with a property `length` set to the "new" length instead of the actual string value.