### PR TITLE
Visual Character counter for post titles, poll options

### DIFF
--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -9,7 +9,7 @@ import { bountySchema } from '../lib/validate'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
-import { normalizeForwards, titleInputHint } from '../lib/form'
+import { normalizeForwards } from '../lib/form'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 
 export function BountyForm ({
@@ -105,7 +105,6 @@ export function BountyForm ({
         required
         autoFocus
         clear
-        hint={titleInputHint}
         maxLength={MAX_TITLE_LENGTH}
       />
       <Input

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -10,6 +10,7 @@ import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
 import { normalizeForwards } from '../lib/form'
+import { MAX_TITLE_LENGTH } from '../lib/constants'
 
 export function BountyForm ({
   item,
@@ -98,7 +99,15 @@ export function BountyForm ({
       storageKeyPrefix={item ? undefined : 'bounty'}
     >
       {children}
-      <Input label={titleLabel} name='title' required autoFocus clear />
+      <Input
+        label={titleLabel}
+        name='title'
+        required
+        autoFocus
+        clear
+        hint={(formik) => <span className='text-muted'>{`${MAX_TITLE_LENGTH - (formik.values.title || '').length} characters remaining`}</span>}
+        maxLength={MAX_TITLE_LENGTH}
+      />
       <Input
         label={bountyLabel} name='bounty' required
         append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -9,7 +9,7 @@ import { bountySchema } from '../lib/validate'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
-import { normalizeForwards } from '../lib/form'
+import { normalizeForwards, titleInputHint } from '../lib/form'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 
 export function BountyForm ({
@@ -105,7 +105,7 @@ export function BountyForm ({
         required
         autoFocus
         clear
-        hint={(formik) => <span className='text-muted'>{`${MAX_TITLE_LENGTH - (formik.values.title || '').length} characters remaining`}</span>}
+        hint={titleInputHint}
         maxLength={MAX_TITLE_LENGTH}
       />
       <Input

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -13,7 +13,7 @@ import { discussionSchema } from '../lib/validate'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
-import { normalizeForwards } from '../lib/form'
+import { normalizeForwards, titleInputHint } from '../lib/form'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 
 export function DiscussionForm ({
@@ -102,7 +102,7 @@ export function DiscussionForm ({
             })
           }
         }}
-        hint={(formik) => <span className='text-muted'>{`${MAX_TITLE_LENGTH - (formik.values.title || '').length} characters remaining`}</span>}
+        hint={titleInputHint}
         maxLength={MAX_TITLE_LENGTH}
       />
       <MarkdownInput

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -13,7 +13,7 @@ import { discussionSchema } from '../lib/validate'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
-import { normalizeForwards, titleInputHint } from '../lib/form'
+import { normalizeForwards } from '../lib/form'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 
 export function DiscussionForm ({
@@ -102,7 +102,6 @@ export function DiscussionForm ({
             })
           }
         }}
-        hint={titleInputHint}
         maxLength={MAX_TITLE_LENGTH}
       />
       <MarkdownInput

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -14,6 +14,7 @@ import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
 import { normalizeForwards } from '../lib/form'
+import { MAX_TITLE_LENGTH } from '../lib/constants'
 
 export function DiscussionForm ({
   item, sub, editThreshold, titleLabel = 'title',
@@ -101,6 +102,8 @@ export function DiscussionForm ({
             })
           }
         }}
+        hint={(formik) => <span className='text-muted'>{`${MAX_TITLE_LENGTH - (formik.values.title || '').length} characters remaining`}</span>}
+        maxLength={MAX_TITLE_LENGTH}
       />
       <MarkdownInput
         topLevel

--- a/components/form.js
+++ b/components/form.js
@@ -310,14 +310,14 @@ function InputInner ({
             className={`${styles.clearButton} ${styles.appendButton} ${invalid ? styles.isInvalid : ''}`}
           ><CloseIcon className='fill-grey' height={20} width={20} />
           </Button>}
-        {append}
+        {typeof append === 'function' ? append(formik) : append}
         <BootstrapForm.Control.Feedback type='invalid'>
           {meta.touched && meta.error}
         </BootstrapForm.Control.Feedback>
       </InputGroup>
       {hint && (
         <BootstrapForm.Text>
-          {hint}
+          {typeof hint === 'function' ? hint(formik) : hint}
         </BootstrapForm.Text>
       )}
     </>

--- a/components/form.js
+++ b/components/form.js
@@ -222,7 +222,7 @@ function FormGroup ({ className, label, children }) {
   )
 }
 
-function InputInner ({
+export function InputInner ({
   prepend, append, hint, showValid, onChange, onBlur, overrideValue,
   innerRef, noForm, clear, onKeyDown, inputGroupClassName, debounce, ...props
 }) {

--- a/components/form.js
+++ b/components/form.js
@@ -20,6 +20,7 @@ import { USER_SEARCH } from '../fragments/users'
 import TextareaAutosize from 'react-textarea-autosize'
 import { useToast } from './toast'
 import { useInvoiceable } from './invoice'
+import { numWithUnits } from '../lib/format'
 
 export function SubmitButton ({
   children, variant, value, onClick, disabled, cost, ...props
@@ -222,7 +223,7 @@ function FormGroup ({ className, label, children }) {
   )
 }
 
-export function InputInner ({
+function InputInner ({
   prepend, append, hint, showValid, onChange, onBlur, overrideValue,
   innerRef, noForm, clear, onKeyDown, inputGroupClassName, debounce, ...props
 }) {
@@ -310,14 +311,19 @@ export function InputInner ({
             className={`${styles.clearButton} ${styles.appendButton} ${invalid ? styles.isInvalid : ''}`}
           ><CloseIcon className='fill-grey' height={20} width={20} />
           </Button>}
-        {typeof append === 'function' ? append(formik) : append}
+        {append}
         <BootstrapForm.Control.Feedback type='invalid'>
           {meta.touched && meta.error}
         </BootstrapForm.Control.Feedback>
       </InputGroup>
       {hint && (
         <BootstrapForm.Text>
-          {typeof hint === 'function' ? hint(formik) : hint}
+          {hint}
+        </BootstrapForm.Text>
+      )}
+      {props.maxLength && (
+        <BootstrapForm.Text>
+          {`${numWithUnits(props.maxLength - (field.value || '').length, { abbreviate: false, unitSingular: 'character', unitPlural: 'characters' })} remaining`}
         </BootstrapForm.Text>
       )}
     </>

--- a/components/job-form.js
+++ b/components/job-form.js
@@ -17,6 +17,7 @@ import Avatar from './avatar'
 import ActionTooltip from './action-tooltip'
 import { jobSchema } from '../lib/validate'
 import CancelButton from './cancel-button'
+import { MAX_TITLE_LENGTH } from '../lib/constants'
 
 function satsMin2Mo (minute) {
   return minute * 30 * 24 * 60
@@ -116,6 +117,8 @@ export default function JobForm ({ item, sub }) {
           required
           autoFocus
           clear
+          hint={(formik) => <span className='text-muted'>{`${MAX_TITLE_LENGTH - (formik.values.title || '').length} characters remaining`}</span>}
+          maxLength={MAX_TITLE_LENGTH}
         />
         <Input
           label='company'

--- a/components/job-form.js
+++ b/components/job-form.js
@@ -18,7 +18,6 @@ import ActionTooltip from './action-tooltip'
 import { jobSchema } from '../lib/validate'
 import CancelButton from './cancel-button'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
-import { titleInputHint } from '../lib/form'
 
 function satsMin2Mo (minute) {
   return minute * 30 * 24 * 60
@@ -118,7 +117,6 @@ export default function JobForm ({ item, sub }) {
           required
           autoFocus
           clear
-          hint={titleInputHint}
           maxLength={MAX_TITLE_LENGTH}
         />
         <Input

--- a/components/job-form.js
+++ b/components/job-form.js
@@ -18,6 +18,7 @@ import ActionTooltip from './action-tooltip'
 import { jobSchema } from '../lib/validate'
 import CancelButton from './cancel-button'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
+import { titleInputHint } from '../lib/form'
 
 function satsMin2Mo (minute) {
   return minute * 30 * 24 * 60
@@ -117,7 +118,7 @@ export default function JobForm ({ item, sub }) {
           required
           autoFocus
           clear
-          hint={(formik) => <span className='text-muted'>{`${MAX_TITLE_LENGTH - (formik.values.title || '').length} characters remaining`}</span>}
+          hint={titleInputHint}
           maxLength={MAX_TITLE_LENGTH}
         />
         <Input

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -14,7 +14,7 @@ import { linkSchema } from '../lib/validate'
 import Moon from '../svgs/moon-fill.svg'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
-import { normalizeForwards, titleInputHint } from '../lib/form'
+import { normalizeForwards } from '../lib/form'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 
 export function LinkForm ({ item, sub, editThreshold, children }) {
@@ -147,7 +147,6 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
               txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()))
           }
         }}
-        hint={titleInputHint}
         maxLength={MAX_TITLE_LENGTH}
       />
       <Input

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -14,7 +14,7 @@ import { linkSchema } from '../lib/validate'
 import Moon from '../svgs/moon-fill.svg'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
-import { normalizeForwards } from '../lib/form'
+import { normalizeForwards, titleInputHint } from '../lib/form'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 
 export function LinkForm ({ item, sub, editThreshold, children }) {
@@ -147,7 +147,7 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
               txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()))
           }
         }}
-        hint={(formik) => <span className='text-muted'>{`${MAX_TITLE_LENGTH - (formik.values.title || '').length} characters remaining`}</span>}
+        hint={titleInputHint}
         maxLength={MAX_TITLE_LENGTH}
       />
       <Input

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -15,6 +15,7 @@ import Moon from '../svgs/moon-fill.svg'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { normalizeForwards } from '../lib/form'
+import { MAX_TITLE_LENGTH } from '../lib/constants'
 
 export function LinkForm ({ item, sub, editThreshold, children }) {
   const router = useRouter()
@@ -146,6 +147,8 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
               txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()))
           }
         }}
+        hint={(formik) => <span className='text-muted'>{`${MAX_TITLE_LENGTH - (formik.values.title || '').length} characters remaining`}</span>}
+        maxLength={MAX_TITLE_LENGTH}
       />
       <Input
         label='url'

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -12,6 +12,7 @@ import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
 import { normalizeForwards, titleInputHint } from '../lib/form'
+import { numWithUnits } from '../lib/format'
 
 export function PollForm ({ item, sub, editThreshold, children }) {
   const router = useRouter()
@@ -100,7 +101,7 @@ export function PollForm ({ item, sub, editThreshold, children }) {
             name={`options[${index}]`}
             readOnly={readOnly}
             placeholder={placeholder}
-            hint={(formik) => <span className='text-muted'>{`${MAX_POLL_CHOICE_LENGTH - (formik.values.options?.[index] || '').length} characters remaining`}</span>}
+            hint={(formik) => <span className='text-muted'>{`${numWithUnits(MAX_POLL_CHOICE_LENGTH - (formik.values.options?.[index] || '').length, { abbreviate: false, unitSingular: 'character', unitPlural: 'characters' })} remaining`}</span>}
             maxLength={MAX_POLL_CHOICE_LENGTH}
           />)}
       </VariableInput>

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -1,4 +1,4 @@
-import { Form, Input, MarkdownInput, SubmitButton, VariableInput } from '../components/form'
+import { Form, Input, MarkdownInput, SubmitButton, VariableInput, InputInner } from '../components/form'
 import { useRouter } from 'next/router'
 import { gql, useApolloClient, useMutation } from '@apollo/client'
 import Countdown from './countdown'
@@ -96,7 +96,7 @@ export function PollForm ({ item, sub, editThreshold, children }) {
           : null}
       >
         {({ index, readOnly, placeholder }) => (
-          <Input
+          <InputInner
             name={`options[${index}]`}
             readOnly={readOnly}
             placeholder={placeholder}

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import { gql, useApolloClient, useMutation } from '@apollo/client'
 import Countdown from './countdown'
 import AdvPostForm, { AdvPostInitial } from './adv-post-form'
-import { MAX_POLL_NUM_CHOICES } from '../lib/constants'
+import { MAX_POLL_CHOICE_LENGTH, MAX_POLL_NUM_CHOICES, MAX_TITLE_LENGTH } from '../lib/constants'
 import FeeButton, { EditFeeButton } from './fee-button'
 import Delete from './delete'
 import Button from 'react-bootstrap/Button'
@@ -76,6 +76,8 @@ export function PollForm ({ item, sub, editThreshold, children }) {
         label='title'
         name='title'
         required
+        hint={(formik) => <span className='text-muted'>{`${MAX_TITLE_LENGTH - (formik.values.title || '').length} characters remaining`}</span>}
+        maxLength={MAX_TITLE_LENGTH}
       />
       <MarkdownInput
         topLevel
@@ -92,7 +94,16 @@ export function PollForm ({ item, sub, editThreshold, children }) {
         hint={editThreshold
           ? <div className='text-muted fw-bold'><Countdown date={editThreshold} /></div>
           : null}
-      />
+      >
+        {({ index, readOnly, placeholder }) => (
+          <Input
+            name={`options[${index}]`}
+            readOnly={readOnly}
+            placeholder={placeholder}
+            hint={(formik) => <span className='text-muted'>{`${MAX_POLL_CHOICE_LENGTH - (formik.values.options?.[index] || '').length} characters remaining`}</span>}
+            maxLength={MAX_POLL_CHOICE_LENGTH}
+          />)}
+      </VariableInput>
       <AdvPostForm edit={!!item} />
       <div className='mt-3'>
         {item

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -1,4 +1,4 @@
-import { Form, Input, MarkdownInput, SubmitButton, VariableInput, InputInner } from '../components/form'
+import { Form, Input, MarkdownInput, SubmitButton, VariableInput } from '../components/form'
 import { useRouter } from 'next/router'
 import { gql, useApolloClient, useMutation } from '@apollo/client'
 import Countdown from './countdown'
@@ -11,8 +11,7 @@ import { pollSchema } from '../lib/validate'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
-import { normalizeForwards, titleInputHint } from '../lib/form'
-import { numWithUnits } from '../lib/format'
+import { normalizeForwards } from '../lib/form'
 
 export function PollForm ({ item, sub, editThreshold, children }) {
   const router = useRouter()
@@ -77,7 +76,6 @@ export function PollForm ({ item, sub, editThreshold, children }) {
         label='title'
         name='title'
         required
-        hint={titleInputHint}
         maxLength={MAX_TITLE_LENGTH}
       />
       <MarkdownInput
@@ -95,16 +93,8 @@ export function PollForm ({ item, sub, editThreshold, children }) {
         hint={editThreshold
           ? <div className='text-muted fw-bold'><Countdown date={editThreshold} /></div>
           : null}
-      >
-        {({ index, readOnly, placeholder }) => (
-          <InputInner
-            name={`options[${index}]`}
-            readOnly={readOnly}
-            placeholder={placeholder}
-            hint={(formik) => <span className='text-muted'>{`${numWithUnits(MAX_POLL_CHOICE_LENGTH - (formik.values.options?.[index] || '').length, { abbreviate: false, unitSingular: 'character', unitPlural: 'characters' })} remaining`}</span>}
-            maxLength={MAX_POLL_CHOICE_LENGTH}
-          />)}
-      </VariableInput>
+        maxLength={MAX_POLL_CHOICE_LENGTH}
+      />
       <AdvPostForm edit={!!item} />
       <div className='mt-3'>
         {item

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -11,7 +11,7 @@ import { pollSchema } from '../lib/validate'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
-import { normalizeForwards } from '../lib/form'
+import { normalizeForwards, titleInputHint } from '../lib/form'
 
 export function PollForm ({ item, sub, editThreshold, children }) {
   const router = useRouter()
@@ -76,7 +76,7 @@ export function PollForm ({ item, sub, editThreshold, children }) {
         label='title'
         name='title'
         required
-        hint={(formik) => <span className='text-muted'>{`${MAX_TITLE_LENGTH - (formik.values.title || '').length} characters remaining`}</span>}
+        hint={titleInputHint}
         maxLength={MAX_TITLE_LENGTH}
       />
       <MarkdownInput

--- a/lib/form.js
+++ b/lib/form.js
@@ -1,6 +1,3 @@
-import { MAX_TITLE_LENGTH } from './constants'
-import { numWithUnits } from './format'
-
 /**
  * Normalize an array of forwards by converting the pct from a string to a number
  * Also extracts nym from nested user object, if necessary
@@ -13,8 +10,3 @@ export const normalizeForwards = (forward) => {
   }
   return forward.filter(fwd => fwd.nym || fwd.user?.name).map(fwd => ({ nym: fwd.nym ?? fwd.user?.name, pct: Number(fwd.pct) }))
 }
-
-export const titleInputHint = (formik) =>
-  <span className='text-muted'>
-    {`${numWithUnits(MAX_TITLE_LENGTH - (formik.values.title || '').length, { abbreviate: false, unitSingular: 'character', unitPlural: 'characters' })} remaining`}
-  </span>

--- a/lib/form.js
+++ b/lib/form.js
@@ -1,3 +1,5 @@
+import { MAX_TITLE_LENGTH } from './constants'
+
 /**
  * Normalize an array of forwards by converting the pct from a string to a number
  * Also extracts nym from nested user object, if necessary
@@ -10,3 +12,6 @@ export const normalizeForwards = (forward) => {
   }
   return forward.filter(fwd => fwd.nym || fwd.user?.name).map(fwd => ({ nym: fwd.nym ?? fwd.user?.name, pct: Number(fwd.pct) }))
 }
+
+export const titleInputHint = (formik) =>
+  <span className='text-muted'>{`${MAX_TITLE_LENGTH - (formik.values.title || '').length} characters remaining`}</span>

--- a/lib/form.js
+++ b/lib/form.js
@@ -1,4 +1,5 @@
 import { MAX_TITLE_LENGTH } from './constants'
+import { numWithUnits } from './format'
 
 /**
  * Normalize an array of forwards by converting the pct from a string to a number
@@ -14,4 +15,6 @@ export const normalizeForwards = (forward) => {
 }
 
 export const titleInputHint = (formik) =>
-  <span className='text-muted'>{`${MAX_TITLE_LENGTH - (formik.values.title || '').length} characters remaining`}</span>
+  <span className='text-muted'>
+    {`${numWithUnits(MAX_TITLE_LENGTH - (formik.values.title || '').length, { abbreviate: false, unitSingular: 'character', unitPlural: 'characters' })} remaining`}
+  </span>


### PR DESCRIPTION
Live counter update to help authors know how many more chars they have to use in their post titles, and also poll options

applies across all post types (discussion, link, poll, bounty, job)

<img width="712" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/e92e8067-97c0-4a73-929b-18c582efa6dc">
