### PR TITLE
Add contacts for responsible disclosure to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # contributing
 We pay sats for PRs. Sats will be proportional to the impact of the PR. If there's something you'd like to work on, suggest how much you'd do it for on the issue. If there's something you'd like to work on that isn't already an issue, whether its a bug fix or a new feature, create one.
 
+# responsible disclosure
+
+If you found a vulnerability, we would greatly appreciate it if you contact us via [kk@stacker.news](mailto:kk@stacker.news) or t.me/k00bideh.
+
 # stacker.news
 [Stacker News](https://stacker.news) is like Hacker News but we pay you Bitcoin. We use Bitcoin and the Lightning Network to provide Sybil resistance and any karma earned is withdrawable as Bitcoin.
 


### PR DESCRIPTION
I think it would also be good to add similar text to the [FAQ](https://stacker.news/faq) since @orthzar mentioned he only looked there. Maybe others will only look there, too.

However, I think this must be done by updating the database entry for the item the FAQ points to.

I think below "Where Should I Submit Bug Reports?" would be best.

So like this:

> #### Where Should I Submit Bug Reports?
>Also the git repo https://github.com/stackernews/stacker.news/issues.
>
>#### I found a vulnerability. How to responsibly disclose it?
>
>Please contact us via [kk@stacker.news](mailto:kk@stacker.news) or t.me/k00bideh.


For reference: https://stacker.news/items/175117