### PR TITLE
Fix image detection in client not decoding original URL

### DIFF
--- a/components/image.js
+++ b/components/image.js
@@ -38,7 +38,10 @@ export function useImgUrlCache (text, { imgproxyUrls, tab }) {
     const urls = extractUrls(text)
 
     urls.forEach((url) => {
-      if (IMG_URL_REGEXP.test(url) || !!imgproxyUrls?.[url]) {
+      let processedAsImage = !!imgproxyUrls?.[url]
+      url = IMGPROXY_URL_REGEXP.test(url) ? decodeOriginalUrl(url) : url
+      processedAsImage ||= !!imgproxyUrls?.[url]
+      if (IMG_URL_REGEXP.test(url) || processedAsImage) {
         // it's probably an image if the regexp matches or if we processed the URL as an image in the worker
         updateCache(url, IMG_CACHE_STATES.LOADED)
       } else {

--- a/components/text.js
+++ b/components/text.js
@@ -108,8 +108,8 @@ export default memo(function Text ({ topLevel, noFragments, nofollow, imgproxyUr
               return <>{children}</>
             }
 
-            if (imgUrlCache[href] === IMG_CACHE_STATES.LOADED) {
-              const url = IMGPROXY_URL_REGEXP.test(href) ? decodeOriginalUrl(href) : href
+            const url = IMGPROXY_URL_REGEXP.test(href) ? decodeOriginalUrl(href) : href
+            if (imgUrlCache[url] === IMG_CACHE_STATES.LOADED) {
               // if `srcSet` is undefined, it means the image was not processed by worker yet
               // if `srcSet` is null, image was processed but this specific url was not detected as an image by the worker
               const srcSet = imgproxyUrls ? (imgproxyUrls[url] || null) : undefined


### PR DESCRIPTION
The worker is decoding proxy URLs to use the original URL since we want to process the original images, not already processed images. It then uses the original URL as the key to save the signed proxy URLs.

The client however does not do this. So for proxy URLs, this check always fails since the worker never uses proxy URLs as the key.

This commit fixes that during populating the image cache and when querying it.
