### PR TITLE
Fix next.config.js to apply CORS and cache response headers to ttf font file

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -95,7 +95,7 @@ module.exports = withPlausibleProxy()({
           ...corsHeaders
         ]
       },
-      ...['tff', 'woff', 'woff2'].map(ext => ({
+      ...['ttf', 'woff', 'woff2'].map(ext => ({
         source: `/Lightningvolt-xoqm.${ext}`,
         headers: [
           ...corsHeaders,


### PR DESCRIPTION
Closes #601 , fix the typo in `next.config.js` to apply CORS and Cache-Control headers to the `.ttf` font file.