### PR TITLE
Fix double submit

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -124,7 +124,6 @@ export function MarkdownInput ({ label, topLevel, groupClassName, onChange, setH
             onKeyDown={(e) => {
               const metaOrCtrl = e.metaKey || e.ctrlKey
               if (metaOrCtrl) {
-                if (e.key === 'Enter') formik?.submitForm()
                 if (e.key === 'k') {
                   // some browsers use CTRL+K to focus search bar so we have to prevent that behavior
                   e.preventDefault()


### PR DESCRIPTION
Closes #327

```diff
diff --git a/components/form.js b/components/form.js
index 4567897..8710322 100644
--- a/components/form.js
+++ b/components/form.js
@@ -457,6 +457,7 @@ export function Form ({
       validateOnBlur={false}
       onSubmit={async (values, ...args) =>
         onSubmit && onSubmit(values, ...args).then(() => {
+          console.trace()
           if (!storageKeyPrefix) return
           Object.keys(values).forEach(v => {
             localStorage.removeItem(storageKeyPrefix + '-' + v)
```

First trace:

```
form.js:460 console.trace
eval @ form.js:460
Promise.then (async)
_callee$ @ form.js:459
[...]
eval @ form.js:458
[...]
onKeyDown @ form.js:249
[...]
```

_form.js:249_:
```javascript
245 <BootstrapForm.Control
246   onKeyDown={(e) => {
247     const metaOrCtrl = e.metaKey || e.ctrlKey
248       if (metaOrCtrl) {
249         if (e.key === 'Enter') formik?.submitForm()
250       }
251
252       if (onKeyDown) onKeyDown(e)
253   }}
```

Second trace:

```
form.js:460 console.trace
eval @ form.js:460
Promise.then (async)
_callee$ @ form.js:459
[...]
eval @ form.js:458
[...]
onKeyDown @ form.js:127
onKeyDown @ form.js:252
[...]
```

_form.js:252_:
```javascript
245 <BootstrapForm.Control
246   onKeyDown={(e) => {
247     const metaOrCtrl = e.metaKey || e.ctrlKey
248     if (metaOrCtrl) {
249       if (e.key === 'Enter') formik?.submitForm()
250     }
251
252     if (onKeyDown) onKeyDown(e)
253   }}
```

_form.js:127_:

```javascript
116 <InputInner
117   {...props} onChange={(formik, e) => {
118     if (onChange) onChange(formik, e)
119     if (setHasImgLink) {
120       setHasImgLink(mdHas(e.target.value, ['link', 'image']))
121     }
122   }}
123   innerRef={innerRef}
124   onKeyDown={(e) => {
125     const metaOrCtrl = e.metaKey || e.ctrlKey
126     if (metaOrCtrl) {
127       if (e.key === 'Enter') formik?.submitForm()
```

Therefore, I removed the submit code passed into `InputInner` since it already exists within.

But I am wondering if there is a reason why not to put the markdown formatting code also within `InputInner`?


https://github.com/stackernews/stacker.news/assets/27162016/a62dc0fb-c4c5-45f5-b16b-67b08333167e

