### PR TITLE
Fix TypeError during push notifications

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -684,7 +684,7 @@ export default {
             parents.map(({ userId }) => sendUserNotification(userId, {
               title: `@${user.name} replied to you`,
               body: item.text,
-              item,
+              item: rItem,
               tag: 'REPLY'
             }))
           )


### PR DESCRIPTION
Without this, following error is thrown when notifying users about new replies:

> [webPush] error sending user notification:  TypeError: Cannot read properties of undefined (reading 'id')
app  |     at createItemUrl (webpack-internal:///(api)/./api/webPush/index.js:76:29)
app  |     at async sendUserNotification (webpack-internal:///(api)/./api/webPush/index.js:125:33)
app  |     at async Promise.allSettled (index 0)

Bug introduced in a847b16