### PR TITLE
Implementing LUD-12 comments on payRequest in LNURLP Lightning Address flow (sending and receiving)

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -259,7 +259,7 @@ export default {
 
         const [inv] = await serialize(models,
           models.$queryRaw`SELECT * FROM create_invoice(${invoice.id}, ${invoice.request},
-            ${expiresAt}::timestamp, ${amount * 1000}, ${user.id}::INTEGER, ${description},
+            ${expiresAt}::timestamp, ${amount * 1000}, ${user.id}::INTEGER, ${description}, NULL,
             ${invLimit}::INTEGER, ${balanceLimit})`)
 
         if (hodlInvoice) await models.invoice.update({ where: { hash: invoice.id }, data: { preimage: invoice.secret } })

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -91,6 +91,8 @@ export default {
               WHEN "expiresAt" <= $2 THEN 'EXPIRED'
               WHEN cancelled THEN 'CANCELLED'
               ELSE 'PENDING' END as status,
+              "desc" as description,
+            comment as "invoiceComment",
           'invoice' as type
           FROM "Invoice"
           WHERE "userId" = $1
@@ -105,6 +107,8 @@ export default {
           CASE WHEN status = 'CONFIRMED' THEN "msatsFeePaid"
           ELSE "msatsFeePaying" END as "msatsFee",
           COALESCE(status::text, 'PENDING') as status,
+          NULL as description,
+          NULL as "invoiceComment",
           'withdrawal' as type
           FROM "Withdrawl"
           WHERE "userId" = $1
@@ -129,6 +133,8 @@ export default {
             ) AS "msats",
             0 AS "msatsFee",
             NULL AS status,
+            NULL as description,
+            NULL as "invoiceComment",
             'stacked' AS type
           FROM "ItemAct"
           JOIN "Item" ON "ItemAct"."itemId" = "Item".id
@@ -142,14 +148,14 @@ export default {
         queries.push(
             `(SELECT ('earn' || min("Earn".id)) as id, min("Earn".id) as "factId", NULL as bolt11,
             created_at as "createdAt", sum(msats),
-            0 as "msatsFee", NULL as status, 'earn' as type
+            0 as "msatsFee", NULL as status, NULL as description, NULL as "invoiceComment", 'earn' as type
             FROM "Earn"
             WHERE "Earn"."userId" = $1 AND "Earn".created_at <= $2
             GROUP BY "userId", created_at)`)
         queries.push(
             `(SELECT ('referral' || "ReferralAct".id) as id, "ReferralAct".id as "factId", NULL as bolt11,
             created_at as "createdAt", msats,
-            0 as "msatsFee", NULL as status, 'referral' as type
+            0 as "msatsFee", NULL as status, NULL as description, NULL as "invoiceComment", 'referral' as type
             FROM "ReferralAct"
             WHERE "ReferralAct"."referrerId" = $1 AND "ReferralAct".created_at <= $2)`)
       }
@@ -158,7 +164,7 @@ export default {
         queries.push(
           `(SELECT ('spent' || "Item".id) as id, "Item".id as "factId", NULL as bolt11,
           MAX("ItemAct".created_at) as "createdAt", sum("ItemAct".msats) as msats,
-          0 as "msatsFee", NULL as status, 'spent' as type
+          0 as "msatsFee", NULL as status, NULL as description, NULL as "invoiceComment", 'spent' as type
           FROM "ItemAct"
           JOIN "Item" on "ItemAct"."itemId" = "Item".id
           WHERE "ItemAct"."userId" = $1
@@ -167,7 +173,7 @@ export default {
         queries.push(
             `(SELECT ('donation' || "Donation".id) as id, "Donation".id as "factId", NULL as bolt11,
             created_at as "createdAt", sats * 1000 as msats,
-            0 as "msatsFee", NULL as status, 'donation' as type
+            0 as "msatsFee", NULL as status, NULL as description, NULL as "invoiceComment", 'donation' as type
             FROM "Donation"
             WHERE "userId" = $1
             AND created_at <= $2)`)
@@ -193,6 +199,7 @@ export default {
             const { tags } = inv
             for (const tag of tags) {
               if (tag.tagName === 'description') {
+                // prioritize description from bolt11 over description from our DB
                 f.description = tag.data
                 break
               }

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -11,7 +11,7 @@ export default gql`
   extend type Mutation {
     createInvoice(amount: Int!, expireSecs: Int, hodlInvoice: Boolean): Invoice!
     createWithdrawl(invoice: String!, maxFee: Int!): Withdrawl!
-    sendToLnAddr(addr: String!, amount: Int!, maxFee: Int!): Withdrawl!
+    sendToLnAddr(addr: String!, amount: Int!, maxFee: Int!, comment: String): Withdrawl!
     cancelInvoice(hash: String!, hmac: String!): Invoice!
   }
 

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -53,6 +53,7 @@ export default gql`
     type: String!
     description: String
     item: Item
+    invoiceComment: String
   }
 
   type History {

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -26,6 +26,7 @@ export default gql`
     satsReceived: Int
     satsRequested: Int!
     nostr: JSONObject
+    comment: String
     hmac: String
     isHeld: Boolean
   }

--- a/components/form.js
+++ b/components/form.js
@@ -486,9 +486,11 @@ export function Form ({
   initial, schema, onSubmit, children, initialError, validateImmediately, storageKeyPrefix, validateOnChange = true, invoiceable, ...props
 }) {
   const toaster = useToast()
+  const initialErrorToasted = useRef(false)
   useEffect(() => {
-    if (initialError) {
+    if (initialError && !initialErrorToasted) {
       toaster.danger(initialError.message || initialError.toString?.())
+      initialErrorToasted.current = true
     }
   }, [])
 

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -241,6 +241,7 @@ function InvoicePaid ({ n }) {
     <div className='fw-bold text-info ms-2 py-1'>
       <Check className='fill-info me-1' />{numWithUnits(n.earnedSats, { abbreviate: false })} were deposited in your account
       <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.sortTime))}</small>
+      {n.invoice.comment && <small className='d-block ms-4 ps-1 mt-1 mb-1 text-muted fw-normal'><Text>{n.invoice.comment}</Text></small>}
     </div>
   )
 }

--- a/fragments/notifications.js
+++ b/fragments/notifications.js
@@ -99,6 +99,7 @@ export const NOTIFICATIONS = gql`
           invoice {
             id
             nostr
+            comment
           }
         }
       }

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -62,8 +62,8 @@ export const CREATE_WITHDRAWL = gql`
 }`
 
 export const SEND_TO_LNADDR = gql`
-  mutation sendToLnAddr($addr: String!, $amount: Int!, $maxFee: Int!) {
-    sendToLnAddr(addr: $addr, amount: $amount, maxFee: $maxFee) {
+  mutation sendToLnAddr($addr: String!, $amount: Int!, $maxFee: Int!, $comment: String) {
+    sendToLnAddr(addr: $addr, amount: $amount, maxFee: $maxFee, comment: $comment) {
       id
     }
 }`

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -44,6 +44,7 @@ export const WALLET_HISTORY = gql`
         status
         type
         description
+        invoiceComment
         item {
           ...ItemFullFields
         }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -52,5 +52,6 @@ module.exports = {
   ANON_POST_FEE: 1000,
   ANON_COMMENT_FEE: 100,
   SSR: typeof window === 'undefined',
-  MAX_FORWARDS: 5
+  MAX_FORWARDS: 5,
+  LNURLP_COMMENT_MAX_LENGTH: 1000
 }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -242,7 +242,8 @@ export const withdrawlSchema = object({
 export const lnAddrSchema = object({
   addr: string().email('address is no good').required('required'),
   amount: intValidator.required('required').positive('must be positive'),
-  maxFee: intValidator.required('required').min(0, 'must be at least 0')
+  maxFee: intValidator.required('required').min(0, 'must be at least 0'),
+  comment: string()
 })
 
 export const bioSchema = object({

--- a/pages/api/lnurlp/[username]/index.js
+++ b/pages/api/lnurlp/[username]/index.js
@@ -1,6 +1,7 @@
 import { getPublicKey } from 'nostr'
 import models from '../../../../api/models'
 import { lnurlPayMetadataString } from '../../../../lib/lnurl'
+import { LNURLP_COMMENT_MAX_LENGTH } from '../../../../lib/constants'
 
 export default async ({ query: { username } }, res) => {
   const user = await models.user.findUnique({ where: { name: username } })
@@ -13,8 +14,9 @@ export default async ({ query: { username } }, res) => {
     minSendable: 1000, // Min amount LN SERVICE is willing to receive, can not be less than 1 or more than `maxSendable`
     maxSendable: 1000000000,
     metadata: lnurlPayMetadataString(username), // Metadata json which must be presented as raw string here, this is required to pass signature verification at a later step
+    commentAllowed: LNURLP_COMMENT_MAX_LENGTH, // LUD-12 Comments for payRequests https://github.com/lnurl/luds/blob/luds/12.md
     tag: 'payRequest', // Type of LNURL
-    nostrPubkey: getPublicKey(process.env.NOSTR_PRIVATE_KEY),
-    allowsNostr: true
+    nostrPubkey: process.env.NOSTR_PRIVATE_KEY ? getPublicKey(process.env.NOSTR_PRIVATE_KEY) : undefined,
+    allowsNostr: !!process.env.NOSTR_PRIVATE_KEY
   })
 }

--- a/pages/satistics.js
+++ b/pages/satistics.js
@@ -111,7 +111,14 @@ function Detail ({ fact }) {
     return (
       <div className='px-3'>
         <Link className={satusClass(fact.status)} href={`/${fact.type}s/${fact.factId}`}>
-          {fact.description || 'no invoice description'}
+          {fact.description && fact.invoiceComment &&
+            <>
+              <div>{fact.description}</div>
+              <div>Payer comment: {fact.invoiceComment}</div>
+            </>}
+          {fact.description && !fact.invoiceComment && <div>{fact.description}</div>}
+          {!fact.description && fact.invoiceComment && <div>Payer comment: {fact.invoiceComment}</div>}
+          {!fact.description && !fact.invoiceComment && 'no invoice description'}
           <Satus status={fact.status} />
         </Link>
       </div>

--- a/pages/satistics.js
+++ b/pages/satistics.js
@@ -111,14 +111,9 @@ function Detail ({ fact }) {
     return (
       <div className='px-3'>
         <Link className={satusClass(fact.status)} href={`/${fact.type}s/${fact.factId}`}>
-          {fact.description && fact.invoiceComment &&
-            <>
-              <div>{fact.description}</div>
-              <div>Payer comment: {fact.invoiceComment}</div>
-            </>}
-          {fact.description && !fact.invoiceComment && <div>{fact.description}</div>}
-          {!fact.description && fact.invoiceComment && <div>Payer comment: {fact.invoiceComment}</div>}
-          {!fact.description && !fact.invoiceComment && 'no invoice description'}
+          {fact.description && <span className='d-block'>{fact.description}</span>}
+          {fact.invoiceComment && <small className='text-muted'>sender says: {fact.invoiceComment}</small>}
+          {!fact.invoiceComment && !fact.description && <span className='d-block'>no description</span>}
           <Satus status={fact.status} />
         </Link>
       </div>

--- a/pages/wallet.js
+++ b/pages/wallet.js
@@ -324,7 +324,6 @@ export function LnAddrWithdrawal () {
           label='amount'
           name='amount'
           required
-          autoFocus
           append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
         />
         <Input
@@ -334,7 +333,7 @@ export function LnAddrWithdrawal () {
           append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
         />
         <Input
-          label='comment (optional)'
+          label={<>comment <small className='text-muted ms-2'>optional</small></>}
           name='comment'
           hint='only certain lightning addresses can accept comments, and only of a certain length'
         />

--- a/pages/wallet.js
+++ b/pages/wallet.js
@@ -304,12 +304,13 @@ export function LnAddrWithdrawal () {
         initial={{
           addr: '',
           amount: 1,
-          maxFee: 10
+          maxFee: 10,
+          comment: ''
         }}
         schema={lnAddrSchema}
         initialError={error ? error.toString() : undefined}
-        onSubmit={async ({ addr, amount, maxFee }) => {
-          const { data } = await sendToLnAddr({ variables: { addr, amount: Number(amount), maxFee: Number(maxFee) } })
+        onSubmit={async ({ addr, amount, maxFee, comment }) => {
+          const { data } = await sendToLnAddr({ variables: { addr, amount: Number(amount), maxFee: Number(maxFee), comment } })
           router.push(`/withdrawals/${data.sendToLnAddr.id}`)
         }}
       >
@@ -331,6 +332,11 @@ export function LnAddrWithdrawal () {
           name='maxFee'
           required
           append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
+        />
+        <Input
+          label='comment (optional)'
+          name='comment'
+          hint='only certain lightning addresses can accept comments, and only of a certain length'
         />
         <SubmitButton variant='success' className='mt-2'>send</SubmitButton>
       </Form>

--- a/prisma/migrations/20230915234627_lnaddr_pay_comments/migration.sql
+++ b/prisma/migrations/20230915234627_lnaddr_pay_comments/migration.sql
@@ -1,0 +1,45 @@
+-- AlterTable
+ALTER TABLE "Invoice" ADD COLUMN     "comment" TEXT;
+
+-- Add comment parameter to invoice creation
+CREATE OR REPLACE FUNCTION create_invoice(hash TEXT, bolt11 TEXT, expires_at timestamp(3) without time zone,
+    msats_req BIGINT, user_id INTEGER, idesc TEXT, comment TEXT, inv_limit INTEGER, balance_limit_msats BIGINT)
+RETURNS "Invoice"
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    invoice "Invoice";
+    inv_limit_reached BOOLEAN;
+    balance_limit_reached BOOLEAN;
+    inv_pending_msats BIGINT;
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    -- prevent too many pending invoices
+    SELECT inv_limit > 0 AND count(*) >= inv_limit, sum("msatsRequested") INTO inv_limit_reached, inv_pending_msats
+    FROM "Invoice"
+    WHERE "userId" = user_id AND "expiresAt" > now_utc() AND "confirmedAt" IS NULL AND cancelled = false;
+
+    IF inv_limit_reached THEN
+        RAISE EXCEPTION 'SN_INV_PENDING_LIMIT';
+    END IF;
+
+    -- prevent pending invoices + msats from exceeding the limit
+    SELECT balance_limit_msats > 0 AND inv_pending_msats+msats_req+msats > balance_limit_msats INTO balance_limit_reached
+    FROM users
+    WHERE id = user_id;
+
+    IF balance_limit_reached THEN
+        RAISE EXCEPTION 'SN_INV_EXCEED_BALANCE';
+    END IF;
+
+    -- we good, proceed frens
+    INSERT INTO "Invoice" (hash, bolt11, "expiresAt", "msatsRequested", "userId", created_at, updated_at, "desc", comment)
+    VALUES (hash, bolt11, expires_at, msats_req, user_id, now_utc(), now_utc(), idesc, comment) RETURNING * INTO invoice;
+
+    INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter)
+    VALUES ('checkInvoice', jsonb_build_object('hash', hash), 21, true, now() + interval '10 seconds');
+
+    RETURN invoice;
+END;
+$$;

--- a/prisma/migrations/20230915234627_lnaddr_pay_comments/migration.sql
+++ b/prisma/migrations/20230915234627_lnaddr_pay_comments/migration.sql
@@ -43,3 +43,7 @@ BEGIN
     RETURN invoice;
 END;
 $$;
+
+-- make sure old function is gone
+DROP FUNCTION IF EXISTS create_invoice(hash TEXT, bolt11 TEXT, expires_at timestamp(3) without time zone,
+    msats_req BIGINT, user_id INTEGER, idesc TEXT, inv_limit INTEGER, balance_limit_msats BIGINT);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -434,6 +434,7 @@ model Invoice {
   msatsRequested BigInt
   msatsReceived  BigInt?
   desc           String?
+  comment        String?
   user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([createdAt], map: "Invoice.created_at_index")


### PR DESCRIPTION
Related to #230 

This PR enhances SN on the receiving end to support comments when someone sends to a user@stacker.news lightning address.

It also enhances the withdraw to lightning address flow _from_ SN to allow comments to be included, if the lightning address provider supports them.

Sample wallet history UI:
<img width="765" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/6ef0a58a-4ba9-471a-90de-011809c5a35c">
