### PR TITLE
Resubscribe if service worker lost push subscription

### DIFF
--- a/components/serviceworker.js
+++ b/components/serviceworker.js
@@ -109,24 +109,23 @@ export const ServiceWorkerProvider = ({ children }) => {
       pushManager: 'PushManager' in window
     })
     setPermission({ notification: 'Notification' in window ? window.Notification.permission : 'denied' })
-    // since (a lot of) browsers don't support the pushsubscriptionchange event,
-    // we sync with server manually by checking on every page reload if the push subscription changed.
-    // see https://medium.com/@madridserginho/how-to-handle-webpush-api-pushsubscriptionchange-event-in-modern-browsers-6e47840d756f
-    navigator?.serviceWorker?.controller?.postMessage?.({ action: 'SYNC_SUBSCRIPTION' })
-    logger.info('sent SYNC_SUBSCRIPTION to service worker')
-  }, [])
 
-  useEffect(() => {
-    if (!support.serviceWorker) {
+    if (!('serviceWorker' in navigator)) {
       logger.info('device does not support service worker')
       return
     }
+
     const wb = new Workbox('/sw.js', { scope: '/' })
     wb.register().then(registration => {
       logger.info('service worker registration successful')
       setRegistration(registration)
+      // since (a lot of) browsers don't support the pushsubscriptionchange event,
+      // we sync with server manually by checking on every page reload if the push subscription changed.
+      // see https://medium.com/@madridserginho/how-to-handle-webpush-api-pushsubscriptionchange-event-in-modern-browsers-6e47840d756f
+      navigator?.serviceWorker?.controller?.postMessage?.({ action: 'SYNC_SUBSCRIPTION' })
+      logger.info('sent SYNC_SUBSCRIPTION to service worker')
     })
-  }, [support.serviceWorker])
+  }, [])
 
   return (
     <ServiceWorkerContext.Provider value={{ registration, support, permission, requestNotificationPermission, togglePushSubscription }}>

--- a/components/serviceworker.js
+++ b/components/serviceworker.js
@@ -88,6 +88,9 @@ export const ServiceWorkerProvider = ({ children }) => {
     const { endpoint } = subscription
     logger.info('unsubscribed from push notifications', { endpoint })
     await deletePushSubscription({ variables: { endpoint } })
+    // also delete push subscription in IndexedDB so we can tell if the user disabled push subscriptions
+    // or we lost the push subscription due to a bug
+    navigator.serviceWorker.controller.postMessage({ action: 'DELETE_SUBSCRIPTION' })
     logger.info('deleted push subscription from server', { endpoint })
   }
 

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -155,5 +155,8 @@ export function onMessage (sw) {
     if (event.data.action === 'SYNC_SUBSCRIPTION') {
       return event.waitUntil(onPushSubscriptionChange(sw)(event.oldSubscription, event.newSubscription))
     }
+    if (event.data.action === 'DELETE_SUBSCRIPTION') {
+      return event.waitUntil(storage.removeItem('subscription'))
+    }
   }
 }

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -7,6 +7,7 @@ const storage = new ServiceWorkerStorage('sw:storage', 1)
 // for communication between app and service worker
 // see https://developer.mozilla.org/en-US/docs/Web/API/MessageChannel
 let messageChannelPort
+let actionChannelPort
 
 // keep track of item ids where we received a MENTION notification already to not show one again
 const itemMentions = []
