### PR TITLE
Fix cursor reset after innerRef initialized

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -93,7 +93,7 @@ export function MarkdownInput ({ label, topLevel, groupClassName, onChange, setH
       const input = innerRef.current
       input.setSelectionRange(start, end)
     }
-  }, [innerRef?.current, selectionRange.start, selectionRange.end])
+  }, [innerRef, selectionRange.start, selectionRange.end])
 
   return (
     <FormGroup label={label} className={groupClassName}>


### PR DESCRIPTION
The error was caused because `innerRef.current` is not initialized on first render. On second render (after the user typed something), it is and thus `useEffect` runs with the default values (start: 0, end: 0); resetting the cursor.

So I fixed it by removing the dependency on `innerRef.current`.

Closes #316 