### PR TITLE
Fix forward required in GraphQL mutations

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -83,12 +83,12 @@ export function advPostSchemaMembers (client) {
       .compact((v) => !v.nym && !v.pct)
       .test({
         name: 'sum',
-        test: forwards => forwards.map(fwd => Number(fwd.pct)).reduce((sum, cur) => sum + cur, 0) <= 100,
+        test: forwards => forwards ? forwards.map(fwd => Number(fwd.pct)).reduce((sum, cur) => sum + cur, 0) <= 100 : true,
         message: 'the total forward percentage exceeds 100%'
       })
       .test({
         name: 'uniqueStackers',
-        test: forwards => new Set(forwards.map(fwd => fwd.nym)).size === forwards.length,
+        test: forwards => forwards ? new Set(forwards.map(fwd => fwd.nym)).size === forwards.length : true,
         message: 'duplicate stackers cannot be specified to receive forwarded sats'
       })
   }


### PR DESCRIPTION
If no forward variable is set, the API responds with

> Cannot read properties of undefined (reading 'map')

I have noticed this because [@hn](https://stacker.news/hn) stopped working

> error posting link: [{"message":"Cannot read properties of undefined (reading 'map')"}]

You can test this with the following payload:

_link.json_:
 ```
{
  "operationName": "upsertLink",
  "variables": {
    "sub": "bitcoin",
    "title": "Hacker News",
    "url": "https://news.ycombinator.com/"
  },
  "query": "mutation upsertLink($sub: String, $id: ID, $title: String!, $url: String!, $boost: Int, $forward: [ItemForwardInput], $invoiceHash: String, $invoiceHmac: String) {\n  upsertLink(\n    sub: $sub\n    id: $id\n    title: $title\n    url: $url\n    boost: $boost\n    forward: $forward\n    invoiceHash: $invoiceHash\n    invoiceHmac: $invoiceHmac\n  ) {\n    id\n    __typename\n  }\n}"
}
```

```
$ curl -XPOST -H "Cookie: <next_auth_cookie>" -H "Content-type: application/json" --data @link.json https://sn.ekzyis.com/api/graphql 
```