### PR TITLE
Add search hints to initial search page

### DIFF
--- a/pages/~/search.js
+++ b/pages/~/search.js
@@ -3,6 +3,7 @@ import { getGetServerSideProps } from '../../api/ssrApollo'
 import { useRouter } from 'next/router'
 import { SUB_SEARCH } from '../../fragments/subs'
 import Items from '../../components/items'
+import styles from './search.module.css'
 
 export const getServerSideProps = getGetServerSideProps({
   query: SUB_SEARCH,
@@ -24,9 +25,23 @@ export default function Index ({ ssrData }) {
             noMoreText='NO MORE'
           />
         : (
-          <div className='text-muted text-center mt-5' style={{ fontFamily: 'lightning', fontSize: '2rem', opacity: '0.75' }}>
-            search for something
-          </div>)}
+          <div className={styles.content}>
+            <div className={styles.box}>
+              <div className={styles.header}>
+                <div className='text-muted text-center' style={{ fontFamily: 'lightning', fontSize: '2rem', opacity: '0.75' }}>
+                  more filters
+                </div>
+              </div>
+              <div className={styles.body}>
+                <div className={styles.inner}>
+                  <div><b>nym:</b>&#8203;<em>sn</em> - limit results by stacker nym</div>
+                  <div><b>url:</b>&#8203;<em>stacker&#8203;.news</em> - limit to specific site</div>
+                  <div><b>~</b><em>bitcoin</em> - limit results to specific sub</div>
+                </div>
+              </div>
+            </div>
+          </div>
+          )}
     </SearchLayout>
   )
 }

--- a/pages/~/search.js
+++ b/pages/~/search.js
@@ -36,7 +36,7 @@ export default function Index ({ ssrData }) {
                 <div className={styles.inner}>
                   <div><b>nym:</b>&#8203;<em>sn</em> - limit results by stacker nym</div>
                   <div><b>url:</b>&#8203;<em>stacker&#8203;.news</em> - limit to specific site</div>
-                  <div><b>~</b><em>bitcoin</em> - limit results to specific sub</div>
+                  <div>you are searching <em>{variables.sub || 'home'}</em><br /><em>home</em> searches show results from all</div>
                 </div>
               </div>
             </div>

--- a/pages/~/search.module.css
+++ b/pages/~/search.module.css
@@ -1,0 +1,29 @@
+.content {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+}
+.box {
+  border: 1px solid var(--theme-borderColor);
+  border-radius: 10px;
+  box-shadow: 2px 2px 10px var(--theme-borderColor);
+  min-width: 50%;
+  display: flex;
+  flex-direction: column;
+}
+.header {
+  border-bottom: 1px solid var(--theme-borderColor);
+}
+.body {
+  display: flex;
+  align-self: center;
+}
+.inner {
+  padding: 0.5rem 0;
+  display: flex;
+  flex-direction: column;
+}
+.inner > div {
+  padding: 5px 2rem;
+}


### PR DESCRIPTION
This is to address issue #274.

![Untitled](https://github.com/stackernews/stacker.news/assets/101502594/70642b6a-1396-4eb5-b713-5b40ca03984a)

(The ~sub syntax didn't seem to work for me...note to self to check into it.)