### PR TITLE
SN wallet transaction details

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -76,13 +76,6 @@ export default {
         throw new GraphQLError('not ur withdrawal', { extensions: { code: 'FORBIDDEN' } })
       }
 
-      try {
-        const lnInv = await getInvoiceFromLnd({ id: wdrwl.hash, lnd })
-        wdrwl.preimage = lnInv.secret
-      } catch (err) {
-        console.error('error fetching invoice from LND', err)
-      }
-
       return wdrwl
     },
     connectAddress: async (parent, args, { lnd }) => {

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -41,8 +41,10 @@ export async function getInvoice (parent, { id }, { me, models, lnd }) {
   }
 
   try {
-    const lnInv = await getInvoiceFromLnd({ id: inv.hash, lnd })
-    inv.preimage = lnInv.secret
+    if (inv.confirmedAt) {
+      const lnInv = await getInvoiceFromLnd({ id: inv.hash, lnd })
+      inv.preimage = lnInv.secret
+    }
   } catch (err) {
     console.error('error fetching invoice from LND', err)
   }

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -30,6 +30,7 @@ export default gql`
     lud18Data: JSONObject
     hmac: String
     isHeld: Boolean
+    preimage: String
   }
 
   type Withdrawl {
@@ -42,6 +43,7 @@ export default gql`
     satsFeePaying: Int!
     satsFeePaid: Int
     status: String
+    preimage: String
   }
 
   type Fact {

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -43,7 +43,6 @@ export default gql`
     satsFeePaying: Int!
     satsFeePaid: Int
     status: String
-    preimage: String
   }
 
   type Fact {

--- a/components/bolt11-info.js
+++ b/components/bolt11-info.js
@@ -1,0 +1,51 @@
+import { decode } from 'bolt11'
+import AccordianItem from './accordian-item'
+import { CopyInput } from './form'
+
+export default ({ bolt11, preimage }) => {
+  const { tagsObject: { description, payment_hash: paymentHash } } = decode(bolt11)
+  //   console.log(decode(bolt11))
+  if (!description && !paymentHash && !preimage) {
+    return null
+  }
+
+  return (
+    <div className='w-100'>
+
+      <AccordianItem
+        header='BOLT11 information'
+        body={
+          <>
+            {description &&
+              <CopyInput
+                label='description'
+                size='sm'
+                groupClassName='w-100'
+                readOnly
+                noForm
+                placeholder={description}
+              />}
+            {paymentHash &&
+              <CopyInput
+                label='payment hash'
+                size='sm'
+                groupClassName='w-100'
+                readOnly
+                noForm
+                placeholder={paymentHash}
+              />}
+            {preimage &&
+              <CopyInput
+                label='preimage'
+                size='sm'
+                groupClassName='w-100'
+                readOnly
+                noForm
+                placeholder={preimage}
+              />}
+          </>
+          }
+      />
+    </div>
+  )
+}

--- a/components/bolt11-info.js
+++ b/components/bolt11-info.js
@@ -4,14 +4,12 @@ import { CopyInput } from './form'
 
 export default ({ bolt11, preimage }) => {
   const { tagsObject: { description, payment_hash: paymentHash } } = decode(bolt11)
-  //   console.log(decode(bolt11))
   if (!description && !paymentHash && !preimage) {
     return null
   }
 
   return (
     <div className='w-100'>
-
       <AccordianItem
         header='BOLT11 information'
         body={

--- a/components/form.js
+++ b/components/form.js
@@ -4,7 +4,6 @@ import BootstrapForm from 'react-bootstrap/Form'
 import { Formik, Form as FormikForm, useFormikContext, useField, FieldArray } from 'formik'
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import copy from 'clipboard-copy'
-import Thumb from '../svgs/thumb-up-fill.svg'
 import Col from 'react-bootstrap/Col'
 import Dropdown from 'react-bootstrap/Dropdown'
 import Nav from 'react-bootstrap/Nav'
@@ -53,12 +52,15 @@ export function SubmitButton ({
 }
 
 export function CopyInput (props) {
-  const [copied, setCopied] = useState(false)
+  const toaster = useToast()
 
-  const handleClick = () => {
-    copy(props.placeholder)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 1500)
+  const handleClick = async () => {
+    try {
+      await copy(props.placeholder)
+      toaster.success('copied')
+    } catch (err) {
+      toaster.danger('failed to copy')
+    }
   }
 
   return (
@@ -69,10 +71,9 @@ export function CopyInput (props) {
           className={styles.appendButton}
           size={props.size}
           onClick={handleClick}
-        >
-          {copied ? <Thumb width={18} height={18} /> : 'copy'}
+        >copy
         </Button>
-}
+      }
       {...props}
     />
   )

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -12,6 +12,7 @@ import { useShowModal } from './modal'
 import { sleep } from '../lib/time'
 import Countdown from './countdown'
 import PayerData from './payer-data'
+import Bolt11Info from './bolt11-info'
 
 export function Invoice ({ invoice, onPayment, info, successVerb }) {
   const [expired, setExpired] = useState(new Date(invoice.expiredAt) <= new Date())
@@ -39,7 +40,9 @@ export function Invoice ({ invoice, onPayment, info, successVerb }) {
     }
   }, [invoice.confirmedAt, invoice.isHeld, invoice.satsReceived])
 
-  const { nostr, comment, lud18Data } = invoice
+  const { nostr, comment, lud18Data, bolt11, preimage } = invoice
+
+  // console.log(invoice)
 
   return (
     <>
@@ -85,6 +88,7 @@ export function Invoice ({ invoice, onPayment, info, successVerb }) {
             body={<span className='text-muted ms-3'>{comment}</span>}
           />
         </div>}
+      <Bolt11Info bolt11={bolt11} preimage={preimage} />
     </>
   )
 }

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -42,8 +42,6 @@ export function Invoice ({ invoice, onPayment, info, successVerb }) {
 
   const { nostr, comment, lud18Data, bolt11, preimage } = invoice
 
-  // console.log(invoice)
-
   return (
     <>
       <Qr

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -29,7 +29,6 @@ export const WITHDRAWL = gql`
       satsFeePaying
       satsFeePaid
       status
-      preimage
     }
   }`
 

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -16,6 +16,7 @@ export const INVOICE = gql`
       isHeld
       comment
       lud18Data
