### PR TITLE
Mention slashtags auth in README

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,6 +18,9 @@ LOGIN_EMAIL_FROM=<YOUR FROM ALIAS>
 # lnurl-auth
 LNAUTH_URL=<YOUR PUBLIC TUNNEL TO LOCALHOST, e.g. NGROK>
 
+# slashtags
+SLASHTAGS_SECRET=
+
 #######################################################
 # LND / OPTIONAL                                      #
 # if you want to work with payments you'll need these #

--- a/api/slashtags/index.js
+++ b/api/slashtags/index.js
@@ -19,7 +19,7 @@ async function createProfile (slashtag) {
 
 const slashtags = global.slashtags || (() => {
   console.log('initing slashtags')
-  const sdk = new SDK({ primaryKey: Buffer.from(process.env.SLASHTAGS_SECRET, 'hex') })
+  const sdk = new SDK({ primaryKey: process.env.SLASHTAGS_SECRET ? Buffer.from(process.env.SLASHTAGS_SECRET, 'hex') : undefined })
 
   // Get the default slashtag
   const slashtag = sdk.slashtag()


### PR DESCRIPTION
This also makes `SLASHTAGS_SECRET` optional.
If none is set, random bytes will be generated. This is useful for local development.