### PR TITLE
Format bounty sats with separators

### DIFF
--- a/components/item-full.js
+++ b/components/item-full.js
@@ -150,7 +150,7 @@ function TopLevelItem ({ item, noReply, ...props }) {
                 </div>)
               : (
                 <div className='px-3 py-1 d-inline-block bg-grey-darkmode rounded text-light'>
-                  {numWithUnits(item.bounty, { abbreviate: false })} bounty
+                  {numWithUnits(item.bounty, { abbreviate: false, format: true })} bounty
                 </div>)}
           </div>}
       </div>

--- a/lib/format.js
+++ b/lib/format.js
@@ -15,16 +15,18 @@ export const abbrNum = n => {
  * @param opts.abbreviate Whether to abbreviate the number
  * @param opts.unitSingular The singular unit label
  * @param opts.unitPlural The plural unit label
+ * @param opts.format Format the number with `Intl.NumberFormat`. Can only be used if `abbreviate` is false
  */
 export const numWithUnits = (n, {
   abbreviate = true,
   unitSingular = 'sat',
-  unitPlural = 'sats'
+  unitPlural = 'sats',
+  format = false
 } = {}) => {
   if (isNaN(n)) {
     return `${n} ${unitPlural}`
   }
-  return `${abbreviate ? abbrNum(n) : n} ${n === 1 ? unitSingular : unitPlural}`
+  return `${abbreviate ? abbrNum(n) : format ? new Intl.NumberFormat().format(n) : n} ${n === 1 ? unitSingular : unitPlural}`
 }
 
 export const fixedDecimal = (n, f) => {


### PR DESCRIPTION
Introduce `format` option on `numWithUnits` fn, consumed by bounty listing. Format option is disabled by default, and only applicable when `abbreviate` is `false`.

Uses [`Intl.NumberFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat), so it should honor each user's browser locale settings automatically.

Inspired by [this](https://stacker.news/items/255020/r/WeAreAllSatoshi) thread.

Can be used elsewhere in the codebase, but this is the place of inspiration, so I only adopted it here.

<img width="589" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/e7d4ca5e-cb0b-4008-99fb-53e103e0e8be">
