### PR TITLE
Nostr crossposting improvements

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1066,8 +1066,8 @@ export const updateItem = async (parent, { sub: subName, forward, options, ...it
     await models.item.update({
       where: { id: Number(item.id) },
       data: { noteId: item.noteId }
-    });
-    return { id: item.id, noteId: item.noteId };
+    })
+    return { id: item.id, noteId: item.noteId }
   }
 
   // prevent update if it's not explicitly allowed, not their bio, not their job and older than 10 minutes

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1061,6 +1061,16 @@ export const updateItem = async (parent, { sub: subName, forward, options, ...it
   // in case they lied about their existing boost
   await ssValidate(advSchema, { boost: item.boost }, { models, me, existingBoost: old.boost })
 
+  // Check if we ar ejust updating nEventId
+  if (item.nEventId) {
+    // Update only nEventId and return
+    await models.item.update({
+      where: { id: Number(item.id) },
+      data: { nEventId: item.nEventId }
+    });
+    return { id: item.id, nEventId: item.nEventId }; // Or any other relevant data you want to return
+  }
+
   // prevent update if it's not explicitly allowed, not their bio, not their job and older than 10 minutes
   const user = await models.user.findUnique({ where: { id: me.id } })
   if (!ITEM_ALLOW_EDITS.includes(old.id) && user.bioId !== old.id &&

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1061,14 +1061,13 @@ export const updateItem = async (parent, { sub: subName, forward, options, ...it
   // in case they lied about their existing boost
   await ssValidate(advSchema, { boost: item.boost }, { models, me, existingBoost: old.boost })
 
-  // Check if we ar ejust updating nEventId
-  if (item.nEventId) {
-    // Update only nEventId and return
+  // Check if we are just updating noteId
+  if (item.noteId) {
     await models.item.update({
       where: { id: Number(item.id) },
-      data: { nEventId: item.nEventId }
+      data: { noteId: item.noteId }
     });
-    return { id: item.id, nEventId: item.nEventId }; // Or any other relevant data you want to return
+    return { id: item.id, noteId: item.noteId };
   }
 
   // prevent update if it's not explicitly allowed, not their bio, not their job and older than 10 minutes
@@ -1186,7 +1185,7 @@ const getForwardUsers = async (models, forward) => {
 export const SELECT =
   `SELECT "Item".id, "Item".created_at, "Item".created_at as "createdAt", "Item".updated_at,
   "Item".updated_at as "updatedAt", "Item".title, "Item".text, "Item".url, "Item"."bounty",
-  "Item"."nEventId", "Item"."userId", "Item"."parentId", "Item"."pinId", "Item"."maxBid",
+  "Item"."noteId", "Item"."userId", "Item"."parentId", "Item"."pinId", "Item"."maxBid",
   "Item"."rootId", "Item".upvotes, "Item".company, "Item".location, "Item".remote, "Item"."deletedAt",
   "Item"."subName", "Item".status, "Item"."uploadId", "Item"."pollCost", "Item".boost, "Item".msats,
   "Item".ncomments, "Item"."commentMsats", "Item"."lastCommentAt", "Item"."weightedVotes",

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1176,7 +1176,7 @@ const getForwardUsers = async (models, forward) => {
 export const SELECT =
   `SELECT "Item".id, "Item".created_at, "Item".created_at as "createdAt", "Item".updated_at,
   "Item".updated_at as "updatedAt", "Item".title, "Item".text, "Item".url, "Item"."bounty",
-  "Item"."userId", "Item"."parentId", "Item"."pinId", "Item"."maxBid",
+  "Item"."nEventId", "Item"."userId", "Item"."parentId", "Item"."pinId", "Item"."maxBid",
   "Item"."rootId", "Item".upvotes, "Item".company, "Item".location, "Item".remote, "Item"."deletedAt",
   "Item"."subName", "Item".status, "Item"."uploadId", "Item"."pollCost", "Item".boost, "Item".msats,
   "Item".ncomments, "Item"."commentMsats", "Item"."lastCommentAt", "Item"."weightedVotes",

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -27,7 +27,7 @@ export default gql`
     subscribeItem(id: ID): Item
     deleteItem(id: ID): Item
     upsertLink(id: ID, sub: String, title: String!, url: String!, text: String, boost: Int, forward: [ItemForwardInput], hash: String, hmac: String): Item!
-    upsertDiscussion(id: ID, sub: String, title: String!, text: String, boost: Int, forward: [ItemForwardInput], hash: String, hmac: String): Item!
+    upsertDiscussion(id: ID, sub: String, title: String!, text: String, boost: Int, forward: [ItemForwardInput], hash: String, hmac: String, nEventId: String): Item!
     upsertBounty(id: ID, sub: String, title: String!, text: String, bounty: Int, hash: String, hmac: String, boost: Int, forward: [ItemForwardInput]): Item!
     upsertJob(id: ID, sub: String!, title: String!, company: String!, location: String, remote: Boolean,
       text: String!, url: String!, maxBid: Int!, status: String, logo: Int, hash: String, hmac: String): Item!

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -82,6 +82,7 @@ export default gql`
     boost: Int!
     bounty: Int
     bountyPaidTo: [Int]
+    nEventId: String
     sats: Int!
     commentSats: Int!
     lastCommentAt: Date

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -27,7 +27,7 @@ export default gql`
     subscribeItem(id: ID): Item
     deleteItem(id: ID): Item
     upsertLink(id: ID, sub: String, title: String!, url: String!, text: String, boost: Int, forward: [ItemForwardInput], hash: String, hmac: String): Item!
-    upsertDiscussion(id: ID, sub: String, title: String!, text: String, boost: Int, forward: [ItemForwardInput], hash: String, hmac: String, nEventId: String): Item!
+    upsertDiscussion(id: ID, sub: String, title: String!, text: String, boost: Int, forward: [ItemForwardInput], hash: String, hmac: String, noteId: String): Item!
     upsertBounty(id: ID, sub: String, title: String!, text: String, bounty: Int, hash: String, hmac: String, boost: Int, forward: [ItemForwardInput]): Item!
     upsertJob(id: ID, sub: String!, title: String!, company: String!, location: String, remote: Boolean,
       text: String!, url: String!, maxBid: Int!, status: String, logo: Int, hash: String, hmac: String): Item!
@@ -82,7 +82,7 @@ export default gql`
     boost: Int!
     bounty: Int
     bountyPaidTo: [Int]
-    nEventId: String
+    noteId: String
     sats: Int!
     commentSats: Int!
     lastCommentAt: Date

--- a/components/crosspost-item.js
+++ b/components/crosspost-item.js
@@ -31,8 +31,7 @@ export default function CrosspostDropdownItem({ item }) {
 
                 try {
                     if (item?.id) {
-                        const createdAt = Math.floor(Date.now() / 1000)
-                        const crosspostResult = await crossposter({ ...data.item, createdAt: createdAt })
+                        const crosspostResult = await crossposter({ ...data.item })
                         const eventId = crosspostResult?.eventId;
                         if (eventId) {
                             await upsertDiscussion({

--- a/components/crosspost-item.js
+++ b/components/crosspost-item.js
@@ -1,0 +1,37 @@
+import useCrossposter from './use-crossposter'
+import Dropdown from 'react-bootstrap/Dropdown'
+import { useToast } from './toast'
+import { useMe } from './me'
+
+export default function CrosspostDropdownItem({ item }) {
+    const toaster = useToast()
+    const me = useMe()
+    // Update createdAt
+    const crossposter = useCrossposter()
+    return (
+        <Dropdown.Item
+            onClick={async () => {
+                try {
+                    if (!(await window.nostr.getPublicKey())) {
+                      throw new Error('not available')
+                    }
+                  } catch (e) {
+                    throw new Error(`Nostr extension error: ${e.message}`)
+                  }
+
+                try {
+                    if (item?.id) {
+                        await crossposter({ ...item, id: item.id, createdAt: item.createdAt })
+                    }
+                } catch (e) {
+                    console.error(e)
+                }
+            }}
+        >
+            {me && !me.nEventId ? 'crosspost to nostr' :
+                <Link href={`https://habla.news`} className='text-reset dropdown-item'>
+                    nostr note
+                </Link>}
+        </Dropdown.Item>
+    )
+}

--- a/components/crosspost-item.js
+++ b/components/crosspost-item.js
@@ -4,58 +4,62 @@ import { ITEM } from '../fragments/items'
 import { useRouter } from 'next/router'
 import { gql, useQuery, useMutation } from '@apollo/client'
 
-export default function CrosspostDropdownItem({ item }) {
-    const { data } = useQuery(ITEM, { variables: { id: item.id } })
-    const router = useRouter()
+export default function CrosspostDropdownItem ({ item }) {
+  const { data } = useQuery(ITEM, { variables: { id: item.id } })
+  const router = useRouter()
 
-    const [upsertDiscussion] = useMutation(
-        gql`
-          mutation upsertDiscussion($sub: String, $id: ID, $title: String!, $text: String, $boost: Int, $forward: [ItemForwardInput], $hash: String, $hmac: String, $noteId: String) {
-            upsertDiscussion(sub: $sub, id: $id, title: $title, text: $text, boost: $boost, forward: $forward, hash: $hash, hmac: $hmac, noteId: $noteId) {
-              id
+  const [upsertDiscussion] = useMutation(
+    gql`
+      mutation upsertDiscussion($sub: String, $id: ID, $title: String!, $text: String, $boost: Int, $forward: [ItemForwardInput], $hash: String, $hmac: String, $noteId: String) {
+        upsertDiscussion(sub: $sub, id: $id, title: $title, text: $text, boost: $boost, forward: $forward, hash: $hash, hmac: $hmac, noteId: $noteId) {
+          id
+        }
+      }
+    `
+  )
+
+  const crossposter = useCrossposter()
+
+  return !item?.noteId
+    ? (
+      <Dropdown.Item
+        onClick={async () => {
+          try {
+            if (!(await window.nostr.getPublicKey())) {
+              throw new Error('not available')
             }
-          }`
-      )
+          } catch (e) {
+            throw new Error(`Nostr extension error: ${e.message}`)
+          }
 
-    const crossposter = useCrossposter()
-    return !item?.noteId ? (
-        <Dropdown.Item
-            onClick={async () => {
-                try {
-                    if (!(await window.nostr.getPublicKey())) {
-                      throw new Error('not available')
-                    }
-                  } catch (e) {
-                    throw new Error(`Nostr extension error: ${e.message}`)
+          try {
+            if (item?.id) {
+              const crosspostResult = await crossposter({ ...data.item })
+              const eventId = crosspostResult?.eventId
+              if (eventId) {
+                await upsertDiscussion({
+                  variables: {
+                    sub: item?.subName,
+                    id: item?.id,
+                    boost: item?.boost ? (Number(item?.boost) >= 25000 ? Number(item?.boost) : undefined) : undefined,
+                    noteId: eventId,
+                    title: item?.title
                   }
-
-                try {
-                    if (item?.id) {
-                        const crosspostResult = await crossposter({ ...data.item })
-                        const eventId = crosspostResult?.eventId;
-                        if (eventId) {
-                            await upsertDiscussion({
-                              variables: {
-                                sub: item?.subName || sub?.name,
-                                id: item?.id,
-                                boost: item?.boost ? (Number(item?.boost) >= 25000 ? Number(item?.boost) : undefined) : undefined,
-                                noteId: eventId,
-                                title: item?.title
-                              }
-                            })
-                        }
-                        await router.push(`/items/${item.id}`)
-                    }
-                } catch (e) {
-                    console.error(e)
-                }
-            }}
-        >
-            crosspost to nostr
-        </Dropdown.Item>
-    ) : (
-        <Dropdown.Item onClick={() => window.open(`https://nostr.band/${item.noteId}`, '_blank')}>
-            nostr note
-        </Dropdown.Item>
-    )
+                })
+              }
+              await router.push(`/items/${item.id}`)
+            }
+          } catch (e) {
+            console.error(e)
+          }
+        }}
+      >
+        crosspost to nostr
+      </Dropdown.Item>
+      )
+    : (
+      <Dropdown.Item onClick={() => window.open(`https://nostr.band/${item.noteId}`, '_blank')}>
+        nostr note
+      </Dropdown.Item>
+      )
 }

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -76,16 +76,12 @@ export function DiscussionForm ({
         console.error(e)
       }
       
-      // If crossposting was successful, save the event id
       if (eventId) {
         await upsertDiscussion({
           variables: {
-            sub: item?.subName || sub?.name,
             id: discussionId,
-            boost: boost ? Number(boost) : undefined,
             ...values,
             forward: normalizeForwards(values.forward),
-            crosspost: true,
             noteId: eventId
           }
         })

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -59,23 +59,23 @@ export function DiscussionForm ({
           forward: normalizeForwards(values.forward)
         }
       })
-      
+
       if (error) {
         throw new Error({ message: error.toString() })
       }
-      
-      let eventId = null;
-      let discussionId = data?.upsertDiscussion?.id;
-      
+
+      let eventId = null
+      const discussionId = data?.upsertDiscussion?.id
+
       try {
         if (crosspost && discussionId) {
           const crosspostResult = await crossposter({ ...values, id: discussionId })
-          eventId = crosspostResult?.eventId;
+          eventId = crosspostResult?.eventId
         }
       } catch (e) {
         console.error(e)
       }
-      
+
       if (eventId) {
         await upsertDiscussion({
           variables: {
@@ -85,7 +85,7 @@ export function DiscussionForm ({
             noteId: eventId
           }
         })
-      }      
+      }
 
       if (item) {
         await router.push(`/items/${item.id}`)

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -33,8 +33,8 @@ export function DiscussionForm ({
 
   const [upsertDiscussion] = useMutation(
     gql`
-      mutation upsertDiscussion($sub: String, $id: ID, $title: String!, $text: String, $boost: Int, $forward: [ItemForwardInput], $hash: String, $hmac: String, $nEventId: String) {
-        upsertDiscussion(sub: $sub, id: $id, title: $title, text: $text, boost: $boost, forward: $forward, hash: $hash, hmac: $hmac, nEventId: $nEventId) {
+      mutation upsertDiscussion($sub: String, $id: ID, $title: String!, $text: String, $boost: Int, $forward: [ItemForwardInput], $hash: String, $hmac: String, $noteId: String) {
+        upsertDiscussion(sub: $sub, id: $id, title: $title, text: $text, boost: $boost, forward: $forward, hash: $hash, hmac: $hmac, noteId: $noteId) {
           id
         }
       }`
@@ -86,7 +86,7 @@ export function DiscussionForm ({
             ...values,
             forward: normalizeForwards(values.forward),
             crosspost: true,
-            nEventId: eventId
+            noteId: eventId
           }
         })
       }      

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -33,8 +33,8 @@ export function DiscussionForm ({
 
   const [upsertDiscussion] = useMutation(
     gql`
-      mutation upsertDiscussion($sub: String, $id: ID, $title: String!, $text: String, $boost: Int, $forward: [ItemForwardInput], $hash: String, $hmac: String) {
-        upsertDiscussion(sub: $sub, id: $id, title: $title, text: $text, boost: $boost, forward: $forward, hash: $hash, hmac: $hmac) {
+      mutation upsertDiscussion($sub: String, $id: ID, $title: String!, $text: String, $boost: Int, $forward: [ItemForwardInput], $hash: String, $hmac: String, $nEventId: String) {
+        upsertDiscussion(sub: $sub, id: $id, title: $title, text: $text, boost: $boost, forward: $forward, hash: $hash, hmac: $hmac, nEventId: $nEventId) {
           id
         }
       }`
@@ -59,18 +59,37 @@ export function DiscussionForm ({
           forward: normalizeForwards(values.forward)
         }
       })
-
+      
       if (error) {
         throw new Error({ message: error.toString() })
       }
-
+      
+      let eventId = null;
+      let discussionId = data?.upsertDiscussion?.id;
+      
       try {
-        if (crosspost && data?.upsertDiscussion?.id) {
-          await crossposter({ ...values, id: data.upsertDiscussion.id })
+        if (crosspost && discussionId) {
+          const crosspostResult = await crossposter({ ...values, id: discussionId })
+          eventId = crosspostResult?.eventId;
         }
       } catch (e) {
         console.error(e)
       }
+      
+      // If crossposting was successful, save the event id
+      if (eventId) {
+        await upsertDiscussion({
+          variables: {
+            sub: item?.subName || sub?.name,
+            id: discussionId,
+            boost: boost ? Number(boost) : undefined,
+            ...values,
+            forward: normalizeForwards(values.forward),
+            crosspost: true,
+            nEventId: eventId
+          }
+        })
+      }      
 
       if (item) {
         await router.push(`/items/${item.id}`)

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -25,7 +25,6 @@ export default function ItemInfo ({
   commentTextSingular = 'comment', className, embellishUser, extraInfo, onEdit, editText,
   onQuoteReply, nofollow
 }) {
-  console.log('item', item)
   const editThreshold = new Date(item.createdAt).getTime() + 10 * 60000
   const me = useMe()
   const router = useRouter()
@@ -146,7 +145,7 @@ export default function ItemInfo ({
           </Link>}
         {me && !item.meSats && !item.position &&
           !item.mine && !item.deletedAt && <DontLikeThisDropdownItem id={item.id} />}
-        {me && <CrosspostDropdownItem item={item} />}
+        {me && !item.pollCost && !item.url && !item.bounty && <CrosspostDropdownItem item={item} />}
         {item.mine && !item.position && !item.deletedAt &&
           <DeleteDropdownItem itemId={item.id} type={item.title ? 'post' : 'comment'} />}
         {me && !item.mine &&

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -18,12 +18,14 @@ import Hat from './hat'
 import { AD_USER_ID } from '../lib/constants'
 import ActionDropdown from './action-dropdown'
 import MuteDropdownItem from './mute'
+import CrosspostDropdownItem from './crosspost-item'
 
 export default function ItemInfo ({
   item, pendingSats, full, commentsText = 'comments',
   commentTextSingular = 'comment', className, embellishUser, extraInfo, onEdit, editText,
   onQuoteReply, nofollow
 }) {
+  console.log('item', item)
   const editThreshold = new Date(item.createdAt).getTime() + 10 * 60000
   const me = useMe()
   const router = useRouter()
@@ -144,6 +146,7 @@ export default function ItemInfo ({
           </Link>}
         {me && !item.meSats && !item.position &&
           !item.mine && !item.deletedAt && <DontLikeThisDropdownItem id={item.id} />}
+        {me && <CrosspostDropdownItem item={item} />}
         {item.mine && !item.position && !item.deletedAt &&
           <DeleteDropdownItem itemId={item.id} type={item.title ? 'post' : 'comment'} />}
         {me && !item.mine &&

--- a/components/use-crossposter.js
+++ b/components/use-crossposter.js
@@ -5,17 +5,20 @@ import { DEFAULT_CROSSPOSTING_RELAYS, crosspost } from '../lib/nostr'
 import { useQuery } from '@apollo/client'
 import { SETTINGS } from '../fragments/users'
 
-async function discussionToEvent (item) {
-  const createdAt = Math.floor(Date.now() / 1000)
+async function discussionToEvent (item, publishedAt=null) {
+
+  if (!publishedAt) {
+    publishedAt = Math.floor(Date.now() / 1000)
+  }
 
   return {
-    created_at: createdAt,
+    created_at: Math.floor(Date.now() / 1000),
     kind: 30023,
     content: item.text,
     tags: [
       ['d', item.id.toString()],
       ['title', item.title],
-      ['published_at', createdAt.toString()]
+      ['published_at', publishedAt.toString()]
     ]
   }
 }

--- a/components/use-crossposter.js
+++ b/components/use-crossposter.js
@@ -6,14 +6,16 @@ import { useQuery } from '@apollo/client'
 import { SETTINGS } from '../fragments/users'
 
 async function discussionToEvent (item) {
+  const createdAt = Math.floor(Date.now() / 1000)
+
   return {
-    created_at: Math.floor(Date.now() / 1000),
+    created_at: createdAt,
     kind: 30023,
     content: item.text,
     tags: [
       ['d', item.id.toString()],
       ['title', item.title],
-      ['published_at', Math.floor(Date.now() / 1000).toString()]
+      ['published_at', createdAt.toString()]
     ]
   }
 }

--- a/components/use-crossposter.js
+++ b/components/use-crossposter.js
@@ -5,12 +5,7 @@ import { DEFAULT_CROSSPOSTING_RELAYS, crosspost } from '../lib/nostr'
 import { useQuery } from '@apollo/client'
 import { SETTINGS } from '../fragments/users'
 
-async function discussionToEvent (item, publishedAt=null) {
-
-  if (!publishedAt) {
-    publishedAt = Math.floor(Date.now() / 1000)
-  }
-
+async function discussionToEvent (item) {
   return {
     created_at: Math.floor(Date.now() / 1000),
     kind: 30023,
@@ -18,7 +13,7 @@ async function discussionToEvent (item, publishedAt=null) {
     tags: [
       ['d', item.id.toString()],
       ['title', item.title],
-      ['published_at', publishedAt.toString()]
+      ['published_at', Math.floor(Date.now() / 1000).toString()]
     ]
   }
 }

--- a/components/use-crossposter.js
+++ b/components/use-crossposter.js
@@ -53,11 +53,14 @@ export default function useCrossposter () {
   return useCallback(async item => {
     let failedRelays
     let allSuccessful = false
+    let eventId
 
     do {
       // XXX we only use discussions right now
       const event = await discussionToEvent(item)
       const result = await crosspost(event, failedRelays || relays)
+
+      eventId = result.eventId
 
       failedRelays = result.failedRelays.map(relayObj => relayObj.relay)
 
@@ -73,6 +76,6 @@ export default function useCrossposter () {
       }
     } while (failedRelays.length > 0)
 
-    return { allSuccessful }
+    return { allSuccessful, eventId }
   }, [relays, toast])
 }

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -24,6 +24,7 @@ export const ITEM_FIELDS = gql`
     boost
     bounty
     bountyPaidTo
+    nEventId
     path
     upvotes
     meSats

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -24,7 +24,7 @@ export const ITEM_FIELDS = gql`
     boost
     bounty
     bountyPaidTo
-    nEventId
+    noteId
     path
     upvotes
     meSats

--- a/lib/nostr.js
+++ b/lib/nostr.js
@@ -98,7 +98,7 @@ export async function crosspost (event, relays = DEFAULT_CROSSPOSTING_RELAYS) {
       }
     })
 
-    const eventId = hexToBech32(signedEvent.id, 'nevent')
+    const eventId = hexToBech32(signedEvent.id, 'note')
 
     return { successfulRelays, failedRelays, eventId }
   } catch (error) {

--- a/prisma/migrations/20231015221558_add_nostr_event_id/migration.sql
+++ b/prisma/migrations/20231015221558_add_nostr_event_id/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "Item" ADD COLUMN     "nEventId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Item.nEventId_unique" ON "Item"("nEventId");

--- a/prisma/migrations/20231015221558_add_nostr_event_id/migration.sql
+++ b/prisma/migrations/20231015221558_add_nostr_event_id/migration.sql
@@ -1,4 +1,4 @@
-ALTER TABLE "Item" ADD COLUMN     "nEventId" TEXT;
+ALTER TABLE "Item" ADD COLUMN     "noteId" TEXT;
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Item.nEventId_unique" ON "Item"("nEventId");
+CREATE UNIQUE INDEX "Item.noteId_unique" ON "Item"("noteId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -296,7 +296,7 @@ model Item {
   otsHash            String?
   imgproxyUrls       Json?
   bounty             Int?
-  noteId           String?               @unique(map: "Item.noteId_unique")
+  noteId             String?               @unique(map: "Item.noteId_unique")
   rootId             Int?
   bountyPaidTo       Int[]
   upvotes            Int                   @default(0)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -296,6 +296,7 @@ model Item {
   otsHash            String?
   imgproxyUrls       Json?
   bounty             Int?
+  nEventId           String?               @unique(map: "Item.nEventId_unique")
   rootId             Int?
   bountyPaidTo       Int[]
   upvotes            Int                   @default(0)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -296,7 +296,7 @@ model Item {
   otsHash            String?
   imgproxyUrls       Json?
   bounty             Int?
-  nEventId           String?               @unique(map: "Item.nEventId_unique")
+  noteId           String?               @unique(map: "Item.noteId_unique")
   rootId             Int?
   bountyPaidTo       Int[]
   upvotes            Int                   @default(0)


### PR DESCRIPTION
This PR allows for crossposting past discussion items to nostr and it also saves the nostr event id for any crossposted items allowing the user to easily link out to it.

## High level summary:
- crosspost old discussion items to nostr
- Save noteId on item when crossposted
- Option to crosspost old discussion is available on item-info
- If it has been crossposted and eventId has been saved then a 'nostr note' dropdown item is presented that will link you to your crosposted note on nostr.band

## User facing changes
- "crosspost to nostr" dropdown item on item-info for old discussions
- "nostr note" dropdown item on item-info for crossposted discussions that links to the note on nostr.band

## Internal code changes:
- Migration to add noteId to Item table
- noteId String added to Item in schema.prisma
- noteId added to typedefs/item
- noteId added to resolvers/item
- noteId added to fragments/item
- Added an Item update mutation in discussion form:
  - In discussion form the Item is now saved to the db, crossposted, and then the noteId from the crosspost is saved to the item
- Added crosspost-item component that lives as a dropdown item under item-info (rendered for discussion items only)