### PR TITLE
Fix fetched data not shown if last action was title clear

### DIFF
--- a/components/link-form.js
+++ b/components/link-form.js
@@ -143,6 +143,14 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
             getPageTitleAndUnshorted({
               variables: { url: e.target.value }
             })
+          } else {
+            client.cache.modify({
+              fields: {
+                pageTitleAndUnshorted () {
+                  return null
+                }
+              }
+            })
           }
           if (e.target.value) {
             setPostDisabled(true)


### PR DESCRIPTION
There are two flows when clearing both inputs:

1. First clear title, then clear URL, then enter new URL

In this case, new data will be fetched when the URL is cleared since the title is empty. Due to the fetch with empty variables, the fetched data is essentially reset. Entering a new URL thus triggers a new fetch (since title is still empty) and the fetched data is shown since it is different compared to the previous render.

2. First clear URL, then clear title, then enter new URL

In this case, new data will not be fetched when the URL is cleared since the title is not empty. When entering a new URL, new data is fetched but will not be shown since the fetched data was never reset and thus did not change compared to the previous render.

This is fixed by always either a) resetting the fetched data or b) fetching new data if the URL changed.


https://github.com/stackernews/stacker.news/assets/27162016/d44450f0-8e3e-4e80-becd-961c2daaca86

