### PR TITLE
Image refactor refactor

### DIFF
--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -23,7 +23,7 @@ export default gql`
     setSettings(tipDefault: Int!, turboTipping: Boolean!, fiatCurrency: String!, noteItemSats: Boolean!,
       noteEarning: Boolean!, noteAllDescendants: Boolean!, noteMentions: Boolean!, noteDeposits: Boolean!,
       noteInvites: Boolean!, noteJobIndicator: Boolean!, noteCowboyHat: Boolean!, hideInvoiceDesc: Boolean!,
-      hideFromTopUsers: Boolean!, hideCowboyHat: Boolean!, clickToLoadImg: Boolean!,
+      hideFromTopUsers: Boolean!, hideCowboyHat: Boolean!, imgproxyOnly: Boolean!,
       wildWestMode: Boolean!, greeterMode: Boolean!, nostrPubkey: String, nostrRelays: [String!], hideBookmarks: Boolean!,
       noteForwardedSats: Boolean!, hideWalletBalance: Boolean!, hideIsContributor: Boolean!, diagnostics: Boolean!): User
     setPhoto(photoId: ID!): Int!
@@ -89,7 +89,7 @@ export default gql`
     hideWelcomeBanner: Boolean!
     hideWalletBalance: Boolean!
     diagnostics: Boolean!
-    clickToLoadImg: Boolean!
+    imgproxyOnly: Boolean!
     wildWestMode: Boolean!
     greeterMode: Boolean!
     lastCheckedJobs: String

