### PR TITLE
toast border color based on variant

### DIFF
--- a/components/toast.js
+++ b/components/toast.js
@@ -56,7 +56,7 @@ export const ToastProvider = ({ children }) => {
         {toasts.map(toast => (
           <Toast
             key={toast.id} bg={toast.variant} show autohide={toast.autohide}
-            delay={toast.delay} className={styles.toast} onClose={() => removeToast(toast.id)}
+            delay={toast.delay} className={`${styles.toast} ${styles[toast.variant]}`} onClose={() => removeToast(toast.id)}
           >
             <ToastBody>
               <div className='d-flex align-items-center'>

--- a/components/toast.module.css
+++ b/components/toast.module.css
@@ -4,8 +4,17 @@
 
 .toast {
   width: auto;
-  border: 1px solid var(--bs-success-border-subtle);
   color: #fff;
+  border-width: 1px;
+  border-style: solid;
+}
+
+.success {
+  border-color: var(--bs-success-border-subtle);
+}
+
+.danger {
+  border-color: var(--bs-danger-border-subtle);
 }
 
 .toastClose {


### PR DESCRIPTION
Closes #468 

Side note: I wanted to just do `.toast.bg-success { ... }`, `.toast.bg-danger { ... }` in the CSS module, but with how Next.JS loads CSS modules via className, that didn't seem to work how I'd like, so I went with this approach instead. I am open to different implementations if there's a cleaner option.