@@ -99,7 +100,9 @@ export function onNotificationClick (sw) {
 
 export function onPushSubscriptionChange (sw) {
   // https://medium.com/@madridserginho/how-to-handle-webpush-api-pushsubscriptionchange-event-in-modern-browsers-6e47840d756f
-  return async (event) => {
+  // `isSync` is passed if function was called because of 'SYNC_SUBSCRIPTION' event
+  // this makes sure we can differentiate between 'pushsubscriptionchange' events and our custom 'SYNC_SUBSCRIPTION' event
+  return async (event, isSync) => {
     let { oldSubscription, newSubscription } = event
     // https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/pushsubscriptionchange_event
     // fallbacks since browser may not set oldSubscription and newSubscription
@@ -107,7 +110,13 @@ export function onPushSubscriptionChange (sw) {
     oldSubscription ??= await storage.getItem('subscription')
     newSubscription ??= await sw.registration.pushManager.getSubscription()
     if (!newSubscription) {
-    // no subscription exists at the moment
+      if (isSync && oldSubscription) {
+        // service worker lost the push subscription somehow
+        messageChannelPort?.postMessage({ message: '[sw:handlePushSubscriptionChange] service worker lost subscription' })
+        actionChannelPort?.postMessage({ action: 'RESUBSCRIBE' })
+        return
+      }
+      // no subscription exists at the moment
       messageChannelPort?.postMessage({ message: '[sw:handlePushSubscriptionChange] no existing subscription found' })
       return
     }
@@ -145,6 +154,10 @@ export function onPushSubscriptionChange (sw) {
 
 export function onMessage (sw) {
   return (event) => {
+    if (event.data.action === 'ACTION_PORT') {
+      actionChannelPort = event.ports[0]
+      return
+    }
     if (event.data.action === 'MESSAGE_PORT') {
       messageChannelPort = event.ports[0]
     }
@@ -154,7 +167,7 @@ export function onMessage (sw) {
       return event.waitUntil(storage.setItem('subscription', event.data.subscription))
     }
     if (event.data.action === 'SYNC_SUBSCRIPTION') {
-      return event.waitUntil(onPushSubscriptionChange(sw)(event))
+      return event.waitUntil(onPushSubscriptionChange(sw)(event, true))
     }
     if (event.data.action === 'DELETE_SUBSCRIPTION') {
       return event.waitUntil(storage.removeItem('subscription'))

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -99,7 +99,8 @@ export function onNotificationClick (sw) {
 
 export function onPushSubscriptionChange (sw) {
   // https://medium.com/@madridserginho/how-to-handle-webpush-api-pushsubscriptionchange-event-in-modern-browsers-6e47840d756f
-  return async (oldSubscription, newSubscription) => {
+  return async (event) => {
+    let { oldSubscription, newSubscription } = event
     // https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/pushsubscriptionchange_event
     // fallbacks since browser may not set oldSubscription and newSubscription
     messageChannelPort?.postMessage({ message: '[sw:handlePushSubscriptionChange] invoked' })
@@ -153,7 +154,7 @@ export function onMessage (sw) {
       return event.waitUntil(storage.setItem('subscription', event.data.subscription))
     }
     if (event.data.action === 'SYNC_SUBSCRIPTION') {
-      return event.waitUntil(onPushSubscriptionChange(sw)(event.oldSubscription, event.newSubscription))
+      return event.waitUntil(onPushSubscriptionChange(sw)(event))
     }
     if (event.data.action === 'DELETE_SUBSCRIPTION') {
       return event.waitUntil(storage.removeItem('subscription'))


### PR DESCRIPTION
Potential fix for #411 

> However, I have an idea for a possible workaround (without really fixing the underlying issue since we don't know what is causing this):
> 
> We could delete the push subscription in IndexedDB if the user manually unchecks the push subscription.
>
> In that case, we know that if the service worker has no push subscription but there is a push subscription in IndexedDB during `SYNC_SUBSCRIPTION`, this is probably the bug and we can register a new push subscription in the background and send that one to the server. Currently, we aren't able to distinguish between the bug and manually unsubscribing since in both cases, there would still be a push subscription in IndexedDB.
> 
> So this means that during `unsubscribeFromPushNotifications`, we would add code that also deletes the push subscription in IndexedDB

-- https://github.com/stackernews/stacker.news/issues/411#issuecomment-1790675861

_simulating the bug by unsubscribing but not deleting the subscription in IndexedDB_:

https://github.com/stackernews/stacker.news/assets/27162016/76c11081-8ef6-4753-81b5-c00a0e5bcc93

That it shows `Stacker News notification are now active` on resubscribing may be annoying but I think it would be useful to keep this for now. With this notification, we can see if it's working or not since you will see this notification if you got resubscribed automatically if you lost your subscription for unknown reasons.

Since we delete the push subscription in IndexedDB on manual unsubscription, you won't get automatically resubscribed in this case.
