### PR TITLE
Fix dropdown items not visible in darkmode on some browsers

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -310,9 +310,9 @@ select.form-select {
   appearance: none;
 }
 
-select option {
+select.form-select option {
   // fix dropdown items not visible in darkmode on some browsers
-  color: initial;
+  color: rgba(0, 0, 0, 0.9);
 }
 
 select:focus {


### PR DESCRIPTION
Related to 6354913420a11c2f199d21ea59740651704ff17e

The CSS selector changed and `color: initial` no longer worked.

According to my research, WebKit browsers don't style `<option>` anyway so this change should be safe for all browsers since every browser should use a white background for the raw HTML dropdown afaict.

