### PR TITLE
Notification badges

### DIFF
--- a/api/webPush/index.js
+++ b/api/webPush/index.js
@@ -26,7 +26,11 @@ const createPayload = (notification) => {
       body,
       timestamp: Date.now(),
       icon: '/icons/icon_x96.png',
-      ...options
+      ...options,
+      data: {
+        ...(options.data || {}),
+        id: Math.random(0, 1).toString().substring(2)
+      }
     }
   })
 }

--- a/api/webPush/index.js
+++ b/api/webPush/index.js
@@ -26,11 +26,7 @@ const createPayload = (notification) => {
       body,
       timestamp: Date.now(),
       icon: '/icons/icon_x96.png',
-      ...options,
-      data: {
-        ...(options.data || {}),
-        id: Math.random(0, 1).toString().substring(2)
-      }
+      ...options
     }
   })
 }

--- a/components/header.js
+++ b/components/header.js
@@ -25,7 +25,7 @@ import { HAS_NOTIFICATIONS } from '../fragments/notifications'
 import AnonIcon from '../svgs/spy-fill.svg'
 import Hat from './hat'
 import HiddenWalletSummary from './hidden-wallet-summary'
-import { dispatchClearBadgeAction } from '../lib/badge'
+import { clearNotifications } from '../lib/badge'
 
 function WalletSummary ({ me }) {
   if (!me) return null
@@ -60,7 +60,7 @@ function NotificationBell () {
         nextFetchPolicy: 'cache-and-network',
         onCompleted: ({ hasNewNotes }) => {
           if (!hasNewNotes) {
-            dispatchClearBadgeAction()
+            clearNotifications()
           }
         }
       })

--- a/components/header.js
+++ b/components/header.js
@@ -25,6 +25,7 @@ import { HAS_NOTIFICATIONS } from '../fragments/notifications'
 import AnonIcon from '../svgs/spy-fill.svg'
 import Hat from './hat'
 import HiddenWalletSummary from './hidden-wallet-summary'
+import { dispatchClearBadgeAction } from '../lib/badge'
 
 function WalletSummary ({ me }) {
   if (!me) return null
@@ -59,7 +60,7 @@ function NotificationBell () {
         nextFetchPolicy: 'cache-and-network',
         onCompleted: ({ hasNewNotes }) => {
           if (!hasNewNotes) {
-            navigator.serviceWorker?.controller?.postMessage({ action: 'CLEAR_BADGE' })
+            dispatchClearBadgeAction()
           }
         }
       })

--- a/components/header.js
+++ b/components/header.js
@@ -25,6 +25,7 @@ import { HAS_NOTIFICATIONS } from '../fragments/notifications'
 import AnonIcon from '../svgs/spy-fill.svg'
 import Hat from './hat'
 import HiddenWalletSummary from './hidden-wallet-summary'
