### PR TITLE
Fix client-side error boundary

### DIFF
--- a/components/block-height.js
+++ b/components/block-height.js
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react'
+import { createContext, useContext, useMemo } from 'react'
 import { useQuery } from '@apollo/client'
 import { SSR } from '../lib/constants'
 import { BLOCK_HEIGHT } from '../fragments/blockHeight'
@@ -18,9 +18,9 @@ export const BlockHeightProvider = ({ blockHeight, children }) => {
           nextFetchPolicy: 'cache-and-network'
         })
   })
-  const value = {
+  const value = useMemo(() => ({
     height: data?.blockHeight ?? blockHeight ?? 0
-  }
+  }), [data, blockHeight])
   return (
     <BlockHeightContext.Provider value={value}>
       {children}

--- a/components/error-boundary.js
+++ b/components/error-boundary.js
@@ -35,7 +35,7 @@ class ErrorBoundary extends Component {
     if (this.state.hasError) {
       // You can render any custom fallback UI
       return (
-        <StaticLayout>
+        <StaticLayout footer={false}>
           <Image width='500' height='375' className='rounded-1 shadow-sm' src={`${process.env.NEXT_PUBLIC_ASSET_PREFIX}/floating.gif`} fluid />
           <h1 className={styles.status} style={{ fontSize: '48px' }}>something went wrong</h1>
           {this.state.error &&
@@ -48,7 +48,6 @@ class ErrorBoundary extends Component {
     }
 
     // Return children components in case of no error
-
     return this.props.children
   }
 }

--- a/components/error-boundary.js
+++ b/components/error-boundary.js
@@ -4,6 +4,8 @@ import styles from '../styles/error.module.css'
 import Image from 'react-bootstrap/Image'
 import copy from 'clipboard-copy'
 import { LoggerContext } from './logger'
+import Button from 'react-bootstrap/Button'
+import { useToast } from './toast'
 
 class ErrorBoundary extends Component {
   constructor (props) {
@@ -22,27 +24,32 @@ class ErrorBoundary extends Component {
     return { hasError: true, error }
   }
 
+  getErrorDetails () {
+    let details = this.state.error.stack
+    if (this.state.errorInfo?.componentStack) {
+      details += `\n\nComponent stack:${this.state.errorInfo.componentStack}`
+    }
+    return details
+  }
+
   componentDidCatch (error, errorInfo) {
     // You can use your own error logging service here
     console.log({ error, errorInfo })
     this.setState({ errorInfo })
     const logger = this.context
-    logger?.error(error + '\n' + errorInfo.componentStack)
+    logger?.error(this.getErrorDetails())
   }
 
   render () {
     // Check if the error is thrown
     if (this.state.hasError) {
       // You can render any custom fallback UI
+      const errorDetails = this.getErrorDetails()
       return (
         <StaticLayout footer={false}>
           <Image width='500' height='375' className='rounded-1 shadow-sm' src={`${process.env.NEXT_PUBLIC_ASSET_PREFIX}/floating.gif`} fluid />
           <h1 className={styles.status} style={{ fontSize: '48px' }}>something went wrong</h1>
-          {this.state.error &&
-            <>
-              <textarea readOnly value={this.state.error.stack + '\n' + this.state.errorInfo?.componentStack} style={{ width: '500px' }} />
-              <button onClick={() => { copy(this.state.error.stack + '\n' + this.state.errorInfo?.componentStack) }}>copy error</button>
-            </>}
+          {this.state.error && <CopyErrorButton errorDetails={errorDetails} />}
         </StaticLayout>
       )
     }
@@ -55,3 +62,19 @@ class ErrorBoundary extends Component {
 ErrorBoundary.contextType = LoggerContext
 
 export default ErrorBoundary
+
+// This button is a functional component so we can use `useToast` hook, which
+// can't be easily done in a class component that already consumes a context
+const CopyErrorButton = ({ errorDetails }) => {
+  const toaster = useToast()
+  const onClick = async () => {
+    try {
+      await copy(errorDetails)
+      toaster?.success?.('copied')
+    } catch (err) {
+      console.error(err)
+      toaster?.danger?.('failed to copy')
+    }
+  }
+  return <Button className='mt-3' onClick={onClick}>copy error information</Button>
+}

--- a/components/logger.js
+++ b/components/logger.js
@@ -36,7 +36,7 @@ function detectOS () {
   return os
 }
 
-const LoggerContext = createContext()
+export const LoggerContext = createContext()
 
 export function LoggerProvider ({ children }) {
   const me = useMe()

--- a/components/me.js
+++ b/components/me.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useMemo } from 'react'
 import { useQuery } from '@apollo/client'
 import { ME } from '../fragments/users'
 import { SSR } from '../lib/constants'
@@ -11,11 +11,11 @@ export function MeProvider ({ me, children }) {
   const { data } = useQuery(ME, SSR ? {} : { pollInterval: 1000, nextFetchPolicy: 'cache-and-network' })
   const futureMe = data?.me || me
 
-  const contextValue = {
+  const contextValue = useMemo(() => ({
     me: futureMe
       ? { ...futureMe, ...futureMe.privates, ...futureMe.optional }
       : null
-  }
+  }), [me, data])
 
   return (
     <MeContext.Provider value={contextValue}>

--- a/components/price.js
+++ b/components/price.js
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useMemo, useState } from 'react'
 import { useQuery } from '@apollo/client'
 import { fixedDecimal } from '../lib/format'
 import { useMe } from './me'
@@ -29,10 +29,10 @@ export function PriceProvider ({ price, children }) {
         })
   })
 
-  const contextValue = {
+  const contextValue = useMemo(() => ({
     price: data?.price || price,
     fiatSymbol: CURRENCY_SYMBOLS[fiatCurrency] || '$'
-  }
+  }), [data?.price, price, me?.fiatCurrency])
 
   return (
     <PriceContext.Provider value={contextValue}>

--- a/components/serviceworker.js
+++ b/components/serviceworker.js
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState, useCallback } from 'react'
+import { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react'
 import { Workbox } from 'workbox-window'
 import { gql, useMutation } from '@apollo/client'
 import { useLogger } from './logger'
@@ -140,8 +140,16 @@ export const ServiceWorkerProvider = ({ children }) => {
     logger.info('sent SYNC_SUBSCRIPTION to service worker')
   }, [registration])
 
+  const contextValue = useMemo(() => ({
+    registration,
+    support,
+    permission,
+    requestNotificationPermission,
+    togglePushSubscription
+  }), [registration, support, permission, requestNotificationPermission, togglePushSubscription])
+
   return (
-    <ServiceWorkerContext.Provider value={{ registration, support, permission, requestNotificationPermission, togglePushSubscription }}>
+    <ServiceWorkerContext.Provider value={contextValue}>
       {children}
     </ServiceWorkerContext.Provider>
   )

--- a/components/toast.js
+++ b/components/toast.js
@@ -46,7 +46,7 @@ export const ToastProvider = ({ children }) => {
         removeToast: () => removeToast(id)
       }
     }
-  }), [dispatchToast])
+  }), [dispatchToast, removeToast])
 
   // Clear all toasts on page navigation
   useEffect(() => {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -87,27 +87,45 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
       </Head>
       <ErrorBoundary>
         <PlausibleProvider domain='stacker.news' trackOutboundLinks>
-          <ApolloProvider client={client}>
-            <MeProvider me={me}>
-              <LoggerProvider>
-                <ServiceWorkerProvider>
-                  <PriceProvider price={price}>
-                    <LightningProvider>
-                      <ToastProvider>
-                        <ShowModalProvider>
-                          <BlockHeightProvider blockHeight={blockHeight}>
-                            <ErrorBoundary>
-                              <Component ssrData={ssrData} {...otherProps} />
-                            </ErrorBoundary>
-                          </BlockHeightProvider>
-                        </ShowModalProvider>
-                      </ToastProvider>
-                    </LightningProvider>
-                  </PriceProvider>
-                </ServiceWorkerProvider>
-              </LoggerProvider>
-            </MeProvider>
-          </ApolloProvider>
+          <ErrorBoundary>
+            <ApolloProvider client={client}>
+              <ErrorBoundary>
+                <MeProvider me={me}>
+                  <ErrorBoundary>
+                    <LoggerProvider>
+                      <ErrorBoundary>
+                        <ServiceWorkerProvider>
+                          <ErrorBoundary>
+                            <PriceProvider price={price}>
+                              <ErrorBoundary>
+                                <LightningProvider>
+                                  <ErrorBoundary>
+                                    <ToastProvider>
+                                      <ErrorBoundary>
+                                        <ShowModalProvider>
+                                          <ErrorBoundary>
+                                            <BlockHeightProvider blockHeight={blockHeight}>
+                                              <ErrorBoundary>
+                                                <Component ssrData={ssrData} {...otherProps} />
+                                              </ErrorBoundary>
+                                            </BlockHeightProvider>
+                                          </ErrorBoundary>
+                                        </ShowModalProvider>
+                                      </ErrorBoundary>
+                                    </ToastProvider>
+                                  </ErrorBoundary>
+                                </LightningProvider>
+                              </ErrorBoundary>
+                            </PriceProvider>
+                          </ErrorBoundary>
+                        </ServiceWorkerProvider>
+                      </ErrorBoundary>
+                    </LoggerProvider>
+                  </ErrorBoundary>
+                </MeProvider>
+              </ErrorBoundary>
+            </ApolloProvider>
+          </ErrorBoundary>
         </PlausibleProvider>
       </ErrorBoundary>
     </>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -87,45 +87,25 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
       </Head>
       <ErrorBoundary>
         <PlausibleProvider domain='stacker.news' trackOutboundLinks>
-          <ErrorBoundary>
-            <ApolloProvider client={client}>
-              <ErrorBoundary>
-                <MeProvider me={me}>
-                  <ErrorBoundary>
-                    <LoggerProvider>
-                      <ErrorBoundary>
-                        <ServiceWorkerProvider>
-                          <ErrorBoundary>
-                            <PriceProvider price={price}>
-                              <ErrorBoundary>
-                                <LightningProvider>
-                                  <ErrorBoundary>
-                                    <ToastProvider>
-                                      <ErrorBoundary>
-                                        <ShowModalProvider>
-                                          <ErrorBoundary>
-                                            <BlockHeightProvider blockHeight={blockHeight}>
-                                              <ErrorBoundary>
-                                                <Component ssrData={ssrData} {...otherProps} />
-                                              </ErrorBoundary>
-                                            </BlockHeightProvider>
-                                          </ErrorBoundary>
-                                        </ShowModalProvider>
-                                      </ErrorBoundary>
-                                    </ToastProvider>
-                                  </ErrorBoundary>
-                                </LightningProvider>
-                              </ErrorBoundary>
-                            </PriceProvider>
-                          </ErrorBoundary>
-                        </ServiceWorkerProvider>
-                      </ErrorBoundary>
-                    </LoggerProvider>
-                  </ErrorBoundary>
-                </MeProvider>
-              </ErrorBoundary>
-            </ApolloProvider>
-          </ErrorBoundary>
+          <ApolloProvider client={client}>
+            <MeProvider me={me}>
+              <LoggerProvider>
+                <ServiceWorkerProvider>
+                  <PriceProvider price={price}>
+                    <LightningProvider>
+                      <ToastProvider>
+                        <ShowModalProvider>
+                          <BlockHeightProvider blockHeight={blockHeight}>
+                            <Component ssrData={ssrData} {...otherProps} />
+                          </BlockHeightProvider>
+                        </ShowModalProvider>
+                      </ToastProvider>
+                    </LightningProvider>
+                  </PriceProvider>
+                </ServiceWorkerProvider>
+              </LoggerProvider>
+            </MeProvider>
+          </ApolloProvider>
         </PlausibleProvider>
       </ErrorBoundary>
     </>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -96,7 +96,9 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
                       <ToastProvider>
                         <ShowModalProvider>
                           <BlockHeightProvider blockHeight={blockHeight}>
-                            <Component ssrData={ssrData} {...otherProps} />
+                            <ErrorBoundary>
+                              <Component ssrData={ssrData} {...otherProps} />
+                            </ErrorBoundary>
                           </BlockHeightProvider>
                         </ShowModalProvider>
                       </ToastProvider>


### PR DESCRIPTION
Closes #609 

This PR makes a few changes related to error boundaries:

1. Updates the `ErrorBoundary` component itself to display a button which will copy relevant error details to the clipboard, so users can share it in a bug report
2. Updates the `ErrorBoundary` component to log errors caught to our logging API service (if the current use has opted in to sharing diagnostic info)
3. Updates the `ErrorBoundary` component to not render a page footer, since the footer has dynamic content which can itself fail at render time
4. Update the application root component tree to wrap the main page component with an error boundary, within all of our context providers. This is so that the most likely source of errors (the page content itself) can be instrumented via logger and toaster for copying the error details via shared context. The top-level error boundary, above all of our context providers, will not be able to use those shared contexts.
5. The main fix, I think, was just to properly memoize all of our context providers' values. It seems like fixing that caused our error boundary to actually catch errors now, instead of whatever it was doing before.

<img width="774" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/3015a31c-0ae7-4b6e-8cc2-08bdf921d085">


It's a little difficult to test locally, but I simulated an uncaught error like this:

```diff
diff --git a/pages/~/post.js b/pages/~/post.js
index efb26e0..481a699 100644
--- a/pages/~/post.js
+++ b/pages/~/post.js
@@ -12,6 +12,11 @@ export const getServerSideProps = getGetServerSideProps({
 })
 
 export default function PostPage ({ ssrData }) {
+  if (Math.random() > 0.7) {
+    const err = new Error('post page error')
+    err.digest = 'NEXT_DYNAMIC_NO_SSR_CODE'
+    throw err
+  }
   const router = useRouter()
   const { data } = useQuery(SUB, { variables: { sub: router.query.sub } })
   if (!data && !ssrData) return <PageLoading />
```

The `err.digest = 'NEXT_DYNAMIC_NO_SSR_CODE'` seems to be a trick to not treat the error as "recoverable" in dev mode, which then causes the error boundary to actually handle the error.