### PR TITLE
Bugfix crosspostr remove a tag

### DIFF
--- a/components/adv-post-form.js
+++ b/components/adv-post-form.js
@@ -7,6 +7,7 @@ import Info from './info'
 import { numWithUnits } from '../lib/format'
 import styles from './adv-post-form.module.css'
 import { useMe } from './me'
+import { useRouter } from 'next/router'
 
 const EMPTY_FORWARD = { nym: '', pct: '' }
 
@@ -19,6 +20,7 @@ export function AdvPostInitial ({ forward, boost }) {
 
 export default function AdvPostForm () {
   const me = useMe()
+  const router = useRouter()
 
   return (
     <AccordianItem
@@ -81,7 +83,7 @@ export default function AdvPostForm () {
               )
             }}
           </VariableInput>
-          {me &&
+          {me && router.query.type === 'discussion' &&
             <Checkbox
               label={
                 <div className='d-flex align-items-center'>crosspost to nostr

--- a/components/use-crossposter.js
+++ b/components/use-crossposter.js
@@ -14,8 +14,7 @@ async function discussionToEvent (item) {
     kind: 30023,
     content: item.text,
     tags: [
-      ['d', `https://stacker.news/items/${item.id}`],
-      ['a', `30023:${pubkey}:https://stacker.news/items/${item.id}`, 'wss://relay.nostr.band'],
+      ['d', `${item.id}`],
       ['title', item.title],
       ['published_at', createdAt.toString()]
     ]


### PR DESCRIPTION
Removes unnecessary 'a' tag from nostr crosspost event which is causing the note to look like it is replying to itself.

[Thread](https://nostr.band/note1af6utxp8mudg8ducspyxzwh34qqu0t9yavwdmzvpkjftjqgqeqmsspws0g)