### PR TITLE
Remove orientation from manifest

### DIFF
--- a/pages/api/site.webmanifest.js
+++ b/pages/api/site.webmanifest.js
@@ -91,7 +91,6 @@ const defaultManifest = {
     }
   ],
   display: 'standalone',
-  orientation: 'any',
   theme_color: black,
   background_color: yellow,
   id: '/',


### PR DESCRIPTION
This overrides OS auto-rotate settings on Android. This means that the PWA does auto-rotate even if the OS setting to auto-rotate is not enabled.

This property is experimental and only supported by Chromium-based browsers anyway.

Also, you can still manually rotate if you want.

Fixes #482 