### PR TITLE
Minor tweaks to the page footer

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -14,6 +14,7 @@ import Amboss from '../svgs/amboss.svg'
 import { useEffect, useState } from 'react'
 import Rewards from './footer-rewards'
 import useDarkMode from './dark-mode'
+import ActionTooltip from './action-tooltip'
 
 const RssPopover = (
   <Popover>
@@ -156,8 +157,12 @@ export default function Footer ({ links = true }) {
         {links &&
           <>
             <div className='mb-1'>
-              <DarkModeIcon onClick={darkModeToggle} width={20} height={20} className='fill-grey theme' suppressHydrationWarning />
-              <LnIcon onClick={toggleLightning} width={20} height={20} className='ms-2 fill-grey theme' suppressHydrationWarning />
+              <ActionTooltip notForm overlayText={`${darkMode ? 'disable' : 'enable'} dark mode`}>
+                <DarkModeIcon onClick={darkModeToggle} width={20} height={20} className='fill-grey theme' suppressHydrationWarning />
+              </ActionTooltip>
+              <ActionTooltip notForm overlayText={`${lightning === 'yes' ? 'disable' : 'enable'} lightning animations`}>
+                <LnIcon onClick={toggleLightning} width={20} height={20} className='ms-2 fill-grey theme' suppressHydrationWarning />
+              </ActionTooltip>
             </div>
             <div className='mb-0' style={{ fontWeight: 500 }}>
               <Rewards />
@@ -252,7 +257,7 @@ export default function Footer ({ links = true }) {
         </small>
         {version &&
           <div className={styles.version}>
-            running <a className='text-reset' href={`https://github.com/stackernews/stacker.news/commit/${version}`}>{version}</a>
+            running <a className='text-reset' href={`https://github.com/stackernews/stacker.news/commit/${version}`} target='_blank' rel='noreferrer'>{version}</a>
           </div>}
       </Container>
     </footer>


### PR DESCRIPTION
1. Use an ActionTooltip to explain what the light/dark mode and lightning buttons are for
2. Open the current commit github link in a new tab
<img width="318" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/30d73e90-8175-42b3-a21c-113115a60e8f">

<img width="223" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/de2f96d0-44da-488b-a24b-5286261d69b7">

<img width="249" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/3e06a6ab-e55f-4db6-a451-ddf47bd9d1d0">

<img width="197" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/3344623e-85c9-4898-a6de-a024569baecc">
