### PR TITLE
Wallet history timestamps

### DIFF
--- a/pages/satistics.js
+++ b/pages/satistics.js
@@ -15,6 +15,7 @@ import { CommentFlat } from '../components/comment'
 import ItemJob from '../components/item-job'
 import PageLoading from '../components/page-loading'
 import PayerData from '../components/payer-data'
+import { timeSince } from '../lib/time'
 
 export const getServerSideProps = getGetServerSideProps({ query: WALLET_HISTORY, authRequired: true })
 
@@ -142,6 +143,7 @@ function Fact ({ fact }) {
       <div className={`${styles.type} ${satusClass(fact.status)} ${fact.sats > 0 ? '' : 'text-muted'}`}>{fact.type}</div>
       <div className={styles.detail}>
         <Detail fact={fact} />
+        <div className='text-muted px-3' title={fact.createdAt}>{timeSince(new Date(fact.createdAt))}</div>
       </div>
       <div className={`${styles.sats} ${satusClass(fact.status)} ${fact.sats > 0 ? '' : 'text-muted'}`}>{fact.sats}</div>
     </>

--- a/pages/satistics.js
+++ b/pages/satistics.js
@@ -15,7 +15,6 @@ import { CommentFlat } from '../components/comment'
 import ItemJob from '../components/item-job'
 import PageLoading from '../components/page-loading'
 import PayerData from '../components/payer-data'
-import { timeSince } from '../lib/time'
 
 export const getServerSideProps = getGetServerSideProps({ query: WALLET_HISTORY, authRequired: true })
 
@@ -138,12 +137,13 @@ function Detail ({ fact }) {
 }
 
 function Fact ({ fact }) {
+  const factDate = new Date(fact.createdAt)
   return (
     <>
       <div className={`${styles.type} ${satusClass(fact.status)} ${fact.sats > 0 ? '' : 'text-muted'}`}>{fact.type}</div>
       <div className={styles.detail}>
         <Detail fact={fact} />
-        <div className='text-muted px-3' title={fact.createdAt} suppressHydrationWarning>{timeSince(new Date(fact.createdAt))}</div>
+        <div className='text-muted px-3'>{`${factDate.toLocaleDateString()} ${factDate.toLocaleTimeString()}`}</div>
       </div>
       <div className={`${styles.sats} ${satusClass(fact.status)} ${fact.sats > 0 ? '' : 'text-muted'}`}>{fact.sats}</div>
     </>

--- a/pages/satistics.js
+++ b/pages/satistics.js
@@ -143,7 +143,7 @@ function Fact ({ fact }) {
       <div className={`${styles.type} ${satusClass(fact.status)} ${fact.sats > 0 ? '' : 'text-muted'}`}>{fact.type}</div>
       <div className={styles.detail}>
         <Detail fact={fact} />
-        <div className='text-muted px-3' title={fact.createdAt}>{timeSince(new Date(fact.createdAt))}</div>
+        <div className='text-muted px-3' title={fact.createdAt} suppressHydrationWarning>{timeSince(new Date(fact.createdAt))}</div>
       </div>
       <div className={`${styles.sats} ${satusClass(fact.status)} ${fact.sats > 0 ? '' : 'text-muted'}`}>{fact.sats}</div>
     </>


### PR DESCRIPTION
Closes #583 

This PR updates the wallet history page's `Fact` component to include when each wallet fact occurred.

It makes use of the common `timeSince` function that we use in item-related components to show a relative time that a wallet history event occurred.

Users can also hover over the relative time in each table row to see the full ISO timestamp (via `title` attribute).

Sample screenshot:
<img width="633" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/80b43d7d-53bc-4de5-a9e1-5211eb955140">