+      preimage
     }
   }`
 
@@ -28,6 +29,7 @@ export const WITHDRAWL = gql`
       satsFeePaying
       satsFeePaid
       status
+      preimage
     }
   }`
 

--- a/pages/withdrawals/[id].js
+++ b/pages/withdrawals/[id].js
@@ -8,6 +8,7 @@ import { WITHDRAWL } from '../../fragments/wallet'
 import Link from 'next/link'
 import { SSR } from '../../lib/constants'
 import { numWithUnits } from '../../lib/format'
+import Bolt11Info from '../../components/bolt11-info'
 
 export default function Withdrawl () {
   return (
@@ -97,6 +98,7 @@ function LoadWithdrawl () {
         />
       </div>
       <InvoiceStatus variant={variant} status={status} />
+      <Bolt11Info bolt11={data.withdrawl.bolt11} />
     </>
   )
 }


### PR DESCRIPTION
Closes #503 

This PR introduces a new `Bolt11Info` component to show info extracted from a BOLT11 after decoding. This component is used for Invoices and Withdrawals. It shows:
1. payment hash
2. payment description (if exists)
3. preimage (for invoices only, not withdrawals)

The preimage is fetched from LND via lookup by hash.

Fields are displayed in `CopyInput`, so they're readonly and easily copyable, if that's useful. 

This PR also updates the `CopyInput` component to use our toast hook for success/failure instead of showing the Thumb icon, just to standardize the UX. We don't have to keep this, but I thought the consistency would be good.

Are there other bits of info we should include? I am not really sure what's worth exposing.

## Invoice screenshot
<img width="864" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/6fa9b89b-f43e-45b2-a38e-dfedd1c2dfd3">

## Withdrawal screenshot
<img width="751" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/4f20ccc7-e7ca-4f4f-8c8b-bb6e5c8bc893">
