### PR TITLE
Fix dropdown items not visible in darkmode on some browsers

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -184,6 +184,11 @@ select.custom-select {
   background-size: 1.5rem;
 }
 
+select.custom-select option {
+  // fix dropdown items not visible in darkmode on some browsers
+  color: initial;
+}
+
 select.custom-select:focus {
   border-color: none !important;
   box-shadow: none !important;


### PR DESCRIPTION
This fixes the issue mentioned in https://stacker.news/items/172931.

The reason why the dropdown items were not visible on darkmode was that browsers which use WebKit/Blink (fork of WebKit) as the rendering engine seem to use the color of the selected item for the options, too.

Chrome and Brave use Blink since they include `WebKit/537.36` in their user agent header [0]. Firefox uses Gecko.

However, this also seems to be OS-dependent since you mentioned that Brave on iOS and Chrome on macOS works.

So I did a bit of research and found the following:

> Most of Chrome's source code comes from Google's free and open-source software project Chromium, but Chrome is licensed as proprietary freeware. WebKit was the original rendering engine, but Google eventually forked it to create the Blink engine; all Chrome variants except iOS used Blink as of 2017.

-- https://en.wikipedia.org/wiki/Google_Chrome

So I am confused why the bug didn't appear on Brave on iOS or Chrome on macOS.

Aren't you also running Blink engine? What's your user agent and browser versions?

| Browser | Version | User Agent | works? | 
| --- | --- | --- | --- |
| Chrome | Version 112.0.5615.165 (Official Build) (64-bit) | Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36 | no |
| Brave | Version 1.50.125 Chromium: 112.0.5615.165 (Official Build) (64-bit) | Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36 | no |
| Firefox | 112.0 (64-bit) | Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/112.0 | yes |

[0] https://stackoverflow.com/a/20866141