--- a/components/image.js
+++ b/components/image.js
@@ -32,7 +32,6 @@ function ImageOriginal ({ src, topLevel, nofollow, tab, children, onClick, ...pr
   }, [src, showImage])
 
   if (showImage && (tab === 'preview' || !me?.clickToLoadImg)) {
-    // image is still processing and user is okay with loading original url automatically
     return (
       <img
         className={topLevel ? styles.topLevel : undefined}
@@ -42,7 +41,7 @@ function ImageOriginal ({ src, topLevel, nofollow, tab, children, onClick, ...pr
       />
     )
   } else {
-    // image is still processing or user is not okay with loading original url automatically
+    // user is not okay with loading original url automatically or there was an error loading the image
     return (
       <a
         target='_blank'

--- a/components/image.js
+++ b/components/image.js
@@ -42,12 +42,16 @@ function ImageOriginal ({ src, topLevel, nofollow, tab, children, onClick, ...pr
     )
   } else {
     // user is not okay with loading original url automatically or there was an error loading the image
+
+    // If element parsed by markdown is a raw URL, we use src as the text to not mislead users.
+    // This will not be the case if [text](url) format is used. Then we will show what was chosen as text.
+    const isRawURL = /^https?:\/\//.test(children?.[0])
     return (
       <a
         target='_blank'
         rel={`noreferrer ${nofollow ? 'nofollow' : ''} noopener`}
         href={src}
-      >{src}
+      >{isRawURL ? src : children}
       </a>
     )
   }

--- a/components/image.js
+++ b/components/image.js
@@ -89,8 +89,8 @@ function ImageProxy ({ src, srcSet: srcSetObj, onClick, topLevel, onError, ...pr
 export function ZoomableImage ({ src, srcSet, ...props }) {
   const showModal = useShowModal()
 
-  // if `srcSet` is undefined, it means the image was not processed by worker yet
-  const [imgproxy, setImgproxy] = useState(srcSet || IMGPROXY_URL_REGEXP.test(src))
+  // if `srcSet` is falsy, it means the image was not processed by worker yet
+  const [imgproxy, setImgproxy] = useState(!!srcSet || IMGPROXY_URL_REGEXP.test(src))
 
   // backwards compatibility:
   // src may already be imgproxy url since we used to replace image urls with imgproxy urls

--- a/components/image.js
+++ b/components/image.js
@@ -48,7 +48,7 @@ function ImageOriginal ({ src, topLevel, nofollow, tab, children, onClick, ...pr
         target='_blank'
         rel={`noreferrer ${nofollow ? 'nofollow' : ''} noopener`}
         href={src}
-      >{children || src}
+      >{src}
       </a>
     )
   }

--- a/components/image.js
+++ b/components/image.js
@@ -31,7 +31,7 @@ function ImageOriginal ({ src, topLevel, nofollow, tab, children, onClick, ...pr
     }
   }, [src, showImage])
 
-  if (showImage && (tab === 'preview' || !me?.clickToLoadImg)) {
+  if (showImage) {
     return (
       <img
         className={topLevel ? styles.topLevel : undefined}

--- a/components/image.js
+++ b/components/image.js
@@ -19,7 +19,7 @@ function ImageOriginal ({ src, topLevel, nofollow, tab, children, onClick, ...pr
   const [showImage, setShowImage] = useState(false)
 
   useEffect(() => {
-    if (me?.clickToLoadImg && tab !== 'preview') return
+    if (me?.imgproxyOnly && tab !== 'preview') return
     // make sure it's not a false negative by trying to load URL as <img>
     const img = new window.Image()
     img.onload = () => setShowImage(true)

--- a/components/text.js
+++ b/components/text.js
@@ -101,8 +101,6 @@ export default memo(function Text ({ nofollow, imgproxyUrls, children, tab, ...o
 
   const Img = useCallback(({ node, src, ...props }) => {
     const url = IMGPROXY_URL_REGEXP.test(src) ? decodeOriginalUrl(src) : src
-    // if `srcSet` is undefined, it means the image was not processed by worker yet
-    // if `srcSet` is null, image was processed but this specific url was not detected as an image by the worker
     const srcSet = imgproxyUrls?.[url]
     return <ZoomableImage srcSet={srcSet} tab={tab} src={src} {...props} {...outerProps} />
   }, [imgproxyUrls, outerProps, tab])

--- a/components/text.js
+++ b/components/text.js
@@ -124,6 +124,13 @@ export default memo(function Text ({ nofollow, imgproxyUrls, children, tab, ...o
               return <>{children}</>
             }
 
+            // If [text](url) was parsed as <a> and text is not empty and not a link itself,
+            // we don't render it as an image since it was probably a concious choice to include text.
+            const text = children?.[0]
+            if (!!text && !/^https?:\/\//.test(text)) {
+              return <a target='_blank' rel={`noreferrer ${nofollow ? 'nofollow' : ''} noopener`} href={href}>{text}</a>
+            }
+
             // assume the link is an image which will fallback to link if it's not
             return <Img src={href} nofollow={nofollow} {...props}>{children}</Img>
           },

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -30,7 +30,7 @@ export const ME = gql`
       hideInvoiceDesc
       hideFromTopUsers
       hideCowboyHat
-      clickToLoadImg
+      imgproxyOnly
       diagnostics
       wildWestMode
       greeterMode
@@ -61,7 +61,7 @@ export const SETTINGS_FIELDS = gql`
     hideCowboyHat
     hideBookmarks
     hideIsContributor
-    clickToLoadImg
+    imgproxyOnly
     hideWalletBalance
     diagnostics
     nostrPubkey
@@ -91,14 +91,14 @@ ${SETTINGS_FIELDS}
 mutation setSettings($tipDefault: Int!, $turboTipping: Boolean!, $fiatCurrency: String!, $noteItemSats: Boolean!,
   $noteEarning: Boolean!, $noteAllDescendants: Boolean!, $noteMentions: Boolean!, $noteDeposits: Boolean!,
   $noteInvites: Boolean!, $noteJobIndicator: Boolean!, $noteCowboyHat: Boolean!, $hideInvoiceDesc: Boolean!,
-  $hideFromTopUsers: Boolean!, $hideCowboyHat: Boolean!, $clickToLoadImg: Boolean!,
+  $hideFromTopUsers: Boolean!, $hideCowboyHat: Boolean!, $imgproxyOnly: Boolean!,
   $wildWestMode: Boolean!, $greeterMode: Boolean!, $nostrPubkey: String, $nostrRelays: [String!], $hideBookmarks: Boolean!,
   $noteForwardedSats: Boolean!, $hideWalletBalance: Boolean!, $hideIsContributor: Boolean!, $diagnostics: Boolean!) {
   setSettings(tipDefault: $tipDefault, turboTipping: $turboTipping,  fiatCurrency: $fiatCurrency,
     noteItemSats: $noteItemSats, noteEarning: $noteEarning, noteAllDescendants: $noteAllDescendants,
     noteMentions: $noteMentions, noteDeposits: $noteDeposits, noteInvites: $noteInvites,
     noteJobIndicator: $noteJobIndicator, noteCowboyHat: $noteCowboyHat, hideInvoiceDesc: $hideInvoiceDesc,
-    hideFromTopUsers: $hideFromTopUsers, hideCowboyHat: $hideCowboyHat, clickToLoadImg: $clickToLoadImg,
+    hideFromTopUsers: $hideFromTopUsers, hideCowboyHat: $hideCowboyHat, imgproxyOnly: $imgproxyOnly,
     wildWestMode: $wildWestMode, greeterMode: $greeterMode, nostrPubkey: $nostrPubkey, nostrRelays: $nostrRelays, hideBookmarks: $hideBookmarks,
     noteForwardedSats: $noteForwardedSats, hideWalletBalance: $hideWalletBalance, hideIsContributor: $hideIsContributor, diagnostics: $diagnostics) {
       ...SettingsFields

--- a/pages/settings.js
+++ b/pages/settings.js
@@ -75,7 +75,7 @@ export default function Settings ({ ssrData }) {
             hideInvoiceDesc: settings?.hideInvoiceDesc,
             hideFromTopUsers: settings?.hideFromTopUsers,
             hideCowboyHat: settings?.hideCowboyHat,
-            clickToLoadImg: settings?.clickToLoadImg,
+            imgproxyOnly: settings?.imgproxyOnly,
             wildWestMode: settings?.wildWestMode,
             greeterMode: settings?.greeterMode,
             nostrPubkey: settings?.nostrPubkey ? bech32encode(settings.nostrPubkey) : '',
@@ -254,8 +254,8 @@ export default function Settings ({ ssrData }) {
               groupClassName='mb-0'
             />}
           <Checkbox
-            label={<>click to load external images</>}
-            name='clickToLoadImg'
+            label={<>only load images from proxy</>}
+            name='imgproxyOnly'
             groupClassName='mb-0'
           />
           <Checkbox

--- a/pages/settings.js
+++ b/pages/settings.js
@@ -254,7 +254,17 @@ export default function Settings ({ ssrData }) {
               groupClassName='mb-0'
             />}
           <Checkbox
-            label={<>only load images from proxy</>}
+            label={
+              <div className='d-flex align-items-center'>only load images from proxy
+                <Info>
+                  <ul className='fw-bold'>
+                    <li>only load images from our image proxy automatically</li>
+                    <li>this prevents IP address leaks to arbitrary sites</li>
+                    <li>if we fail to load an image, the raw link will be shown</li>
+                  </ul>
+                </Info>
+              </div>
+            }
             name='imgproxyOnly'
             groupClassName='mb-0'
           />

--- a/prisma/migrations/20231003134505_rename_to_imgproxy_only/migration.sql
+++ b/prisma/migrations/20231003134505_rename_to_imgproxy_only/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" RENAME COLUMN "clickToLoadImg" TO "imgproxyOnly";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,7 +50,7 @@ model User {
   fiatCurrency        String               @default("USD")
   hideFromTopUsers    Boolean              @default(false)
   turboTipping        Boolean              @default(false)
-  clickToLoadImg      Boolean              @default(false)
+  imgproxyOnly        Boolean              @default(false)
   hideWalletBalance   Boolean              @default(false)
   referrerId          Int?
   nostrPubkey         String?


### PR DESCRIPTION
- Removed comments about `srcSet` which no longer made sense
- Update comments in `<ImageOriginal>`
- Simplify condition when image is loaded in `<ImageOriginal>`
- Rename column from `clickToLoadImg` to `imgproxyOnly` since we no longer use clicking to bypass setting. We simply show the link for the user to click. (I also never liked the name of the setting)
- Add info about setting in /settings
- Fix misleading URL on imgproxy errors: I read [your comment here](https://github.com/stackernews/stacker.news/commit/62b53e1b3e5e57bcdce553bca7b4fb52075931a3#r129010564) and will make sure it supports markdown links, too