### PR TITLE
Allow CTRL+click to open /post in new tab

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -263,7 +263,15 @@ export default function Header ({ sub }) {
       ? (
         <Nav.Link eventKey='post' className={`${className}`}>
           <Link href={prefix + '/post'} passHref>
-            <button className='btn btn-md btn-primary px-3 py-1'>post</button>
+            <button
+              className='btn btn-md btn-primary px-3 py-1' onClick={(e) => {
+                if (e.ctrlKey) {
+                  e.preventDefault()
+                  window.open('/post', '_blank')
+                }
+              }}
+            >post
+            </button>
           </Link>
         </Nav.Link>)
       : null


### PR DESCRIPTION
This at least allows CTRL+click on the post button to open it in a new tab.

`window.open` seems to have good support between browsers so I think it's safe to use:
https://developer.mozilla.org/en-US/docs/Web/API/Window/open#browser_compatibility

Related to #290


https://github.com/stackernews/stacker.news/assets/27162016/2e589c9d-e6b5-4a25-a764-6cd11ae1da9e

