### PR TITLE
Add auto-complete support when withdrawing to ln addr

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -394,15 +394,28 @@ function InputInner ({
   )
 }
 
-export function UserSuggest ({ query, onSelect, dropdownStyle, children, transformUser = user => user }) {
+export function UserSuggest ({
+  query, onSelect, dropdownStyle, children,
+  transformUser = user => user, selectWithTab = true, filterUsers = () => true
+}) {
   const [getUsers] = useLazyQuery(TOP_USERS, {
     onCompleted: data => {
-      setSuggestions({ array: data.topUsers.users.map(transformUser), index: 0 })
+      setSuggestions({
+        array: data.topUsers.users
+          .filter((...args) => filterUsers(query, ...args))
+          .map(transformUser),
+        index: 0
+      })
     }
   })
   const [getSuggestions] = useLazyQuery(USER_SEARCH, {
     onCompleted: data => {
-      setSuggestions({ array: data.searchUsers.map(transformUser), index: 0 })
+      setSuggestions({
+        array: data.searchUsers
+          .filter((...args) => filterUsers(query, ...args))
+          .map(transformUser),
+        index: 0
+      })
     }
   })
 
@@ -449,6 +462,9 @@ export function UserSuggest ({ query, onSelect, dropdownStyle, children, transfo
         break
       case 'Tab':
       case 'Enter':
+        if (e.code === 'Tab' && !selectWithTab) {
+          break
+        }
         if (suggestions.array?.length === 0) {
           break
         }
@@ -486,13 +502,15 @@ export function UserSuggest ({ query, onSelect, dropdownStyle, children, transfo
   )
 }
 
-export function InputUserSuggest ({ label, groupClassName, transformUser, ...props }) {
+export function InputUserSuggest ({ label, groupClassName, transformUser, filterUsers, selectWithTab, ...props }) {
   const [ovalue, setOValue] = useState()
   const [query, setQuery] = useState()
   return (
     <FormGroup label={label} className={groupClassName}>
       <UserSuggest
         transformUser={transformUser}
+        filterUsers={filterUsers}
+        selectWithTab={selectWithTab}
         onSelect={setOValue}
         query={query}
       >

--- a/pages/wallet.js
+++ b/pages/wallet.js
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { Checkbox, Form, Input, SubmitButton } from '../components/form'
+import { Checkbox, Form, Input, InputUserSuggest, SubmitButton } from '../components/form'
 import Link from 'next/link'
 import Button from 'react-bootstrap/Button'
 import { gql, useMutation, useQuery } from '@apollo/client'
@@ -349,12 +349,13 @@ export function LnAddrWithdrawal () {
           router.push(`/withdrawals/${data.sendToLnAddr.id}`)
         }}
       >
-        <Input
+        <InputUserSuggest
           label='lightning address'
           name='addr'
           required
           autoFocus
           onChange={onAddrChange}
+          transformUser={user => ({ ...user, name: `${user.name}@stacker.news` })}
         />
         <Input
           label='amount'

--- a/pages/wallet.js
+++ b/pages/wallet.js
@@ -356,6 +356,14 @@ export function LnAddrWithdrawal () {
           autoFocus
           onChange={onAddrChange}
           transformUser={user => ({ ...user, name: `${user.name}@stacker.news` })}
+          selectWithTab={false}
+          filterUsers={(query) => {
+            if (!query.includes('@')) {
+              return true
+            }
+            const [, domain] = query.split('@')
+            return 'stacker.news'.startsWith(domain)
+          }}
         />
         <Input
           label='amount'


### PR DESCRIPTION
adds auto-complete support for other stacker.news users when withdrawing to a lightning address

implemented via adding an optional `transformUser` prop to the `UserSuggest` and `InputUserSuggest` components, which allows you to transform fetched user results before displaying in the suggestion dropdown

this is used to transform a user nym to nym@stacker.news, the corresponding lightning address

by default, `transformUser` is an identity fn aka no transformation

this change also clears suggestions when the surrounding input field is blurred, which is a better UX IMO

https://github.com/stackernews/stacker.news/assets/128755788/656970be-d7df-4d59-99c1-58382c302f50
