### PR TITLE
Disable reply button while uploading

### DIFF
--- a/components/fee-button.js
+++ b/components/fee-button.js
@@ -64,6 +64,7 @@ export function postCommentUseRemoteLineItems ({ parentId, me } = {}) {
 
 export function FeeButtonProvider ({ baseLineItems = {}, useRemoteLineItems = () => null, children }) {
   const [lineItems, setLineItems] = useState({})
+  const [disabled, setDisabled] = useState(false)
 
   const remoteLineItems = useRemoteLineItems()
 
@@ -79,9 +80,11 @@ export function FeeButtonProvider ({ baseLineItems = {}, useRemoteLineItems = ()
     return {
       lines,
       merge: mergeLineItems,
-      total: Object.values(lines).reduce((acc, { modifier }) => modifier(acc), 0)
+      total: Object.values(lines).reduce((acc, { modifier }) => modifier(acc), 0),
+      disabled,
+      setDisabled
     }
-  }, [baseLineItems, lineItems, remoteLineItems, mergeLineItems])
+  }, [baseLineItems, lineItems, remoteLineItems, mergeLineItems, disabled, setDisabled])
 
   return (
     <FeeButtonContext.Provider value={value}>
@@ -96,12 +99,12 @@ export function useFeeButton () {
 
 export default function FeeButton ({ ChildButton = SubmitButton, variant, text, disabled }) {
   const me = useMe()
-  const { lines, total } = useFeeButton()
+  const { lines, total, disabled: ctxDisabled } = useFeeButton()
 
   return (
     <div className={styles.feeButton}>
       <ActionTooltip overlayText={numWithUnits(total, { abbreviate: false })}>
-        <ChildButton variant={variant} disabled={disabled}>{text}{total > 1 && <small> {numWithUnits(total, { abbreviate: false, format: true })}</small>}</ChildButton>
+        <ChildButton variant={variant} disabled={disabled || ctxDisabled}>{text}{total > 1 && <small> {numWithUnits(total, { abbreviate: false, format: true })}</small>}</ChildButton>
       </ActionTooltip>
       {!me && <AnonInfo />}
       {total > 1 &&

--- a/components/form.js
+++ b/components/form.js
@@ -105,7 +105,7 @@ export function MarkdownInput ({ label, topLevel, groupClassName, onChange, onKe
   innerRef = innerRef || useRef(null)
   const imageUploadRef = useRef(null)
   const previousTab = useRef(tab)
-  const { merge } = useFeeButton()
+  const { merge, setDisabled: setSubmitDisabled } = useFeeButton()
   const toaster = useToast()
   const [updateImageFeesInfo] = useLazyQuery(gql`
   query imageFeesInfo($s3Keys: [Int]!) {
@@ -284,6 +284,7 @@ export function MarkdownInput ({ label, topLevel, groupClassName, onChange, onKe
                 if (text) text += '\n\n'
                 text += `![Uploading ${file.name}…]()`
                 helpers.setValue(text)
+                setSubmitDisabled?.(true)
               }}
               onSuccess={({ url, name }) => {
                 let text = innerRef.current.value
@@ -291,11 +292,13 @@ export function MarkdownInput ({ label, topLevel, groupClassName, onChange, onKe
                 helpers.setValue(text)
                 const s3Keys = [...text.matchAll(AWS_S3_URL_REGEXP)].map(m => Number(m[1]))
                 updateImageFeesInfo({ variables: { s3Keys } })
+                setSubmitDisabled?.(false)
               }}
               onError={({ name }) => {
                 let text = innerRef.current.value
                 text = text.replace(`![Uploading ${name}…]()`, '')
                 helpers.setValue(text)
+                setSubmitDisabled?.(false)
               }}
             >
               <AddImageIcon width={18} height={18} />


### PR DESCRIPTION
https://github.com/stackernews/stacker.news/assets/27162016/28d5353a-128c-4940-9d61-9993224ec83c

Using the new `FeeButtonContext` helped to avoid some copy paste code in _components/reply.js_ and _components/*-form.js_ since I initially wanted to just pass state to both child components (`<MarkdownInput>` and `<FeeButton>`) from the parent (`<Reply>`, `<DiscussionForm>`, ...) :tada:

Closes #608 