### PR TITLE
Autofocus reply inputs

### DIFF
--- a/components/reply.js
+++ b/components/reply.js
@@ -4,7 +4,7 @@ import styles from './reply.module.css'
 import { COMMENTS } from '../fragments/comments'
 import { useMe } from './me'
 import TextareaAutosize from 'react-textarea-autosize'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import Link from 'next/link'
 import FeeButton from './fee-button'
 import { commentsViewedAfterComment } from '../lib/new-comments'
@@ -75,6 +75,11 @@ export default function Reply ({ item, onSuccess, replyOpen, children }) {
     }
   )
 
+  const replyInput = useRef(null)
+  useEffect(() => {
+    if (replyInput.current && reply) replyInput.current.focus()
+  }, [reply])
+
   return (
     <div>
       {replyOpen
@@ -112,6 +117,7 @@ export default function Reply ({ item, onSuccess, replyOpen, children }) {
             autoFocus={!replyOpen}
             required
             hint={me?.freeComments && me?.sats < 1 ? <span className='text-success'>{me.freeComments} free comments left</span> : null}
+            innerRef={replyInput}
           />
           {reply &&
             <div className='mt-1'>


### PR DESCRIPTION
Closes #237 


https://user-images.githubusercontent.com/27162016/220821282-6e914a87-5fb6-4a30-bbc0-b6c5e488ee16.mp4

I wasn't entirely sure if with "comment textareas" every textarea is meant or only comment replies.

To not have autofocus for directly replying to posts, only `!replyOpen` needs to be added to the condition in `useEffect`.