### PR TITLE
Forward sats to user: text trimming and menu click-out UX improvements

### DIFF
--- a/components/adv-post-form.js
+++ b/components/adv-post-form.js
@@ -46,7 +46,6 @@ export default function AdvPostForm ({ edit }) {
           />
           <InputUserSuggest
             label={<>forward sats to</>}
-            groupClassName='forward-group'
             name='forward'
             hint={<span className='text-muted'>100% of sats will be sent to this stacker</span>}
             prepend={<InputGroup.Text>@</InputGroup.Text>}

--- a/components/adv-post-form.js
+++ b/components/adv-post-form.js
@@ -46,6 +46,7 @@ export default function AdvPostForm ({ edit }) {
           />
           <InputUserSuggest
             label={<>forward sats to</>}
+            groupClassName='forward-group'
             name='forward'
             hint={<span className='text-muted'>100% of sats will be sent to this stacker</span>}
             prepend={<InputGroup.Text>@</InputGroup.Text>}

--- a/components/form.js
+++ b/components/form.js
@@ -218,7 +218,7 @@ function FormGroup ({ className, label, children }) {
 }
 
 function InputInner ({
-  prepend, append, hint, showValid, onInput, onChange, onBlur, overrideValue,
+  prepend, append, hint, showValid, onChange, onBlur, overrideValue,
   innerRef, noForm, clear, onKeyDown, debounce, ...props
 }) {
   const [field, meta, helpers] = noForm ? [{}, {}, {}] : useField(props)

--- a/components/form.js
+++ b/components/form.js
@@ -321,6 +321,14 @@ function InputInner ({
 }
 
 export function InputUserSuggest ({ label, groupClassName, ...props }) {
+  const formik = useFormikContext()
+  const blurFunc = (e) => {
+    formik.handleBlur(e)
+    if (!document.getElementsByClassName(groupClassName)[0].contains(e.relatedTarget)) {
+      setSuggestions(INITIAL_SUGGESTIONS)
+    }
+  }
+
   const [getSuggestions] = useLazyQuery(USER_SEARCH, {
     onCompleted: data => {
       setSuggestions({ array: data.searchUsers, index: 0 })
@@ -370,11 +378,7 @@ export function InputUserSuggest ({ label, groupClassName, ...props }) {
               break
           }
         }}
-        onBlur={(e) => {
-          if (!document.getElementsByClassName(groupClassName)[0].contains(e.relatedTarget)) {
-            setSuggestions(INITIAL_SUGGESTIONS)
-          }
-        }}
+        onBlur={blurFunc}
       />
       <Dropdown show={suggestions.array.length > 0}>
         <Dropdown.Menu className={styles.suggestionsMenu}>
@@ -386,11 +390,7 @@ export function InputUserSuggest ({ label, groupClassName, ...props }) {
                 setOValue(v.name)
                 setSuggestions(INITIAL_SUGGESTIONS)
               }}
-              onBlur={(e) => {
-                if (!document.getElementsByClassName(groupClassName)[0].contains(e.relatedTarget)) {
-                  setSuggestions(INITIAL_SUGGESTIONS)
-                }
-              }}
+              onBlur={blurFunc}
             >
               {v.name}
             </Dropdown.Item>)}

--- a/components/form.js
+++ b/components/form.js
@@ -218,8 +218,8 @@ function FormGroup ({ className, label, children }) {
 }
 
 function InputInner ({
-  prepend, append, hint, showValid, onChange, overrideValue,
-  innerRef, noForm, clear, onKeyDown, debounce, ...props
+  prepend, append, hint, showValid, onInput, onChange, overrideValue,
+  innerRef, noForm, clear, onKeyDown, debounce, autoRestrict, ...props
 }) {
   const [field, meta, helpers] = noForm ? [{}, {}, {}] : useField(props)
   const formik = noForm ? null : useFormikContext()
@@ -272,6 +272,11 @@ function InputInner ({
           }}
           ref={innerRef}
           {...field} {...props}
+          onInput={(e) => {
+            if (autoRestrict && e.target.value !== autoRestrict(e.target.value)) {
+              e.target.value = autoRestrict(e.target.value)
+            }
+          }}
           onChange={(e) => {
             field.onChange(e)
 
@@ -331,6 +336,7 @@ export function InputUserSuggest ({ label, groupClassName, ...props }) {
       <InputInner
         {...props}
         autoComplete='off'
+        autoRestrict={(s) => s.replace(/^[@ ]+|[ ]+$/g, '')} // handles copy-and-paste offenders
         onChange={(_, e) => getSuggestions({ variables: { q: e.target.value } })}
         overrideValue={ovalue}
         onKeyDown={(e) => {
@@ -364,6 +370,11 @@ export function InputUserSuggest ({ label, groupClassName, ...props }) {
               break
           }
         }}
+        onBlur={(e) => {
+          if (!document.getElementsByClassName(groupClassName)[0].contains(e.relatedTarget)) {
+            setSuggestions(INITIAL_SUGGESTIONS)
+          }
+        }}
       />
       <Dropdown show={suggestions.array.length > 0}>
         <Dropdown.Menu className={styles.suggestionsMenu}>
@@ -374,6 +385,11 @@ export function InputUserSuggest ({ label, groupClassName, ...props }) {
               onClick={() => {
                 setOValue(v.name)
                 setSuggestions(INITIAL_SUGGESTIONS)
+              }}
+              onBlur={(e) => {
+                if (!document.getElementsByClassName(groupClassName)[0].contains(e.relatedTarget)) {
+                  setSuggestions(INITIAL_SUGGESTIONS)
+                }
               }}
             >
               {v.name}


### PR DESCRIPTION
Approach: on input, check for leading/trailing spaces and the leading @ symbol on the username (e.g. when pasting a username with extra characters) and strip them. This has the effect of also restricting the user from typing such characters too.

While working on this, I discovered the drop-down suggestions menu was too sticky; it covered the post button and virtually obliged the user to pick a name in the list (even if not necessary because it was pasted in, e.g.) so I added logic to hide the menu when the user clicks out or tabs away.

(issue #185)