### PR TITLE
FIX #499 - nostr: URIs doesn't work in bio

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -5,7 +5,7 @@ import { LightAsync as SyntaxHighlighter } from 'react-syntax-highlighter'
 import atomDark from 'react-syntax-highlighter/dist/cjs/styles/prism/atom-dark'
 import mention from '../lib/remark-mention'
 import sub from '../lib/remark-sub'
-import remarkDirective from 'remark-directive'
+// import remarkDirective from 'remark-directive'
 import { visit } from 'unist-util-visit'
 import reactStringReplace from 'react-string-replace'
 import React, { useRef, useEffect, useState, memo } from 'react'
@@ -187,7 +187,8 @@ export default memo(function Text ({ topLevel, noFragments, nofollow, fetchOnlyI
             return <ZoomableImage topLevel={topLevel} useClickToLoad={fetchOnlyImgProxy} {...props} />
           }
         }}
-        remarkPlugins={[gfm, mention, sub, remarkDirective, searchHighlighter]}
+        // plugin remarkDirective removed, see https://github.com/stackernews/stacker.news/issues/499
+        remarkPlugins={[gfm, mention, sub, searchHighlighter]}
       >
         {children}
       </ReactMarkdown>


### PR DESCRIPTION
This PR removes `remarkDirective` plugin from `text.js` component.

According to issue #499 on Github, text patterns starting with a colon `:` were removed from rendered Markdown.

This is partly expected, since the plugin works for expressions conforming to [generic directives proposal](https://talk.commonmark.org/t/generic-directives-plugins-syntax/444), for example `:cite[smith04]`. However, if the pattern is incomplete, it fails and text doesn't appear.

If this plugin cannot be removed temporarily, its behaviour could be fixed on a plugin fork, as suggestion.