### PR TITLE
fix singular/plural for invoice deposit notification

### DIFF
--- a/components/notifications.js
+++ b/components/notifications.js
@@ -239,7 +239,7 @@ function NostrZap ({ n }) {
 function InvoicePaid ({ n }) {
   return (
     <div className='fw-bold text-info ms-2 py-1'>
-      <Check className='fill-info me-1' />{numWithUnits(n.earnedSats, { abbreviate: false })} were deposited in your account
+      <Check className='fill-info me-1' />{numWithUnits(n.earnedSats, { abbreviate: false, unitSingular: 'sat was', unitPlural: 'sats were' })} deposited in your account
       <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.sortTime))}</small>
       {n.invoice.comment && <small className='d-block ms-4 ps-1 mt-1 mb-1 text-muted fw-normal'><Text>{n.invoice.comment}</Text></small>}
     </div>


### PR DESCRIPTION
`1 sat was deposited`, `2 sats were deposited`, etc.

I found this while testing LUD-12 with a 1-sat invoice :P 