### PR TITLE
Use <atom:author> in RSS feeds

### DIFF
--- a/lib/rss.js
+++ b/lib/rss.js
@@ -31,6 +31,7 @@ const generateRssItem = (item) => {
       <comments>${guid}</comments>
       <description><![CDATA[<a href="${guid}">Comments</a>]]></description>
       <pubDate>${new Date(item.createdAt).toUTCString()}</pubDate>
+      <atom:author><atom:name>${item.user.name}</atom:name></atom:author>
     </item>
   `
 }


### PR DESCRIPTION
Since we are already using `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">`, I looked up the RFC for and have noticed that it also has a tag for authors: `<atom:author>`

See https://datatracker.ietf.org/doc/html/rfc4287#section-4.2.1

Closes #139 