### PR TITLE
Ephemeral items

### DIFF
--- a/lib/item.js
+++ b/lib/item.js
@@ -11,3 +11,38 @@ export const defaultCommentSort = (pinned, bio, createdAt) => {
 }
 
 export const isJob = item => typeof item.maxBid !== 'undefined'
+
+const deletePattern = /\B@delete\s+in\s+(\d+)\s+(second|minute|hour|day|week|month|year)s?/gi
+
+export const getDeleteCommand = (text = '') => {
+  const matches = [...text.matchAll(deletePattern)]
+  const commands = matches?.map(match => ({ number: match[1], unit: match[2] }))
+  return commands.length ? commands[commands.length - 1] : undefined
+}
+
+export const hasDeleteCommand = (text) => !!getDeleteCommand(text)
+
+export const deleteItemByAuthor = async ({ models, id, item }) => {
+  if (!item) {
+    item = await models.item.findUnique({ where: { id: Number(id) } })
+  }
+  if (!item) {
+    console.log('attempted to delete an item that does not exist', id)
+    return
+  }
+  const updateData = { deletedAt: new Date() }
+  if (item.text) {
+    updateData.text = '*deleted by author*'
+  }
+  if (item.title) {
+    updateData.title = 'deleted by author'
+  }
+  if (item.url) {
+    updateData.url = null
+  }
+  if (item.pollCost) {
+    updateData.pollCost = null
+  }
+
+  return await models.item.update({ where: { id: Number(id) }, data: updateData })
+}

--- a/worker/ephemeralItems.js
+++ b/worker/ephemeralItems.js
@@ -1,0 +1,13 @@
+import { deleteItemByAuthor } from '../lib/item.js'
+
+export function deleteItem ({ models }) {
+  return async function ({ data: eventData }) {
+    console.log('deleteItem', eventData)
+    const { id } = eventData
+    try {
+      await deleteItemByAuthor({ models, id })
+    } catch (err) {
+      console.error('failed to delete item', err)
+    }
+  }
+}

--- a/worker/index.js
+++ b/worker/index.js
@@ -15,6 +15,7 @@ import fetch from 'cross-fetch'
 import { authenticatedLndGrpc } from 'ln-service'
 import { views, rankViews } from './views.js'
 import { imgproxy } from './imgproxy.js'
+import { deleteItem } from './ephemeralItems.js'
 
 const { loadEnvConfig } = nextEnv
 const { ApolloClient, HttpLink, InMemoryCache } = apolloClient
@@ -68,6 +69,7 @@ async function work () {
   await boss.work('views', views(args))
   await boss.work('rankViews', rankViews(args))
   await boss.work('imgproxy', imgproxy(args))
+  await boss.work('deleteItem', deleteItem(args))
 
   console.log('working jobs')
 }


### PR DESCRIPTION
Closes #472 

Introduce support for ephemeral items, i.e. items that delete themselves after a specified amount of time.

Stackers can enable this by including text in their items that follows this pattern: 

`@delete in <number> <unit>`

e.g. `@delete in 1 minute`, `@delete in 5 days`, etc.

* `<number>` must be a positive integer
* `<unit>` must be one of: `second`, `minute`, `hour`, `day`, `week`, `month`, `year`, or the plurals of each

If there are multiple "delete commands" found in the text of an item, the last command found in the text is honored.

If an item is edited, the delete commands are re-evaluated. In other words, if there was a delete command originally and it was removed in the edit, the deletion will not occur. Likewise, if there was not a delete command originally but one is added, it will take effect. Finally, if the delete command is changed in an edit, the old one will no longer take effect but the new one will.

Making an item ephemeral does not cost the stacker any extra sats (see discussion on this PR for context).

Note that since link posts don't have a text property, they cannot be ephemeral.