### PR TITLE
Toast success and danger for donate action

### DIFF
--- a/pages/rewards/index.js
+++ b/pages/rewards/index.js
@@ -14,6 +14,7 @@ import PageLoading from '../../components/page-loading'
 import { useShowModal } from '../../components/modal'
 import dynamic from 'next/dynamic'
 import { SSR } from '../../lib/constants'
+import { useToast } from '../../components/toast'
 
 const GrowthPieChart = dynamic(() => import('../../components/charts').then(mod => mod.GrowthPieChart), {
   loading: () => <div>Loading...</div>
@@ -88,6 +89,7 @@ export default function Rewards ({ ssrData }) {
 
 export function DonateButton () {
   const showModal = useShowModal()
+  const toaster = useToast()
   const [donateToRewards] = useMutation(
     gql`
       mutation donateToRewards($sats: Int!) {
@@ -103,12 +105,18 @@ export function DonateButton () {
           }}
           schema={amountSchema}
           onSubmit={async ({ amount }) => {
-            await donateToRewards({
-              variables: {
-                sats: Number(amount)
-              }
-            })
-            onClose()
+            try {
+              await donateToRewards({
+                variables: {
+                  sats: Number(amount)
+                }
+              })
+              onClose()
+              toaster.success('donated')
+            } catch (err) {
+              console.error(err)
+              toaster.danger('failed to donate')
+            }
           }}
         >
           <Input


### PR DESCRIPTION
Danger case was already handled by the common `Form` component, but success wasn't toasted. I like having feedback on actions like this one.

Now, the danger toast message is also specific to the donate action, and not just the underlying JS error that occurred (which is logged, instead).

<img width="549" alt="sn-donate-success-toast" src="https://github.com/stackernews/stacker.news/assets/128755788/e06a403e-5458-4e80-8e4a-6915c96b2c50">

<img width="689" alt="sn-donate-danger-toast" src="https://github.com/stackernews/stacker.news/assets/128755788/e6c30447-5454-47e7-81b4-ec26a59aeab0">
