### PR TITLE
Show version in footer

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -43,6 +43,9 @@ LND_CONNECT_ADDRESS=03cc1d0932bb99b0697f5b5e5961b83ab7fd66f1efc4c9f5c7bad66c1bcb
 NEXTAUTH_SECRET=3_0W_PhDRZVanbeJsZZGIEljexkKoGbL6qGIqSwTjjI
 JWT_SIGNING_PRIVATE_KEY={"kty":"oct","kid":"FvD__hmeKoKHu2fKjUrWbRKfhjimIM4IKshyrJG4KSM","alg":"HS512","k":"3_0W_PhDRZVanbeJsZZGIEljexkKoGbL6qGIqSwTjjI"}
 
+# git version
+NEXT_PUBLIC_COMMIT_HASH=0de1343
+
 # prisma db url
 DATABASE_URL="postgresql://sn:password@db:5432/stackernews?schema=public"
 

--- a/components/footer.js
+++ b/components/footer.js
@@ -207,6 +207,8 @@ export default function Footer ({ noLinks }) {
   const DarkModeIcon = darkMode.value ? Sun : Moon
   const LnIcon = lightning === 'yes' ? No : Bolt
 
+  const version = process.env.NEXT_PUBLIC_COMMIT_HASH
+
   return (
     <footer>
       <Container className='mb-3 mt-4'>
@@ -318,6 +320,7 @@ export default function Footer ({ noLinks }) {
             </Link>
           </span>
         </small>
+        <div className="version">version <a href={`https://github.com/stackernews/stacker.news/commit/${version}`}>{version}</a></div>
       </Container>
     </footer>
   )

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -617,3 +617,9 @@ div[contenteditable]:focus,
     color: #212529;
   }
 }
+
+.version {
+  margin: auto;
+  font-size: x-small;
+  color: var(--theme-grey) !important;
+}


### PR DESCRIPTION
You can use `git rev-parse --short HEAD` to get a short commit hash for the env var `NEXT_PUBLIC_COMMIT_HASH`

![2023-05-31-075305_601x275_scrot](https://github.com/stackernews/stacker.news/assets/27162016/a712e654-f7cd-4af8-a630-554376f6266b)

Close #275
