### PR TITLE
Make withdrawal options more visible

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -47,11 +47,23 @@ export function StaticLayout ({ children, footer = true, footerLinks, ...props }
   )
 }
 
+export function TopDownLayout ({ children, ...props }) {
+  return (
+    <div className={styles.page}>
+      <Layout contain={false} {...props}>
+        <main className={`${styles.content} ${styles.topdown}`}>
+          {children}
+        </main>
+      </Layout>
+    </div>
+  )
+}
+
 export function CenterLayout ({ children, ...props }) {
   return (
     <div className={styles.page}>
       <Layout contain={false} {...props}>
-        <main className={styles.content}>
+        <main className={`${styles.content} ${styles.verticalcenter}`}>
           {children}
         </main>
       </Layout>

--- a/components/layout.module.css
+++ b/components/layout.module.css
@@ -33,8 +33,14 @@
     padding-bottom: 0.5em;
 }
 
+.content button[role=tab]:not(:global(.active)) {
+    border-bottom: 1px solid var(--theme-borderColor);
+}
+
 .content :global(.tab-content) {
-    border: 1px solid var(--theme-borderColor);
+    border-left: 1px solid var(--theme-borderColor);
+    border-right: 1px solid var(--theme-borderColor);
+    border-bottom: 1px solid var(--theme-borderColor);
     align-self: stretch;
     display: grid;
 }

--- a/components/layout.module.css
+++ b/components/layout.module.css
@@ -7,7 +7,7 @@
     align-items: center;
 }
 
-.content {
+.content, .content div[role=tabpanel] {
     flex-grow: 1;
     display: flex;
     align-items: center;
@@ -18,6 +18,39 @@
     padding-left: 15px;
     margin-top: 1.5rem;
     flex-direction: column;
+}
+
+.content [role=tablist] {
+    align-self: stretch;
+}
+
+.content button[role=tab] {
+    font-family: var(--bs-btn-font-family);
+    font-size: var(--bs-btn-font-size);
+    font-weight: var(--bs-btn-font-weight);
+    height: 100%;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
+}
+
+.content :global(.tab-content) {
+    border: 1px solid var(--theme-borderColor);
+    align-self: stretch;
+    display: grid;
+}
+
+.content :global(.tab-content) > :global(.tab-pane) {
+    visibility: hidden;
+}
+
+.content :global(.tab-content) > :global(.active) {
+    visibility: visible;
+}
+
+.content div[role=tabpanel] {
+    grid-row-start: 1;
+    grid-column-start: 1;
+    margin-bottom: 1.5rem;
 }
 
 .content form {

--- a/components/layout.module.css
+++ b/components/layout.module.css
@@ -40,7 +40,6 @@
     padding-bottom: 0.5em;
 }
 
-<<<<<<< HEAD
 .content button[role=tab]:not(:global(.active)) {
     border-bottom: 1px solid var(--theme-borderColor);
 }
@@ -49,10 +48,6 @@
     border-left: 1px solid var(--theme-borderColor);
     border-right: 1px solid var(--theme-borderColor);
     border-bottom: 1px solid var(--theme-borderColor);
-=======
-.content :global(.tab-content) {
-    border: 1px solid var(--theme-borderColor);
->>>>>>> bbb41db (add tabs for different payment methods)
     align-self: stretch;
     display: grid;
 }

--- a/components/layout.module.css
+++ b/components/layout.module.css
@@ -40,6 +40,7 @@
     padding-bottom: 0.5em;
 }
 
+<<<<<<< HEAD
 .content button[role=tab]:not(:global(.active)) {
     border-bottom: 1px solid var(--theme-borderColor);
 }
@@ -48,6 +49,10 @@
     border-left: 1px solid var(--theme-borderColor);
     border-right: 1px solid var(--theme-borderColor);
     border-bottom: 1px solid var(--theme-borderColor);
+=======
+.content :global(.tab-content) {
+    border: 1px solid var(--theme-borderColor);
+>>>>>>> bbb41db (add tabs for different payment methods)
     align-self: stretch;
     display: grid;
 }

--- a/components/layout.module.css
+++ b/components/layout.module.css
@@ -11,13 +11,20 @@
     flex-grow: 1;
     display: flex;
     align-items: center;
-    justify-content: center;
     max-width: 740px;
     width: 100%;
     padding-right: 15px;
     padding-left: 15px;
     margin-top: 1.5rem;
     flex-direction: column;
