### PR TITLE
Verify invoice amount in lightning address withdrawal

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -313,6 +313,9 @@ export default {
         throw new Error('description hash does not match')
       }
 
+      if (!decoded.mtokens || BigInt(decoded.mtokens) !== BigInt(milliamount)) {
+        throw new Error('invoice has incorrect amount')
+      }
       // take pr and createWithdrawl
       return await createWithdrawal(parent, { invoice: res2.pr, maxFee }, { me, models, lnd })
     },

--- a/contributors.txt
+++ b/contributors.txt
@@ -4,3 +4,4 @@ ekzyis
 WeAreAllSatoshi
 rleed
 bitcoinplebdev
+benthecarman


### PR DESCRIPTION
Not sure how to test, but looking at the `decodePaymentRequest` docs this looks correct.