+import { clearAppBadge, setAppBadge } from '../lib/badge'
 
 function WalletSummary ({ me }) {
   if (!me) return null
@@ -56,7 +57,14 @@ function NotificationBell () {
     ? {}
     : {
         pollInterval: 30000,
-        nextFetchPolicy: 'cache-and-network'
+        nextFetchPolicy: 'cache-and-network',
+        onCompleted: ({ hasNewNotes }) => {
+          if (hasNewNotes) {
+            setAppBadge()
+          } else {
+            clearAppBadge()
+          }
+        }
       })
 
   return (

--- a/components/header.js
+++ b/components/header.js
@@ -25,7 +25,7 @@ import { HAS_NOTIFICATIONS } from '../fragments/notifications'
 import AnonIcon from '../svgs/spy-fill.svg'
 import Hat from './hat'
 import HiddenWalletSummary from './hidden-wallet-summary'
-import { clearAppBadge, setAppBadge } from '../lib/badge'
+import { clearAppBadge } from '../lib/badge'
 
 function WalletSummary ({ me }) {
   if (!me) return null
@@ -59,9 +59,7 @@ function NotificationBell () {
         pollInterval: 30000,
         nextFetchPolicy: 'cache-and-network',
         onCompleted: ({ hasNewNotes }) => {
-          if (hasNewNotes) {
-            setAppBadge()
-          } else {
+          if (!hasNewNotes) {
             clearAppBadge()
           }
         }

--- a/components/header.js
+++ b/components/header.js
@@ -25,7 +25,6 @@ import { HAS_NOTIFICATIONS } from '../fragments/notifications'
 import AnonIcon from '../svgs/spy-fill.svg'
 import Hat from './hat'
 import HiddenWalletSummary from './hidden-wallet-summary'
-import { clearAppBadge } from '../lib/badge'
 
 function WalletSummary ({ me }) {
   if (!me) return null
@@ -60,7 +59,7 @@ function NotificationBell () {
         nextFetchPolicy: 'cache-and-network',
         onCompleted: ({ hasNewNotes }) => {
           if (!hasNewNotes) {
-            clearAppBadge()
+            navigator.serviceWorker?.controller?.postMessage({ action: 'CLEAR_BADGE' })
           }
         }
       })

--- a/lib/badge.js
+++ b/lib/badge.js
@@ -1,0 +1,29 @@
+export const badgingApiSupported = (sw = window) => 'setAppBadge' in sw.navigator
+
+export const permissionGranted = async (sw = window, name = 'notifications') => {
+  let permission
+  try {
+    permission = await sw.navigator.permissions.query({ name })
+  } catch (err) {
+    console.error('Failed to check permissions', err)
+  }
+  return permission?.state === 'granted'
+}
+
+export const setAppBadge = async (sw = window) => {
+  if (!badgingApiSupported(sw) || !(await permissionGranted(sw))) return
+  try {
+    await sw.navigator.setAppBadge()
+  } catch (err) {
+    console.error('Failed to set app badge', err)
+  }
+}
+
+export const clearAppBadge = async (sw = window) => {
+  if (!badgingApiSupported(sw) || !(await permissionGranted(sw))) return
+  try {
+    await sw.navigator.clearAppBadge()
+  } catch (err) {
+    console.error('Failed to clear app badge', err)
+  }
+}

--- a/lib/badge.js
+++ b/lib/badge.js
@@ -1,3 +1,7 @@
+export const CLEAR_BADGE_ACTION = 'CLEAR_BADGE'
+
+export const dispatchClearBadgeAction = () => navigator.serviceWorker?.controller?.postMessage({ action: CLEAR_BADGE_ACTION })
+
 export const badgingApiSupported = (sw = window) => 'setAppBadge' in sw.navigator
 
 export const permissionGranted = async (sw = window, name = 'notifications') => {

--- a/lib/badge.js
+++ b/lib/badge.js
@@ -1,10 +1,10 @@
-export const CLEAR_BADGE_ACTION = 'CLEAR_BADGE'
+export const CLEAR_NOTIFICATIONS = 'CLEAR_NOTIFICATIONS'
 
-export const dispatchClearBadgeAction = () => navigator.serviceWorker?.controller?.postMessage({ action: CLEAR_BADGE_ACTION })
+export const clearNotifications = () => navigator.serviceWorker?.controller?.postMessage({ action: CLEAR_NOTIFICATIONS })
 
-export const badgingApiSupported = (sw = window) => 'setAppBadge' in sw.navigator
+const badgingApiSupported = (sw = window) => 'setAppBadge' in sw.navigator
 
-export const permissionGranted = async (sw = window, name = 'notifications') => {
+const permissionGranted = async (sw = window, name = 'notifications') => {
   let permission
   try {
     permission = await sw.navigator.permissions.query({ name })

--- a/lib/badge.js
+++ b/lib/badge.js
@@ -10,10 +10,10 @@ export const permissionGranted = async (sw = window, name = 'notifications') => 
   return permission?.state === 'granted'
 }
 
-export const setAppBadge = async (sw = window) => {
+export const setAppBadge = async (sw = window, count) => {
   if (!badgingApiSupported(sw) || !(await permissionGranted(sw))) return
   try {
-    await sw.navigator.setAppBadge()
+    await sw.navigator.setAppBadge(count)
   } catch (err) {
     console.error('Failed to set app badge', err)
   }

--- a/pages/notifications.js
+++ b/pages/notifications.js
@@ -4,7 +4,7 @@ import Layout from '../components/layout'
 import Notifications, { NotificationAlert } from '../components/notifications'
 import { HAS_NOTIFICATIONS, NOTIFICATIONS } from '../fragments/notifications'
 import { useApolloClient } from '@apollo/client'
-import { dispatchClearBadgeAction } from '../lib/badge'
+import { clearNotifications } from '../lib/badge'
 
 export const getServerSideProps = getGetServerSideProps({ query: NOTIFICATIONS, authRequired: true })
 
@@ -18,7 +18,7 @@ export default function NotificationPage ({ ssrData }) {
         hasNewNotes: false
       }
     })
-    dispatchClearBadgeAction()
+    clearNotifications()
   }, [ssrData])
 
   return (

--- a/pages/notifications.js
+++ b/pages/notifications.js
@@ -4,6 +4,7 @@ import Layout from '../components/layout'
 import Notifications, { NotificationAlert } from '../components/notifications'
 import { HAS_NOTIFICATIONS, NOTIFICATIONS } from '../fragments/notifications'
 import { useApolloClient } from '@apollo/client'
+import { dispatchClearBadgeAction } from '../lib/badge'
 
 export const getServerSideProps = getGetServerSideProps({ query: NOTIFICATIONS, authRequired: true })
 
@@ -17,7 +18,7 @@ export default function NotificationPage ({ ssrData }) {
         hasNewNotes: false
       }
     })
-    navigator.serviceWorker?.controller?.postMessage({ action: 'CLEAR_BADGE' })
+    dispatchClearBadgeAction()
   }, [ssrData])
 
   return (

--- a/pages/notifications.js
+++ b/pages/notifications.js
@@ -4,6 +4,7 @@ import Layout from '../components/layout'
 import Notifications, { NotificationAlert } from '../components/notifications'
 import { HAS_NOTIFICATIONS, NOTIFICATIONS } from '../fragments/notifications'
 import { useApolloClient } from '@apollo/client'
+import { clearAppBadge } from '../lib/badge'
 
 export const getServerSideProps = getGetServerSideProps({ query: NOTIFICATIONS, authRequired: true })
 
@@ -17,6 +18,7 @@ export default function NotificationPage ({ ssrData }) {
         hasNewNotes: false
       }
     })
+    clearAppBadge()
   }, [ssrData])
 
   return (

--- a/pages/notifications.js
+++ b/pages/notifications.js
@@ -4,7 +4,6 @@ import Layout from '../components/layout'
 import Notifications, { NotificationAlert } from '../components/notifications'
 import { HAS_NOTIFICATIONS, NOTIFICATIONS } from '../fragments/notifications'
 import { useApolloClient } from '@apollo/client'
-import { clearAppBadge } from '../lib/badge'
 
 export const getServerSideProps = getGetServerSideProps({ query: NOTIFICATIONS, authRequired: true })
 
@@ -18,7 +17,7 @@ export default function NotificationPage ({ ssrData }) {
         hasNewNotes: false
       }
     })
