### PR TITLE
hasNewNotes for your own comments in subscribed threads

### DIFF
--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -329,6 +329,7 @@ export default {
           ${whereClause(
             '"ThreadSubscription"."userId" = $1',
             '"Item".created_at > $2::timestamp(3) without time zone',
+            '"Item"."userId" <> $1',
             await filterClause(me, models),
             muteClause(me)
           )})`, me.id, lastChecked)


### PR DESCRIPTION
Don't include your own comments when determining if there are new thread subscription replies for user hasNewNotes. 

Basically, if you subscribed to a thread and then made a comment on it, your notification bell would suggest you have new notifications to read, but when you go to the notifications page, there weren't any. Fun!