### PR TITLE
Return 500 if callback URL is external

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -6,6 +6,14 @@ import Login from '../components/login'
 export async function getServerSideProps ({ req, res, query: { callbackUrl, error = null } }) {
   const session = await getSession({ req })
 
+  const regex = /^https?:\/\/stacker.news\/?/
+  const external = !regex.test(decodeURIComponent(callbackUrl))
+  if (external) {
+    // This is a hotfix for open redirects. See https://github.com/stackernews/stacker.news/issues/264
+    // TODO: Add redirect notice to warn users
+    return res.status(500).end()
+  }
+
   if (session && res && callbackUrl) {
     res.writeHead(302, {
       Location: callbackUrl

--- a/pages/login.js
+++ b/pages/login.js
@@ -6,7 +6,7 @@ import Login from '../components/login'
 export async function getServerSideProps ({ req, res, query: { callbackUrl, error = null } }) {
   const session = await getSession({ req })
 
-  const regex = /^https?:\/\/stacker.news\/?/
+  const regex = /^https?:\/\/stacker.news\//
   const external = !regex.test(decodeURIComponent(callbackUrl))
   if (external) {
     // This is a hotfix for open redirects. See https://github.com/stackernews/stacker.news/issues/264

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -6,6 +6,14 @@ import Login from '../components/login'
 export async function getServerSideProps ({ req, res, query: { callbackUrl, error = null } }) {
   const session = await getSession({ req })
 
+  const regex = /^https?:\/\/stacker.news\/?/
+  const external = !regex.test(decodeURIComponent(callbackUrl))
+  if (external) {
+    // This is a hotfix for open redirects. See https://github.com/stackernews/stacker.news/issues/264
+    // TODO: Add redirect notice to warn users
+    return res.status(500).end()
+  }
+
   if (session && res && callbackUrl) {
     res.writeHead(302, {
       Location: callbackUrl

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -6,7 +6,7 @@ import Login from '../components/login'
 export async function getServerSideProps ({ req, res, query: { callbackUrl, error = null } }) {
   const session = await getSession({ req })
 
-  const regex = /^https?:\/\/stacker.news\/?/
+  const regex = /^https?:\/\/stacker.news\//
   const external = !regex.test(decodeURIComponent(callbackUrl))
   if (external) {
     // This is a hotfix for open redirects. See https://github.com/stackernews/stacker.news/issues/264


### PR DESCRIPTION
This should fix the open redirect mentioned in #264.

**However, I wasn't able to test this since I can't login/signup on my local machine at the moment.**

I just tested that `decodeURIComponent` and the regex work as I expected manually:

```
// open_redirect_test.js
const regex = /^https?:\/\/stacker.news\/?/

let callbackUrl = "https%3A%2F%2Fwww.google.com%2F"
let decoded = decodeURIComponent(callbackUrl)
let isExternal = !regex.test(decoded) 
console.log(isExternal) // should print true

callbackUrl = "https%3A%2F%2Fstacker.news%2F"
decoded = decodeURIComponent(callbackUrl)
isExternal = !regex.test(decoded)
console.log(isExternal) // should print false
```

```
$ node open_redirect_test.js
true
false
```

These changes should return 500 Internal Server Error if there exists a session already for a user instead of redirecting them to an external site.

However, I think for users with no session yet, the callback url should also be validated. Else, they will be redirected to a external site _after_ login which is probably also not in our interest.