### PR TITLE
Add Markdown formatting hotkeys: CTRL+K, CTRL+I, CTRL+B

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -168,7 +168,7 @@ function InputInner ({
         )}
         <BootstrapForm.Control
           onKeyDown={(e) => {
-            if (e.keyCode === 13 && (e.metaKey || e.ctrlKey)) {
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
               formik?.submitForm()
             }
             if (onKeyDown) onKeyDown(e)

--- a/components/form.js
+++ b/components/form.js
@@ -132,6 +132,8 @@ function insertMarkdownFormatting (replaceFn, selectFn) {
     const mdFormatted = replaceFn(selectedText)
     const newVal = val.substring(0, start) + mdFormatted + val.substring(end)
     setValue(newVal)
+    // required for undo, see https://stackoverflow.com/a/27028258
+    document.execCommand('insertText', false, mdFormatted)
     // see https://github.com/facebook/react/issues/6483
     // for why we don't use `input.setSelectionRange` directly (hint: event order)
     setSelectionRange(selectFn ? selectFn(start, mdFormatted) : { start: start + mdFormatted.length, end: start + mdFormatted.length })


### PR DESCRIPTION
As mentioned in our call, I would love to use CTRL+K to insert Markdown link formatting [like in GH](https://docs.github.com/en/get-started/using-github/keyboard-shortcuts#source-code-editing).

In my opinion, this is ready to ship but something to notice is that [`document.execCommand()` is deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand) but still works as mentioned in [this SO answer](https://stackoverflow.com/a/62266439) and is still supported by every browser according to the [section about browser compatibility](https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#browser_compatibility).

Also, it is mentioned that when it is unsupported, it will just return `false`: 

> **Return value**
A boolean value that is false if the command is unsupported or disabled.

-- https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand#return_value

When it's not supported, only undo for this action will not be usable. It will continue to work afterwards.


I had to use it to fix CTRL+Z since the undo stack is broken after using `helpers.setValue()`.

I found using `document.execCommand()` as the solution [here](https://stackoverflow.com/a/27028258).

I also added hotkeys for bold and italic formatting since it was easy to include in this change.

Showcase:


https://github.com/stackernews/stacker.news/assets/27162016/093c13c9-ff9f-41b4-924c-12663e0abf6d

