### PR TITLE
Removing a tag, retested crossposts and edits

### DIFF
--- a/components/use-crossposter.js
+++ b/components/use-crossposter.js
@@ -6,7 +6,6 @@ import { useQuery } from '@apollo/client'
 import { SETTINGS } from '../fragments/users'
 
 async function discussionToEvent (item) {
-  const pubkey = await window.nostr.getPublicKey()
   const createdAt = Math.floor(Date.now() / 1000)
 
   return {
@@ -14,8 +13,7 @@ async function discussionToEvent (item) {
     kind: 30023,
     content: item.text,
     tags: [
-      ['d', `https://stacker.news/items/${item.id}`],
-      ['a', `30023:${pubkey}:https://stacker.news/items/${item.id}`, 'wss://relay.nostr.band'],
+      ['d', item.id.toString()],
       ['title', item.title],
       ['published_at', createdAt.toString()]
     ]


### PR DESCRIPTION
Removes unnecessary 'a' tag from nostr crosspost event which is causing the note to look like it is replying to itself.

[Thread](https://nostr.band/note1af6utxp8mudg8ducspyxzwh34qqu0t9yavwdmzvpkjftjqgqeqmsspws0g)