+}
+
+.verticalcenter {
+  justify-content: center;
+}
+
+.topdown {
+  justify-content: normal;
 }
 
 .content [role=tablist] {

--- a/pages/wallet.js
+++ b/pages/wallet.js
@@ -43,7 +43,7 @@ function YouHaveSats () {
 
 function WalletHistory () {
   return (
-    <div className='pb-5' style={{fontWeight: 500}}>
+    <div className='pb-5' style={{ fontWeight: 500 }}>
       <Link href='/satistics?inc=invoice,withdrawal' className='nav-link p-0'>
         wallet history
       </Link>
@@ -131,7 +131,7 @@ export function FundForm () {
   )
 }
 
-export function WithdrawalMethods() {
+export function WithdrawalMethods () {
   const router = useRouter()
 
   return (
@@ -139,32 +139,36 @@ export function WithdrawalMethods() {
       <YouHaveSats />
       <Tabs
         defaultActiveKey={
-          router.query.type === 'lnurl-withdraw'?'qrcode':
-          router.query.type === 'lnaddr-withdraw'?'lnaddr':
-          'invoice'
+          router.query.type === 'lnurl-withdraw'
+            ? 'qrcode'
+            : router.query.type === 'lnaddr-withdraw'
+              ? 'lnaddr'
+              : 'invoice'
         }
-        id="withdrawal-tabs"
+        id='withdrawal-tabs'
         justify
-        mountOnEnter={true}
-        onSelect={(k,e) => {
+        mountOnEnter
+        onSelect={(k, e) => {
           router.replace(
-            k === 'qrcode'?'/wallet?type=lnurl-withdraw':
-            k === 'lnaddr'?'/wallet?type=lnaddr-withdraw':
-            '/wallet?type=withdraw')
+            k === 'qrcode'
+              ? '/wallet?type=lnurl-withdraw'
+              : k === 'lnaddr'
+                ? '/wallet?type=lnaddr-withdraw'
+                : '/wallet?type=withdraw')
         }}
       >
-        <Tab eventKey="invoice" title="Invoice">
+        <Tab eventKey='invoice' title='Invoice'>
           <WithdrawlForm />
         </Tab>
-        <Tab eventKey="qrcode" title="QR Code">
+        <Tab eventKey='qrcode' title='QR Code'>
           <LnWithdrawal />
         </Tab>
-        <Tab eventKey="lnaddr" title="Lightning Address">
+        <Tab eventKey='lnaddr' title='Lightning Address'>
           <LnAddrWithdrawal />
         </Tab>
       </Tabs>
     </>
-  );
+  )
 }
 
 const MAX_FEE_DEFAULT = 10

--- a/pages/wallet.js
+++ b/pages/wallet.js
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import Button from 'react-bootstrap/Button'
 import { gql, useMutation, useQuery } from '@apollo/client'
 import Qr, { QrSkeleton } from '../components/qr'
-import { CenterLayout } from '../components/layout'
+import { CenterLayout, TopDownLayout } from '../components/layout'
 import InputGroup from 'react-bootstrap/InputGroup'
 import { WithdrawlSkeleton } from './withdrawals/[id]'
 import { useMe } from '../components/me'
@@ -22,11 +22,34 @@ import { numWithUnits } from '../lib/format'
 export const getServerSideProps = getGetServerSideProps()
 
 export default function Wallet () {
-  return (
-    <CenterLayout>
-      <WalletForm />
-    </CenterLayout>
-  )
+  const router = useRouter()
+
+  if (!router.query.type) {
+    return (
+      <CenterLayout>
+        <YouHaveSats />
+        <WalletForm />
+      </CenterLayout>
+    )
+  } else {
+    if (router.query.type === 'fund') {
+      return (
+        <TopDownLayout>
+          <YouHaveSats />
+          <h5 className='pb-4'>Funding Options</h5>
+          <FundForm />
+        </TopDownLayout>
+      )
+    } else {
+      return (
+        <TopDownLayout>
+          <YouHaveSats />
+          <h5 className='pb-4'>Withdrawal Options</h5>
+          <WithdrawalMethods />
+        </TopDownLayout>
+      )
+    }
+  }
 }
 
 function YouHaveSats () {
@@ -52,28 +75,17 @@ function WalletHistory () {
 }
 
 export function WalletForm () {
-  const router = useRouter()
-
-  if (!router.query.type) {
-    return (
-      <div className='align-items-center text-center'>
-        <YouHaveSats />
-        <Link href='/wallet?type=fund'>
-          <Button variant='success'>fund</Button>
-        </Link>
-        <span className='mx-3 fw-bold text-muted'>or</span>
-        <Link href='/wallet?type=withdraw'>
-          <Button variant='success'>withdraw</Button>
-        </Link>
-      </div>
-    )
-  }
-
-  if (router.query.type === 'fund') {
-    return <FundForm />
-  } else {
-    return <WithdrawalMethods />
-  }
+  return (
+    <div className='align-items-center text-center'>
+      <Link href='/wallet?type=fund'>
+        <Button variant='success'>fund</Button>
+      </Link>
+      <span className='mx-3 fw-bold text-muted'>or</span>
+      <Link href='/wallet?type=withdraw'>
+        <Button variant='success'>withdraw</Button>
+      </Link>
+    </div>
+  )
 }
 
 export function FundForm () {
@@ -97,7 +109,6 @@ export function FundForm () {
 
   return (
     <>
-      <YouHaveSats />
       {me && showAlert &&
         <Alert
           variant='success' dismissible onClose={() => {
@@ -136,7 +147,6 @@ export function WithdrawalMethods () {
 
   return (
     <>
-      <YouHaveSats />
       <Tabs
         defaultActiveKey={
           router.query.type === 'lnurl-withdraw'


### PR DESCRIPTION
The discussion of issue #167 offered some ideas for a good way to fix the easily overlooked withdrawal options, such as radio buttons. In this PR, I implemented that idea in the form of tabs, which I think is intuitive and visually organized, but let me know your opinions. I'm not convinced it fits the look of the site.

I also moved the history link up under the balance because that seems like a more logical place for it in terms of the flow of thought as a person reviews their balance, perhaps wants to understand it by clicking the history link, or just moves down to choose a withdrawal method and/or enter the data.

(EDIT: I see my linter broke...I will push a fix for the standard errors.)