-    clearAppBadge()
+    navigator.serviceWorker?.controller?.postMessage({ action: 'CLEAR_BADGE' })
   }, [ssrData])
 
   return (

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -95,7 +95,7 @@ const mergeAndShowNotification = (sw, payload, currentNotification) => {
 
 export function onNotificationClick (sw) {
   return (event) => {
-    const url = event.notification.data.url
+    const url = event.notification.data?.url
     if (url) {
       event.waitUntil(sw.clients.openWindow(url))
     }

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -1,6 +1,6 @@
 import ServiceWorkerStorage from 'serviceworker-storage'
 import { numWithUnits } from '../lib/format'
-import { clearAppBadge, setAppBadge } from '../lib/badge'
+import { CLEAR_BADGE_ACTION, clearAppBadge, setAppBadge } from '../lib/badge'
 
 // we store existing push subscriptions to keep them in sync with server
 const storage = new ServiceWorkerStorage('sw:storage', 1)
@@ -107,6 +107,8 @@ export function onNotificationClick (sw) {
       receivedPushIds.delete(id)
       if (receivedPushIds.size === 0) {
         clearAppBadge(sw)
+      } else {
+        setAppBadge(sw, receivedPushIds.size)
       }
     }
     event.notification.close()
@@ -171,7 +173,7 @@ export function onMessage (sw) {
     if (event.data.action === 'SYNC_SUBSCRIPTION') {
       return event.waitUntil(onPushSubscriptionChange(sw)(event.oldSubscription, event.newSubscription))
     }
-    if (event.data.action === 'CLEAR_BADGE') {
+    if (event.data.action === CLEAR_BADGE_ACTION) {
       receivedPushIds.clear()
       return event.waitUntil(clearAppBadge(sw))
     }

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -1,5 +1,6 @@
 import ServiceWorkerStorage from 'serviceworker-storage'
 import { numWithUnits } from '../lib/format'
+import { setAppBadge } from '../lib/badge'
 
 // we store existing push subscriptions to keep them in sync with server
 const storage = new ServiceWorkerStorage('sw:storage', 1)
@@ -19,6 +20,7 @@ export function onPush (sw) {
     event.waitUntil((async () => {
       if (skipNotification(payload)) return
       if (immediatelyShowNotification(payload)) {
+        setAppBadge(sw)
         return sw.registration.showNotification(payload.title, payload.options)
       }
 
@@ -37,11 +39,13 @@ export function onPush (sw) {
       if (tag === 'MENTION' && payload.options.data?.itemId) itemMentions.push(payload.options.data.itemId)
 
       if (notifications.length === 0) {
+        setAppBadge(sw)
         // incoming notification is first notification with this tag
         return sw.registration.showNotification(payload.title, payload.options)
       }
 
       const currentNotification = notifications[0]
+      setAppBadge(sw)
       return mergeAndShowNotification(sw, payload, currentNotification)
     })())
   }

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -1,6 +1,6 @@
 import ServiceWorkerStorage from 'serviceworker-storage'
 import { numWithUnits } from '../lib/format'
-import { CLEAR_BADGE_ACTION, clearAppBadge, setAppBadge } from '../lib/badge'
+import { CLEAR_NOTIFICATIONS, clearAppBadge, setAppBadge } from '../lib/badge'
 
 // we store existing push subscriptions to keep them in sync with server
 const storage = new ServiceWorkerStorage('sw:storage', 1)
@@ -167,7 +167,7 @@ export function onMessage (sw) {
     if (event.data.action === 'SYNC_SUBSCRIPTION') {
       return event.waitUntil(onPushSubscriptionChange(sw)(event.oldSubscription, event.newSubscription))
     }
-    if (event.data.action === CLEAR_BADGE_ACTION) {
+    if (event.data.action === CLEAR_NOTIFICATIONS) {
       return event.waitUntil((async () => {
         let notifications = []
         try {


### PR DESCRIPTION
Closes #594 

This PR adds support for notification badges on the app's icon on the home screen.

I originally was going to mimic the behavior of the notification bell in the UI itself (no count, just an empty badge). However, as I worked on these changes, I changed approaches.

Since badges correspond to push notifications, I thought it made sense to show the badge based on receiving push notifications, instead of just doing some kind of polling on the notes API. This also gives the implicit benefit of only showing badges to users who have enabled push notifications, which is ideal.

The changes work as follows:

* Track the number of push notifications received. Increment the count by 1 for every notification received _that we show_. e.g. notifications that get merged with current notifications don't increment the count. Skipped notifications don't increment the count, etc.
* Every time the count of notifications goes up, update the app's badge w/this new number
* Every time a notification is clicked, decrement the count and update the app's badge accordingly
* If the count is updated to 0, clear the badge altogether instead of displaying 0
* When a user loads the notifications page in the UI itself, clear all open notifications and reset the internal count to 0
* When the notification bell header polls and indicates no new notes, clear all open notifications and reset the internal count to 0

So there's some slight tweaks to the existing behavior here, plus the new badge behavior as well.

As usual, I am open to feedback!