### PR TITLE
Toast on delete bot directive usage

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -991,6 +991,10 @@ export default {
       }
       const parent = await models.item.findUnique({ where: { id: item.parentId } })
       return parent.otsHash
+    },
+    deleteScheduledAt: async (item, args, { models }) => {
+      const deleteJobs = await models.$queryRawUnsafe(`SELECT startafter FROM pgboss.job WHERE name = 'deleteItem' AND data->>'id' = '${item.id}'`)
+      return deleteJobs[0]?.startafter ?? null
     }
   }
 }

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -992,7 +992,12 @@ export default {
       const parent = await models.item.findUnique({ where: { id: item.parentId } })
       return parent.otsHash
     },
-    deleteScheduledAt: async (item, args, { models }) => {
+    deleteScheduledAt: async (item, args, { me, models }) => {
+      const meId = me?.id ?? ANON_USER_ID
+      if (meId !== item.userId) {
+        // Only query for deleteScheduledAt for your own items to keep DB queries minimized
+        return null
+      }
       const deleteJobs = await models.$queryRawUnsafe(`SELECT startafter FROM pgboss.job WHERE name = 'deleteItem' AND data->>'id' = '${item.id}'`)
       return deleteJobs[0]?.startafter ?? null
     }

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -67,6 +67,7 @@ export default gql`
     createdAt: Date!
     updatedAt: Date!
     deletedAt: Date
+    deleteScheduledAt: Date
     title: String
     searchTitle: String
     url: String

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -9,7 +9,7 @@ import { bountySchema } from '../lib/validate'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
-import { normalizeForwards } from '../lib/form'
+import { normalizeForwards, toastSuccessfulDeleteScheduled } from '../lib/form'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 import { useMe } from './me'
 import { useToast } from './toast'
@@ -76,22 +76,13 @@ export function BountyForm ({
       if (error) {
         throw new Error({ message: error.toString() })
       }
-      let deleteScheduledAt
-      if (data.upsertBounty.deleteScheduledAt) {
-        deleteScheduledAt = new Date(data.upsertBounty.deleteScheduledAt)
-      }
       if (item) {
         await router.push(`/items/${item.id}`)
-        if (deleteScheduledAt) {
-          toaster.success(`this bounty will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
-        }
       } else {
         const prefix = sub?.name ? `/~${sub.name}` : ''
         await router.push(prefix + '/recent')
-        if (deleteScheduledAt) {
-          toaster.success(`your new bounty will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
-        }
       }
+      toastSuccessfulDeleteScheduled(toaster, data, !!item)
     }, [upsertBounty, router]
   )
 

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -76,6 +76,7 @@ export function BountyForm ({
       if (error) {
         throw new Error({ message: error.toString() })
       }
+
       if (item) {
         await router.push(`/items/${item.id}`)
       } else {

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -9,7 +9,7 @@ import { bountySchema } from '../lib/validate'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
-import { normalizeForwards, toastSuccessfulDeleteScheduled } from '../lib/form'
+import { normalizeForwards, toastDeleteScheduled } from '../lib/form'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 import { useMe } from './me'
 import { useToast } from './toast'
@@ -83,7 +83,7 @@ export function BountyForm ({
         const prefix = sub?.name ? `/~${sub.name}` : ''
         await router.push(prefix + '/recent')
       }
-      toastSuccessfulDeleteScheduled(toaster, data, !!item)
+      toastDeleteScheduled(toaster, data, !!item, values.text)
     }, [upsertBounty, router]
   )
 

--- a/components/comment-edit.js
+++ b/components/comment-edit.js
@@ -6,6 +6,7 @@ import Delete from './delete'
 import { commentSchema } from '../lib/validate'
 import FeeButton, { FeeButtonProvider } from './fee-button'
 import { useToast } from './toast'
+import { toastSuccessfulDeleteScheduled } from '../lib/form'
 
 export default function CommentEdit ({ comment, editThreshold, onSuccess, onCancel }) {
   const toaster = useToast()
@@ -43,10 +44,7 @@ export default function CommentEdit ({ comment, editThreshold, onSuccess, onCanc
             if (error) {
               throw new Error({ message: error.toString() })
             }
-            if (data?.upsertComment?.deleteScheduledAt) {
-              const deleteScheduledAt = new Date(data.upsertComment.deleteScheduledAt)
-              toaster.success(`your comment will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
-            }
+            toastSuccessfulDeleteScheduled(toaster, data, true)
             if (onSuccess) {
               onSuccess()
             }

--- a/components/comment-edit.js
+++ b/components/comment-edit.js
@@ -6,7 +6,7 @@ import Delete from './delete'
 import { commentSchema } from '../lib/validate'
 import FeeButton, { FeeButtonProvider } from './fee-button'
 import { useToast } from './toast'
-import { toastSuccessfulDeleteScheduled } from '../lib/form'
+import { toastDeleteScheduled } from '../lib/form'
 
 export default function CommentEdit ({ comment, editThreshold, onSuccess, onCancel }) {
   const toaster = useToast()
@@ -44,7 +44,7 @@ export default function CommentEdit ({ comment, editThreshold, onSuccess, onCanc
             if (error) {
               throw new Error({ message: error.toString() })
             }
-            toastSuccessfulDeleteScheduled(toaster, data, true)
+            toastDeleteScheduled(toaster, data, true, values.text)
             if (onSuccess) {
               onSuccess()
             }

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -17,6 +17,7 @@ import { normalizeForwards } from '../lib/form'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 import { useMe } from './me'
 import useCrossposter from './use-crossposter'
+import { useToast } from './toast'
 
 export function DiscussionForm ({
   item, sub, editThreshold, titleLabel = 'title',
@@ -30,12 +31,14 @@ export function DiscussionForm ({
   // if Web Share Target API was used
   const shareTitle = router.query.title
   const crossposter = useCrossposter()
+  const toaster = useToast()
 
   const [upsertDiscussion] = useMutation(
     gql`
       mutation upsertDiscussion($sub: String, $id: ID, $title: String!, $text: String, $boost: Int, $forward: [ItemForwardInput], $hash: String, $hmac: String) {
         upsertDiscussion(sub: $sub, id: $id, title: $title, text: $text, boost: $boost, forward: $forward, hash: $hash, hmac: $hmac) {
           id
+          deleteScheduledAt
         }
       }`
   )
@@ -71,12 +74,21 @@ export function DiscussionForm ({
       } catch (e) {
         console.error(e)
       }
-
+      let deleteScheduledAt
+      if (data.upsertDiscussion.deleteScheduledAt) {
+        deleteScheduledAt = new Date(data.upsertDiscussion.deleteScheduledAt)
+      }
       if (item) {
         await router.push(`/items/${item.id}`)
+        if (deleteScheduledAt) {
+          toaster.success(`this discussion post will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
+        }
       } else {
         const prefix = sub?.name ? `/~${sub.name}` : ''
         await router.push(prefix + '/recent')
+        if (deleteScheduledAt) {
+          toaster.success(`your new discussion post will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
+        }
       }
     }, [upsertDiscussion, router, item, sub, crossposter]
   )

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -13,7 +13,7 @@ import { discussionSchema } from '../lib/validate'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
-import { normalizeForwards, toastSuccessfulDeleteScheduled } from '../lib/form'
+import { normalizeForwards, toastDeleteScheduled } from '../lib/form'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 import { useMe } from './me'
 import useCrossposter from './use-crossposter'
@@ -81,7 +81,7 @@ export function DiscussionForm ({
         const prefix = sub?.name ? `/~${sub.name}` : ''
         await router.push(prefix + '/recent')
       }
-      toastSuccessfulDeleteScheduled(toaster, data, !!item)
+      toastDeleteScheduled(toaster, data, !!item, values.text)
     }, [upsertDiscussion, router, item, sub, crossposter]
   )
 

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -13,7 +13,7 @@ import { discussionSchema } from '../lib/validate'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
-import { normalizeForwards } from '../lib/form'
+import { normalizeForwards, toastSuccessfulDeleteScheduled } from '../lib/form'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 import { useMe } from './me'
 import useCrossposter from './use-crossposter'
@@ -74,22 +74,13 @@ export function DiscussionForm ({
       } catch (e) {
         console.error(e)
       }
-      let deleteScheduledAt
-      if (data.upsertDiscussion.deleteScheduledAt) {
-        deleteScheduledAt = new Date(data.upsertDiscussion.deleteScheduledAt)
-      }
       if (item) {
         await router.push(`/items/${item.id}`)
-        if (deleteScheduledAt) {
-          toaster.success(`this discussion post will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
-        }
       } else {
         const prefix = sub?.name ? `/~${sub.name}` : ''
         await router.push(prefix + '/recent')
-        if (deleteScheduledAt) {
-          toaster.success(`your new discussion post will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
-        }
       }
+      toastSuccessfulDeleteScheduled(toaster, data, !!item)
     }, [upsertDiscussion, router, item, sub, crossposter]
   )
 

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -74,6 +74,7 @@ export function DiscussionForm ({
       } catch (e) {
         console.error(e)
       }
+
       if (item) {
         await router.push(`/items/${item.id}`)
       } else {

--- a/components/job-form.js
+++ b/components/job-form.js
@@ -19,6 +19,7 @@ import CancelButton from './cancel-button'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 import FeeButton from './fee-button'
 import { useToast } from './toast'
+import { toastSuccessfulDeleteScheduled } from '../lib/form'
 
 function satsMin2Mo (minute) {
   return minute * 30 * 24 * 60
@@ -76,21 +77,12 @@ export default function JobForm ({ item, sub }) {
       if (error) {
         throw new Error({ message: error.toString() })
       }
-      let deleteScheduledAt
-      if (data.upsertJob.deleteScheduledAt) {
-        deleteScheduledAt = new Date(data.upsertJob.deleteScheduledAt)
-      }
       if (item) {
         await router.push(`/items/${item.id}`)
-        if (deleteScheduledAt) {
-          toaster.success(`this job will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
-        }
       } else {
         await router.push(`/~${sub.name}/recent`)
-        if (deleteScheduledAt) {
-          toaster.success(`your new job will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
-        }
       }
+      toastSuccessfulDeleteScheduled(toaster, data, !!item)
     }, [upsertJob, router, logoId]
   )
 

--- a/components/job-form.js
+++ b/components/job-form.js
@@ -18,6 +18,7 @@ import { jobSchema } from '../lib/validate'
 import CancelButton from './cancel-button'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 import FeeButton from './fee-button'
+import { useToast } from './toast'
 
 function satsMin2Mo (minute) {
   return minute * 30 * 24 * 60
@@ -39,6 +40,7 @@ function PriceHint ({ monthly }) {
 export default function JobForm ({ item, sub }) {
   const storageKeyPrefix = item ? undefined : `${sub.name}-job`
   const router = useRouter()
+  const toaster = useToast()
   const [logoId, setLogoId] = useState(item?.uploadId)
   const [upsertJob] = useMutation(gql`
     mutation upsertJob($sub: String!, $id: ID, $title: String!, $company: String!, $location: String,
@@ -47,6 +49,7 @@ export default function JobForm ({ item, sub }) {
         location: $location, remote: $remote, text: $text,
         url: $url, maxBid: $maxBid, status: $status, logo: $logo, hash: $hash, hmac: $hmac) {
         id
+        deleteScheduledAt
       }
     }`
   )
@@ -60,7 +63,7 @@ export default function JobForm ({ item, sub }) {
         status = 'STOPPED'
       }
 
-      const { error } = await upsertJob({
+      const { data, error } = await upsertJob({
         variables: {
           id: item?.id,
           sub: item?.subName || sub?.name,
@@ -73,11 +76,20 @@ export default function JobForm ({ item, sub }) {
       if (error) {
         throw new Error({ message: error.toString() })
       }
-
+      let deleteScheduledAt
+      if (data.upsertJob.deleteScheduledAt) {
+        deleteScheduledAt = new Date(data.upsertJob.deleteScheduledAt)
+      }
       if (item) {
         await router.push(`/items/${item.id}`)
+        if (deleteScheduledAt) {
+          toaster.success(`this job will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
+        }
       } else {
         await router.push(`/~${sub.name}/recent`)
+        if (deleteScheduledAt) {
+          toaster.success(`your new job will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
+        }
       }
     }, [upsertJob, router, logoId]
   )

--- a/components/job-form.js
+++ b/components/job-form.js
@@ -19,7 +19,7 @@ import CancelButton from './cancel-button'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 import FeeButton from './fee-button'
 import { useToast } from './toast'
-import { toastSuccessfulDeleteScheduled } from '../lib/form'
+import { toastDeleteScheduled } from '../lib/form'
 
 function satsMin2Mo (minute) {
   return minute * 30 * 24 * 60
@@ -83,7 +83,7 @@ export default function JobForm ({ item, sub }) {
       } else {
         await router.push(`/~${sub.name}/recent`)
       }
-      toastSuccessfulDeleteScheduled(toaster, data, !!item)
+      toastDeleteScheduled(toaster, data, !!item, values.text)
     }, [upsertJob, router, logoId]
   )
 

--- a/components/job-form.js
+++ b/components/job-form.js
@@ -77,6 +77,7 @@ export default function JobForm ({ item, sub }) {
       if (error) {
         throw new Error({ message: error.toString() })
       }
+
       if (item) {
         await router.push(`/items/${item.id}`)
       } else {

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -14,7 +14,7 @@ import { linkSchema } from '../lib/validate'
 import Moon from '../svgs/moon-fill.svg'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
-import { normalizeForwards } from '../lib/form'
+import { normalizeForwards, toastSuccessfulDeleteScheduled } from '../lib/form'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 import { useMe } from './me'
 import { useToast } from './toast'
@@ -95,22 +95,13 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
       if (error) {
         throw new Error({ message: error.toString() })
       }
-      let deleteScheduledAt
-      if (data.upsertLink.deleteScheduledAt) {
-        deleteScheduledAt = new Date(data.upsertLink.deleteScheduledAt)
-      }
       if (item) {
         await router.push(`/items/${item.id}`)
-        if (deleteScheduledAt) {
-          toaster.success(`this link post will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
-        }
       } else {
         const prefix = sub?.name ? `/~${sub.name}` : ''
         await router.push(prefix + '/recent')
-        if (deleteScheduledAt) {
-          toaster.success(`your new link post will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
-        }
       }
+      toastSuccessfulDeleteScheduled(toaster, data, !!item)
     }, [upsertLink, router]
   )
 

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -14,7 +14,7 @@ import { linkSchema } from '../lib/validate'
 import Moon from '../svgs/moon-fill.svg'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
-import { normalizeForwards, toastSuccessfulDeleteScheduled } from '../lib/form'
+import { normalizeForwards, toastDeleteScheduled } from '../lib/form'
 import { MAX_TITLE_LENGTH } from '../lib/constants'
 import { useMe } from './me'
 import { useToast } from './toast'
@@ -101,7 +101,7 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
         const prefix = sub?.name ? `/~${sub.name}` : ''
         await router.push(prefix + '/recent')
       }
-      toastSuccessfulDeleteScheduled(toaster, data, !!item)
+      toastDeleteScheduled(toaster, data, !!item, values.text)
     }, [upsertLink, router]
   )
 

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -11,7 +11,7 @@ import { pollSchema } from '../lib/validate'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
-import { normalizeForwards, toastSuccessfulDeleteScheduled } from '../lib/form'
+import { normalizeForwards, toastDeleteScheduled } from '../lib/form'
 import { useMe } from './me'
 import { useToast } from './toast'
 
@@ -57,7 +57,7 @@ export function PollForm ({ item, sub, editThreshold, children }) {
         const prefix = sub?.name ? `/~${sub.name}` : ''
         await router.push(prefix + '/recent')
       }
-      toastSuccessfulDeleteScheduled(toaster, data, !!item)
+      toastDeleteScheduled(toaster, data, !!item, values.text)
     }, [upsertPoll, router]
   )
 

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -11,7 +11,7 @@ import { pollSchema } from '../lib/validate'
 import { SubSelectInitial } from './sub-select-form'
 import CancelButton from './cancel-button'
 import { useCallback } from 'react'
-import { normalizeForwards } from '../lib/form'
+import { normalizeForwards, toastSuccessfulDeleteScheduled } from '../lib/form'
 import { useMe } from './me'
 import { useToast } from './toast'
 
@@ -51,22 +51,13 @@ export function PollForm ({ item, sub, editThreshold, children }) {
       if (error) {
         throw new Error({ message: error.toString() })
       }
-      let deleteScheduledAt
-      if (data.upsertPoll.deleteScheduledAt) {
-        deleteScheduledAt = new Date(data.upsertPoll.deleteScheduledAt)
-      }
       if (item) {
         await router.push(`/items/${item.id}`)
-        if (deleteScheduledAt) {
-          toaster.success(`this poll will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
-        }
       } else {
         const prefix = sub?.name ? `/~${sub.name}` : ''
         await router.push(prefix + '/recent')
-        if (deleteScheduledAt) {
-          toaster.success(`your new poll will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
-        }
       }
+      toastSuccessfulDeleteScheduled(toaster, data, !!item)
     }, [upsertPoll, router]
   )
 

--- a/components/reply.js
+++ b/components/reply.js
@@ -12,6 +12,7 @@ import Info from './info'
 import { quote } from '../lib/md'
 import { COMMENT_DEPTH_LIMIT } from '../lib/constants'
 import { useToast } from './toast'
+import { toastSuccessfulDeleteScheduled } from '../lib/form'
 
 export function ReplyOnAnotherPage ({ item }) {
   const path = item.path.split('.')
@@ -157,10 +158,7 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
 
   const onSubmit = useCallback(async ({ amount, hash, hmac, ...values }, { resetForm }) => {
     const { data } = await upsertComment({ variables: { parentId, hash, hmac, ...values } })
-    if (data?.upsertComment?.deleteScheduledAt) {
-      const deleteScheduledAt = new Date(data.upsertComment.deleteScheduledAt)
-      toaster.success(`your comment will be deleted at ${deleteScheduledAt.toLocaleDateString()} ${deleteScheduledAt.toLocaleTimeString()}`)
-    }
+    toastSuccessfulDeleteScheduled(toaster, data, false)
     resetForm({ text: '' })
     setReply(replyOpen || false)
   }, [upsertComment, setReply, parentId])

--- a/components/reply.js
+++ b/components/reply.js
@@ -12,7 +12,7 @@ import Info from './info'
 import { quote } from '../lib/md'
 import { COMMENT_DEPTH_LIMIT } from '../lib/constants'
 import { useToast } from './toast'
-import { toastSuccessfulDeleteScheduled } from '../lib/form'
+import { toastDeleteScheduled } from '../lib/form'
 
 export function ReplyOnAnotherPage ({ item }) {
   const path = item.path.split('.')
@@ -158,7 +158,7 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
 
   const onSubmit = useCallback(async ({ amount, hash, hmac, ...values }, { resetForm }) => {
     const { data } = await upsertComment({ variables: { parentId, hash, hmac, ...values } })
-    toastSuccessfulDeleteScheduled(toaster, data, false)
+    toastDeleteScheduled(toaster, data, false, values.text)
     resetForm({ text: '' })
     setReply(replyOpen || false)
   }, [upsertComment, setReply, parentId])

--- a/components/toast.js
+++ b/components/toast.js
@@ -25,12 +25,20 @@ export const ToastProvider = ({ children }) => {
   }, [])
 
   const toaster = useMemo(() => ({
-    success: body => {
+    success: (body, delay = 5000) => {
       dispatchToast({
         body,
         variant: 'success',
         autohide: true,
-        delay: 5000
+        delay
+      })
+    },
+    warning: (body, delay = 5000) => {
+      dispatchToast({
+        body,
+        variant: 'warning',
+        autohide: true,
+        delay
       })
     },
     danger: (body, onCloseCallback) => {
@@ -64,7 +72,7 @@ export const ToastProvider = ({ children }) => {
         {toasts.map(toast => (
           <Toast
             key={toast.id} bg={toast.variant} show autohide={toast.autohide}
-            delay={toast.delay} className={`${styles.toast} ${styles[toast.variant]}`} onClose={() => removeToast(toast.id)}
+            delay={toast.delay} className={`${styles.toast} ${styles[toast.variant]} ${toast.variant === 'warning' ? 'text-dark' : ''}`} onClose={() => removeToast(toast.id)}
           >
             <ToastBody>
               <div className='d-flex align-items-center'>
@@ -77,7 +85,7 @@ export const ToastProvider = ({ children }) => {
                     if (toast.onCloseCallback) toast.onCloseCallback()
                     removeToast(toast.id)
                   }}
-                ><div className={styles.toastClose}>X</div>
+                ><div className={`${styles.toastClose} ${toast.variant === 'warning' ? 'text-dark' : ''}`}>X</div>
                 </Button>
               </div>
             </ToastBody>

--- a/components/toast.module.css
+++ b/components/toast.module.css
@@ -17,6 +17,10 @@
   border-color: var(--bs-danger-border-subtle);
 }
 
+.warning {
+  border-color: var(--bs-warning-border-subtle);
+}
+
 .toastClose {
   color: #fff;
   font-family: "lightning";

--- a/fragments/comments.js
+++ b/fragments/comments.js
@@ -6,6 +6,7 @@ export const COMMENT_FIELDS = gql`
     parentId
     createdAt
     deletedAt
+    deleteScheduledAt
     text
     user {
       id

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -54,6 +54,7 @@ export const ITEM_FULL_FIELDS = gql`
   fragment ItemFullFields on Item {
     ...ItemFields
     text
+    deleteScheduledAt
     root {
       id
       title

--- a/lib/form.js
+++ b/lib/form.js
@@ -10,3 +10,23 @@ export const normalizeForwards = (forward) => {
   }
   return forward.filter(fwd => fwd.nym || fwd.user?.name).map(fwd => ({ nym: fwd.nym ?? fwd.user?.name, pct: Number(fwd.pct) }))
 }
+
+export const toastSuccessfulDeleteScheduled = (toaster, upsertResponseData, isEdit) => {
+  const keys = Object.keys(upsertResponseData)
+  const data = upsertResponseData[keys[0]]
+  if (!data) return
+  const deleteScheduledAt = data.deleteScheduledAt ? new Date(data.deleteScheduledAt) : undefined
+  if (deleteScheduledAt) {
+    const itemType = {
+      upsertDiscussion: 'discussion post',
+      upsertLink: 'link post',
+      upsertPoll: 'poll',
+      upsertBounty: 'bounty',
+      upsertJob: 'job',
+      upsertComment: 'comment'
+    }[keys[0]] ?? 'item'
+
+    const message = `${itemType === 'comment' ? 'your comment' : isEdit ? `this ${itemType}` : `your new ${itemType}`} will be deleted at ${deleteScheduledAt.toLocaleString()}`
+    toaster.success(message)
+  }
+}

--- a/lib/form.js
+++ b/lib/form.js
@@ -1,3 +1,5 @@
+import { hasDeleteMention } from './item'
+
 /**
  * Normalize an array of forwards by converting the pct from a string to a number
  * Also extracts nym from nested user object, if necessary
@@ -11,7 +13,7 @@ export const normalizeForwards = (forward) => {
   return forward.filter(fwd => fwd.nym || fwd.user?.name).map(fwd => ({ nym: fwd.nym ?? fwd.user?.name, pct: Number(fwd.pct) }))
 }
 
-export const toastSuccessfulDeleteScheduled = (toaster, upsertResponseData, isEdit) => {
+export const toastDeleteScheduled = (toaster, upsertResponseData, isEdit, itemText) => {
   const keys = Object.keys(upsertResponseData)
   const data = upsertResponseData[keys[0]]
   if (!data) return
@@ -28,5 +30,10 @@ export const toastSuccessfulDeleteScheduled = (toaster, upsertResponseData, isEd
 
     const message = `${itemType === 'comment' ? 'your comment' : isEdit ? `this ${itemType}` : `your new ${itemType}`} will be deleted at ${deleteScheduledAt.toLocaleString()}`
     toaster.success(message)
+    return
+  }
+  if (hasDeleteMention(itemText)) {
+    // There's a delete mention but the deletion wasn't scheduled
+    toaster.warning('it looks like you tried to use the delete bot but it didn\'t work. make sure you use the correct format: "@delete in n units" e.g. "@delete in 2 hours"', 10000)
   }
 }

--- a/lib/item.js
+++ b/lib/item.js
@@ -15,6 +15,10 @@ export const isJob = item => typeof item.maxBid !== 'undefined'
 // a delete directive preceded by a non word character that isn't a backtick
 const deletePattern = /\B(?<!`)@delete\s+in\s+(\d+)\s+(second|minute|hour|day|week|month|year)s?/gi
 
+const deleteMentionPattern = /\B(?<!`)@delete/i
+
+export const hasDeleteMention = (text) => deleteMentionPattern.test(text ?? '')
+
 export const getDeleteCommand = (text) => {
   if (!text) return false
   const matches = [...text.matchAll(deletePattern)]

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,6 +1,7 @@
 $primary: #FADA5E;
 $secondary: #F6911D;
 $danger: #c03221;
+$warning: #ffc107;
 $info: #007cbe;
 $success: #5c8001;
 $twitter: #1da1f2;
@@ -13,6 +14,7 @@ $theme-colors: (
   "primary" : #FADA5E,
   "secondary" : #F6911D,
   "danger" : #c03221,
+  "warning" : #ffc107,
   "info" : #007cbe,
   "success" : #5c8001,
   "twitter" : #1da1f2,

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,7 +1,7 @@
 $primary: #FADA5E;
 $secondary: #F6911D;
 $danger: #c03221;
-$warning: #ffc107;
+$warning: $secondary;
 $info: #007cbe;
 $success: #5c8001;
 $twitter: #1da1f2;
@@ -14,7 +14,7 @@ $theme-colors: (
   "primary" : #FADA5E,
   "secondary" : #F6911D,
   "danger" : #c03221,
-  "warning" : #ffc107,
+  "warning" : $secondary,
   "info" : #007cbe,
   "success" : #5c8001,
   "twitter" : #1da1f2,


### PR DESCRIPTION
Closes #614 

This PR toasts when an item is created or updated and successfully schedules a deletion job via the `@delete` bot.

It supports all post types and comments, both new and edited.

The toast displays the time at which the item will be deleted, localized to the user's current browser.

If the user mentioned the delete bot but the deletion wasn't scheduled, these changes also toast a warning toast indicating that they may have tried to schedule a deletion but it didn't work, and gives an example of the correct usage.

I also optimized the resolver to only query the DB to find scheduled deletion jobs for your own items, since it's only really necessary for yourself.