### PR TITLE
Add block height to price carousel

### DIFF
--- a/api/resolvers/blockHeight.js
+++ b/api/resolvers/blockHeight.js
@@ -7,7 +7,7 @@ async function fetchBlockHeight () {
     .then(res => res.text())
     .then((body) => Number(body))
     .catch((err) => {
-      console.error(err)
+      console.error('blockHeight', err)
       return 0
     })
   cache.set('block', { height: blockHeight, createdAt: Date.now() })
@@ -23,7 +23,7 @@ async function getBlockHeight () {
   } else {
     fetchBlockHeight().catch(console.error)
   }
-  return null
+  return 0
 }
 
 export default {

--- a/api/resolvers/blockHeight.js
+++ b/api/resolvers/blockHeight.js
@@ -1,0 +1,35 @@
+const cache = new Map()
+const expiresIn = 30000 // in milliseconds
+
+async function fetchBlockHeight () {
+  const url = 'https://mempool.space/api/blocks/tip/height'
+  const blockHeight = await fetch(url)
+    .then(res => res.text())
+    .then((body) => Number(body))
+    .catch((err) => {
+      console.error(err)
+      return 0
+    })
+  cache.set('block', { height: blockHeight, createdAt: Date.now() })
+  return blockHeight
+}
+
+async function getBlockHeight () {
+  if (cache.has('block')) {
+    const { height, createdAt } = cache.get('block')
+    const expired = createdAt + expiresIn < Date.now()
+    if (expired) fetchBlockHeight().catch(console.error) // update cache
+    return height // serve stale block height (this on the SSR critical path)
+  } else {
+    fetchBlockHeight().catch(console.error)
+  }
+  return null
+}
+
+export default {
+  Query: {
+    blockHeight: async (parent, opts, ctx) => {
+      return await getBlockHeight()
+    }
+  }
+}

--- a/api/resolvers/blockHeight.js
+++ b/api/resolvers/blockHeight.js
@@ -1,5 +1,5 @@
 const cache = new Map()
-const expiresIn = 30000 // in milliseconds
+const expiresIn = 1000 * 60 // in milliseconds
 
 async function fetchBlockHeight () {
   const url = 'https://mempool.space/api/blocks/tip/height'

--- a/api/resolvers/blockHeight.js
+++ b/api/resolvers/blockHeight.js
@@ -1,15 +1,17 @@
+import lndService from 'ln-service'
+import lnd from '../lnd'
+
 const cache = new Map()
-const expiresIn = 1000 * 60 // in milliseconds
+const expiresIn = 1000 * 30 // 30 seconds in milliseconds
 
 async function fetchBlockHeight () {
-  const url = 'https://mempool.space/api/blocks/tip/height'
-  const blockHeight = await fetch(url)
-    .then(res => res.text())
-    .then((body) => Number(body))
-    .catch((err) => {
-      console.error('blockHeight', err)
-      return 0
-    })
+  let blockHeight = 0
+  try {
+    const height = await lndService.getHeight({ lnd })
+    blockHeight = height.current_block_height
+  } catch (err) {
+    console.error('fetchBlockHeight', err)
+  }
   cache.set('block', { height: blockHeight, createdAt: Date.now() })
   return blockHeight
 }

--- a/api/resolvers/index.js
+++ b/api/resolvers/index.js
@@ -14,6 +14,7 @@ import referrals from './referrals'
 import price from './price'
 import { GraphQLJSONObject as JSONObject } from 'graphql-type-json'
 import admin from './admin'
+import blockHeight from './blockHeight'
 import { GraphQLScalarType, Kind } from 'graphql'
 
 const date = new GraphQLScalarType({
@@ -44,4 +45,4 @@ const date = new GraphQLScalarType({
 })
 
 export default [user, item, message, wallet, lnurl, notifications, invite, sub,
-  upload, search, growth, rewards, referrals, price, admin, { JSONObject }, { Date: date }]
+  upload, search, growth, rewards, referrals, price, admin, blockHeight, { JSONObject }, { Date: date }]

--- a/api/ssrApollo.js
+++ b/api/ssrApollo.js
@@ -9,6 +9,7 @@ import lnd from './lnd'
 import search from './search'
 import { ME } from '../fragments/users'
 import { PRICE } from '../fragments/price'
+import { BLOCK_HEIGHT } from '../fragments/blockHeight'
 import { getServerSession } from 'next-auth/next'
 import { getAuthOptions } from '../pages/api/auth/[...nextauth]'
 
@@ -92,6 +93,10 @@ export function getGetServerSideProps (
       query: PRICE, variables: { fiatCurrency: me?.fiatCurrency }
     })
 
+    const { data: { blockHeight } } = await client.query({
+      query: BLOCK_HEIGHT, variables: {}
+    })
+
     let error = null; let data = null; let props = {}
     if (query) {
       try {
@@ -122,6 +127,7 @@ export function getGetServerSideProps (
         ...props,
         me,
         price,
+        blockHeight,
         ssrData: data
       }
     }

--- a/api/typeDefs/blockHeight.js
+++ b/api/typeDefs/blockHeight.js
@@ -1,0 +1,7 @@
+import { gql } from 'graphql-tag'
+
+export default gql`
+  extend type Query {
+    blockHeight: Int
+  }
+`

--- a/api/typeDefs/blockHeight.js
+++ b/api/typeDefs/blockHeight.js
@@ -2,6 +2,6 @@ import { gql } from 'graphql-tag'
 
 export default gql`
   extend type Query {
-    blockHeight: Int
+    blockHeight: Int!
   }
 `

--- a/api/typeDefs/index.js
+++ b/api/typeDefs/index.js
@@ -15,6 +15,7 @@ import rewards from './rewards'
 import referrals from './referrals'
 import price from './price'
 import admin from './admin'
+import blockHeight from './blockHeight'
 
 const common = gql`
   type Query {
@@ -34,4 +35,4 @@ const common = gql`
 `
 
 export default [common, user, item, itemForward, message, wallet, lnurl, notifications, invite,
-  sub, upload, growth, rewards, referrals, price, admin]
+  sub, upload, growth, rewards, referrals, price, admin, blockHeight]

--- a/components/block-height.js
+++ b/components/block-height.js
@@ -1,0 +1,29 @@
+import { createContext, useContext } from 'react'
+import { useQuery } from '@apollo/client'
+import { SSR } from '../lib/constants'
+import { BLOCK_HEIGHT } from '../fragments/block-height'
+
+export const BlockHeightContext = createContext({
+  height: 0
+})
+
+export const useBlockHeight = () => useContext(BlockHeightContext)
+
+export const BlockHeightProvider = ({ children }) => {
+  const { data } = useQuery(BLOCK_HEIGHT, {
+    ...(SSR
+      ? {}
+      : {
+          pollInterval: 30000,
+          nextFetchPolicy: 'cache-and-network'
+        })
+  })
+  const value = {
+    height: data?.blockHeight ?? 0
+  }
+  return (
+    <BlockHeightContext.Provider value={value}>
+      {children}
+    </BlockHeightContext.Provider>
+  )
+}

--- a/components/block-height.js
+++ b/components/block-height.js
@@ -1,7 +1,7 @@
 import { createContext, useContext } from 'react'
 import { useQuery } from '@apollo/client'
 import { SSR } from '../lib/constants'
-import { BLOCK_HEIGHT } from '../fragments/block-height'
+import { BLOCK_HEIGHT } from '../fragments/blockHeight'
 
 export const BlockHeightContext = createContext({
   height: 0
@@ -9,7 +9,7 @@ export const BlockHeightContext = createContext({
 
 export const useBlockHeight = () => useContext(BlockHeightContext)
 
-export const BlockHeightProvider = ({ children }) => {
+export const BlockHeightProvider = ({ blockHeight, children }) => {
   const { data } = useQuery(BLOCK_HEIGHT, {
     ...(SSR
       ? {}
@@ -19,7 +19,7 @@ export const BlockHeightProvider = ({ children }) => {
         })
   })
   const value = {
-    height: data?.blockHeight ?? 0
+    height: data?.blockHeight ?? blockHeight ?? 0
   }
   return (
     <BlockHeightContext.Provider value={value}>

--- a/components/price.js
+++ b/components/price.js
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react'
 import { useQuery } from '@apollo/client'
-import { fixedDecimal, numWithUnits } from '../lib/format'
+import { fixedDecimal } from '../lib/format'
 import { useMe } from './me'
 import { PRICE } from '../fragments/price'
 import { CURRENCY_SYMBOLS } from '../lib/currency'
@@ -90,7 +90,7 @@ export default function Price ({ className }) {
   if (asSats === 'blockHeight') {
     return (
       <div className={compClassName} onClick={handleClick} variant='link'>
-        {numWithUnits(blockHeight, { abbreviate: false, unitSingular: 'block', unitPlural: 'blocks' })}
+        {`block ${blockHeight}`}
       </div>
     )
   }

--- a/components/price.js
+++ b/components/price.js
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react'
 import { useQuery } from '@apollo/client'
-import { fixedDecimal } from '../lib/format'
+import { fixedDecimal, numWithUnits } from '../lib/format'
 import { useMe } from './me'
 import { PRICE } from '../fragments/price'
 import { CURRENCY_SYMBOLS } from '../lib/currency'
@@ -90,7 +90,7 @@ export default function Price ({ className }) {
   if (asSats === 'blockHeight') {
     return (
       <div className={compClassName} onClick={handleClick} variant='link'>
-        {`${blockHeight} blocks`}
+        {numWithUnits(blockHeight, { abbreviate: false, unitSingular: 'block', unitPlural: 'blocks' })}
       </div>
     )
   }

--- a/components/price.js
+++ b/components/price.js
@@ -5,6 +5,7 @@ import { useMe } from './me'
 import { PRICE } from '../fragments/price'
 import { CURRENCY_SYMBOLS } from '../lib/currency'
 import { SSR } from '../lib/constants'
+import { useBlockHeight } from './block-height'
 
 export const PriceContext = React.createContext({
   price: null,
@@ -46,14 +47,20 @@ export default function Price ({ className }) {
     setAsSats(window.localStorage.getItem('asSats'))
   }, [])
   const { price, fiatSymbol } = usePrice()
+  const { height: blockHeight } = useBlockHeight()
 
-  if (!price || price < 0) return null
+  if (!price || price < 0 || blockHeight <= 0) return null
 
+  // Options: yep, 1btc, blockHeight, undefined
+  // yep -> 1btc -> blockHeight -> undefined -> yep
   const handleClick = () => {
     if (asSats === 'yep') {
       window.localStorage.setItem('asSats', '1btc')
       setAsSats('1btc')
     } else if (asSats === '1btc') {
+      window.localStorage.setItem('asSats', 'blockHeight')
+      setAsSats('blockHeight')
+    } else if (asSats === 'blockHeight') {
       window.localStorage.removeItem('asSats')
       setAsSats(undefined)
     } else {
@@ -76,6 +83,14 @@ export default function Price ({ className }) {
     return (
       <div className={compClassName} onClick={handleClick} variant='link'>
         1sat=1sat
+      </div>
+    )
+  }
+
+  if (asSats === 'blockHeight') {
+    return (
+      <div className={compClassName} onClick={handleClick} variant='link'>
+        {`${blockHeight} blocks`}
       </div>
     )
   }

--- a/fragments/block-height.js
+++ b/fragments/block-height.js
@@ -1,6 +1,0 @@
-import { gql } from '@apollo/client'
-
-export const BLOCK_HEIGHT = gql`
-  query blockHeight {
-    blockHeight
-  }`

--- a/fragments/block-height.js
+++ b/fragments/block-height.js
@@ -1,0 +1,6 @@
+import { gql } from '@apollo/client'
+
+export const BLOCK_HEIGHT = gql`
+  query blockHeight {
+    blockHeight
+  }`

--- a/fragments/blockHeight.js
+++ b/fragments/blockHeight.js
@@ -1,0 +1,3 @@
+import { gql } from '@apollo/client'
+
+export const BLOCK_HEIGHT = gql`{ blockHeight }`

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -4,6 +4,7 @@ import { MeProvider } from '../components/me'
 import PlausibleProvider from 'next-plausible'
 import getApolloClient from '../lib/apollo'
 import { PriceProvider } from '../components/price'
+import { BlockHeightProvider } from '../components/block-height'
 import Head from 'next/head'
 import { useRouter } from 'next/dist/client/router'
 import { useEffect } from 'react'
@@ -92,7 +93,9 @@ function MyApp ({ Component, pageProps: { ...props } }) {
                   <LightningProvider>
                     <ToastProvider>
                       <ShowModalProvider>
-                        <Component ssrData={ssrData} {...otherProps} />
+                        <BlockHeightProvider>
+                          <Component ssrData={ssrData} {...otherProps} />
+                        </BlockHeightProvider>
                       </ShowModalProvider>
                     </ToastProvider>
                   </LightningProvider>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -74,7 +74,7 @@ function MyApp ({ Component, pageProps: { ...props } }) {
     If we are on the client, we populate the apollo cache with the
     ssr data
   */
-  const { apollo, ssrData, me, price, ...otherProps } = props
+  const { apollo, ssrData, me, price, blockHeight, ...otherProps } = props
   useEffect(() => {
     writeQuery(client, apollo, ssrData)
   }, [client, apollo, ssrData])
@@ -93,7 +93,7 @@ function MyApp ({ Component, pageProps: { ...props } }) {
                   <LightningProvider>
                     <ToastProvider>
                       <ShowModalProvider>
-                        <BlockHeightProvider>
+                        <BlockHeightProvider blockHeight={blockHeight}>
                           <Component ssrData={ssrData} {...otherProps} />
                         </BlockHeightProvider>
                       </ShowModalProvider>


### PR DESCRIPTION
Source the current block height from [mempool.space API](https://mempool.space/docs/api/rest#get-block-tip-height)

The price carousel now shows (in order):
1. price per BTC in fiat
2. sats per fiat unit
3. 1sat=1sat
4. current block height (I am open to feedback on how to present this number in the carousel)

<img width="810" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/105a1502-7358-4f8f-8fe7-bd732e51a319">


Closes #435