### PR TITLE
Comment, Reply count singular/plural labels

### DIFF
--- a/components/comment.js
+++ b/components/comment.js
@@ -148,6 +148,7 @@ export default function Comment ({
               item={item}
               pendingSats={pendingSats}
               commentsText='replies'
+              commentTextSingular='reply'
               className={`${itemStyles.other} ${styles.other}`}
               embellishUser={op && <Badge bg='boost' className={`ms-1 ${styles.op} bg-opacity-75`}>OP</Badge>}
               extraInfo={

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -17,7 +17,7 @@ import BookmarkDropdownItem from './bookmark'
 import SubscribeDropdownItem from './subscribe'
 import { CopyLinkDropdownItem } from './share'
 
-export default function ItemInfo ({ item, pendingSats, full, commentsText, className, embellishUser, extraInfo, onEdit, editText }) {
+export default function ItemInfo ({ item, pendingSats, full, commentsText, commentTextSingular, className, embellishUser, extraInfo, onEdit, editText }) {
   const editThreshold = new Date(item.createdAt).getTime() + 10 * 60000
   const me = useMe()
   const router = useRouter()
@@ -53,7 +53,7 @@ export default function ItemInfo ({ item, pendingSats, full, commentsText, class
           }
         }} title={`${item.commentSats} sats`} className='text-reset position-relative'
       >
-        {item.ncomments} {commentsText || 'comments'}
+        {item.ncomments} {item.ncomments === 1 ? commentTextSingular || 'comment' : commentsText || 'comments'}
         {hasNewComments &&
           <span className={styles.notification}>
             <span className='invisible'>{' '}</span>


### PR DESCRIPTION
This PR updates the Comment and ItemInfo components to render comment/reply counts using the appropriate singular/plural label, based on the number of comments/replies.

Apparently this has bothered me enough to fix it :) 