### PR TITLE
Add ZAR currency

### DIFF
--- a/components/price.js
+++ b/components/price.js
@@ -16,7 +16,8 @@ export const CURRENCY_SYMBOLS = {
   EUR: '€',
   GBP: '£',
   USD: '$',
-  NZD: '$'
+  NZD: '$',
+  ZAR: 'R '
 }
 
 const endpoint = (fiat) => `https://api.coinbase.com/v2/prices/BTC-${fiat ?? 'USD'}/spot`


### PR DESCRIPTION
As discussed in https://stacker.news/items/83883.

I noticed that for ZAR, there is a space between the symbol and amount.
See https://en.wikipedia.org/wiki/South_African_rand (see "Denomination" at right side)

For EUR or USD, there is no such space:
https://en.wikipedia.org/wiki/Euro
https://en.wikipedia.org/wiki/United_States_dollar