### PR TITLE
multiple forwards on a post

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -900,9 +900,12 @@ export default {
       }
       return await models.user.findUnique({ where: { id: item.userId } })
     },
-    // forwardUsers: async (item, args, { models }) => {
-    //   return await models.itemForward.find({ where: { itemId: item.id } })
-    // },
+    forwards: async (item, args, { models }) => {
+      const forwards = await models.itemForward.findMany({ where: { itemId: item.id } })
+      const userPromises = forwards.map(fwd => models.user.findUnique({ where: { id: fwd.userId } }))
+      const userResults = await Promise.allSettled(userPromises)
+      return forwards.map((fwd, index) => ({ ...fwd, user: userResults[index].value ?? null }))
+    },
     comments: async (item, { sort }, { me, models }) => {
       if (typeof item.comments !== 'undefined') return item.comments
       if (item.ncomments === 0) return []

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1173,7 +1173,8 @@ const getForwardUsers = async (models, forward) => {
       // 1. no more than 5 forward entries
       // 2. each percentage is a positive integer between 1 and 100 inclusive
       // 3. the sum of all percentages is <= 100
-      // 4. each specified nym exists
+      // 4. no duplicate nyms
+      // 5. each specified nym exists
       if (forward.length > MAX_FORWARDS) {
         throw new GraphQLError(`forward user count of [${forward.length}] exceeds limit of [${MAX_FORWARDS}]`, { extensions: { code: 'BAD_INPUT' } })
       }
@@ -1192,6 +1193,9 @@ const getForwardUsers = async (models, forward) => {
       })
       if (forward.map(fwd => Number(fwd.pct)).reduce((sum, cur) => sum + cur, 0) > 100) {
         throw new GraphQLError('the total forward percentage exceeds 100%', { extensions: { code: 'BAD_INPUT' } })
+      }
+      if (new Set(forward.map(fwd => fwd.nym)).size !== forward.length) {
+        throw new GraphQLError('duplicate stackers cannot be specified.', { extensions: { code: 'BAD_INPUT' } })
       }
       const userQueryResults = await Promise.allSettled(
         forward.map(fwd => (models.user.findUnique({ where: { name: fwd.nym } })))

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1167,7 +1167,7 @@ const createItem = async (parent, { sub, title, url, text, boost, forward, bount
       )
       userQueryResults.forEach((promise, index) => {
         if (promise.status === 'fulfilled') {
-          fwdUsers.push({ user: promise.value, pct: forward[index].pct })
+          fwdUsers.push({ userId: promise.value.id, pct: forward[index].pct })
         } else {
           throw new GraphQLError(`forward user [@${forward[index].nym}] does not exist`, { extensions: { code: 'BAD_INPUT' } })
         }
@@ -1181,7 +1181,7 @@ const createItem = async (parent, { sub, title, url, text, boost, forward, bount
   const [query] = await serialize(
     models,
     models.$queryRawUnsafe(
-    `${SELECT} FROM create_item($1, $2, $3, $4, $5::INTEGER, $6::INTEGER, $7::INTEGER, $8::INTEGER, $9::INTEGER, '${spamInterval}') AS "Item"`,
+    `${SELECT} FROM create_item($1, $2, $3, $4, $5::INTEGER, $6::INTEGER, $7::INTEGER, $8::INTEGER, $9::JSON, '${spamInterval}') AS "Item"`,
     parentId ? null : sub || 'bitcoin',
     title,
     url,
@@ -1190,7 +1190,7 @@ const createItem = async (parent, { sub, title, url, text, boost, forward, bount
     bounty ? Number(bounty) : null,
     Number(parentId),
     Number(author.id),
-    Number(fwdUsers?.id)),
+    JSON.stringify(fwdUsers)),
     ...trx)
   const item = trx.length > 0 ? query[0] : query
 

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -774,6 +774,12 @@ export default {
         }
       }
 
+      // Disallow tips if me is one of the forward user recipients
+      const existingForwards = await models.itemForward.findMany({ where: { itemId: Number(id) } })
+      if (existingForwards.some(fwd => Number(fwd.userId) === Number(user.id))) {
+        throw new GraphQLError('cannot zap a post for which you are forwarded zaps', { extensions: { code: 'BAD_INPUT' } })
+      }
+
       const calls = [
         models.$queryRaw`SELECT item_act(${Number(id)}::INTEGER, ${user.id}::INTEGER, 'TIP', ${Number(sats)}::INTEGER)`
       ]

--- a/api/resolvers/rewards.js
+++ b/api/resolvers/rewards.js
@@ -34,6 +34,7 @@ export default {
             FROM "Donation"
             WHERE date_trunc('day', created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago') = day_cte.day)
             UNION ALL
+          -- any earnings from anon's stack that are not forwarded to other users
           (SELECT "ItemAct".msats / 1000.0 as sats, 'ANON' as type
             FROM "Item"
             JOIN "ItemAct" ON "ItemAct"."itemId" = "Item".id

--- a/api/resolvers/rewards.js
+++ b/api/resolvers/rewards.js
@@ -37,7 +37,9 @@ export default {
           (SELECT "ItemAct".msats / 1000.0 as sats, 'ANON' as type
             FROM "Item"
             JOIN "ItemAct" ON "ItemAct"."itemId" = "Item".id
-            WHERE "Item"."userId" = ${ANON_USER_ID} AND "ItemAct".act = 'TIP' AND "Item"."fwdUserId" IS NULL
+            JOIN "ItemForward" ON "ItemForward"."itemId" = "Item".id
+            WHERE "Item"."userId" = ${ANON_USER_ID} AND "ItemAct".act = 'TIP'
+            AND (SELECT COUNT(*) FROM "ItemForward" WHERE "ItemForward"."itemId" = "Item".id) = 0
             AND date_trunc('day', "ItemAct".created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago') = day_cte.day)
         ) subquery`
 

--- a/api/resolvers/rewards.js
+++ b/api/resolvers/rewards.js
@@ -37,10 +37,11 @@ export default {
           (SELECT "ItemAct".msats / 1000.0 as sats, 'ANON' as type
             FROM "Item"
             JOIN "ItemAct" ON "ItemAct"."itemId" = "Item".id
-            JOIN "ItemForward" ON "ItemForward"."itemId" = "Item".id
+            LEFT JOIN "ItemForward" ON "ItemForward"."itemId" = "Item".id
             WHERE "Item"."userId" = ${ANON_USER_ID} AND "ItemAct".act = 'TIP'
-            AND (SELECT COUNT(*) FROM "ItemForward" WHERE "ItemForward"."itemId" = "Item".id) = 0
-            AND date_trunc('day', "ItemAct".created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago') = day_cte.day)
+            AND date_trunc('day', "ItemAct".created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago') = day_cte.day
+            GROUP BY "ItemAct".id, "ItemAct".msats
+            HAVING COUNT("ItemForward".id) = 0)
         ) subquery`
 
       return result || { total: 0, time: 0, sources: [] }

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -142,7 +142,7 @@ export default {
             (
               (100 - FLOOR(SUM("ItemForward"."pct") / COUNT(DISTINCT "ItemAct".id)))
               / 100
-              * FLOOR(SUM("ItemAct".msats) / COUNT(DISTINCT "ItemAct".id))
+              * FLOOR(SUM("ItemAct".msats) / COUNT(DISTINCT "ItemForward".id))
             ) AS "msats",
             0 AS "msatsFee",
             NULL AS status,

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -156,7 +156,12 @@ export default {
           )
           AND "Item"."userId" = $1
           AND "ItemAct".created_at <= $2
-          GROUP BY "Item".id)`
+          GROUP BY "Item".id
+          HAVING (
+            (100 - FLOOR(SUM("ItemForward"."pct") / COUNT(DISTINCT "ItemAct".id)))
+            / 100
+            * FLOOR(SUM("ItemAct".msats) / COUNT(DISTINCT "ItemForward".id))
+          ) > 0)`
         )
         // query 3, get all sats stacked by the user by way of being forwarded to them from someone else
         queries.push(

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -111,42 +111,32 @@ export default {
       }
 
       if (include.has('stacked')) {
-        // query1 - get all sats stacked as OP
+        // query1 - get all sats stacked as OP or as a forward
         queries.push(
           `(SELECT
             ('stacked' || "Item".id) AS id,
             "Item".id AS "factId",
             NULL AS bolt11,
             MAX("ItemAct".created_at) AS "createdAt",
-            FLOOR(SUM("ItemAct".msats) * COALESCE(1 - (SELECT SUM(pct) FROM "ItemForward" WHERE "itemId" = "Item".id) / 100.0, 1)) AS "msats",
+            FLOOR(
+              SUM("ItemAct".msats)
+              * (CASE WHEN "Item"."userId" = $1 THEN
+                  COALESCE(1 - ((SELECT SUM(pct) FROM "ItemForward" WHERE "itemId" = "Item".id) / 100.0), 1)
+                ELSE
+                  (SELECT pct FROM "ItemForward" WHERE "itemId" = "Item".id AND "userId" = $1) / 100.0
+                END)
+            ) AS "msats",
             0 AS "msatsFee",
             NULL AS status,
             'stacked' AS type
           FROM "ItemAct"
           JOIN "Item" ON "ItemAct"."itemId" = "Item".id
+          -- only join to with item forward for items where we aren't the OP
+          LEFT JOIN "ItemForward" ON "ItemForward"."itemId" = "Item".id AND "Item"."userId" <> $1
           WHERE "ItemAct".act = 'TIP'
-          AND "Item"."userId" = $1
+          AND ("Item"."userId" = $1 OR "ItemForward"."userId" = $1)
           AND "ItemAct".created_at <= $2
           GROUP BY "Item".id)`
-        )
-        // query 2, get all sats stacked by the user by way of being forwarded to them from someone else
-        queries.push(
-          `(SELECT
-            ('stacked' || "Item".id) AS id,
-            "Item".id AS "factId",
-            NULL AS bolt11,
-            MAX("ItemAct".created_at) AS "createdAt",
-            FLOOR(SUM("ItemAct".msats) * "ItemForward".pct / 100.0)  as msats,
-            0 AS "msatsFee",
-            NULL AS status,
-            'stacked' AS type
-          FROM "ItemAct"
-          JOIN "Item" ON "ItemAct"."itemId" = "Item".id
-          JOIN "ItemForward" ON "ItemForward"."itemId" = "Item".id AND "ItemForward"."userId" = $1
-          WHERE "ItemAct".act = 'TIP'
-          AND "ItemAct"."userId" <> "Item"."userId"
-          AND "ItemAct".created_at <= $2
-          GROUP BY "Item".id, "ItemForward".pct)`
         )
         queries.push(
             `(SELECT ('earn' || min("Earn".id)) as id, min("Earn".id) as "factId", NULL as bolt11,

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -170,7 +170,9 @@ export default {
             "Item".id AS "factId",
             NULL AS bolt11,
             MAX("ItemAct".created_at) AS "createdAt",
-            SUM("ItemAct".msats) AS msats,
+            FLOOR(SUM("ItemForward".pct) / COUNT(DISTINCT "ItemAct".id))
+            / 100 *
+            FLOOR(SUM("ItemAct".msats) / COUNT(DISTINCT "ItemForward".id)) as msats,
             0 AS "msatsFee",
             NULL AS status,
             'stacked' AS type

--- a/api/typeDefs/index.js
+++ b/api/typeDefs/index.js
@@ -3,6 +3,7 @@ import { gql } from 'graphql-tag'
 import user from './user'
 import message from './message'
 import item from './item'
+import itemForward from './itemForward'
 import wallet from './wallet'
 import lnurl from './lnurl'
 import notifications from './notifications'
@@ -32,5 +33,5 @@ const common = gql`
   scalar Date
 `
 
-export default [common, user, item, message, wallet, lnurl, notifications, invite,
+export default [common, user, item, itemForward, message, wallet, lnurl, notifications, invite,
   sub, upload, growth, rewards, referrals, price, admin]

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -27,7 +27,7 @@ export default gql`
     subscribeItem(id: ID): Item
     deleteItem(id: ID): Item
     upsertLink(id: ID, sub: String, title: String!, url: String!, boost: Int, forward: String, invoiceHash: String, invoiceHmac: String): Item!
-    upsertDiscussion(id: ID, sub: String, title: String!, text: String, boost: Int, forward: String, invoiceHash: String, invoiceHmac: String): Item!
+    upsertDiscussion(id: ID, sub: String, title: String!, text: String, boost: Int, forward: [ItemForwardInput], invoiceHash: String, invoiceHmac: String): Item!
     upsertBounty(id: ID, sub: String, title: String!, text: String, bounty: Int!, boost: Int, forward: String): Item!
     upsertJob(id: ID, sub: String!, title: String!, company: String!, location: String, remote: Boolean,
       text: String!, url: String!, maxBid: Int!, status: String, logo: Int): Item!
@@ -115,5 +115,10 @@ export default gql`
     uploadId: Int
     otsHash: String
     parentOtsHash: String
+  }
+
+  input ItemForwardInput {
+    nym: String!
+    pct: Int!
   }
 `

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -26,12 +26,12 @@ export default gql`
     bookmarkItem(id: ID): Item
     subscribeItem(id: ID): Item
     deleteItem(id: ID): Item
-    upsertLink(id: ID, sub: String, title: String!, url: String!, boost: Int, forward: String, invoiceHash: String, invoiceHmac: String): Item!
+    upsertLink(id: ID, sub: String, title: String!, url: String!, boost: Int, forward: [ItemForwardInput], invoiceHash: String, invoiceHmac: String): Item!
     upsertDiscussion(id: ID, sub: String, title: String!, text: String, boost: Int, forward: [ItemForwardInput], invoiceHash: String, invoiceHmac: String): Item!
-    upsertBounty(id: ID, sub: String, title: String!, text: String, bounty: Int!, boost: Int, forward: String): Item!
+    upsertBounty(id: ID, sub: String, title: String!, text: String, bounty: Int!, boost: Int, forward: [ItemForwardInput]): Item!
     upsertJob(id: ID, sub: String!, title: String!, company: String!, location: String, remote: Boolean,
       text: String!, url: String!, maxBid: Int!, status: String, logo: Int): Item!
-    upsertPoll(id: ID, sub: String, title: String!, text: String, options: [String!]!, boost: Int, forward: String, invoiceHash: String, invoiceHmac: String): Item!
+    upsertPoll(id: ID, sub: String, title: String!, text: String, options: [String!]!, boost: Int, forward: [ItemForwardInput], invoiceHash: String, invoiceHmac: String): Item!
     createComment(text: String!, parentId: ID!, invoiceHash: String, invoiceHmac: String): Item!
     updateComment(id: ID!, text: String!): Item!
     dontLikeThis(id: ID!): Boolean!
@@ -78,8 +78,6 @@ export default gql`
     root: Item
     user: User!
     userId: Int!
-    fwdUserId: Int
-    fwdUser: User
     depth: Int!
     mine: Boolean!
     boost: Int!
@@ -115,6 +113,16 @@ export default gql`
     uploadId: Int
     otsHash: String
     parentOtsHash: String
+    itemForwards: [ItemForward]
+  }
+
+  type ItemForward {
+    id: ID!
+    created_at: Date!
+    updated_at: Date!
+    itemId: Int!
+    userId: Int!
+    pct: Int!
   }
 
   input ItemForwardInput {

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -113,16 +113,7 @@ export default gql`
     uploadId: Int
     otsHash: String
     parentOtsHash: String
-    itemForwards: [ItemForward]
-  }
-
-  type ItemForward {
-    id: ID!
-    created_at: Date!
-    updated_at: Date!
-    itemId: Int!
-    userId: Int!
-    pct: Int!
+    forwards: [ItemForward]
   }
 
   input ItemForwardInput {

--- a/api/typeDefs/itemForward.js
+++ b/api/typeDefs/itemForward.js
@@ -1,0 +1,13 @@
+import { gql } from 'graphql-tag'
+
+export default gql`
+  type ItemForward {
+    id: ID!
+    created_at: Date!
+    updated_at: Date!
+    itemId: Int!
+    userId: Int!
+    user: User!
+    pct: Int!
+  }
+`

--- a/components/adv-post-form.js
+++ b/components/adv-post-form.js
@@ -1,5 +1,7 @@
+import Button from 'react-bootstrap/Button'
+import { useFormikContext } from 'formik'
 import AccordianItem from './accordian-item'
-import { Input, InputUserSuggest } from './form'
+import { Input, InputUserSuggest, VariableInput } from './form'
 import InputGroup from 'react-bootstrap/InputGroup'
 import { BOOST_MIN, MAX_FORWARDS } from '../lib/constants'
 import Info from './info'
@@ -13,6 +15,7 @@ export function AdvPostInitial ({ forward }) {
 }
 
 export default function AdvPostForm ({ edit }) {
+  const formik = useFormikContext()
   return (
     <AccordianItem
       header={<div style={{ fontWeight: 'bold', fontSize: '92%' }}>options</div>}
@@ -44,28 +47,37 @@ export default function AdvPostForm ({ edit }) {
             hint={<span className='text-muted'>ranks posts higher temporarily based on the amount</span>}
             append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
           />
-          <label className='form-label'>Forward sats to up to 5 other stackers. Any remaining sats go to you.</label>
-          {Array(MAX_FORWARDS).fill().map((_, index) => (
-            <div key={index} className='flex-row' style={{ display: 'flex' }}>
-              <InputUserSuggest
-                label={<>forward sats to</>}
-                name={`forward[${index}].nym`}
-                prepend={<InputGroup.Text>@</InputGroup.Text>}
-                showValid
-                groupClassName='flex-grow-1'
-              />
-              <Input
-                label={<>percent</>}
-                name={`forward[${index}].pct`}
-                showValid
-                type='number'
-                step='1'
-                min='1'
-                max='100'
-                groupClassName='flex-grow-1'
-              />
-            </div>
-          ))}
+          <VariableInput
+            label='Forward sats to up to 5 other stackers. Any remaining sats go to you.'
+            name='forward'
+            min={1}
+            max={MAX_FORWARDS}
+            emptyItem={{ }}
+            inputFn={({ index }) => {
+              return (
+                <div key={index} className='d-flex flex-row' style={{ display: 'flex' }}>
+                  <InputUserSuggest
+                    label={<>forward sats to</>}
+                    name={`forward[${index}].nym`}
+                    prepend={<InputGroup.Text>@</InputGroup.Text>}
+                    showValid
+                    groupClassName='flex-grow-1'
+                  />
+                  <Input
+                    label={<>percent</>}
+                    name={`forward[${index}].pct`}
+                    showValid
+                    type='number'
+                    step='1'
+                    min='1'
+                    max='100'
+                    groupClassName='flex-grow-1'
+                  />
+                </div>
+              )
+            }}
+          />
+          {formik.values.forward?.length === 0 && <Button variant='link' onClick={() => formik.setFieldValue('forward', [{}])}>Add stacker</Button>}
         </>
       }
     />

--- a/components/adv-post-form.js
+++ b/components/adv-post-form.js
@@ -8,7 +8,7 @@ import { numWithUnits } from '../lib/format'
 export function AdvPostInitial ({ forward }) {
   return {
     boost: '',
-    forward: forward || ''
+    forward: forward || []
   }
 }
 
@@ -44,13 +44,92 @@ export default function AdvPostForm ({ edit }) {
             hint={<span className='text-muted'>ranks posts higher temporarily based on the amount</span>}
             append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
           />
-          <InputUserSuggest
-            label={<>forward sats to</>}
-            name='forward'
-            hint={<span className='text-muted'>100% of sats will be sent to this stacker</span>}
-            prepend={<InputGroup.Text>@</InputGroup.Text>}
-            showValid
-          />
+          <div>Forward sats to up to 5 other stackers</div>
+          <div>
+            <InputUserSuggest
+              label={<>forward sats to</>}
+              name='forward[0].nym'
+              prepend={<InputGroup.Text>@</InputGroup.Text>}
+              showValid
+            />
+            <Input
+              label={<>percent</>}
+              name='forward[0].pct'
+              showValid
+              type='number'
+              step='1'
+              min='1'
+              max='100'
+            />
+          </div>
+          <div>
+            <InputUserSuggest
+              label={<>forward sats to</>}
+              name='forward[1].nym'
+              prepend={<InputGroup.Text>@</InputGroup.Text>}
+              showValid
+            />
+            <Input
+              label={<>percent</>}
+              name='forward[1].pct'
+              showValid
+              type='number'
+              step='1'
+              min='1'
+              max='100'
+            />
+          </div>
+          <div>
+            <InputUserSuggest
+              label={<>forward sats to</>}
+              name='forward[2].nym'
+              prepend={<InputGroup.Text>@</InputGroup.Text>}
+              showValid
+            />
+            <Input
+              label={<>percent</>}
+              name='forward[2].pct'
+              showValid
+              type='number'
+              step='1'
+              min='1'
+              max='100'
+            />
+          </div>
+          <div>
+            <InputUserSuggest
+              label={<>forward sats to</>}
+              name='forward[3].nym'
+              prepend={<InputGroup.Text>@</InputGroup.Text>}
+              showValid
+            />
+            <Input
+              label={<>percent</>}
+              name='forward[3].pct'
+              showValid
+              type='number'
+              step='1'
+              min='1'
+              max='100'
+            />
+          </div>
+          <div>
+            <InputUserSuggest
+              label={<>forward sats to</>}
+              name='forward[4].nym'
+              prepend={<InputGroup.Text>@</InputGroup.Text>}
+              showValid
+            />
+            <Input
+              label={<>percent</>}
+              name='forward[4].pct'
+              showValid
+              type='number'
+              step='1'
+              min='1'
+              max='100'
+            />
+          </div>
         </>
       }
     />

--- a/components/adv-post-form.js
+++ b/components/adv-post-form.js
@@ -1,7 +1,7 @@
 import AccordianItem from './accordian-item'
 import { Input, InputUserSuggest } from './form'
 import InputGroup from 'react-bootstrap/InputGroup'
-import { BOOST_MIN } from '../lib/constants'
+import { BOOST_MIN, MAX_FORWARDS } from '../lib/constants'
 import Info from './info'
 import { numWithUnits } from '../lib/format'
 
@@ -45,7 +45,7 @@ export default function AdvPostForm ({ edit }) {
             append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
           />
           <label className='form-label'>Forward sats to up to 5 other stackers. Any remaining sats go to you.</label>
-          {Array(5).fill().map((_, index) => (
+          {Array(MAX_FORWARDS).fill().map((_, index) => (
             <div key={index} className='flex-row' style={{ display: 'flex' }}>
               <InputUserSuggest
                 label={<>forward sats to</>}

--- a/components/adv-post-form.js
+++ b/components/adv-post-form.js
@@ -1,5 +1,3 @@
-import Button from 'react-bootstrap/Button'
-import { useFormikContext } from 'formik'
 import AccordianItem from './accordian-item'
 import { Input, InputUserSuggest, VariableInput } from './form'
 import InputGroup from 'react-bootstrap/InputGroup'
@@ -7,15 +5,16 @@ import { BOOST_MIN, MAX_FORWARDS } from '../lib/constants'
 import Info from './info'
 import { numWithUnits } from '../lib/format'
 
+const EMPTY_FORWARD = { nym: '', pct: '' }
+
 export function AdvPostInitial ({ forward }) {
   return {
     boost: '',
-    forward: forward || []
+    forward: forward?.length ? forward : [EMPTY_FORWARD]
   }
 }
 
 export default function AdvPostForm ({ edit }) {
-  const formik = useFormikContext()
   return (
     <AccordianItem
       header={<div style={{ fontWeight: 'bold', fontSize: '92%' }}>options</div>}
@@ -48,36 +47,35 @@ export default function AdvPostForm ({ edit }) {
             append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
           />
           <VariableInput
-            label='Forward sats to up to 5 other stackers. Any remaining sats go to you.'
+            label='forward sats to'
             name='forward'
-            min={1}
+            min={0}
             max={MAX_FORWARDS}
-            emptyItem={{ }}
-            inputFn={({ index }) => {
+            emptyItem={EMPTY_FORWARD}
+            hint={<span className='text-muted'>Forward sats to up to 5 other stackers. Any remaining sats go to you.</span>}
+          >
+            {({ index, placeholder }) => {
               return (
-                <div key={index} className='d-flex flex-row' style={{ display: 'flex' }}>
+                <div key={index} className='d-flex flex-row'>
                   <InputUserSuggest
-                    label={<>forward sats to</>}
                     name={`forward[${index}].nym`}
                     prepend={<InputGroup.Text>@</InputGroup.Text>}
                     showValid
-                    groupClassName='flex-grow-1'
+                    groupClassName='flex-grow-1 me-3 mb-0'
                   />
                   <Input
-                    label={<>percent</>}
                     name={`forward[${index}].pct`}
-                    showValid
                     type='number'
                     step='1'
                     min='1'
                     max='100'
-                    groupClassName='flex-grow-1'
+                    append={<InputGroup.Text className='text-monospace'>%</InputGroup.Text>}
+                    groupClassName='flex-shrink-1 mb-0'
                   />
                 </div>
               )
             }}
-          />
-          {formik.values.forward?.length === 0 && <Button variant='link' onClick={() => formik.setFieldValue('forward', [{}])}>Add stacker</Button>}
+          </VariableInput>
         </>
       }
     />

--- a/components/adv-post-form.js
+++ b/components/adv-post-form.js
@@ -44,92 +44,28 @@ export default function AdvPostForm ({ edit }) {
             hint={<span className='text-muted'>ranks posts higher temporarily based on the amount</span>}
             append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
           />
-          <div>Forward sats to up to 5 other stackers</div>
-          <div>
-            <InputUserSuggest
-              label={<>forward sats to</>}
-              name='forward[0].nym'
-              prepend={<InputGroup.Text>@</InputGroup.Text>}
-              showValid
-            />
-            <Input
-              label={<>percent</>}
-              name='forward[0].pct'
-              showValid
-              type='number'
-              step='1'
-              min='1'
-              max='100'
-            />
-          </div>
-          <div>
-            <InputUserSuggest
-              label={<>forward sats to</>}
-              name='forward[1].nym'
-              prepend={<InputGroup.Text>@</InputGroup.Text>}
-              showValid
-            />
-            <Input
-              label={<>percent</>}
-              name='forward[1].pct'
-              showValid
-              type='number'
-              step='1'
-              min='1'
-              max='100'
-            />
-          </div>
-          <div>
-            <InputUserSuggest
-              label={<>forward sats to</>}
-              name='forward[2].nym'
-              prepend={<InputGroup.Text>@</InputGroup.Text>}
-              showValid
-            />
-            <Input
-              label={<>percent</>}
-              name='forward[2].pct'
-              showValid
-              type='number'
-              step='1'
-              min='1'
-              max='100'
-            />
-          </div>
-          <div>
-            <InputUserSuggest
-              label={<>forward sats to</>}
-              name='forward[3].nym'
-              prepend={<InputGroup.Text>@</InputGroup.Text>}
-              showValid
-            />
-            <Input
-              label={<>percent</>}
-              name='forward[3].pct'
-              showValid
-              type='number'
-              step='1'
-              min='1'
-              max='100'
-            />
-          </div>
-          <div>
-            <InputUserSuggest
-              label={<>forward sats to</>}
-              name='forward[4].nym'
-              prepend={<InputGroup.Text>@</InputGroup.Text>}
-              showValid
-            />
-            <Input
-              label={<>percent</>}
-              name='forward[4].pct'
-              showValid
-              type='number'
-              step='1'
-              min='1'
-              max='100'
-            />
-          </div>
+          <label className='form-label'>Forward sats to up to 5 other stackers. Any remaining sats go to you.</label>
+          {Array(5).fill().map((_, index) => (
+            <div key={index} className='flex-row' style={{ display: 'flex' }}>
+              <InputUserSuggest
+                label={<>forward sats to</>}
+                name={`forward[${index}].nym`}
+                prepend={<InputGroup.Text>@</InputGroup.Text>}
+                showValid
+                groupClassName='flex-grow-1'
+              />
+              <Input
+                label={<>percent</>}
+                name={`forward[${index}].pct`}
+                showValid
+                type='number'
+                step='1'
+                min='1'
+                max='100'
+                groupClassName='flex-grow-1'
+              />
+            </div>
+          ))}
         </>
       }
     />

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -10,6 +10,7 @@ import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
 import { useInvoiceable } from './invoice'
+import { normalizeForwards } from '../lib/form'
 
 export function BountyForm ({
   item,
@@ -34,7 +35,7 @@ export function BountyForm ({
         $bounty: Int!
         $text: String
         $boost: Int
-        $forward: String
+        $forward: [ItemForwardInput]
       ) {
         upsertBounty(
           sub: $sub
@@ -60,7 +61,8 @@ export function BountyForm ({
           id: item?.id,
           boost: boost ? Number(boost) : undefined,
           bounty: bounty ? Number(bounty) : undefined,
-          ...values
+          ...values,
+          forward: normalizeForwards(values.forward)
         }
       })
       if (error) {

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -85,7 +85,7 @@ export function BountyForm ({
         title: item?.title || '',
         text: item?.text || '',
         bounty: item?.bounty || 1000,
-        ...AdvPostInitial({ forward: item?.fwdUser?.name }),
+        ...AdvPostInitial({ forward: item?.forwards?.map(fwd => ({ nym: fwd.user.name, pct: fwd.pct })) }),
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -85,7 +85,7 @@ export function BountyForm ({
         title: item?.title || '',
         text: item?.text || '',
         bounty: item?.bounty || 1000,
-        ...AdvPostInitial({ forward: item?.forwards?.map(fwd => ({ nym: fwd.user.name, pct: fwd.pct })) }),
+        ...AdvPostInitial({ forward: normalizeForwards(item?.forwards) }),
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -83,7 +83,7 @@ export function DiscussionForm ({
       initial={{
         title: item?.title || shareTitle || '',
         text: item?.text || '',
-        ...AdvPostInitial({ forward: item?.fwdUser?.name }),
+        ...AdvPostInitial({ forward: item?.forwards?.map(fwd => ({ nym: fwd.user.name, pct: fwd.pct })) }),
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -14,6 +14,7 @@ import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
 import { useInvoiceable } from './invoice'
+import { normalizeForwards } from '../lib/form'
 
 export function DiscussionForm ({
   item, sub, editThreshold, titleLabel = 'title',
@@ -44,7 +45,7 @@ export function DiscussionForm ({
           id: item?.id,
           boost: boost ? Number(boost) : undefined,
           ...values,
-          forward: values.forward ? values.forward.map(fwd => ({ ...fwd, pct: Number(fwd.pct) })) : undefined,
+          forward: normalizeForwards(values.forward),
           invoiceHash,
           invoiceHmac
         }

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -29,7 +29,7 @@ export function DiscussionForm ({
   // const me = useMe()
   const [upsertDiscussion] = useMutation(
     gql`
-      mutation upsertDiscussion($sub: String, $id: ID, $title: String!, $text: String, $boost: Int, $forward: String, $invoiceHash: String, $invoiceHmac: String) {
+      mutation upsertDiscussion($sub: String, $id: ID, $title: String!, $text: String, $boost: Int, $forward: [ItemForwardInput], $invoiceHash: String, $invoiceHmac: String) {
         upsertDiscussion(sub: $sub, id: $id, title: $title, text: $text, boost: $boost, forward: $forward, invoiceHash: $invoiceHash, invoiceHmac: $invoiceHmac) {
           id
         }
@@ -39,7 +39,15 @@ export function DiscussionForm ({
   const submitUpsertDiscussion = useCallback(
     async (_, boost, values, invoiceHash, invoiceHmac) => {
       const { error } = await upsertDiscussion({
-        variables: { sub: item?.subName || sub?.name, id: item?.id, boost: boost ? Number(boost) : undefined, ...values, invoiceHash, invoiceHmac }
+        variables: {
+          sub: item?.subName || sub?.name,
+          id: item?.id,
+          boost: boost ? Number(boost) : undefined,
+          ...values,
+          forward: values.forward ? values.forward.map(fwd => ({ ...fwd, pct: Number(fwd.pct) })) : undefined,
+          invoiceHash,
+          invoiceHmac
+        }
       })
       if (error) {
         throw new Error({ message: error.toString() })

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -83,7 +83,7 @@ export function DiscussionForm ({
       initial={{
         title: item?.title || shareTitle || '',
         text: item?.text || '',
-        ...AdvPostInitial({ forward: item?.forwards?.map(fwd => ({ nym: fwd.user.name, pct: fwd.pct })) }),
+        ...AdvPostInitial({ forward: normalizeForwards(item?.forwards) }),
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}

--- a/components/form.js
+++ b/components/form.js
@@ -398,10 +398,10 @@ export function Input ({ label, groupClassName, ...props }) {
   )
 }
 
-export function VariableInput ({ label, groupClassName, name, hint, max, min, readOnlyLen, inputFn, emptyItem = '', ...props }) {
+export function VariableInput ({ label, groupClassName, name, hint, max, min, readOnlyLen, children, emptyItem = '', ...props }) {
   return (
     <FormGroup label={label} className={groupClassName}>
-      <FieldArray name={name}>
+      <FieldArray name={name} hasValidation>
         {({ form, ...fieldArrayHelpers }) => {
           const options = form.values[name]
           return (
@@ -410,8 +410,8 @@ export function VariableInput ({ label, groupClassName, name, hint, max, min, re
                 <div key={i}>
                   <Row className='mb-2'>
                     <Col>
-                      {inputFn
-                        ? inputFn({ index: i, readOnly: i < readOnlyLen, placeholder: i >= min ? 'optional' : undefined })
+                      {children
+                        ? children({ index: i, readOnly: i < readOnlyLen, placeholder: i >= min ? 'optional' : undefined })
                         : <InputInner name={`${name}[${i}]`} {...props} readOnly={i < readOnlyLen} placeholder={i >= min ? 'optional' : undefined} />}
                     </Col>
                     <Col className='d-flex ps-0' xs='auto'>
@@ -420,6 +420,12 @@ export function VariableInput ({ label, groupClassName, name, hint, max, min, re
                         // filler div for col alignment across rows
                         : <div style={{ width: '24px', height: '24px' }} />}
                     </Col>
+                    {options.length - 1 === i &&
+                      <>
+                        {hint && <BootstrapForm.Text>{hint}</BootstrapForm.Text>}
+                        {form.touched[name] && typeof form.errors[name] === 'string' &&
+                          <div className='invalid-feedback d-block'>{form.errors[name]}</div>}
+                      </>}
                   </Row>
                 </div>
               ))}
@@ -427,11 +433,6 @@ export function VariableInput ({ label, groupClassName, name, hint, max, min, re
           )
         }}
       </FieldArray>
-      {hint && (
-        <BootstrapForm.Text>
-          {hint}
-        </BootstrapForm.Text>
-      )}
     </FormGroup>
   )
 }
@@ -487,7 +488,12 @@ export function Form ({
             window.localStorage.removeItem(storageKeyPrefix + '-' + v)
             if (Array.isArray(values[v])) {
               values[v].forEach(
-                (_, i) => window.localStorage.removeItem(`${storageKeyPrefix}-${v}[${i}]`))
+                (iv, i) => {
+                  Object.keys(iv).forEach(k => {
+                    window.localStorage.removeItem(`${storageKeyPrefix}-${v}[${i}].${k}`)
+                  })
+                  window.localStorage.removeItem(`${storageKeyPrefix}-${v}[${i}]`)
+                })
             }
           }
           )

--- a/components/form.js
+++ b/components/form.js
@@ -398,7 +398,7 @@ export function Input ({ label, groupClassName, ...props }) {
   )
 }
 
-export function VariableInput ({ label, groupClassName, name, hint, max, min, readOnlyLen, ...props }) {
+export function VariableInput ({ label, groupClassName, name, hint, max, min, readOnlyLen, inputFn, emptyItem = '', ...props }) {
   return (
     <FormGroup label={label} className={groupClassName}>
       <FieldArray name={name}>
@@ -410,11 +410,16 @@ export function VariableInput ({ label, groupClassName, name, hint, max, min, re
                 <div key={i}>
                   <Row className='mb-2'>
                     <Col>
-                      <InputInner name={`${name}[${i}]`} {...props} readOnly={i < readOnlyLen} placeholder={i >= min ? 'optional' : undefined} />
+                      {inputFn
+                        ? inputFn({ index: i, readOnly: i < readOnlyLen, placeholder: i >= min ? 'optional' : undefined })
+                        : <InputInner name={`${name}[${i}]`} {...props} readOnly={i < readOnlyLen} placeholder={i >= min ? 'optional' : undefined} />}
                     </Col>
-                    {options.length - 1 === i && options.length !== max
-                      ? <Col className='d-flex ps-0' xs='auto'><AddIcon className='fill-grey align-self-center justify-self-center pointer' onClick={() => fieldArrayHelpers.push('')} /></Col>
-                      : null}
+                    <Col className='d-flex ps-0' xs='auto'>
+                      {options.length - 1 === i && options.length !== max
+                        ? <AddIcon className='fill-grey align-self-center justify-self-center pointer' onClick={() => fieldArrayHelpers.push(emptyItem)} />
+                        // filler div for col alignment across rows
+                        : <div style={{ width: '24px', height: '24px' }} />}
+                    </Col>
                   </Row>
                 </div>
               ))}

--- a/components/item-full.js
+++ b/components/item-full.js
@@ -106,12 +106,13 @@ function ItemEmbed ({ item }) {
 function FwdUsers ({ forwards }) {
   return (
     <div className={styles.other}>
+      zaps forwarded to {' '}
       {forwards.map((fwd, index, arr) => (
         <span key={fwd.user.name}>
-          {fwd.pct}% of zaps are forwarded to{' '}
           <Link href={`/${fwd.user.name}`}>
             @{fwd.user.name}
-          </Link>{index !== arr.length - 1 && ', '}
+          </Link>
+          {` (${fwd.pct}%)`}{index !== arr.length - 1 && ', '}
         </span>))}
 
     </div>

--- a/components/item-full.js
+++ b/components/item-full.js
@@ -103,13 +103,17 @@ function ItemEmbed ({ item }) {
   return null
 }
 
-function FwdUser ({ user }) {
+function FwdUsers ({ forwards }) {
   return (
     <div className={styles.other}>
-      100% of zaps are forwarded to{' '}
-      <Link href={`/${user.name}`}>
-        @{user.name}
-      </Link>
+      {forwards.map((fwd, index, arr) => (
+        <span key={fwd.user.name}>
+          {fwd.pct}% of zaps are forwarded to{' '}
+          <Link href={`/${fwd.user.name}`}>
+            @{fwd.user.name}
+          </Link>{index !== arr.length - 1 && ', '}
+        </span>))}
+
     </div>
   )
 }
@@ -128,7 +132,7 @@ function TopLevelItem ({ item, noReply, ...props }) {
             <Toc text={item.text} />
           </>
       }
-      belowTitle={item.fwdUser && <FwdUser user={item.fwdUser} />}
+      belowTitle={item.forwards && item.forwards.length > 0 && <FwdUsers forwards={item.forwards} />}
       {...props}
     >
       <div className={styles.fullItemContainer}>

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -15,6 +15,7 @@ import Moon from '../svgs/moon-fill.svg'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useInvoiceable } from './invoice'
+import { normalizeForwards } from '../lib/form'
 
 export function LinkForm ({ item, sub, editThreshold, children }) {
   const router = useRouter()
@@ -67,7 +68,7 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
 
   const [upsertLink] = useMutation(
     gql`
-      mutation upsertLink($sub: String, $id: ID, $title: String!, $url: String!, $boost: Int, $forward: String, $invoiceHash: String, $invoiceHmac: String) {
+      mutation upsertLink($sub: String, $id: ID, $title: String!, $url: String!, $boost: Int, $forward: [ItemForwardInput], $invoiceHash: String, $invoiceHmac: String) {
         upsertLink(sub: $sub, id: $id, title: $title, url: $url, boost: $boost, forward: $forward, invoiceHash: $invoiceHash, invoiceHmac: $invoiceHmac) {
           id
         }
@@ -77,7 +78,16 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
   const submitUpsertLink = useCallback(
     async (_, boost, title, values, invoiceHash, invoiceHmac) => {
       const { error } = await upsertLink({
-        variables: { sub: item?.subName || sub?.name, id: item?.id, boost: boost ? Number(boost) : undefined, title: title.trim(), invoiceHash, invoiceHmac, ...values }
+        variables: {
+          sub: item?.subName || sub?.name,
+          id: item?.id,
+          boost: boost ? Number(boost) : undefined,
+          title: title.trim(),
+          invoiceHash,
+          invoiceHmac,
+          ...values,
+          forward: normalizeForwards(values.forward)
+        }
       })
       if (error) {
         throw new Error({ message: error.toString() })

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -124,7 +124,7 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
       initial={{
         title: item?.title || shareTitle || '',
         url: item?.url || shareUrl || '',
-        ...AdvPostInitial({ forward: item?.forwards?.map(fwd => ({ nym: fwd.user.name, pct: fwd.pct })) }),
+        ...AdvPostInitial({ forward: normalizeForwards(item?.forwards) }),
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -124,7 +124,7 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
       initial={{
         title: item?.title || shareTitle || '',
         url: item?.url || shareUrl || '',
-        ...AdvPostInitial({ forward: item?.fwdUser?.name }),
+        ...AdvPostInitial({ forward: item?.forwards?.map(fwd => ({ nym: fwd.user.name, pct: fwd.pct })) }),
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -244,16 +244,26 @@ function Referral ({ n }) {
 
 function Votification ({ n }) {
   let forwardedSats = 0
-  let forwardedUsers = ''
+  let ForwardedUsers = null
   if (n.item.forwards?.length) {
     forwardedSats = Math.floor(n.earnedSats * n.item.forwards.map(fwd => fwd.pct).reduce((sum, cur) => sum + cur) / 100)
-    forwardedUsers = n.item.forwards.map(fwd => `@${fwd.user.name}`).join(', ')
+    ForwardedUsers = () => n.item.forwards.map((fwd, i) =>
+      <span key={fwd.user.name}>
+        <Link className='text-success' href={`/${fwd.user.name}`}>
+          @{fwd.user.name}
+        </Link>
+        {i !== n.item.forwards.length - 1 && ', '}
+      </span>)
   }
   return (
     <>
       <small className='fw-bold text-success ms-2'>
         your {n.item.title ? 'post' : 'reply'} stacked {numWithUnits(n.earnedSats, { abbreviate: false })}
-        {n.item.forwards?.length > 0 && ` and forwarded ${numWithUnits(forwardedSats, { abbreviate: false })} to ${forwardedUsers}`}
+        {n.item.forwards?.length > 0 &&
+          <>
+            {' '}and forwarded {numWithUnits(forwardedSats, { abbreviate: false })} to{' '}
+            <ForwardedUsers />
+          </>}
       </small>
       <div>
         {n.item.title

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -243,14 +243,20 @@ function Referral ({ n }) {
 }
 
 function Votification ({ n }) {
+  let forwardedSats = 0
+  let forwardedUsers = ''
+  if (n.item.forwards?.length) {
+    forwardedSats = Math.floor(n.earnedSats * n.item.forwards.map(fwd => fwd.pct).reduce((sum, cur) => sum + cur) / 100)
+    forwardedUsers = n.item.forwards.map(fwd => `@${fwd.user.name}`).join(', ')
+  }
   return (
     <>
       <small className='fw-bold text-success ms-2'>
-        {n.item.title && n.item.forwards?.length === 0 && `your post stacked ${numWithUnits(n.earnedSats, { abbreviate: false })}`}
-        {n.item.title && n.item.forwards?.length > 0 && `your post forwarded ${numWithUnits(n.earnedSats, { abbreviate: false })} to ${n.item.forwards.map(fwd => `@${fwd.user.name}`).join(', ')}`}
-        {!n.item.title && n.item.forwards?.length === 0 && `your reply stacked ${numWithUnits(n.earnedSats, { abbreviate: false })}`}
+        {n.item.title && !n.item.forwards?.length && `your post stacked ${numWithUnits(n.earnedSats, { abbreviate: false })}`}
+        {n.item.title && n.item.forwards?.length > 0 && `your post forwarded ${numWithUnits(forwardedSats, { abbreviate: false })} to ${forwardedUsers}`}
+        {!n.item.title && !n.item.forwards?.length && `your reply stacked ${numWithUnits(n.earnedSats, { abbreviate: false })}`}
         {/* can you forward sats on a reply? I imagine not... */}
-        {!n.item.title && n.item.forwards?.length > 0 && `your reply forwarded ${numWithUnits(n.earnedSats, { abbreviate: false })} to ${n.item.forwards.map(fwd => `@${fwd.user.name}`).join(', ')}`}
+        {!n.item.title && n.item.forwards?.length > 0 && `your reply forwarded ${numWithUnits(forwardedSats, { abbreviate: false })} to ${forwardedUsers}`}
       </small>
       <div>
         {n.item.title

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -246,7 +246,11 @@ function Votification ({ n }) {
   return (
     <>
       <small className='fw-bold text-success ms-2'>
-        your {n.item.title ? 'post' : 'reply'} {n.item.fwdUser ? 'forwarded' : 'stacked'} {numWithUnits(n.earnedSats, { abbreviate: false })}{n.item.fwdUser && ` to @${n.item.fwdUser.name}`}
+        {n.item.title && n.item.forwards?.length === 0 && `your post stacked ${numWithUnits(n.earnedSats, { abbreviate: false })}`}
+        {n.item.title && n.item.forwards?.length > 0 && `your post forwarded ${numWithUnits(n.earnedSats, { abbreviate: false })} to ${n.item.forwards.map(fwd => `@${fwd.user.name}`).join(', ')}`}
+        {!n.item.title && n.item.forwards?.length === 0 && `your reply stacked ${numWithUnits(n.earnedSats, { abbreviate: false })}`}
+        {/* can you forward sats on a reply? I imagine not... */}
+        {!n.item.title && n.item.forwards?.length > 0 && `your reply forwarded ${numWithUnits(n.earnedSats, { abbreviate: false })} to ${n.item.forwards.map(fwd => `@${fwd.user.name}`).join(', ')}`}
       </small>
       <div>
         {n.item.title

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -252,11 +252,8 @@ function Votification ({ n }) {
   return (
     <>
       <small className='fw-bold text-success ms-2'>
-        {n.item.title && !n.item.forwards?.length && `your post stacked ${numWithUnits(n.earnedSats, { abbreviate: false })}`}
-        {n.item.title && n.item.forwards?.length > 0 && `your post forwarded ${numWithUnits(forwardedSats, { abbreviate: false })} to ${forwardedUsers}`}
-        {!n.item.title && !n.item.forwards?.length && `your reply stacked ${numWithUnits(n.earnedSats, { abbreviate: false })}`}
-        {/* can you forward sats on a reply? I imagine not... */}
-        {!n.item.title && n.item.forwards?.length > 0 && `your reply forwarded ${numWithUnits(forwardedSats, { abbreviate: false })} to ${forwardedUsers}`}
+        your {n.item.title ? 'post' : 'reply'} stacked {numWithUnits(n.earnedSats, { abbreviate: false })}
+        {n.item.forwards?.length > 0 && ` and forwarded ${numWithUnits(forwardedSats, { abbreviate: false })} to ${forwardedUsers}`}
       </small>
       <div>
         {n.item.title

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -12,6 +12,7 @@ import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
 import { useInvoiceable } from './invoice'
+import { normalizeForwards } from '../lib/form'
 
 export function PollForm ({ item, sub, editThreshold, children }) {
   const router = useRouter()
@@ -21,7 +22,7 @@ export function PollForm ({ item, sub, editThreshold, children }) {
   const [upsertPoll] = useMutation(
     gql`
       mutation upsertPoll($sub: String, $id: ID, $title: String!, $text: String,
-        $options: [String!]!, $boost: Int, $forward: String, $invoiceHash: String, $invoiceHmac: String) {
+        $options: [String!]!, $boost: Int, $forward: [ItemForwardInput], $invoiceHash: String, $invoiceHmac: String) {
         upsertPoll(sub: $sub, id: $id, title: $title, text: $text,
           options: $options, boost: $boost, forward: $forward, invoiceHash: $invoiceHash, invoiceHmac: $invoiceHmac) {
           id
@@ -40,6 +41,7 @@ export function PollForm ({ item, sub, editThreshold, children }) {
           title: title.trim(),
           options: optionsFiltered,
           ...values,
+          forward: normalizeForwards(values.forward),
           invoiceHash,
           invoiceHmac
         }

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -67,7 +67,7 @@ export function PollForm ({ item, sub, editThreshold, children }) {
         title: item?.title || '',
         text: item?.text || '',
         options: initialOptions || ['', ''],
-        ...AdvPostInitial({ forward: item?.forwards?.map(fwd => ({ nym: fwd.user.name, pct: fwd.pct })) }),
+        ...AdvPostInitial({ forward: normalizeForwards(item?.forwards) }),
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -67,7 +67,7 @@ export function PollForm ({ item, sub, editThreshold, children }) {
         title: item?.title || '',
         text: item?.text || '',
         options: initialOptions || ['', ''],
-        ...AdvPostInitial({ forward: item?.fwdUser?.name }),
+        ...AdvPostInitial({ forward: item?.forwards?.map(fwd => ({ nym: fwd.user.name, pct: fwd.pct })) }),
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -205,8 +205,17 @@ export default function UpVote ({ item, className, pendingSats, setPendingSats }
   }, [pendingSats, act, item, showModal, setPendingSats])
 
   const disabled = useMemo(() => {
-    return item?.mine || (me && Number(me.id) === item?.fwdUserId) || item?.deletedAt
-  }, [me?.id, item?.fwdUserId, item?.mine, item?.deletedAt])
+    if (item?.mine) {
+      return true
+    }
+    if (me && item?.forwards?.some?.(fwd => Number(fwd.userId) === Number(me?.id))) {
+      return true
+    }
+    if (item?.deletedAt) {
+      return true
+    }
+    return false
+  }, [me?.id, item?.forwards, item?.mine, item?.deletedAt])
 
   const [meSats, sats, overlayText, color] = useMemo(() => {
     const meSats = (item?.meSats || item?.meAnonSats || 0) + pendingSats

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -43,13 +43,6 @@ export const ITEM_FIELDS = gql`
     status
     uploadId
     mine
-    forwards {
-      userId
-      pct
-      user {
-        name
-      }
-    }
   }`
 
 export const ITEM_FULL_FIELDS = gql`
@@ -68,6 +61,13 @@ export const ITEM_FULL_FIELDS = gql`
         streak
         hideCowboyHat
         id
+      }
+    }
+    forwards {
+      userId
+      pct
+      user {
+        name
       }
     }
   }`

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -43,6 +43,13 @@ export const ITEM_FIELDS = gql`
     status
     uploadId
     mine
+    forwards {
+      userId
+      pct
+      user {
+        name
+      }
+    }
   }`
 
 export const ITEM_FULL_FIELDS = gql`

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -15,7 +15,6 @@ export const ITEM_FIELDS = gql`
       hideCowboyHat
       id
     }
-    fwdUserId
     otsHash
     position
     sats
@@ -51,12 +50,6 @@ export const ITEM_FULL_FIELDS = gql`
   fragment ItemFullFields on Item {
     ...ItemFields
     text
-    fwdUser {
-      name
-      streak
-      hideCowboyHat
-      id
-    }
     root {
       id
       title

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -50,5 +50,6 @@ module.exports = {
   AD_USER_ID: 9,
   ANON_POST_FEE: 1000,
   ANON_COMMENT_FEE: 100,
-  SSR: typeof window === 'undefined'
+  SSR: typeof window === 'undefined',
+  MAX_FORWARDS: 5
 }

--- a/lib/form.js
+++ b/lib/form.js
@@ -8,5 +8,5 @@ export const normalizeForwards = (forward) => {
   if (!Array.isArray(forward)) {
     return undefined
   }
-  return forward.map(fwd => ({ nym: fwd.nym ?? fwd.user?.name, pct: Number(fwd.pct) }))
+  return forward.filter(fwd => fwd.nym || fwd.user?.name).map(fwd => ({ nym: fwd.nym ?? fwd.user?.name, pct: Number(fwd.pct) }))
 }

--- a/lib/form.js
+++ b/lib/form.js
@@ -1,11 +1,12 @@
 /**
  * Normalize an array of forwards by converting the pct from a string to a number
- * @param {*} forward Array of forward objects ({nym: string, pct: string})
+ * Also extracts nym from nested user object, if necessary
+ * @param {*} forward Array of forward objects ({nym?: string, pct: string, user?: { name: string } })
  * @returns normalized array, or undefined if not provided
  */
 export const normalizeForwards = (forward) => {
   if (!Array.isArray(forward)) {
     return undefined
   }
-  return forward.map(fwd => ({ ...fwd, pct: Number(fwd.pct) }))
+  return forward.map(fwd => ({ nym: fwd.nym ?? fwd.user?.name, pct: Number(fwd.pct) }))
 }

--- a/lib/form.js
+++ b/lib/form.js
@@ -1,0 +1,11 @@
+/**
+ * Normalize an array of forwards by converting the pct from a string to a number
+ * @param {*} forward Array of forward objects ({nym: string, pct: string})
+ * @returns normalized array, or undefined if not provided
+ */
+export const normalizeForwards = (forward) => {
+  if (!Array.isArray(forward)) {
+    return undefined
+  }
+  return forward.map(fwd => ({ ...fwd, pct: Number(fwd.pct) }))
+}

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -69,6 +69,7 @@ export function advPostSchemaMembers (client) {
         },
         message: `must be divisble be ${BOOST_MIN}`
       }),
+    // XXX this lets you forward to youself (it's financially equivalent but it should be disallowed)
     forward: array()
       .max(MAX_FORWARDS, `you can only configure ${MAX_FORWARDS} forward recipients`)
       .of(object().shape({

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -1,5 +1,5 @@
 import { string, ValidationError, number, object, array, addMethod } from 'yup'
-import { BOOST_MIN, MAX_POLL_CHOICE_LENGTH, MAX_TITLE_LENGTH, MAX_POLL_NUM_CHOICES, MIN_POLL_NUM_CHOICES, SUBS_NO_JOBS } from './constants'
+import { BOOST_MIN, MAX_POLL_CHOICE_LENGTH, MAX_TITLE_LENGTH, MAX_POLL_NUM_CHOICES, MIN_POLL_NUM_CHOICES, SUBS_NO_JOBS, MAX_FORWARDS } from './constants'
 import { NAME_QUERY } from '../fragments/users'
 import { URL_REGEXP, WS_REGEXP } from './url'
 import { SUPPORTED_CURRENCIES } from './currency'
@@ -70,15 +70,19 @@ export function advPostSchemaMembers (client) {
         },
         message: `must be divisble be ${BOOST_MIN}`
       }),
-    forward: string()
-      .test({
-        name: 'name',
-        test: async name => {
-          if (!name || !name.length) return true
-          return await usernameExists(client, name)
-        },
-        message: 'stacker does not exist'
-      })
+    forward: array()
+      .max(MAX_FORWARDS)
+      .of(object().shape({
+        nym: string().test({
+          name: 'name',
+          test: async name => {
+            if (!name || !name.length) return true
+            return await usernameExists(client, name)
+          },
+          message: 'stacker does not exist'
+        }),
+        pct: number().min(1).max(100).integer()
+      }))
   }
 }
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -73,7 +73,7 @@ export function advPostSchemaMembers (client) {
     forward: array()
       .max(MAX_FORWARDS)
       .of(object().shape({
-        nym: string().test({
+        nym: string().required().test({
           name: 'name',
           test: async name => {
             if (!name || !name.length) return true
@@ -81,7 +81,7 @@ export function advPostSchemaMembers (client) {
           },
           message: 'stacker does not exist'
         }),
-        pct: number().min(1).max(100).integer()
+        pct: number().required().min(1).max(100).integer()
       }))
   }
 }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -73,7 +73,7 @@ export function advPostSchemaMembers (client) {
       .max(MAX_FORWARDS, `you can only configure ${MAX_FORWARDS} forward recipients`)
       .of(object().shape({
         nym: string().required('must specify a stacker').test({
-          name: 'name',
+          name: 'nym',
           test: async name => {
             if (!name || !name.length) return true
             return await usernameExists(client, name)
@@ -82,6 +82,7 @@ export function advPostSchemaMembers (client) {
         }),
         pct: intValidator.required('must specify a percentage').min(1, 'percentage must be at least 1').max(100, 'percentage must not exceed 100')
       }))
+      .compact((v) => !v.nym && !v.pct)
       .test({
         name: 'sum',
         test: forwards => forwards.map(fwd => Number(fwd.pct)).reduce((sum, cur) => sum + cur, 0) <= 100,

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -58,7 +58,6 @@ async function usernameExists (client, name) {
   return !!user
 }
 
-// not sure how to use this on server ...
 export function advPostSchemaMembers (client) {
   return {
     boost: intValidator
@@ -71,9 +70,9 @@ export function advPostSchemaMembers (client) {
         message: `must be divisble be ${BOOST_MIN}`
       }),
     forward: array()
-      .max(MAX_FORWARDS)
+      .max(MAX_FORWARDS, `you can only configure ${MAX_FORWARDS} forward recipients`)
       .of(object().shape({
-        nym: string().required().test({
+        nym: string().required('must specify a stacker').test({
           name: 'name',
           test: async name => {
             if (!name || !name.length) return true
@@ -81,8 +80,18 @@ export function advPostSchemaMembers (client) {
           },
           message: 'stacker does not exist'
         }),
-        pct: number().required().min(1).max(100).integer()
+        pct: intValidator.required('must specify a percentage').min(1, 'percentage must be at least 1').max(100, 'percentage must not exceed 100')
       }))
+      .test({
+        name: 'sum',
+        test: forwards => forwards.map(fwd => Number(fwd.pct)).reduce((sum, cur) => sum + cur, 0) <= 100,
+        message: 'the total forward percentage exceeds 100%'
+      })
+      .test({
+        name: 'uniqueStackers',
+        test: forwards => new Set(forwards.map(fwd => fwd.nym)).size === forwards.length,
+        message: 'duplicate stackers cannot be specified to receive forwarded sats'
+      })
   }
 }
 

--- a/prisma/migrations/20230814233157_multiforward/migration.sql
+++ b/prisma/migrations/20230814233157_multiforward/migration.sql
@@ -1,0 +1,140 @@
+-- CreateTable
+CREATE TABLE "ItemForward" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "itemId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "pct" INTEGER NOT NULL,
+
+    CONSTRAINT "ItemForward_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "ItemForward" ADD CONSTRAINT "ItemForward_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "Item"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ItemForward" ADD CONSTRAINT "ItemForward_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "ItemForward.itemId_index" ON "ItemForward"("itemId");
+
+-- Type used in create_item below for JSON processing
+CREATE TYPE ItemForwardType as ("userId" INTEGER, "pct" INTEGER);
+
+-- Migrate existing forward entries to the ItemForward table
+-- All migrated entries will get 100% sats by default
+INSERT INTO "ItemForward" ("itemId", "userId", "pct")
+    SELECT "id" AS "itemId", "fwdUserId", 100 FROM "Item" WHERE "fwdUserId" IS NOT NULL;
+
+-- Remove the existing fwdUserId column now that existing forwards have been migrated
+-- ALTER TABLE "Item" DROP COLUMN "fwdUserId";
+
+-- Delete old create_item function
+DROP FUNCTION IF EXISTS create_item(
+    sub TEXT, title TEXT, url TEXT, text TEXT, boost INTEGER, bounty INTEGER,
+    parent_id INTEGER, user_id INTEGER, forward INTEGER,
+    spam_within INTERVAL);
+
+-- Update to create ItemForward entries accordingly
+CREATE OR REPLACE FUNCTION create_item(
+    sub TEXT, title TEXT, url TEXT, text TEXT, boost INTEGER, bounty INTEGER,
+    parent_id INTEGER, user_id INTEGER, forward JSON,
+    spam_within INTERVAL)
+RETURNS "Item"
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    user_msats BIGINT;
+    cost_msats BIGINT;
+    freebie BOOLEAN;
+    item "Item";
+    med_votes FLOAT;
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    SELECT msats INTO user_msats FROM users WHERE id = user_id;
+
+    cost_msats := 1000 * POWER(10, item_spam(parent_id, user_id, spam_within));
+    -- it's only a freebie if it's a 1 sat cost, they have < 1 sat, and boost = 0
+    freebie := (cost_msats <= 1000) AND (user_msats < 1000) AND (boost = 0);
+
+    IF NOT freebie AND cost_msats > user_msats THEN
+        RAISE EXCEPTION 'SN_INSUFFICIENT_FUNDS';
+    END IF;
+
+    -- get this user's median item score
+    SELECT COALESCE(percentile_cont(0.5) WITHIN GROUP(ORDER BY "weightedVotes" - "weightedDownVotes"), 0)
+        INTO med_votes FROM "Item" WHERE "userId" = user_id;
+
+    -- if their median votes are positive, start at 0
+    -- if the median votes are negative, start their post with that many down votes
+    -- basically: if their median post is bad, presume this post is too
+    -- addendum: if they're an anon poster, always start at 0
+    IF med_votes >= 0 OR user_id = 27 THEN
+        med_votes := 0;
+    ELSE
+        med_votes := ABS(med_votes);
+    END IF;
+
+    INSERT INTO "Item"
+    ("subName", title, url, text, bounty, "userId", "parentId",
+        freebie, "weightedDownVotes", created_at, updated_at)
+    VALUES
+    (sub, title, url, text, bounty, user_id, parent_id,
+        freebie, med_votes, now_utc(), now_utc()) RETURNING * INTO item;
+
+    INSERT INTO "ItemForward" ("itemId", "userId", "pct")
+        SELECT item.id, "userId", "pct" from json_populate_recordset(null::ItemForwardType, forward);
+
+    IF NOT freebie THEN
+        UPDATE users SET msats = msats - cost_msats WHERE id = user_id;
+
+        INSERT INTO "ItemAct" (msats, "itemId", "userId", act, created_at, updated_at)
+        VALUES (cost_msats, item.id, user_id, 'FEE', now_utc(), now_utc());
+    END IF;
+
+    IF boost > 0 THEN
+        PERFORM item_act(item.id, user_id, 'BOOST', boost);
+    END IF;
+
+    RETURN item;
+END;
+$$;
+
+DROP FUNCTION IF EXISTS update_item(
+    sub TEXT, item_id INTEGER, item_title TEXT, item_url TEXT, item_text TEXT, boost INTEGER,
+    item_bounty INTEGER, fwd_user_id INTEGER);
+
+CREATE OR REPLACE FUNCTION update_item(
+    sub TEXT, item_id INTEGER, item_title TEXT, item_url TEXT, item_text TEXT, boost INTEGER,
+    item_bounty INTEGER, forward JSON)
+RETURNS "Item"
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    user_msats INTEGER;
+    item "Item";
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    UPDATE "Item"
+    SET "subName" = sub, title = item_title, url = item_url,
+        text = item_text, bounty = item_bounty
+    WHERE id = item_id
+    RETURNING * INTO item;
+
+    -- Delete all old forward entries, to recreate in next command
+    DELETE FROM "ItemForward"
+    WHERE "itemId" = item_id;
+
+    INSERT INTO "ItemForward" ("itemId", "userId", "pct")
+        SELECT item_id, "userId", "pct" from json_populate_recordset(null::ItemForwardType, forward);
+
+    IF boost > 0 THEN
+        PERFORM item_act(item.id, item."userId", 'BOOST', boost);
+    END IF;
+
+    RETURN item;
+END;
+$$;

--- a/prisma/migrations/20230814233157_multiforward/migration.sql
+++ b/prisma/migrations/20230814233157_multiforward/migration.sql
@@ -28,7 +28,7 @@ INSERT INTO "ItemForward" ("itemId", "userId", "pct")
     SELECT "id" AS "itemId", "fwdUserId", 100 FROM "Item" WHERE "fwdUserId" IS NOT NULL;
 
 -- Remove the existing fwdUserId column now that existing forwards have been migrated
--- ALTER TABLE "Item" DROP COLUMN "fwdUserId";
+ALTER TABLE "Item" DROP COLUMN "fwdUserId";
 
 -- Delete old create_item function
 DROP FUNCTION IF EXISTS create_item(

--- a/prisma/migrations/20230814233157_multiforward/migration.sql
+++ b/prisma/migrations/20230814233157_multiforward/migration.sql
@@ -191,3 +191,103 @@ BEGIN
     RETURN item;
 END;
 $$;
+
+-- Update item_act to support multi-way forward splits
+CREATE OR REPLACE FUNCTION item_act(item_id INTEGER, user_id INTEGER, act "ItemActType", act_sats INTEGER)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    user_msats BIGINT;
+    act_msats BIGINT;
+    fee_msats BIGINT;
+    item_act_id INTEGER;
+    referrer_id INTEGER;
+    fwd_entry record; -- for loop iterator variable to iterate across forward recipients
+    fwd_msats BIGINT; -- for loop variable calculating how many msats to give each forward recipient
+    total_fwd_msats BIGINT; -- accumulator to see how many msats have been forwarded for the act
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    act_msats := act_sats * 1000;
+    SELECT msats, "referrerId" INTO user_msats, referrer_id FROM users WHERE id = user_id;
+    IF act_msats > user_msats THEN
+        RAISE EXCEPTION 'SN_INSUFFICIENT_FUNDS';
+    END IF;
+
+    -- deduct msats from actor
+    UPDATE users SET msats = msats - act_msats WHERE id = user_id;
+
+    IF act = 'VOTE' THEN
+        RAISE EXCEPTION 'SN_UNSUPPORTED';
+    END IF;
+
+    IF act = 'TIP' THEN
+        -- call to influence weightedVotes ... we need to do this before we record the acts because
+        -- the priors acts are taken into account
+        PERFORM weighted_votes_after_tip(item_id, user_id, act_sats);
+
+        -- take 10% and insert as FEE
+        fee_msats := CEIL(act_msats * 0.1);
+        act_msats := act_msats - fee_msats;
+
+        INSERT INTO "ItemAct" (msats, "itemId", "userId", act, created_at, updated_at)
+            VALUES (fee_msats, item_id, user_id, 'FEE', now_utc(), now_utc())
+            RETURNING id INTO item_act_id;
+
+        total_fwd_msats := 0; -- initialize accumulator to 0
+
+        -- add sats to actees' balance and stacked count
+        FOR fwd_entry IN SELECT "userId", "pct" FROM "ItemForward" WHERE "itemId" = item_id
+        LOOP
+            -- fwd_msats represents the sats for this forward recipient from this particular tip action
+            -- use FLOOR just to ensure we don't introduce more msats than we should, give the rest to OP
+            fwd_msats := FLOOR(act_msats * fwd_entry.pct / 100);
+            -- keep track of how many msats have been forwarded, so we can give any remaining to OP
+            total_fwd_msats := fwd_msats + total_fwd_msats;
+            
+            UPDATE users
+            SET msats = msats + fwd_msats, "stackedMsats" = "stackedMsats" + fwd_msats
+            WHERE id = fwd_entry."userId";
+            -- TODO do we want to apply referrals to forwarded sats, too?
+        END LOOP;
+
+        -- Give OP any remaining msats after forwards have been applied
+        UPDATE users
+        SET msats = msats + act_msats - total_fwd_msats, "stackedMsats" = "stackedMsats" + act_msats - total_fwd_msats
+        WHERE id = (SELECT "userId" FROM "Item" WHERE id = item_id)
+        -- TODO how to handle referrals here?
+        RETURNING "referrerId" INTO referrer_id;
+
+        -- leave the rest as a tip
+        INSERT INTO "ItemAct" (msats, "itemId", "userId", act, created_at, updated_at)
+        VALUES (act_msats, item_id, user_id, 'TIP', now_utc(), now_utc());
+
+        -- call to denormalize sats and commentSats
+        PERFORM sats_after_tip(item_id, user_id, act_msats + fee_msats);
+        -- denormalize bounty paid
+        PERFORM bounty_paid_after_act(item_id, user_id);
+    ELSE -- BOOST, POLL, DONT_LIKE_THIS, STREAM
+        -- call to influence if DONT_LIKE_THIS weightedDownVotes
+        IF act = 'DONT_LIKE_THIS' THEN
+            -- make sure they haven't done this before
+            IF EXISTS (SELECT 1 FROM "ItemAct" WHERE "itemId" = item_id AND "userId" = user_id AND "ItemAct".act = 'DONT_LIKE_THIS') THEN
+                RAISE EXCEPTION 'SN_DUPLICATE';
+            END IF;
+
+            PERFORM weighted_downvotes_after_act(item_id, user_id, act_sats);
+        END IF;
+
+        INSERT INTO "ItemAct" (msats, "itemId", "userId", act, created_at, updated_at)
+            VALUES (act_msats, item_id, user_id, act, now_utc(), now_utc())
+            RETURNING id INTO item_act_id;
+    END IF;
+
+    -- they have a referrer and the referrer isn't the one tipping them
+    IF referrer_id IS NOT NULL AND user_id <> referrer_id THEN
+        PERFORM referral_act(referrer_id, item_act_id);
+    END IF;
+
+    RETURN 0;
+END;
+$$;

--- a/prisma/migrations/20230814233157_multiforward/migration.sql
+++ b/prisma/migrations/20230814233157_multiforward/migration.sql
@@ -208,15 +208,14 @@ DECLARE
     act_msats BIGINT;
     fee_msats BIGINT;
     item_act_id INTEGER;
-    referrer_id INTEGER;
     fwd_entry record; -- for loop iterator variable to iterate across forward recipients
     fwd_msats BIGINT; -- for loop variable calculating how many msats to give each forward recipient
-    total_fwd_msats BIGINT; -- accumulator to see how many msats have been forwarded for the act
+    total_fwd_msats BIGINT := 0; -- accumulator to see how many msats have been forwarded for the act
 BEGIN
     PERFORM ASSERT_SERIALIZED();
 
     act_msats := act_sats * 1000;
-    SELECT msats, "referrerId" INTO user_msats, referrer_id FROM users WHERE id = user_id;
+    SELECT msats INTO user_msats FROM users WHERE id = user_id;
     IF act_msats > user_msats THEN
         RAISE EXCEPTION 'SN_INSUFFICIENT_FUNDS';
     END IF;
@@ -224,24 +223,28 @@ BEGIN
     -- deduct msats from actor
     UPDATE users SET msats = msats - act_msats WHERE id = user_id;
 
-    IF act = 'VOTE' THEN
-        RAISE EXCEPTION 'SN_UNSUPPORTED';
-    END IF;
-
     IF act = 'TIP' THEN
         -- call to influence weightedVotes ... we need to do this before we record the acts because
         -- the priors acts are taken into account
         PERFORM weighted_votes_after_tip(item_id, user_id, act_sats);
+        -- call to denormalize sats and commentSats
+        PERFORM sats_after_tip(item_id, user_id, act_msats);
 
         -- take 10% and insert as FEE
         fee_msats := CEIL(act_msats * 0.1);
         act_msats := act_msats - fee_msats;
 
+        -- save the fee act into item_act_id so we can record referral acts
         INSERT INTO "ItemAct" (msats, "itemId", "userId", act, created_at, updated_at)
             VALUES (fee_msats, item_id, user_id, 'FEE', now_utc(), now_utc())
             RETURNING id INTO item_act_id;
 
-        total_fwd_msats := 0; -- initialize accumulator to 0
+        -- leave the rest as a tip
+        INSERT INTO "ItemAct" (msats, "itemId", "userId", act, created_at, updated_at)
+            VALUES (act_msats, item_id, user_id, 'TIP', now_utc(), now_utc());
+
+        -- denormalize bounty paid (if applicable)
+        PERFORM bounty_paid_after_act(item_id, user_id);
 
         -- add sats to actees' balance and stacked count
         FOR fwd_entry IN SELECT "userId", "pct" FROM "ItemForward" WHERE "itemId" = item_id
@@ -250,42 +253,18 @@ BEGIN
             fwd_msats := act_msats * fwd_entry.pct / 100;
             -- keep track of how many msats have been forwarded, so we can give any remaining to OP
             total_fwd_msats := fwd_msats + total_fwd_msats;
-            
+
             UPDATE users
             SET msats = msats + fwd_msats, "stackedMsats" = "stackedMsats" + fwd_msats
-            WHERE id = fwd_entry."userId"
-            RETURNING "referrerId" into referrer_id;
-
-            -- they have a referrer and the referrer isn't the one tipping them
-            IF referrer_id IS NOT NULL AND user_id <> referrer_id THEN
-                -- scale the referral fee to be proportional to the forwarding percentage
-                PERFORM referral_act(referrer_id, item_act_id, fee_msats * fwd_entry.pct / 100);
-            END IF;
+            WHERE id = fwd_entry."userId";
         END LOOP;
 
         -- Give OP any remaining msats after forwards have been applied
-        UPDATE users
-        SET msats = msats + act_msats - total_fwd_msats, "stackedMsats" = "stackedMsats" + act_msats - total_fwd_msats
-        WHERE id = (SELECT "userId" FROM "Item" WHERE id = item_id)
-        RETURNING "referrerId" INTO referrer_id;
-
-        -- leave the rest as a tip
-        INSERT INTO "ItemAct" (msats, "itemId", "userId", act, created_at, updated_at)
-        VALUES (act_msats, item_id, user_id, 'TIP', now_utc(), now_utc());
-
-        -- call to denormalize sats and commentSats
-        PERFORM sats_after_tip(item_id, user_id, act_msats + fee_msats);
-        -- denormalize bounty paid
-        PERFORM bounty_paid_after_act(item_id, user_id);
-
-        -- they have a referrer and the referrer isn't the one tipping them
-        IF referrer_id IS NOT NULL AND user_id <> referrer_id THEN
-            -- explicit referral amount, 10% of any sats that weren't forwarded (10% is the fee amount)
-            -- referral_act will scale it from 10% down to 2.1%, but we only want to refer based on
-            -- any sats that weren't forwarded
-            PERFORM referral_act(referrer_id, item_act_id, CEIL((act_msats - total_fwd_msats) * 0.1));
+        IF act_msats - total_fwd_msats > 0 THEN
+            UPDATE users
+            SET msats = msats + act_msats - total_fwd_msats, "stackedMsats" = "stackedMsats" + act_msats - total_fwd_msats
+            WHERE id = (SELECT "userId" FROM "Item" WHERE id = item_id);
         END IF;
-
     ELSE -- BOOST, POLL, DONT_LIKE_THIS, STREAM
         -- call to influence if DONT_LIKE_THIS weightedDownVotes
         IF act = 'DONT_LIKE_THIS' THEN
@@ -300,10 +279,99 @@ BEGIN
         INSERT INTO "ItemAct" (msats, "itemId", "userId", act, created_at, updated_at)
             VALUES (act_msats, item_id, user_id, act, now_utc(), now_utc())
             RETURNING id INTO item_act_id;
+    END IF;
 
-        -- they have a referrer and the referrer isn't the one tipping them
-        IF referrer_id IS NOT NULL AND user_id <> referrer_id THEN
-            PERFORM referral_act(referrer_id, item_act_id);
+    -- store referral effects
+    PERFORM referral_act(item_act_id);
+
+    RETURN 0;
+END;
+$$;
+
+DROP FUNCTION referral_act(referrer_id INTEGER, item_act_id INTEGER);
+DROP FUNCTION referral_act(referrer_id INTEGER, item_act_id INTEGER, act_msats BIGINT);
+
+-- A new implementation of referral_act that accounts for forwards
+CREATE OR REPLACE FUNCTION referral_act(item_act_id INTEGER)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    act_act "ItemActType";
+    act_msats BIGINT;
+    act_item_id INTEGER;
+    act_user_id INTEGER;
+    referrer_id INTEGER;
+    referral_msats BIGINT;
+    fwd_ref_msats BIGINT;
+    total_fwd_ref_msats BIGINT := 0;
+    fwd_entry record;
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    -- get the sats for the action that haven't already been forwarded
+    SELECT msats, act, "userId", "itemId"
+    INTO act_msats, act_act, act_user_id, act_item_id
+    FROM "ItemAct"
+    WHERE id = item_act_id;
+
+    referral_msats := CEIL(act_msats * .21);
+
+    -- take 21% of the act where the referrer is the actor's referrer
+    IF act_act IN ('BOOST', 'STREAM') THEN
+        SELECT "referrerId" INTO referrer_id FROM users WHERE id = act_user_id;
+
+        IF referrer_id IS NULL THEN
+            RETURN 0;
+        END IF;
+
+        INSERT INTO "ReferralAct" ("referrerId", "itemActId", msats, created_at, updated_at)
+            VALUES(referrer_id, item_act_id, referral_msats, now_utc(), now_utc());
+        UPDATE users
+        SET msats = msats + referral_msats, "stackedMsats" = "stackedMsats" + referral_msats
+        WHERE id = referrer_id;
+    -- take 21% of the fee where the referrer is the item's creator (and/or the item's forward users)
+    ELSIF act_act = 'FEE' THEN
+        FOR fwd_entry IN
+            SELECT users."referrerId" AS referrer_id, "ItemForward"."pct" AS pct
+            FROM "ItemForward"
+            JOIN users ON users.id = "ItemForward"."userId"
+            WHERE "ItemForward"."itemId" = act_item_id
+        LOOP
+            -- fwd_msats represents the sats for this forward recipient from this particular tip action
+            fwd_ref_msats := referral_msats * fwd_entry.pct / 100;
+            -- keep track of how many msats have been forwarded, so we can give any remaining to OP
+            total_fwd_ref_msats := fwd_ref_msats + total_fwd_ref_msats;
+
+            -- no referrer or tipping their own referee, no referral act
+            CONTINUE WHEN fwd_entry.referrer_id IS NULL OR fwd_entry.referrer_id = act_user_id;
+
+            INSERT INTO "ReferralAct" ("referrerId", "itemActId", msats, created_at, updated_at)
+            VALUES (fwd_entry.referrer_id, item_act_id, fwd_ref_msats, now_utc(), now_utc());
+
+            UPDATE users
+            SET msats = msats + fwd_ref_msats, "stackedMsats" = "stackedMsats" + fwd_ref_msats
+            WHERE id = fwd_entry.referrer_id;
+        END LOOP;
+
+        -- Give OP any remaining msats after forwards have been applied
+        IF referral_msats - total_fwd_ref_msats > 0 THEN
+            SELECT users."referrerId" INTO referrer_id
+            FROM "Item"
+            JOIN users ON users.id = "Item"."userId"
+            WHERE "Item".id = act_item_id;
+
+            IF referrer_id IS NULL OR referrer_id = act_user_id THEN
+                RETURN 0;
+            END IF;
+
+            INSERT INTO "ReferralAct" ("referrerId", "itemActId", msats, created_at, updated_at)
+            VALUES (referrer_id, item_act_id, referral_msats - total_fwd_ref_msats, now_utc(), now_utc());
+
+            UPDATE users
+            SET msats = msats + referral_msats - total_fwd_ref_msats,
+                "stackedMsats" = "stackedMsats" + referral_msats - total_fwd_ref_msats
+            WHERE id = referrer_id;
         END IF;
     END IF;
 
@@ -311,30 +379,24 @@ BEGIN
 END;
 $$;
 
--- A second implementation of referral_act that allows for an explicit msats amount,
--- instead of pulling it from the item act itself, to accommodate the multi-forward
--- use case where we are no longer forwarding 100% of sats from a post to a user
-CREATE OR REPLACE FUNCTION referral_act(referrer_id INTEGER, item_act_id INTEGER, msats BIGINT)
-RETURNS INTEGER
-LANGUAGE plpgsql
-AS $$
+
+-- constraints on ItemForward
+ALTER TABLE "ItemForward" ADD CONSTRAINT "ItemForward_pct_range_check" CHECK ("pct" >= 0 AND "pct" <= 100) NOT VALID;
+
+CREATE OR REPLACE FUNCTION item_forward_pct_total_trigger_func() RETURNS trigger
+   LANGUAGE plpgsql AS $$
 DECLARE
-    referral_act "ItemActType";
-    referral_msats BIGINT;
 BEGIN
-    PERFORM ASSERT_SERIALIZED();
-
-    SELECT act INTO referral_act FROM "ItemAct" WHERE id = item_act_id;
-
-    IF referral_act IN ('FEE', 'BOOST', 'STREAM') THEN
-        referral_msats := CEIL(msats * .21);
-        INSERT INTO "ReferralAct" ("referrerId", "itemActId", msats, created_at, updated_at)
-            VALUES(referrer_id, item_act_id, referral_msats, now_utc(), now_utc());
-        UPDATE users
-        SET msats = msats + referral_msats, "stackedMsats" = "stackedMsats" + referral_msats
-        WHERE id = referrer_id;
+    IF (SELECT SUM(pct) FROM "ItemForward" WHERE "itemId" = NEW."itemId") > 100 THEN
+        raise exception 'Total forward pct exceeds 100';
     END IF;
 
-    RETURN 0;
+    RETURN NULL;
 END;
 $$;
+
+CREATE CONSTRAINT TRIGGER item_forward_pct_total_trigger
+   AFTER INSERT OR UPDATE ON "ItemForward"
+   DEFERRABLE INITIALLY DEFERRED
+   FOR EACH ROW
+   EXECUTE PROCEDURE item_forward_pct_total_trigger_func();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,6 +84,7 @@ model User {
   referrees           User[]               @relation("referrals")
   Account             Account[]
   Session             Session[]
+  // itemForwards        ItemForward[]
 
   @@index([createdAt], map: "users.created_at_index")
   @@index([inviteId], map: "users.inviteId_index")
@@ -264,6 +265,7 @@ model Item {
   ThreadSubscription ThreadSubscription[]
   upload             Upload?
   User               User[]
+  // itemForwards       ItemForward[]
 
   @@index([bio], map: "Item.bio_index")
   @@index([createdAt], map: "Item.created_at_index")
@@ -281,6 +283,17 @@ model Item {
   @@index([weightedDownVotes], map: "Item.weightedDownVotes_index")
   @@index([weightedVotes], map: "Item.weightedVotes_index")
 }
+
+// model ItemForward {
+//   id        Int      @id @default(autoincrement())
+//   createdAt DateTime @default(now()) @map("created_at")
+//   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+//   itemId    Int      // The item from which sats are forwarded
+//   userId    Int      // The recipient of the forwarded sats
+//   pct       Int      // The percentage of sats from the item to forward to this user
+//   item      Item     @relation(fields: [itemId], references: [id], onDelete: Cascade)
+//   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+// }
 
 model PollOption {
   id        Int        @id @default(autoincrement())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,7 +63,6 @@ model User {
   Earn                Earn[]
   invites             Invite[]             @relation("Invites")
   invoices            Invoice[]
-  fwdItems            Item[]               @relation("FwdItem")
   items               Item[]               @relation("UserItems")
   actions             ItemAct[]
   mentions            Mention[]
@@ -228,7 +227,6 @@ model Item {
   statusUpdatedAt    DateTime?
   status             Status                @default(ACTIVE)
   company            String?
-  fwdUserId          Int?
   weightedVotes      Float                 @default(0)
   boost              Int                   @default(0)
   uploadId           Int?
@@ -250,7 +248,6 @@ model Item {
   upvotes            Int                   @default(0)
   weightedComments   Float                 @default(0)
   Bookmark           Bookmark[]
-  fwdUser            User?                 @relation("FwdItem", fields: [fwdUserId], references: [id])
   parent             Item?                 @relation("ParentChildren", fields: [parentId], references: [id])
   children           Item[]                @relation("ParentChildren")
   pin                Pin?                  @relation(fields: [pinId], references: [id])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,7 +84,7 @@ model User {
   referrees           User[]               @relation("referrals")
   Account             Account[]
   Session             Session[]
-  // itemForwards        ItemForward[]
+  itemForwards        ItemForward[]
 
   @@index([createdAt], map: "users.created_at_index")
   @@index([inviteId], map: "users.inviteId_index")
@@ -265,7 +265,7 @@ model Item {
   ThreadSubscription ThreadSubscription[]
   upload             Upload?
   User               User[]
-  // itemForwards       ItemForward[]
+  itemForwards       ItemForward[]
 
   @@index([bio], map: "Item.bio_index")
   @@index([createdAt], map: "Item.created_at_index")
@@ -284,16 +284,18 @@ model Item {
   @@index([weightedVotes], map: "Item.weightedVotes_index")
 }
 
-// model ItemForward {
-//   id        Int      @id @default(autoincrement())
-//   createdAt DateTime @default(now()) @map("created_at")
-//   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
-//   itemId    Int      // The item from which sats are forwarded
-//   userId    Int      // The recipient of the forwarded sats
-//   pct       Int      // The percentage of sats from the item to forward to this user
-//   item      Item     @relation(fields: [itemId], references: [id], onDelete: Cascade)
-//   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-// }
+model ItemForward {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+  itemId    Int      // The item from which sats are forwarded
+  userId    Int      // The recipient of the forwarded sats
+  pct       Int      // The percentage of sats from the item to forward to this user
+  item      Item     @relation(fields: [itemId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([itemId], map: "ItemForward.itemId_index")
+}
 
 model PollOption {
   id        Int        @id @default(autoincrement())

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -291,7 +291,9 @@ model ItemForward {
   item      Item     @relation(fields: [itemId], references: [id], onDelete: Cascade)
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@index([itemId], map: "ItemForward.itemId_index")
+  @@index([itemId],     map: "ItemForward.itemId_index")
+  @@index([userId],     map: "ItemForward.userId_index")
+  @@index([createdAt],  map: "ItemForward.createdAt_index")
 }
 
 model PollOption {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -281,19 +281,21 @@ model Item {
   @@index([weightedVotes], map: "Item.weightedVotes_index")
 }
 
+// TODO: make all Item's forward 100% of sats to the OP by default
+// so that forwards aren't a special case everywhere
 model ItemForward {
   id        Int      @id @default(autoincrement())
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
-  itemId    Int      // The item from which sats are forwarded
-  userId    Int      // The recipient of the forwarded sats
-  pct       Int      // The percentage of sats from the item to forward to this user
+  itemId    Int // The item from which sats are forwarded
+  userId    Int // The recipient of the forwarded sats
+  pct       Int // The percentage of sats from the item to forward to this user
   item      Item     @relation(fields: [itemId], references: [id], onDelete: Cascade)
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@index([itemId],     map: "ItemForward.itemId_index")
-  @@index([userId],     map: "ItemForward.userId_index")
-  @@index([createdAt],  map: "ItemForward.createdAt_index")
+  @@index([itemId], map: "ItemForward.itemId_index")
+  @@index([userId], map: "ItemForward.userId_index")
+  @@index([createdAt], map: "ItemForward.createdAt_index")
 }
 
 model PollOption {
@@ -509,6 +511,8 @@ model Bookmark {
   @@index([createdAt], map: "Bookmark.created_at_index")
 }
 
+// TODO: make thread subscriptions for OP by default so they can
+// unsubscribe from their own threads and its not a special case
 model ThreadSubscription {
   userId    Int
   itemId    Int

--- a/worker/earn.js
+++ b/worker/earn.js
@@ -27,7 +27,9 @@ function earn ({ models }) {
         (SELECT "ItemAct".msats
             FROM "Item"
             JOIN "ItemAct" ON "ItemAct"."itemId" = "Item".id
-            WHERE "Item"."userId" = ${ANON_USER_ID} AND "ItemAct".act = 'TIP' AND "Item"."fwdUserId" IS NULL
+            JOIN "ItemForward" ON "ItemForward"."itemId" = "Item".id
+            WHERE "Item"."userId" = ${ANON_USER_ID} AND "ItemAct".act = 'TIP'
+            AND (SELECT COUNT(*) FROM "ItemForward" WHERE "ItemForward"."itemId" = "Item".id) = 0
             AND date_trunc('day', "ItemAct".created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago') = date_trunc('day', (now() - interval '1 day') AT TIME ZONE 'America/Chicago'))
       ) subquery`
 

--- a/worker/earn.js
+++ b/worker/earn.js
@@ -24,6 +24,7 @@ function earn ({ models }) {
           FROM "Donation"
           WHERE date_trunc('day', created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago') = date_trunc('day', (now() - interval '1 day') AT TIME ZONE 'America/Chicago'))
           UNION ALL
+        -- any earnings from anon's stack that are not forwarded to other users
         (SELECT "ItemAct".msats
           FROM "Item"
           JOIN "ItemAct" ON "ItemAct"."itemId" = "Item".id

--- a/worker/earn.js
+++ b/worker/earn.js
@@ -25,12 +25,13 @@ function earn ({ models }) {
           WHERE date_trunc('day', created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago') = date_trunc('day', (now() - interval '1 day') AT TIME ZONE 'America/Chicago'))
           UNION ALL
         (SELECT "ItemAct".msats
-            FROM "Item"
-            JOIN "ItemAct" ON "ItemAct"."itemId" = "Item".id
-            JOIN "ItemForward" ON "ItemForward"."itemId" = "Item".id
-            WHERE "Item"."userId" = ${ANON_USER_ID} AND "ItemAct".act = 'TIP'
-            AND (SELECT COUNT(*) FROM "ItemForward" WHERE "ItemForward"."itemId" = "Item".id) = 0
-            AND date_trunc('day', "ItemAct".created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago') = date_trunc('day', (now() - interval '1 day') AT TIME ZONE 'America/Chicago'))
+          FROM "Item"
+          JOIN "ItemAct" ON "ItemAct"."itemId" = "Item".id
+          LEFT JOIN "ItemForward" ON "ItemForward"."itemId" = "Item".id
+          WHERE "Item"."userId" = ${ANON_USER_ID} AND "ItemAct".act = 'TIP'
+          AND date_trunc('day', "ItemAct".created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago') = date_trunc('day', (now() - interval '1 day') AT TIME ZONE 'America/Chicago')
+          GROUP BY "ItemAct".id, "ItemAct".msats
+          HAVING COUNT("ItemForward".id) = 0)
       ) subquery`
 
     // XXX primsa will return a Decimal (https://mikemcl.github.io/decimal.js)


### PR DESCRIPTION
# Multi-way Forward Splits for Posts

This PR is to address #399, namely allowing users to configure zaps/sats forwarding on posts to up to 5 users, not just 1 user.

Approach taken:
1. Introduce a "ItemForward" model that represents the forwarding of a specific percentage of sats from a particular post to a particular user. There can be up to 5 forward entries for each post
2. Remove the existing "fwdUserId" field on the Item model (migrate existing forwards to the new model as part of the DB migration script)
3. When items and polls are created and updated, ItemForward entries are created/updated accordingly.
4. When a zap occurs on a post with a forwarded item, the item_act function will distribute sats accordingly, based on the forward rules configured.
5. If not 100% of sats are forwarded to other users, the remaining sats go to OP of the post.
6. Referral bonuses are applied to forwarded sats, as they were before. The forward percentage scales the referral bonus accordingly.
7. Forward percentages must be specified in integer amounts, the sum of all forward percentages for an item must be 0<=sum<=100

I think most of the changes are pretty straight-forward, aside from the updated queries in the wallet history resolver. Those were _a pain_.

There's probably more to call out, but that's the highlights. Happy to answer questions, refactor, etc.