### PR TITLE
Add meta sub to rss popover in footer

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -26,14 +26,18 @@ const RssPopover = (
         <a href='/~bitcoin/rss' className='nav-link p-0 d-inline-flex'>
           bitcoin
         </a>
-      </div>
-      <div className='d-flex justify-content-center'>
+        <span className='mx-2 text-muted'> \ </span>
         <a href='/~nostr/rss' className='nav-link p-0 d-inline-flex'>
           nostr
         </a>
-        <span className='mx-2 text-muted'> \ </span>
+      </div>
+      <div className='d-flex justify-content-center'>
         <a href='/~tech/rss' className='nav-link p-0 d-inline-flex'>
           tech
+        </a>
+        <span className='mx-2 text-muted'> \ </span>
+        <a href='/~meta/rss' className='nav-link p-0 d-inline-flex'>
+          meta
         </a>
         <span className='mx-2 text-muted'> \ </span>
         <a href='/~jobs/rss' className='nav-link p-0 d-inline-flex'>


### PR DESCRIPTION
Add meta sub to rss popover in footer and move nostr sub up to top row for 3 and 3 instead of 2 and 4

I mirrored the order from the sub picker select component (home, bitcoin, nostr, tech, meta, jobs)

<img width="388" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/8dc7454a-6a00-428c-b5aa-22a804a8f3a1">
