### PR TITLE
made Item.depth nullable

### DIFF
--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -77,7 +77,7 @@ export default gql`
     root: Item
     user: User!
     userId: Int!
-    depth: Int!
+    depth: Int
     mine: Boolean!
     boost: Int!
     bounty: Int


### PR DESCRIPTION
Quickfix for the following issue by changing the depth field to Int from Int! in the item.js typeDef
https://github.com/stackernews/stacker.news/issues/492