### PR TITLE
Fix quote selection reply in iOS Safari

### DIFF
--- a/docs/useful-dev-commands.md
+++ b/docs/useful-dev-commands.md
@@ -3,7 +3,7 @@
 ### `nvm use 18`
 Switch to use nodejs version 18 in your current shell
 
-### `docker-compose up -d`
+### `docker-compose up --build -d`
 Bring up stacker news app via local docker services
 
 ### `docker-compose down`


### PR DESCRIPTION
Approach borrowed from https://stackoverflow.com/a/72537632

I don't know how the licensing works for using content from stack overflow, but here's the applicable license: https://creativecommons.org/licenses/by-sa/4.0/ ¯\\\_(ツ)_/¯ 

Basically this makes a copy of the selection when the `touchend` event occurs, so we can use it for processing later (when the imperative `quoteReply` method is invoked). It also stores a reference to the containing node, so we can do the DOM tree lookup to confirm the selection is from the parent item.

This code listens to that event for each instance of the reply component, removing the event listener on unmount

I also threw in a minor tweak to the dev commands file that I noticed should be made.