### PR TITLE
Sync push subscriptions on every page load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "remove-markdown": "^0.5.0",
         "sass": "^1.64.1",
         "tldts": "^6.0.13",
+        "serviceworker-storage": "^0.1.0",
         "typescript": "^5.1.6",
         "unist-util-visit": "^5.0.0",
         "url-unshort": "^6.1.0",
@@ -16934,6 +16935,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/serviceworker-storage": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/serviceworker-storage/-/serviceworker-storage-0.1.0.tgz",
+      "integrity": "sha512-Vum11Npe8oiFYY05OIhD6obfVP3oCSfBj/NKQGzNLbn6Fr5424j1pv/SvPcbVrDIovdC3EmgGxLgfsLFXgZR1A=="
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
@@ -31636,6 +31642,11 @@
         "parseurl": "~1.3.3",
         "send": "0.18.0"
       }
+    },
+    "serviceworker-storage": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/serviceworker-storage/-/serviceworker-storage-0.1.0.tgz",
+      "integrity": "sha512-Vum11Npe8oiFYY05OIhD6obfVP3oCSfBj/NKQGzNLbn6Fr5424j1pv/SvPcbVrDIovdC3EmgGxLgfsLFXgZR1A=="
     },
     "set-cookie-parser": {
       "version": "2.6.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "remove-markdown": "^0.5.0",
     "sass": "^1.64.1",
     "tldts": "^6.0.13",
+    "serviceworker-storage": "^0.1.0",
     "typescript": "^5.1.6",
     "unist-util-visit": "^5.0.0",
     "url-unshort": "^6.1.0",


### PR DESCRIPTION
Close #354 (hopefully)

I tested this code using this patch:

```diff
diff --git a/sw/index.js b/sw/index.js
index c8dbee1..38c41ed 100644
--- a/sw/index.js
+++ b/sw/index.js
@@ -86,10 +86,12 @@ async function handlePushSubscriptionChange (oldSubscription, newSubscription) {
   newSubscription ??= await self.registration.pushManager.getSubscription()
   if (!newSubscription) {
     // no subscription exists at the moment
+    console.log('no active push subscription found')
     return
   }
   if (oldSubscription?.endpoint === newSubscription.endpoint) {
     // subscription did not change. no need to sync with server
+    console.log('push subscription did not change. no need for sync. skipping')
     return
   }
   // convert keys from ArrayBuffer to string
@@ -107,6 +109,7 @@ async function handlePushSubscriptionChange (oldSubscription, newSubscription) {
     }
   }`
   const body = JSON.stringify({ query, variables })
+  console.log('syncing new push subscription with server:', newSubscription)
   await fetch('/api/graphql', {
     method: 'POST',
     headers: {
@@ -118,5 +121,6 @@ async function handlePushSubscriptionChange (oldSubscription, newSubscription) {
 }

 self.addEventListener('pushsubscriptionchange', (event) => {
+  console.log('pushsubscriptionchange fired')
   event.waitUntil(handlePushSubscriptionChange(event.oldSubscription, event.newSubscription))
 }, false)
```

You can then test the combination of page reloads, manually calling `navigator.serviceWorker.controller.postMessage({ action: 'SYNC_SUBSCRIPTION' })` and manually deleting the entry in IndexedDB to trigger synchronization.

However, this solution is not perfect as mentioned in [this article](https://medium.com/@madridserginho/how-to-handle-webpush-api-pushsubscriptionchange-event-in-modern-browsers-6e47840d756f ) which was used for reference:

> This solution is not perfect, the user could lose some push notifications if he doesn’t open the webapp for a long time.

[The article](https://medium.com/@madridserginho/how-to-handle-webpush-api-pushsubscriptionchange-event-in-modern-browsers-6e47840d756f) also mentions usage of background sync to also trigger (delayed) synchronization if the user loads a page which is available offline:

> If the page could be loaded offline, then it’s possible to use background sync API to refresh subscription when browser will be online again.

However, we don't have pages which users would regularly visit and are available offline at the moment. I also don't think adding background sync is worth it at the moment. I think the current changes should already fix 99% of cases why push subscriptions are lost.