### PR TITLE
Dont display price component until after initial render

### DIFF
--- a/components/price.js
+++ b/components/price.js
@@ -29,6 +29,8 @@ export function PriceProvider ({ price, children }) {
         })
   })
 
+  console.log('data',data);
+
   const contextValue = {
     price: data?.price || price,
     fiatSymbol: CURRENCY_SYMBOLS[fiatCurrency] || '$'
@@ -44,7 +46,8 @@ export function PriceProvider ({ price, children }) {
 export default function Price ({ className }) {
   const [asSats, setAsSats] = useState(undefined)
   useEffect(() => {
-    setAsSats(window.localStorage.getItem('asSats'))
+    const ticker = window.localStorage.getItem('asSats');
+    setAsSats(ticker ?? 'fiat')
   }, [])
   const { price, fiatSymbol } = usePrice()
   const { height: blockHeight } = useBlockHeight()
@@ -62,7 +65,7 @@ export default function Price ({ className }) {
       setAsSats('blockHeight')
     } else if (asSats === 'blockHeight') {
       window.localStorage.removeItem('asSats')
-      setAsSats(undefined)
+      setAsSats('fiat')
     } else {
       window.localStorage.setItem('asSats', 'yep')
       setAsSats('yep')
@@ -95,9 +98,11 @@ export default function Price ({ className }) {
     )
   }
 
-  return (
-    <div className={compClassName} onClick={handleClick} variant='link'>
-      {fiatSymbol + fixedDecimal(price, 0)}
-    </div>
-  )
+  if (asSats === 'fiat') {
+    return (
+      <div className={compClassName} onClick={handleClick} variant='link'>
+        {fiatSymbol + fixedDecimal(price, 0)}
+      </div>
+    )
+  }
 }

--- a/components/price.js
+++ b/components/price.js
@@ -44,7 +44,7 @@ export function PriceProvider ({ price, children }) {
 export default function Price ({ className }) {
   const [asSats, setAsSats] = useState(undefined)
   useEffect(() => {
-    const satSelection = window.localStorage.getItem('asSats');
+    const satSelection = window.localStorage.getItem('asSats')
     setAsSats(satSelection ?? 'fiat')
   }, [])
   const { price, fiatSymbol } = usePrice()

--- a/components/price.js
+++ b/components/price.js
@@ -29,8 +29,6 @@ export function PriceProvider ({ price, children }) {
         })
   })
 
-  console.log('data',data);
-
   const contextValue = {
     price: data?.price || price,
     fiatSymbol: CURRENCY_SYMBOLS[fiatCurrency] || '$'
@@ -46,8 +44,8 @@ export function PriceProvider ({ price, children }) {
 export default function Price ({ className }) {
   const [asSats, setAsSats] = useState(undefined)
   useEffect(() => {
-    const ticker = window.localStorage.getItem('asSats');
-    setAsSats(ticker ?? 'fiat')
+    const satSelection = window.localStorage.getItem('asSats');
+    setAsSats(satSelection ?? 'fiat')
   }, [])
   const { price, fiatSymbol } = usePrice()
   const { height: blockHeight } = useBlockHeight()


### PR DESCRIPTION
https://stacker.news/items/313119

Currently, the price of bitcoin briefly flashes before the user's selected ticker appears in the header. The fix could involve waiting until after the initial render to display the user's selection, and defaulting to the fiat price of bitcoin.