### PR TITLE
Fix expireSecs ignored for anons

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -215,7 +215,7 @@ export default {
       let balanceLimit = BALANCE_LIMIT_MSATS
       let id = me?.id
       if (!me) {
-        expirePivot = { minutes: 3 }
+        expirePivot = { seconds: Math.min(expireSecs, 180) }
         invLimit = ANON_INV_PENDING_LIMIT
         balanceLimit = ANON_BALANCE_LIMIT_MSATS
         id = ANON_USER_ID


### PR DESCRIPTION
I think it's weird that `expireSecs` is totally ignored for anons.

At least it should be possible to set a lower expiry (even if not used at the moment)