### PR TITLE
Fix image not centered in fullscreen on Firefox

### DIFF
--- a/components/image.js
+++ b/components/image.js
@@ -120,7 +120,7 @@ export function ZoomableImage ({ src, topLevel, srcSet: srcSetObj, tab, ...props
 
   const handleClick = useCallback(() => showModal(close => (
     <div
-      className='d-grid w-100 h-100' style={{ placeContent: 'center' }} onClick={close}
+      className='d-flex w-100 h-100' style={{ placeContent: 'center' }} onClick={close}
     >
       <img
         style={{ cursor: 'zoom-out', maxWidth: '100%', maxHeight: '100%', minHeight: 0, minWidth: 0 }}


### PR DESCRIPTION
Fix #539

For some reason, using `display: flex` on the container instead of `display: grid` fixes this.

No visible changes on Brave.

_`display: grid` on Firefox (Gecko):_
![2023-10-02-222020_1920x1080_scrot](https://github.com/stackernews/stacker.news/assets/27162016/e438abd8-19e0-490e-b300-767b724e357c)

_`display: flex` on Firefox (Gecko):_
![2023-10-02-222044_1920x1080_scrot](https://github.com/stackernews/stacker.news/assets/27162016/bbdb71b2-5955-43b0-928d-abe818bd4dc9)

_`display: grid` on Brave (Blink):_
![2023-10-02-222128_1920x1080_scrot](https://github.com/stackernews/stacker.news/assets/27162016/626981f3-248c-4bc5-b329-58e2334b1012)

_`display: flex` on Brave (Blink):_
![2023-10-02-222142_1920x1080_scrot](https://github.com/stackernews/stacker.news/assets/27162016/28e3cf86-cfaf-4936-b415-bdc3d725dc62)

Was there a reason you used `display: grid` @huumn ? Or just an artifact?