### PR TITLE
Account Switching

### DIFF
--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -130,8 +130,9 @@ export default {
 
       return await models.user.findUnique({ where: { id: me.id } })
     },
-    user: async (parent, { name }, { models }) => {
-      return await models.user.findUnique({ where: { name } })
+    user: async (parent, { id, name }, { models }) => {
+      if (id) id = Number(id)
+      return await models.user.findUnique({ where: { id, name } })
     },
     users: async (parent, args, { models }) =>
       await models.user.findMany(),

--- a/api/ssrApollo.js
+++ b/api/ssrApollo.js
@@ -139,7 +139,13 @@ export function getGetServerSideProps (
 
     const client = await getSSRApolloClient({ req, res })
 
-    const { data: { me } } = await client.query({ query: ME })
+    let { data: { me } } = await client.query({ query: ME })
+
+    // required to redirect to /signup on page reload
+    // if we switched to anon and authentication is required
+    if (req.cookies['multi_auth.user-id'] === 'anonymous') {
+      me = null
+    }
 
     if (authRequired && !me) {
       let callback = process.env.NEXT_PUBLIC_URL + req.url

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -4,7 +4,7 @@ export default gql`
   extend type Query {
     me: User
     settings: User
-    user(name: String!): User
+    user(id: ID, name: String): User
     users: [User!]
     nameAvailable(name: String!): Boolean!
     topUsers(cursor: String, when: String, from: String, to: String, by: String, limit: Limit): UsersNullable!

--- a/components/account.js
+++ b/components/account.js
@@ -39,19 +39,17 @@ export const AccountProvider = ({ children }) => {
     } catch (err) {
       console.error('error parsing cookies:', err)
     }
-  }, [setAccounts])
-
-  useEffect(() => {
-    updateAccountsFromCookie()
   }, [])
+
+  useEffect(updateAccountsFromCookie, [])
 
   const addAccount = useCallback(user => {
     setAccounts(accounts => [...accounts, user])
-  }, [setAccounts])
+  }, [])
 
   const removeAccount = useCallback(userId => {
     setAccounts(accounts => accounts.filter(({ id }) => id !== userId))
-  }, [setAccounts])
+  }, [])
 
   const multiAuthSignout = useCallback(async () => {
     const { status } = await fetch('/api/signout', { credentials: 'include' })

--- a/components/account.js
+++ b/components/account.js
@@ -2,7 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useState } from 'rea
 import { useRouter } from 'next/router'
 import cookie from 'cookie'
 import { useMe } from '@/components/me'
-import { ANON_USER_ID, SSR } from '@/lib/constants'
+import { USER_ID, SSR } from '@/lib/constants'
 import { USER } from '@/fragments/users'
 import { useApolloClient, useQuery } from '@apollo/client'
 import { UserListRow } from '@/components/user-list'
@@ -75,7 +75,7 @@ export const useAccounts = () => useContext(AccountContext)
 const AccountListRow = ({ account, ...props }) => {
   const { isAnon, setIsAnon } = useAccounts()
   const { me, refreshMe } = useMe()
-  const anonRow = account.id === ANON_USER_ID
+  const anonRow = account.id === USER_ID.anon
   const selected = (isAnon && anonRow) || Number(me?.id) === Number(account.id)
   const client = useApolloClient()
 
@@ -103,12 +103,8 @@ const AccountListRow = ({ account, ...props }) => {
     } else {
       await refreshMe()
       // order is important to prevent flashes of inconsistent data in switch account dialog
-      setIsAnon(account.id === ANON_USER_ID)
+      setIsAnon(account.id === USER_ID.anon)
     }
-    // TODO: this throws
-    //   Invalid `prisma.user.findUnique()` invocation:
-    // because for some reason, a USER query with no variables is executed
-    // (next to a USER query with the correct variables)
     await client.refetchQueries({ include: 'active' })
   }
 
@@ -134,7 +130,7 @@ export default function SwitchAccountList () {
     <>
       <div className='my-2'>
         <div className='d-flex flex-column flex-wrap'>
-          <AccountListRow account={{ id: ANON_USER_ID, name: 'anon' }} showHat={false} />
+          <AccountListRow account={{ id: USER_ID.anon, name: 'anon' }} showHat={false} />
           {
             accounts.map((account) => <AccountListRow key={account.id} account={account} showHat={false} />)
           }

--- a/components/account.js
+++ b/components/account.js
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/router'
 import cookie from 'cookie'
 import { useMe } from '@/components/me'
@@ -12,14 +12,14 @@ const AccountContext = createContext()
 const b64Decode = str => Buffer.from(str, 'base64').toString('utf-8')
 const b64Encode = obj => Buffer.from(JSON.stringify(obj)).toString('base64')
 
-const secureCookie = cookie => {
+const maybeSecureCookie = cookie => {
   return window.location.protocol === 'https:' ? cookie + '; Secure' : cookie
 }
 
 export const AccountProvider = ({ children }) => {
   const { me } = useMe()
   const [accounts, setAccounts] = useState([])
-  const [isAnon, setIsAnon] = useState(true)
+  const [meAnon, setMeAnon] = useState(true)
 
   const updateAccountsFromCookie = useCallback(() => {
     try {
@@ -31,7 +31,7 @@ export const AccountProvider = ({ children }) => {
       // required for backwards compatibility: sync cookie with accounts if no multi auth cookie exists
       // this is the case for sessions that existed before we deployed account switching
       if (!multiAuthCookie && !!me) {
-        document.cookie = secureCookie(`multi_auth=${b64Encode(accounts)}; Path=/`)
+        document.cookie = maybeSecureCookie(`multi_auth=${b64Encode(accounts)}; Path=/`)
       }
     } catch (err) {
       console.error('error parsing cookies:', err)
@@ -51,32 +51,33 @@ export const AccountProvider = ({ children }) => {
   }, [setAccounts])
 
   const multiAuthSignout = useCallback(async () => {
-    // switch to next available account
     const { status } = await fetch('/api/signout', { credentials: 'include' })
-    // if status is 201, this mean the server was able to switch us to the next available account
+    // if status is 302, this means the server was able to switch us to the next available account
     // and the current account was simply removed from the list of available accounts including the corresponding JWT.
-    // -> update needed to sync state with cookies
-    if (status === 201) updateAccountsFromCookie()
-    return status
+    const switchSuccess = status === 302
+    if (switchSuccess) updateAccountsFromCookie()
+    return switchSuccess
   }, [updateAccountsFromCookie])
 
   useEffect(() => {
-    // document not defined on server
     if (SSR) return
     const { 'multi_auth.user-id': multiAuthUserIdCookie } = cookie.parse(document.cookie)
-    setIsAnon(multiAuthUserIdCookie === 'anonymous')
+    setMeAnon(multiAuthUserIdCookie === 'anonymous')
   }, [])
 
-  return <AccountContext.Provider value={{ accounts, addAccount, removeAccount, isAnon, setIsAnon, multiAuthSignout }}>{children}</AccountContext.Provider>
+  const value = useMemo(
+    () => ({ accounts, addAccount, removeAccount, meAnon, setMeAnon, multiAuthSignout }),
+    [accounts, addAccount, removeAccount, meAnon, setMeAnon, multiAuthSignout])
+  return <AccountContext.Provider value={value}>{children}</AccountContext.Provider>
 }
 
 export const useAccounts = () => useContext(AccountContext)
 
 const AccountListRow = ({ account, ...props }) => {
-  const { isAnon, setIsAnon } = useAccounts()
+  const { meAnon, setMeAnon } = useAccounts()
   const { me, refreshMe } = useMe()
   const anonRow = account.id === USER_ID.anon
-  const selected = (isAnon && anonRow) || Number(me?.id) === Number(account.id)
+  const selected = (meAnon && anonRow) || Number(me?.id) === Number(account.id)
   const client = useApolloClient()
 
   // fetch updated names and photo ids since they might have changed since we were issued the JWTs
@@ -95,15 +96,15 @@ const AccountListRow = ({ account, ...props }) => {
   const onClick = async (e) => {
     // prevent navigation
     e.preventDefault()
-    document.cookie = secureCookie(`multi_auth.user-id=${anonRow ? 'anonymous' : account.id}; Path=/`)
+    document.cookie = maybeSecureCookie(`multi_auth.user-id=${anonRow ? 'anonymous' : account.id}; Path=/`)
     if (anonRow) {
       // order is important to prevent flashes of no session
-      setIsAnon(true)
+      setMeAnon(true)
       await refreshMe()
     } else {
       await refreshMe()
       // order is important to prevent flashes of inconsistent data in switch account dialog
-      setIsAnon(account.id === USER_ID.anon)
+      setMeAnon(account.id === USER_ID.anon)
     }
     await client.refetchQueries({
       include: 'active',

--- a/components/account.js
+++ b/components/account.js
@@ -1,0 +1,146 @@
+import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { useRouter } from 'next/router'
+import cookie from 'cookie'
+import { useMe } from '@/components/me'
+import { ANON_USER_ID, SSR } from '@/lib/constants'
+import { USER } from '@/fragments/users'
+import { useApolloClient, useQuery } from '@apollo/client'
+import { UserListRow } from '@/components/user-list'
+
+const AccountContext = createContext()
+
+const b64Decode = str => Buffer.from(str, 'base64').toString('utf-8')
+const b64Encode = obj => Buffer.from(JSON.stringify(obj)).toString('base64')
+
+const secureCookie = cookie => {
+  return window.location.protocol === 'https:' ? cookie + '; Secure' : cookie
+}
+
+export const AccountProvider = ({ children }) => {
+  const { me } = useMe()
+  const [accounts, setAccounts] = useState([])
+  const [isAnon, setIsAnon] = useState(true)
+
+  const updateAccountsFromCookie = useCallback(() => {
+    try {
+      const { multi_auth: multiAuthCookie } = cookie.parse(document.cookie)
+      const accounts = multiAuthCookie
+        ? JSON.parse(b64Decode(multiAuthCookie))
+        : me ? [{ id: Number(me.id), name: me.name, photoId: me.photoId }] : []
+      setAccounts(accounts)
+      // required for backwards compatibility: sync cookie with accounts if no multi auth cookie exists
+      // this is the case for sessions that existed before we deployed account switching
+      if (!multiAuthCookie && !!me) {
+        document.cookie = secureCookie(`multi_auth=${b64Encode(accounts)}; Path=/`)
+      }
+    } catch (err) {
+      console.error('error parsing cookies:', err)
+    }
+  }, [setAccounts])
+
+  useEffect(() => {
+    updateAccountsFromCookie()
+  }, [])
+
+  const addAccount = useCallback(user => {
+    setAccounts(accounts => [...accounts, user])
+  }, [setAccounts])
+
+  const removeAccount = useCallback(userId => {
+    setAccounts(accounts => accounts.filter(({ id }) => id !== userId))
+  }, [setAccounts])
+
+  const multiAuthSignout = useCallback(async () => {
+    // switch to next available account
+    const { status } = await fetch('/api/signout', { credentials: 'include' })
+    // if status is 201, this mean the server was able to switch us to the next available account
+    // and the current account was simply removed from the list of available accounts including the corresponding JWT.
+    // -> update needed to sync state with cookies
+    if (status === 201) updateAccountsFromCookie()
+    return status
+  }, [updateAccountsFromCookie])
+
+  useEffect(() => {
+    // document not defined on server
+    if (SSR) return
+    const { 'multi_auth.user-id': multiAuthUserIdCookie } = cookie.parse(document.cookie)
+    setIsAnon(multiAuthUserIdCookie === 'anonymous')
+  }, [])
+
+  return <AccountContext.Provider value={{ accounts, addAccount, removeAccount, isAnon, setIsAnon, multiAuthSignout }}>{children}</AccountContext.Provider>
+}
+
+export const useAccounts = () => useContext(AccountContext)
+
+const AccountListRow = ({ account, ...props }) => {
+  const { isAnon, setIsAnon } = useAccounts()
+  const { me, refreshMe } = useMe()
+  const anonRow = account.id === ANON_USER_ID
+  const selected = (isAnon && anonRow) || Number(me?.id) === Number(account.id)
+  const client = useApolloClient()
+
+  // fetch updated names and photo ids since they might have changed since we were issued the JWTs
+  const [name, setName] = useState(account.name)
+  const [photoId, setPhotoId] = useState(account.photoId)
+  useQuery(USER,
+    {
+      variables: { id: account.id },
+      onCompleted ({ user: { name, photoId } }) {
+        if (photoId) setPhotoId(photoId)
+        if (name) setName(name)
+      }
+    }
+  )
+
+  const onClick = async (e) => {
+    // prevent navigation
+    e.preventDefault()
+    document.cookie = secureCookie(`multi_auth.user-id=${anonRow ? 'anonymous' : account.id}; Path=/`)
+    if (anonRow) {
+      // order is important to prevent flashes of no session
+      setIsAnon(true)
+      await refreshMe()
+    } else {
+      await refreshMe()
+      // order is important to prevent flashes of inconsistent data in switch account dialog
+      setIsAnon(account.id === ANON_USER_ID)
+    }
+    // TODO: this throws
+    //   Invalid `prisma.user.findUnique()` invocation:
+    // because for some reason, a USER query with no variables is executed
+    // (next to a USER query with the correct variables)
+    await client.refetchQueries({ include: 'active' })
+  }
+
+  return (
+    <div className='d-flex flex-row'>
+      <UserListRow user={{ ...account, photoId, name }} className='d-flex align-items-center me-2' {...props} onNymClick={onClick} />
+      {selected && <div className='text-muted fst-italic text-muted'>selected</div>}
+    </div>
+  )
+}
+
+export default function SwitchAccountList () {
+  const { accounts } = useAccounts()
+  const router = useRouter()
+  const addAccount = () => {
+    router.push({
+      pathname: '/login',
+      query: { callbackUrl: window.location.origin + router.asPath, multiAuth: true }
+    })
+  }
+  // can't show hat since the streak is not included in the JWT payload
+  return (
+    <>
+      <div className='my-2'>
+        <div className='d-flex flex-column flex-wrap'>
+          <AccountListRow account={{ id: ANON_USER_ID, name: 'anon' }} showHat={false} />
+          {
+            accounts.map((account) => <AccountListRow key={account.id} account={account} showHat={false} />)
+          }
+          <div style={{ cursor: 'pointer' }} onClick={addAccount}>+ add account</div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/components/account.js
+++ b/components/account.js
@@ -150,15 +150,18 @@ const AccountListRow = ({ account, ...props }) => {
 
     await client.refetchQueries({
       include: 'active',
-      onQueryUpdated: (query, diff, lastDiff) => {
-        if (anonRow) {
-          // don't fetch queries which require a session
-          if (['WalletByType', 'WalletLogs', 'WalletHistory', 'Settings'].includes(query.queryName)) {
-            return false
+      onQueryUpdated: async (query) => {
+        try {
+          return await query.refetch()
+        } catch (err) {
+          const code = err.graphQLErrors?.[0]?.extensions?.code
+          if (['FORBIDDEN', 'UNAUTHENTICATED', 'BAD_INPUT', 'BAD_USER_INPUT'].includes(code)) {
+            return
           }
-        }
 
-        return query.refetch()
+          // never throw but log unexpected errors
+          console.error(err)
+        }
       }
     })
   }

--- a/components/account.js
+++ b/components/account.js
@@ -153,7 +153,7 @@ const AccountListRow = ({ account, ...props }) => {
       onQueryUpdated: (query, diff, lastDiff) => {
         if (anonRow) {
           // don't fetch queries which require a session
-          if (['WalletByType', 'WalletLogs', 'Settings'].includes(query.queryName)) {
+          if (['WalletByType', 'WalletLogs', 'WalletHistory', 'Settings'].includes(query.queryName)) {
             return false
           }
         }

--- a/components/account.js
+++ b/components/account.js
@@ -8,6 +8,7 @@ import { useApolloClient, useQuery } from '@apollo/client'
 import { UserListRow } from '@/components/user-list'
 import { Button } from 'react-bootstrap'
 import { ITEM_FULL } from '@/fragments/items'
+import { E_BAD_INPUT, E_FORBIDDEN, E_UNAUTHENTICATED } from '@/lib/error'
 
 const AccountContext = createContext()
 
@@ -155,7 +156,7 @@ const AccountListRow = ({ account, ...props }) => {
           return await query.refetch()
         } catch (err) {
           const code = err.graphQLErrors?.[0]?.extensions?.code
-          if (['FORBIDDEN', 'UNAUTHENTICATED', 'BAD_INPUT', 'BAD_USER_INPUT'].includes(code)) {
+          if ([E_FORBIDDEN, E_UNAUTHENTICATED, E_BAD_INPUT].includes(code)) {
             return
           }
 

--- a/components/account.js
+++ b/components/account.js
@@ -120,8 +120,7 @@ const AccountListRow = ({ account, ...props }) => {
 
   return (
     <div className='d-flex flex-row'>
-      <UserListRow user={{ ...account, photoId, name }} className='d-flex align-items-center me-2' {...props} onNymClick={onClick} />
-      {selected && <div className='text-muted fst-italic text-muted'>selected</div>}
+      <UserListRow user={{ ...account, photoId, name }} className='d-flex align-items-center me-2' {...props} onNymClick={onClick} selected={selected} />
     </div>
   )
 }

--- a/components/account.js
+++ b/components/account.js
@@ -6,6 +6,7 @@ import { USER_ID, SSR } from '@/lib/constants'
 import { USER } from '@/fragments/users'
 import { useApolloClient, useQuery } from '@apollo/client'
 import { UserListRow } from '@/components/user-list'
+import { Button } from 'react-bootstrap'
 
 const AccountContext = createContext()
 
@@ -138,13 +139,16 @@ export default function SwitchAccountList () {
   return (
     <>
       <div className='my-2'>
-        <div className='d-flex flex-column flex-wrap'>
+        <div className='d-flex flex-column flex-wrap my-2'>
+          <div className='fw-bold'>available accounts</div>
           <AccountListRow account={{ id: USER_ID.anon, name: 'anon' }} showHat={false} />
           {
             accounts.map((account) => <AccountListRow key={account.id} account={account} showHat={false} />)
           }
-          <div style={{ cursor: 'pointer' }} onClick={addAccount}>+ add account</div>
         </div>
+        <Button variant='outline-grey-darkmode' onClick={addAccount}>
+          add account
+        </Button>
       </div>
     </>
   )

--- a/components/account.js
+++ b/components/account.js
@@ -105,7 +105,16 @@ const AccountListRow = ({ account, ...props }) => {
       // order is important to prevent flashes of inconsistent data in switch account dialog
       setIsAnon(account.id === USER_ID.anon)
     }
-    await client.refetchQueries({ include: 'active' })
+    await client.refetchQueries({
+      include: 'active',
+      onQueryUpdated: (query, diff, lastDiff) => {
+        if (anonRow) {
+          // don't fetch queries which require a session
+          if (['WalletByType', 'WalletLogs', 'Settings'].includes(query.queryName)) return
+        }
+        return query.refetch()
+      }
+    })
   }
 
   return (

--- a/components/account.js
+++ b/components/account.js
@@ -165,7 +165,13 @@ const AccountListRow = ({ account, ...props }) => {
 
   return (
     <div className='d-flex flex-row'>
-      <UserListRow user={{ ...account, photoId, name }} className='d-flex align-items-center me-2' {...props} onNymClick={onClick} selected={selected} />
+      <UserListRow
+        user={{ ...account, photoId, name }}
+        className='d-flex align-items-center me-2'
+        {...props}
+        onNymClick={onClick}
+        selected={selected}
+      />
     </div>
   )
 }

--- a/components/account.js
+++ b/components/account.js
@@ -6,7 +6,8 @@ import { USER_ID, SSR } from '@/lib/constants'
 import { USER } from '@/fragments/users'
 import { useQuery } from '@apollo/client'
 import { UserListRow } from '@/components/user-list'
-import { Button } from 'react-bootstrap'
+import Link from 'next/link'
+import AddIcon from '@/svgs/add-fill.svg'
 
 const AccountContext = createContext()
 
@@ -130,26 +131,27 @@ const AccountListRow = ({ account, ...props }) => {
 export default function SwitchAccountList () {
   const { accounts } = useAccounts()
   const router = useRouter()
-  const addAccount = () => {
-    router.push({
-      pathname: '/login',
-      query: { callbackUrl: window.location.origin + router.asPath, multiAuth: true }
-    })
-  }
+
   // can't show hat since the streak is not included in the JWT payload
   return (
     <>
       <div className='my-2'>
-        <div className='d-flex flex-column flex-wrap my-2'>
-          <div className='fw-bold'>available accounts</div>
+        <div className='d-flex flex-column flex-wrap mt-2 mb-3'>
+          <h4 className='text-muted'>Accounts</h4>
           <AccountListRow account={{ id: USER_ID.anon, name: 'anon' }} showHat={false} />
           {
             accounts.map((account) => <AccountListRow key={account.id} account={account} showHat={false} />)
           }
         </div>
-        <Button variant='outline-grey-darkmode' onClick={addAccount}>
-          add account
-        </Button>
+        <Link
+          href={{
+            pathname: '/login',
+            query: { callbackUrl: window.location.origin + router.asPath, multiAuth: true }
+          }}
+          className='text-reset fw-bold'
+        >
+          <AddIcon height={20} width={20} /> another account
+        </Link>
       </div>
     </>
   )

--- a/components/adv-post-form.js
+++ b/components/adv-post-form.js
@@ -27,7 +27,7 @@ const FormStatus = {
 }
 
 export default function AdvPostForm ({ children, item, storageKeyPrefix }) {
-  const me = useMe()
+  const { me } = useMe()
   const { merge } = useFeeButton()
   const router = useRouter()
   const [itemType, setItemType] = useState()

--- a/components/autowithdraw-shared.js
+++ b/components/autowithdraw-shared.js
@@ -17,7 +17,7 @@ export function autowithdrawInitial ({ me }) {
 }
 
 export function AutowithdrawSettings ({ wallet }) {
-  const me = useMe()
+  const { me } = useMe()
   const threshold = autoWithdrawThreshold({ me })
 
   const [sendThreshold, setSendThreshold] = useState(Math.max(Math.floor(threshold / 10), 1))

--- a/components/banners.js
+++ b/components/banners.js
@@ -9,7 +9,7 @@ import { BALANCE_LIMIT_MSATS } from '@/lib/constants'
 import { msatsToSats, numWithUnits } from '@/lib/format'
 
 export function WelcomeBanner ({ Banner }) {
-  const me = useMe()
+  const { me } = useMe()
   const toaster = useToast()
   const [hidden, setHidden] = useState(true)
   const handleClose = async () => {
@@ -70,7 +70,7 @@ export function WelcomeBanner ({ Banner }) {
 }
 
 export function MadnessBanner ({ handleClose }) {
-  const me = useMe()
+  const { me } = useMe()
   return (
     <Alert className={styles.banner} key='info' variant='info' onClose={handleClose} dismissible>
       <Alert.Heading>
@@ -102,7 +102,7 @@ export function MadnessBanner ({ handleClose }) {
 }
 
 export function WalletLimitBanner () {
-  const me = useMe()
+  const { me } = useMe()
 
   const limitReached = me?.privates?.sats >= msatsToSats(BALANCE_LIMIT_MSATS)
   if (!me || !limitReached) return

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -23,7 +23,7 @@ export function BountyForm ({
   children
 }) {
   const client = useApolloClient()
-  const me = useMe()
+  const { me } = useMe()
   const schema = bountySchema({ client, me, existingBoost: item?.boost })
 
   const onSubmit = useItemSubmit(UPSERT_BOUNTY, { item, sub })

--- a/components/comment.js
+++ b/components/comment.js
@@ -96,7 +96,7 @@ export default function Comment ({
   rootText, noComments, noReply, truncate, depth, pin
 }) {
   const [edit, setEdit] = useState()
-  const me = useMe()
+  const { me } = useMe()
   const isHiddenFreebie = me?.privates?.satsFilter !== 0 && !item.mine && item.freebie && !item.freedFreebie
   const [collapse, setCollapse] = useState(
     (isHiddenFreebie || item?.user?.meMute || (item?.outlawed && !me?.privates?.wildWestMode)) && !includeParent

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -22,7 +22,7 @@ export function DiscussionForm ({
 }) {
   const router = useRouter()
   const client = useApolloClient()
-  const me = useMe()
+  const { me } = useMe()
   const onSubmit = useItemSubmit(UPSERT_DISCUSSION, { item, sub })
   const schema = discussionSchema({ client, me, existingBoost: item?.boost })
   // if Web Share Target API was used

--- a/components/fee-button.js
+++ b/components/fee-button.js
@@ -64,7 +64,7 @@ export function postCommentUseRemoteLineItems ({ parentId } = {}) {
 export function FeeButtonProvider ({ baseLineItems = {}, useRemoteLineItems = () => null, children }) {
   const [lineItems, setLineItems] = useState({})
   const [disabled, setDisabled] = useState(false)
-  const me = useMe()
+  const { me } = useMe()
 
   const remoteLineItems = useRemoteLineItems()
 
@@ -115,7 +115,7 @@ function FreebieDialog () {
 }
 
 export default function FeeButton ({ ChildButton = SubmitButton, variant, text, disabled }) {
-  const me = useMe()
+  const { me } = useMe()
   const { lines, total, disabled: ctxDisabled, free } = useFeeButton()
   const feeText = free
     ? 'free'

--- a/components/form.js
+++ b/components/form.js
@@ -808,7 +808,7 @@ export function Form ({
 }) {
   const toaster = useToast()
   const initialErrorToasted = useRef(false)
-  const me = useMe()
+  const { me } = useMe()
 
   useEffect(() => {
     if (initialError && !initialErrorToasted.current) {

--- a/components/hidden-wallet-summary.js
+++ b/components/hidden-wallet-summary.js
@@ -3,7 +3,7 @@ import { abbrNum, numWithUnits } from '@/lib/format'
 import { useMe } from './me'
 
 export default function HiddenWalletSummary ({ abbreviate, fixedWidth }) {
-  const me = useMe()
+  const { me } = useMe()
   const [hover, setHover] = useState(false)
 
   const fixedWidthAbbrSats = useMemo(() => {

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -50,7 +50,7 @@ const setItemMeAnonSats = ({ id, amount }) => {
 
 export default function ItemAct ({ onClose, item, down, children, abortSignal }) {
   const inputRef = useRef(null)
-  const me = useMe()
+  const { me } = useMe()
   const [oValue, setOValue] = useState()
 
   useEffect(() => {
@@ -203,7 +203,7 @@ export function useAct ({ query = ACT_MUTATION, ...options } = {}) {
 
 export function useZap () {
   const act = useAct()
-  const me = useMe()
+  const { me } = useMe()
   const strike = useLightning()
   const toaster = useToast()
 

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -11,6 +11,7 @@ import { nextTip, defaultTipIncludingRandom } from './upvote'
 import { ZAP_UNDO_DELAY_MS } from '@/lib/constants'
 import { usePaidMutation } from './use-paid-mutation'
 import { ACT_MUTATION } from '@/fragments/paidAction'
+import { meAnonSats } from '@/lib/apollo'
 
 const defaultTips = [100, 1000, 10_000, 100_000]
 
@@ -43,8 +44,12 @@ const addCustomTip = (amount) => {
 }
 
 const setItemMeAnonSats = ({ id, amount }) => {
+  const reactiveVar = meAnonSats[id]
+  const existingAmount = reactiveVar()
+  reactiveVar(existingAmount + amount)
+
+  // save for next page load
   const storageKey = `TIP-item:${id}`
-  const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
   window.localStorage.setItem(storageKey, existingAmount + amount)
 }
 

--- a/components/item-full.js
+++ b/components/item-full.js
@@ -25,7 +25,7 @@ import { useQuoteReply } from './use-quote-reply'
 import { UNKNOWN_LINK_REL } from '@/lib/constants'
 
 function BioItem ({ item, handleClick }) {
-  const me = useMe()
+  const { me } = useMe()
   if (!item.text) {
     return null
   }

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -33,7 +33,7 @@ export default function ItemInfo ({
   onQuoteReply, extraBadges, nested, pinnable, showActionDropdown = true, showUser = true
 }) {
   const editThreshold = new Date(item.invoice?.confirmedAt ?? item.createdAt).getTime() + 10 * 60000
-  const me = useMe()
+  const { me } = useMe()
   const toaster = useToast()
   const router = useRouter()
   const [canEdit, setCanEdit] =
@@ -273,7 +273,7 @@ export default function ItemInfo ({
 }
 
 function InfoDropdownItem ({ item }) {
-  const me = useMe()
+  const { me } = useMe()
   const showModal = useShowModal()
 
   const onClick = () => {

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -39,7 +39,6 @@ export default function ItemInfo ({
   const [canEdit, setCanEdit] =
     useState(item.mine && (Date.now() < editThreshold))
   const [hasNewComments, setHasNewComments] = useState(false)
-  const [meTotalSats, setMeTotalSats] = useState(0)
   const root = useRoot()
   const retryCreateItem = useRetryCreateItem({ id: item.id })
   const sub = item?.sub || root?.sub
@@ -54,10 +53,6 @@ export default function ItemInfo ({
     setCanEdit(item.mine && (Date.now() < editThreshold))
   }, [item.mine, editThreshold])
 
-  useEffect(() => {
-    if (item) setMeTotalSats((me ? item.meSats : item.meAnonSats) || 0)
-  }, [me, item?.meSats, item?.meAnonSats])
-
   // territory founders can pin any post in their territory
   // and OPs can pin any root reply in their post
   const isPost = !item.parentId
@@ -65,6 +60,7 @@ export default function ItemInfo ({
   const myPost = (me && root && Number(me.id) === Number(root.user.id))
   const rootReply = item.path.split('.').length === 2
   const canPin = (isPost && mySub) || (myPost && rootReply)
+  const meSats = (me ? item.meSats : item.meAnonSats) || 0
 
   const EditInfo = () => {
     const waitForQrPayment = useQrPayment()
@@ -131,7 +127,7 @@ export default function ItemInfo ({
             unitPlural: 'stackers'
           })} ${item.mine
             ? `\\ ${numWithUnits(item.meSats, { abbreviate: false })} to post`
-            : `(${numWithUnits(meTotalSats, { abbreviate: false })}${item.meDontLikeSats
+            : `(${numWithUnits(meSats, { abbreviate: false })}${item.meDontLikeSats
               ? ` & ${numWithUnits(item.meDontLikeSats, { abbreviate: false, unitSingular: 'downsat', unitPlural: 'downsats' })}`
               : ''} from me)`} `}
           >
@@ -229,7 +225,7 @@ export default function ItemInfo ({
                 <CrosspostDropdownItem item={item} />}
               {me && !item.position &&
             !item.mine && !item.deletedAt &&
-            (item.meDontLikeSats > meTotalSats
+            (item.meDontLikeSats > meSats
               ? <DropdownItemUpVote item={item} />
               : <DontLikeThisDropdownItem item={item} />)}
               {me && sub && !item.mine && !item.outlawed && Number(me.id) === Number(sub.userId) && sub.moderated &&

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -55,8 +55,8 @@ export default function ItemInfo ({
   }, [item.mine, editThreshold])
 
   useEffect(() => {
-    if (item) setMeTotalSats(item.meSats || item.meAnonSats || 0)
-  }, [item?.meSats, item?.meAnonSats])
+    if (item) setMeTotalSats((me ? item.meSats : item.meAnonSats) || 0)
+  }, [me, item?.meSats, item?.meAnonSats])
 
   // territory founders can pin any post in their territory
   // and OPs can pin any root reply in their post

--- a/components/item.js
+++ b/components/item.js
@@ -50,7 +50,7 @@ export function SearchTitle ({ title }) {
 }
 
 function mediaType ({ url, imgproxyUrls }) {
-  const me = useMe()
+  const { me } = useMe()
   const src = IMGPROXY_URL_REGEXP.test(url) ? decodeProxyUrl(url) : url
   if (!imgproxyUrls?.[src] ||
     me?.privates?.showImagesAndVideos === false ||

--- a/components/lightning-auth.js
+++ b/components/lightning-auth.js
@@ -11,7 +11,7 @@ import BackIcon from '@/svgs/arrow-left-line.svg'
 import { useRouter } from 'next/router'
 import { FAST_POLL_INTERVAL, SSR } from '@/lib/constants'
 
-function QrAuth ({ k1, encodedUrl, callbackUrl }) {
+function QrAuth ({ k1, encodedUrl, callbackUrl, multiAuth }) {
   const query = gql`
   {
     lnAuth(k1: "${k1}") {
@@ -23,7 +23,7 @@ function QrAuth ({ k1, encodedUrl, callbackUrl }) {
 
   useEffect(() => {
     if (data?.lnAuth?.pubkey) {
-      signIn('lightning', { ...data.lnAuth, callbackUrl })
+      signIn('lightning', { ...data.lnAuth, callbackUrl, multiAuth })
     }
   }, [data?.lnAuth])
 
@@ -101,15 +101,15 @@ function LightningExplainer ({ text, children }) {
   )
 }
 
-export function LightningAuthWithExplainer ({ text, callbackUrl }) {
+export function LightningAuthWithExplainer ({ text, callbackUrl, multiAuth }) {
   return (
     <LightningExplainer text={text}>
-      <LightningAuth callbackUrl={callbackUrl} />
+      <LightningAuth callbackUrl={callbackUrl} multiAuth={multiAuth} />
     </LightningExplainer>
   )
 }
 
-export function LightningAuth ({ callbackUrl }) {
+export function LightningAuth ({ callbackUrl, multiAuth }) {
   // query for challenge
   const [createAuth, { data, error }] = useMutation(gql`
     mutation createAuth {
@@ -125,5 +125,5 @@ export function LightningAuth ({ callbackUrl }) {
 
   if (error) return <div>error</div>
 
-  return data ? <QrAuth {...data.createAuth} callbackUrl={callbackUrl} /> : <QrSkeleton status='generating' />
+  return data ? <QrAuth {...data.createAuth} callbackUrl={callbackUrl} multiAuth={multiAuth} /> : <QrSkeleton status='generating' />
 }

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -21,7 +21,7 @@ import useDebounceCallback from './use-debounce-callback'
 export function LinkForm ({ item, sub, editThreshold, children }) {
   const router = useRouter()
   const client = useApolloClient()
-  const me = useMe()
+  const { me } = useMe()
   const schema = linkSchema({ client, me, existingBoost: item?.boost })
   // if Web Share Target API was used
   const shareUrl = router.query.url

--- a/components/logger.js
+++ b/components/logger.js
@@ -49,7 +49,7 @@ export const LoggerProvider = ({ children }) => {
 const ServiceWorkerLoggerContext = createContext()
 
 function ServiceWorkerLoggerProvider ({ children }) {
-  const me = useMe()
+  const { me } = useMe()
   const [name, setName] = useState()
   const [os, setOS] = useState()
 

--- a/components/login-button.js
+++ b/components/login-button.js
@@ -4,7 +4,7 @@ import LightningIcon from '@/svgs/bolt.svg'
 import NostrIcon from '@/svgs/nostr.svg'
 import Button from 'react-bootstrap/Button'
 
-export default function LoginButton ({ text, type, className, onClick }) {
+export default function LoginButton ({ text, type, className, onClick, disabled }) {
   let Icon, variant
   switch (type) {
     case 'twitter':
@@ -29,7 +29,7 @@ export default function LoginButton ({ text, type, className, onClick }) {
   const name = type.charAt(0).toUpperCase() + type.substr(1).toLowerCase()
 
   return (
-    <Button className={className} variant={variant} onClick={onClick}>
+    <Button className={className} variant={variant} onClick={onClick} disabled={disabled}>
       <Icon
         width={20}
         height={20} className='me-3'

--- a/components/login.js
+++ b/components/login.js
@@ -8,8 +8,11 @@ import { LightningAuthWithExplainer } from './lightning-auth'
 import { NostrAuthWithExplainer } from './nostr-auth'
 import LoginButton from './login-button'
 import { emailSchema } from '@/lib/validate'
+import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 
 export function EmailLoginForm ({ text, callbackUrl, multiAuth }) {
+  const disabled = multiAuth
+
   return (
     <Form
       initial={{
@@ -26,8 +29,9 @@ export function EmailLoginForm ({ text, callbackUrl, multiAuth }) {
         placeholder='email@example.com'
         required
         autoFocus
+        disabled={disabled}
       />
-      <SubmitButton variant='secondary' className={styles.providerButton}>{text || 'Login'} with Email</SubmitButton>
+      <SubmitButton disabled={disabled} variant='secondary' className={styles.providerButton}>{text || 'Login'} with Email</SubmitButton>
     </Form>
   )
 }
@@ -74,10 +78,16 @@ export default function Login ({ providers, callbackUrl, multiAuth, error, text,
         switch (provider.name) {
           case 'Email':
             return (
-              <div className='w-100' key={provider.id}>
-                <div className='mt-2 text-center text-muted fw-bold'>or</div>
-                <EmailLoginForm text={text} callbackUrl={callbackUrl} multiAuth={multiAuth} />
-              </div>
+              <OverlayTrigger
+                placement='bottom'
+                overlay={multiAuth ? <Tooltip>not available for account switching yet</Tooltip> : <></>}
+                trigger={['hover', 'focus']}
+              >
+                <div className='w-100' key={provider.id}>
+                  <div className='mt-2 text-center text-muted fw-bold'>or</div>
+                  <EmailLoginForm text={text} callbackUrl={callbackUrl} multiAuth={multiAuth} />
+                </div>
+              </OverlayTrigger>
             )
           case 'Lightning':
           case 'Slashtags':
@@ -99,13 +109,22 @@ export default function Login ({ providers, callbackUrl, multiAuth, error, text,
             )
           default:
             return (
-              <LoginButton
-                className={`mt-2 ${styles.providerButton}`}
-                key={provider.id}
-                type={provider.id.toLowerCase()}
-                onClick={() => signIn(provider.id, { callbackUrl, multiAuth })}
-                text={`${text || 'Login'} with`}
-              />
+              <OverlayTrigger
+                placement='bottom'
+                overlay={multiAuth ? <Tooltip>not available for account switching yet</Tooltip> : <></>}
+                trigger={['hover', 'focus']}
+              >
+                <div className='w-100'>
+                  <LoginButton
+                    className={`mt-2 ${styles.providerButton}`}
+                    key={provider.id}
+                    type={provider.id.toLowerCase()}
+                    onClick={() => signIn(provider.id, { callbackUrl, multiAuth })}
+                    text={`${text || 'Login'} with`}
+                    disabled={multiAuth}
+                  />
+                </div>
+              </OverlayTrigger>
             )
         }
       })}

--- a/components/login.js
+++ b/components/login.js
@@ -9,7 +9,7 @@ import NostrAuth from './nostr-auth'
 import LoginButton from './login-button'
 import { emailSchema } from '@/lib/validate'
 
-export function EmailLoginForm ({ text, callbackUrl }) {
+export function EmailLoginForm ({ text, callbackUrl, multiAuth }) {
   return (
     <Form
       initial={{
@@ -17,7 +17,7 @@ export function EmailLoginForm ({ text, callbackUrl }) {
       }}
       schema={emailSchema}
       onSubmit={async ({ email }) => {
-        signIn('email', { email, callbackUrl })
+        signIn('email', { email, callbackUrl, multiAuth })
       }}
     >
       <Input
@@ -48,16 +48,16 @@ export function authErrorMessage (error) {
   return error && (authErrorMessages[error] ?? authErrorMessages.default)
 }
 
-export default function Login ({ providers, callbackUrl, error, text, Header, Footer }) {
+export default function Login ({ providers, callbackUrl, multiAuth, error, text, Header, Footer }) {
   const [errorMessage, setErrorMessage] = useState(authErrorMessage(error))
   const router = useRouter()
 
   if (router.query.type === 'lightning') {
-    return <LightningAuthWithExplainer callbackUrl={callbackUrl} text={text} />
+    return <LightningAuthWithExplainer callbackUrl={callbackUrl} text={text} multiAuth={multiAuth} />
   }
 
   if (router.query.type === 'nostr') {
-    return <NostrAuth callbackUrl={callbackUrl} text={text} />
+    return <NostrAuth callbackUrl={callbackUrl} text={text} multiAuth={multiAuth} />
   }
 
   return (
@@ -76,7 +76,7 @@ export default function Login ({ providers, callbackUrl, error, text, Header, Fo
             return (
               <div className='w-100' key={provider.id}>
                 <div className='mt-2 text-center text-muted fw-bold'>or</div>
-                <EmailLoginForm text={text} callbackUrl={callbackUrl} />
+                <EmailLoginForm text={text} callbackUrl={callbackUrl} multiAuth={multiAuth} />
               </div>
             )
           case 'Lightning':
@@ -103,7 +103,7 @@ export default function Login ({ providers, callbackUrl, error, text, Header, Fo
                 className={`mt-2 ${styles.providerButton}`}
                 key={provider.id}
                 type={provider.id.toLowerCase()}
-                onClick={() => signIn(provider.id, { callbackUrl })}
+                onClick={() => signIn(provider.id, { callbackUrl, multiAuth })}
                 text={`${text || 'Login'} with`}
               />
             )

--- a/components/login.js
+++ b/components/login.js
@@ -5,7 +5,7 @@ import { useState } from 'react'
 import Alert from 'react-bootstrap/Alert'
 import { useRouter } from 'next/router'
 import { LightningAuthWithExplainer } from './lightning-auth'
-import NostrAuth from './nostr-auth'
+import { NostrAuthWithExplainer } from './nostr-auth'
 import LoginButton from './login-button'
 import { emailSchema } from '@/lib/validate'
 
@@ -57,7 +57,7 @@ export default function Login ({ providers, callbackUrl, multiAuth, error, text,
   }
 
   if (router.query.type === 'nostr') {
-    return <NostrAuth callbackUrl={callbackUrl} text={text} multiAuth={multiAuth} />
+    return <NostrAuthWithExplainer callbackUrl={callbackUrl} text={text} multiAuth={multiAuth} />
   }
 
   return (

--- a/components/me.js
+++ b/components/me.js
@@ -8,10 +8,14 @@ export const MeContext = React.createContext({
 })
 
 export function MeProvider ({ me, children }) {
-  const { data } = useQuery(ME, SSR ? {} : { pollInterval: FAST_POLL_INTERVAL, nextFetchPolicy: 'cache-and-network' })
+  const { data, refetch } = useQuery(ME, SSR ? {} : { pollInterval: FAST_POLL_INTERVAL, nextFetchPolicy: 'cache-and-network' })
+  // this makes sure that we always use the fetched data if it's null.
+  // without this, we would always fallback to the `me` object
+  // which was passed during page load which (visually) breaks switching to anon
+  const futureMe = data?.me ?? (data?.me === null ? null : me)
 
   return (
-    <MeContext.Provider value={data?.me || me}>
+    <MeContext.Provider value={{ me: futureMe, refreshMe: refetch }}>
       {children}
     </MeContext.Provider>
   )

--- a/components/media-or-link.js
+++ b/components/media-or-link.js
@@ -109,7 +109,7 @@ export default function MediaOrLink ({ linkFallback = true, ...props }) {
 
 // determines how the media should be displayed given the params, me settings, and editor tab
 export const useMediaHelper = ({ src, srcSet: srcSetIntital, topLevel, tab }) => {
-  const me = useMe()
+  const { me } = useMe()
   const trusted = useMemo(() => !!srcSetIntital || IMGPROXY_URL_REGEXP.test(src) || MEDIA_DOMAIN_REGEXP.test(src), [!!srcSetIntital, src])
   const { dimensions, video, format, ...srcSetObj } = srcSetIntital || {}
   const [isImage, setIsImage] = useState(!video && trusted)

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -267,9 +267,9 @@ export function LogoutDropdownItem () {
       <Dropdown.Item onClick={() => showModal(onClose => <SwitchAccountList onClose={onClose} />)}>switch account</Dropdown.Item>
       <Dropdown.Item
         onClick={async () => {
-          const status = await multiAuthSignout()
+          const switchSuccess = await multiAuthSignout()
           // only signout if multiAuth did not find a next available account
-          if (status === 201) return
+          if (switchSuccess) return
 
           // order is important because we need to be logged in to delete push subscription on server
           const pushSubscription = await swRegistration?.pushManager.getSubscription()

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -245,7 +245,7 @@ export default function LoginButton ({ className }) {
 
   return (
     <Button
-      className='align-items-center px-3 py-1 mb-2'
+      className='align-items-center px-3 py-1'
       id='login'
       style={{ borderWidth: '2px', width: '150px' }}
       variant='outline-grey-darkmode'
@@ -256,7 +256,7 @@ export default function LoginButton ({ className }) {
   )
 }
 
-export function LogoutDropdownItem () {
+export function LogoutDropdownItem ({ handleClose }) {
   const { registration: swRegistration, togglePushSubscription } = useServiceWorker()
   const wallets = useWallets()
   const { multiAuthSignout } = useAccounts()
@@ -264,7 +264,12 @@ export function LogoutDropdownItem () {
 
   return (
     <>
-      <Dropdown.Item onClick={() => showModal(onClose => <SwitchAccountList onClose={onClose} />)}>switch account</Dropdown.Item>
+      <Dropdown.Item onClick={() => {
+        handleClose?.()
+        showModal(onClose => <SwitchAccountList onClose={onClose} />)
+      }}
+      >switch account
+      </Dropdown.Item>
       <Dropdown.Item
         onClick={async () => {
           const switchSuccess = await multiAuthSignout()
@@ -287,7 +292,7 @@ export function LogoutDropdownItem () {
   )
 }
 
-function SwitchAccountButton () {
+function SwitchAccountButton ({ handleClose }) {
   const showModal = useShowModal()
   const { accounts } = useAccounts()
 
@@ -295,22 +300,33 @@ function SwitchAccountButton () {
 
   return (
     <Button
-      className='align-items-center px-3 py-1 mb-2 text-muted'
+      className='align-items-center px-3 py-1'
       variant='outline-grey-darkmode'
       style={{ borderWidth: '2px', width: '150px' }}
-      onClick={() => showModal(onClose => <SwitchAccountList onClose={onClose} />)}
+      onClick={() => {
+        // login buttons rendered in offcanvas aren't wrapped inside <Dropdown>
+        // so we manually close the offcanvas in that case by passing down handleClose here
+        handleClose?.()
+        showModal(onClose => <SwitchAccountList onClose={onClose} />)
+      }}
     >
       switch account
     </Button>
   )
 }
 
-export function LoginButtons () {
+export function LoginButtons ({ handleClose }) {
   return (
     <>
-      <LoginButton />
-      <SignUpButton className='mb-2 py-1' />
-      <SwitchAccountButton />
+      <Dropdown.Item>
+        <LoginButton />
+      </Dropdown.Item>
+      <Dropdown.Item>
+        <SignUpButton />
+      </Dropdown.Item>
+      <Dropdown.Item>
+        <SwitchAccountButton handleClose={handleClose} />
+      </Dropdown.Item>
     </>
   )
 }
@@ -330,7 +346,7 @@ export function AnonDropdown ({ path }) {
 
   return (
     <div className='position-relative'>
-      <Dropdown className={styles.dropdown} align='end'>
+      <Dropdown className={styles.dropdown} align='end' autoClose>
         <Dropdown.Toggle className='nav-link nav-item' id='profile' variant='custom'>
           <Nav.Link eventKey='anon' as='span' className='p-0 fw-normal'>
             @anon<Hat user={{ id: USER_ID.anon }} />

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -222,7 +222,7 @@ export function SignUpButton ({ className = 'py-0', width }) {
 
   return (
     <Button
-      className={classNames('align-items-center ps-2 pe-3', className)}
+      className={classNames('align-items-center ps-2 py-1 pe-3', className)}
       style={{ borderWidth: '2px', width: width || '150px' }}
       id='signup'
       onClick={() => handleLogin('/signup')}

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -163,8 +163,6 @@ export function NavWalletSummary ({ className }) {
 }
 
 export function MeDropdown ({ me, dropNavKey }) {
-  const showModal = useShowModal()
-
   if (!me) return null
   return (
     <div className='position-relative'>
@@ -204,7 +202,6 @@ export function MeDropdown ({ me, dropNavKey }) {
             </Link>
           </div>
           <Dropdown.Divider />
-          <Dropdown.Item onClick={() => showModal(onClose => <SwitchAccountList onClose={onClose} />)}>switch account</Dropdown.Item>
           <LogoutDropdownItem />
         </Dropdown.Menu>
       </Dropdown>
@@ -226,7 +223,7 @@ export function SignUpButton ({ className = 'py-0' }) {
   return (
     <Button
       className={classNames('align-items-center ps-2 pe-3', className)}
-      style={{ borderWidth: '2px', width: '112px' }}
+      style={{ borderWidth: '2px', width: '150px' }}
       id='signup'
       onClick={() => handleLogin('/signup')}
     >
@@ -250,7 +247,7 @@ export default function LoginButton ({ className }) {
     <Button
       className='align-items-center px-3 py-1 mb-2'
       id='login'
-      style={{ borderWidth: '2px', width: '112px' }}
+      style={{ borderWidth: '2px', width: '150px' }}
       variant='outline-grey-darkmode'
       onClick={() => handleLogin('/login')}
     >
@@ -263,37 +260,57 @@ export function LogoutDropdownItem () {
   const { registration: swRegistration, togglePushSubscription } = useServiceWorker()
   const wallets = useWallets()
   const { multiAuthSignout } = useAccounts()
-
-  return (
-    <Dropdown.Item
-      onClick={async () => {
-        const status = await multiAuthSignout()
-        // only signout if multiAuth did not find a next available account
-        if (status === 201) return
-
-        // order is important because we need to be logged in to delete push subscription on server
-        const pushSubscription = await swRegistration?.pushManager.getSubscription()
-        if (pushSubscription) {
-          await togglePushSubscription().catch(console.error)
-        }
-
-        await wallets.resetClient().catch(console.error)
-
-        await signOut({ callbackUrl: '/' })
-      }}
-    >logout
-    </Dropdown.Item>
-  )
-}
-
-export function LoginButtons () {
   const showModal = useShowModal()
 
   return (
     <>
+      <Dropdown.Item onClick={() => showModal(onClose => <SwitchAccountList onClose={onClose} />)}>switch account</Dropdown.Item>
+      <Dropdown.Item
+        onClick={async () => {
+          const status = await multiAuthSignout()
+          // only signout if multiAuth did not find a next available account
+          if (status === 201) return
+
+          // order is important because we need to be logged in to delete push subscription on server
+          const pushSubscription = await swRegistration?.pushManager.getSubscription()
+          if (pushSubscription) {
+            await togglePushSubscription().catch(console.error)
+          }
+
+          await wallets.resetClient().catch(console.error)
+
+          await signOut({ callbackUrl: '/' })
+        }}
+      >logout
+      </Dropdown.Item>
+    </>
+  )
+}
+
+function SwitchAccountButton () {
+  const showModal = useShowModal()
+  const { accounts } = useAccounts()
+
+  if (accounts.length === 0) return null
+
+  return (
+    <Button
+      className='align-items-center px-3 py-1 mb-2 text-muted'
+      variant='outline-grey-darkmode'
+      style={{ borderWidth: '2px', width: '150px' }}
+      onClick={() => showModal(onClose => <SwitchAccountList onClose={onClose} />)}
+    >
+      switch account
+    </Button>
+  )
+}
+
+export function LoginButtons () {
+  return (
+    <>
       <LoginButton />
-      <SignUpButton className='py-1' />
-      <Button onClick={() => showModal(onClose => <SwitchAccountList onClose={onClose} />)}>switch account</Button>
+      <SignUpButton className='mb-2 py-1' />
+      <SwitchAccountButton />
     </>
   )
 }

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -318,13 +318,13 @@ function SwitchAccountButton ({ handleClose }) {
 export function LoginButtons ({ handleClose }) {
   return (
     <>
-      <Dropdown.Item>
+      <Dropdown.Item className='py-1'>
         <LoginButton />
       </Dropdown.Item>
-      <Dropdown.Item>
+      <Dropdown.Item className='py-1'>
         <SignUpButton />
       </Dropdown.Item>
-      <Dropdown.Item>
+      <Dropdown.Item className='py-1'>
         <SwitchAccountButton handleClose={handleClose} />
       </Dropdown.Item>
     </>

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -213,7 +213,7 @@ export function MeDropdown ({ me, dropNavKey }) {
   )
 }
 
-export function SignUpButton ({ className = 'py-0' }) {
+export function SignUpButton ({ className = 'py-0', width }) {
   const router = useRouter()
   const handleLogin = useCallback(async pathname => await router.push({
     pathname,
@@ -223,7 +223,7 @@ export function SignUpButton ({ className = 'py-0' }) {
   return (
     <Button
       className={classNames('align-items-center ps-2 pe-3', className)}
-      style={{ borderWidth: '2px', width: '150px' }}
+      style={{ borderWidth: '2px', width: width || '150px' }}
       id='signup'
       onClick={() => handleLogin('/signup')}
     >

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -236,7 +236,7 @@ export function SignUpButton ({ className = 'py-0', width }) {
   )
 }
 
-export default function LoginButton ({ className }) {
+export default function LoginButton () {
   const router = useRouter()
   const handleLogin = useCallback(async pathname => await router.push({
     pathname,

--- a/components/nav/desktop/top-bar.js
+++ b/components/nav/desktop/top-bar.js
@@ -4,7 +4,7 @@ import { AnonCorner, Back, Brand, MeCorner, NavPrice, SearchItem } from '../comm
 import { useMe } from '../../me'
 
 export default function TopBar ({ prefix, sub, path, topNavKey, dropNavKey }) {
-  const me = useMe()
+  const { me } = useMe()
   return (
     <Navbar>
       <Nav

--- a/components/nav/mobile/footer.js
+++ b/components/nav/mobile/footer.js
@@ -30,7 +30,7 @@ function useDetectKeyboardOpen (minKeyboardHeight = 300, defaultValue) {
 
 export default function BottomBar ({ sub }) {
   const router = useRouter()
-  const me = useMe()
+  const { me } = useMe()
   const isKeyboardOpen = useDetectKeyboardOpen(200, false)
 
   if (isKeyboardOpen) {

--- a/components/nav/mobile/offcanvas.js
+++ b/components/nav/mobile/offcanvas.js
@@ -75,10 +75,10 @@ export default function OffCanvas ({ me, dropNavKey }) {
                     </Link>
                   </div>
                   <Dropdown.Divider />
-                  <LogoutDropdownItem />
+                  <LogoutDropdownItem handleClose={handleClose} />
                 </>
                 )
-              : <LoginButtons />}
+              : <LoginButtons handleClose={handleClose} />}
             <div className={classNames(styles.footerPadding, 'mt-auto')}>
               <Navbar className={classNames('container d-flex flex-row px-0 text-muted')}>
                 <Nav>

--- a/components/nav/mobile/second-bar.js
+++ b/components/nav/mobile/second-bar.js
@@ -4,7 +4,7 @@ import styles from '../../header.module.css'
 import { useMe } from '@/components/me'
 
 export default function SecondBar (props) {
-  const me = useMe()
+  const { me } = useMe()
   const { topNavKey } = props
   if (!hasNavSelect(props)) return null
   return (

--- a/components/nav/mobile/top-bar.js
+++ b/components/nav/mobile/top-bar.js
@@ -17,7 +17,7 @@ export default function TopBar ({ prefix, sub, path, pathname, topNavKey, dropNa
           : (
             <>
               <NavPrice className='flex-shrink-1' />
-              {me ? <NavWalletSummary /> : <SignUpButton />}
+              {me ? <NavWalletSummary /> : <SignUpButton width='fit-content' />}
             </>)}
       </Nav>
     </Navbar>

--- a/components/nav/mobile/top-bar.js
+++ b/components/nav/mobile/top-bar.js
@@ -4,7 +4,7 @@ import { Back, NavPrice, NavSelect, NavWalletSummary, SignUpButton, hasNavSelect
 import { useMe } from '@/components/me'
 
 export default function TopBar ({ prefix, sub, path, pathname, topNavKey, dropNavKey }) {
-  const me = useMe()
+  const { me } = useMe()
   return (
     <Navbar>
       <Nav

--- a/components/nav/sticky-bar.js
+++ b/components/nav/sticky-bar.js
@@ -49,7 +49,7 @@ export default function StickyBar ({ prefix, sub, path, topNavKey, dropNavKey })
           >
             <Back />
             <NavPrice className='flex-shrink-1 flex-grow-0' />
-            {me ? <NavWalletSummary className='px-2' /> : <SignUpButton />}
+            {me ? <NavWalletSummary className='px-2' /> : <SignUpButton width='fit-content' />}
           </Nav>
         </Navbar>
       </Container>

--- a/components/nav/sticky-bar.js
+++ b/components/nav/sticky-bar.js
@@ -7,7 +7,7 @@ import classNames from 'classnames'
 
 export default function StickyBar ({ prefix, sub, path, topNavKey, dropNavKey }) {
   const ref = useRef()
-  const me = useMe()
+  const { me } = useMe()
 
   useEffect(() => {
     const stick = () => {

--- a/components/nostr-auth.js
+++ b/components/nostr-auth.js
@@ -142,14 +142,14 @@ export function NostrAuth ({ text, callbackUrl, multiAuth }) {
   )
 }
 
-export default function NostrAuthWithExplainer ({ text, callbackUrl }) {
+export function NostrAuthWithExplainer ({ text, callbackUrl, multiAuth }) {
   const router = useRouter()
   return (
     <Container>
       <div className={styles.login}>
         <div className='w-100 mb-3 text-muted pointer' onClick={() => router.back()}><BackIcon /></div>
         <h3 className='w-100 pb-2'>{text || 'Login'} with Nostr</h3>
-        <NostrAuth text={text} callbackUrl={callbackUrl} />
+        <NostrAuth text={text} callbackUrl={callbackUrl} multiAuth={multiAuth} />
       </div>
     </Container>
   )

--- a/components/nostr-auth.js
+++ b/components/nostr-auth.js
@@ -64,7 +64,7 @@ function NostrExplainer ({ text }) {
   )
 }
 
-export function NostrAuth ({ text, callbackUrl }) {
+export function NostrAuth ({ text, callbackUrl, multiAuth }) {
   const [createAuth, { data, error }] = useMutation(gql`
     mutation createAuth {
       createAuth {
@@ -112,7 +112,8 @@ export function NostrAuth ({ text, callbackUrl }) {
         try {
           await signIn('nostr', {
             event: JSON.stringify(event),
-            callbackUrl
+            callbackUrl,
+            multiAuth
           })
         } catch (e) {
           throw new Error('authorization failed', e)

--- a/components/pay-bounty.js
+++ b/components/pay-bounty.js
@@ -42,7 +42,7 @@ export const payBountyCacheMods = {
 }
 
 export default function PayBounty ({ children, item }) {
-  const me = useMe()
+  const { me } = useMe()
   const showModal = useShowModal()
   const root = useRoot()
   const strike = useLightning()

--- a/components/payment.js
+++ b/components/payment.js
@@ -201,7 +201,7 @@ export const useQrPayment = () => {
 }
 
 export const usePayment = () => {
-  const me = useMe()
+  const { me } = useMe()
   const feeButton = useFeeButton()
   const invoice = useInvoice()
   const waitForWalletPayment = useWalletPayment()

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -14,7 +14,7 @@ import useItemSubmit from './use-item-submit'
 
 export function PollForm ({ item, sub, editThreshold, children }) {
   const client = useApolloClient()
-  const me = useMe()
+  const { me } = useMe()
   const schema = pollSchema({ client, me, existingBoost: item?.boost })
 
   const onSubmit = useItemSubmit(UPSERT_POLL, { item, sub })

--- a/components/poll.js
+++ b/components/poll.js
@@ -11,7 +11,7 @@ import { usePaidMutation } from './use-paid-mutation'
 import { POLL_VOTE, RETRY_PAID_ACTION } from '@/fragments/paidAction'
 
 export default function Poll ({ item }) {
-  const me = useMe()
+  const { me } = useMe()
   const pollVote = usePollVote({ query: POLL_VOTE, itemId: item.id })
   const toaster = useToast()
 

--- a/components/post.js
+++ b/components/post.js
@@ -17,7 +17,7 @@ import CancelButton from './cancel-button'
 import { TerritoryInfo } from './territory-header'
 
 export function PostForm ({ type, sub, children }) {
-  const me = useMe()
+  const { me } = useMe()
   const [errorMessage, setErrorMessage] = useState()
 
   const prefix = sub?.name ? `/~${sub.name}` : ''
@@ -150,7 +150,7 @@ export function PostForm ({ type, sub, children }) {
   return (
     <FeeButtonProvider
       baseLineItems={sub ? postCommentBaseLineItems({ baseCost: sub.baseCost, me: !!me }) : undefined}
-      useRemoteLineItems={postCommentUseRemoteLineItems({ me: !!me })}
+      useRemoteLineItems={postCommentUseRemoteLineItems()}
     >
       <FormType sub={sub}>{children}</FormType>
     </FeeButtonProvider>

--- a/components/price.js
+++ b/components/price.js
@@ -19,7 +19,7 @@ export function usePrice () {
 }
 
 export function PriceProvider ({ price, children }) {
-  const me = useMe()
+  const { me } = useMe()
   const fiatCurrency = me?.privates?.fiatCurrency
   const { data } = useQuery(PRICE, {
     variables: { fiatCurrency },

--- a/components/reply.js
+++ b/components/reply.js
@@ -40,7 +40,7 @@ export default forwardRef(function Reply ({
   quote
 }, ref) {
   const [reply, setReply] = useState(replyOpen || quote)
-  const me = useMe()
+  const { me } = useMe()
   const parentId = item.id
   const replyInput = useRef(null)
   const showModal = useShowModal()

--- a/components/search.js
+++ b/components/search.js
@@ -11,7 +11,7 @@ export default function Search ({ sub }) {
   const router = useRouter()
   const [q, setQ] = useState(router.query.q || '')
   const inputRef = useRef(null)
-  const me = useMe()
+  const { me } = useMe()
 
   useEffect(() => {
     inputRef.current?.focus()

--- a/components/share.js
+++ b/components/share.js
@@ -38,7 +38,7 @@ async function share (title, url, toaster) {
 }
 
 export default function Share ({ path, title = '', className = '' }) {
-  const me = useMe()
+  const { me } = useMe()
   const toaster = useToast()
   const url = referrurl(path, me)
 
@@ -56,7 +56,7 @@ export default function Share ({ path, title = '', className = '' }) {
 }
 
 export function CopyLinkDropdownItem ({ item }) {
-  const me = useMe()
+  const { me } = useMe()
   const toaster = useToast()
   const router = useRouter()
   let url = referrurl(`/items/${item.id}`, me)

--- a/components/territory-form.js
+++ b/components/territory-form.js
@@ -18,7 +18,7 @@ import { UNARCHIVE_TERRITORY, UPSERT_SUB } from '@/fragments/paidAction'
 export default function TerritoryForm ({ sub }) {
   const router = useRouter()
   const client = useApolloClient()
-  const me = useMe()
+  const { me } = useMe()
   const [upsertSub] = usePaidMutation(UPSERT_SUB)
   const [unarchiveTerritory] = usePaidMutation(UNARCHIVE_TERRITORY)
 

--- a/components/territory-header.js
+++ b/components/territory-header.js
@@ -57,7 +57,7 @@ export function TerritoryInfo ({ sub }) {
 }
 
 export default function TerritoryHeader ({ sub }) {
-  const me = useMe()
+  const { me } = useMe()
   const toaster = useToast()
 
   const [toggleMuteSub] = useMutation(

--- a/components/territory-payment-due.js
+++ b/components/territory-payment-due.js
@@ -12,7 +12,7 @@ import { usePaidMutation } from './use-paid-mutation'
 import { SUB_PAY } from '@/fragments/paidAction'
 
 export default function TerritoryPaymentDue ({ sub }) {
-  const me = useMe()
+  const { me } = useMe()
   const client = useApolloClient()
   const [paySub] = usePaidMutation(SUB_PAY)
 
@@ -72,7 +72,7 @@ export default function TerritoryPaymentDue ({ sub }) {
 }
 
 export function TerritoryBillingLine ({ sub }) {
-  const me = useMe()
+  const { me } = useMe()
   if (!sub || sub.userId !== Number(me?.id)) return null
 
   const dueDate = sub.billPaidUntil && new Date(sub.billPaidUntil)

--- a/components/territory-transfer.js
+++ b/components/territory-transfer.js
@@ -57,7 +57,7 @@ function TransferObstacle ({ sub, onClose, userName }) {
 function TerritoryTransferForm ({ sub, onClose }) {
   const showModal = useShowModal()
   const client = useApolloClient()
-  const me = useMe()
+  const { me } = useMe()
   const schema = territoryTransferSchema({ me, client })
 
   const onSubmit = useCallback(async (values) => {

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -168,7 +168,7 @@ export default function UpVote ({ item, className }) {
       meSats, overlayTextContent,
       getColor(meSats), getColor(meSats + sats)]
   }, [
-    item?.meSats, item?.meAnonSats, me?.privates?.tipDefault, me?.privates?.turboDefault,
+    me, item?.meSats, item?.meAnonSats, me?.privates?.tipDefault, me?.privates?.turboDefault,
     me?.privates?.tipRandom, me?.privates?.tipRandomMin, me?.privates?.tipRandomMax, pending])
 
   const handleModalClosed = () => {

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -14,7 +14,7 @@ import { numWithUnits } from '@/lib/format'
 import { Dropdown } from 'react-bootstrap'
 
 const UpvotePopover = ({ target, show, handleClose }) => {
-  const me = useMe()
+  const { me } = useMe()
   return (
     <Overlay
       show={show}
@@ -107,7 +107,7 @@ export default function UpVote ({ item, className }) {
   const [voteShow, _setVoteShow] = useState(false)
   const [tipShow, _setTipShow] = useState(false)
   const ref = useRef()
-  const me = useMe()
+  const { me } = useMe()
   const [hover, setHover] = useState(false)
   const [setWalkthrough] = useMutation(
     gql`

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -153,7 +153,7 @@ export default function UpVote ({ item, className }) {
     [item?.mine, item?.meForward, item?.deletedAt])
 
   const [meSats, overlayText, color, nextColor] = useMemo(() => {
-    const meSats = (item?.meSats || item?.meAnonSats || 0)
+    const meSats = (me ? item?.meSats : item?.meAnonSats) || 0
 
     // what should our next tip be?
     const sats = pending || nextTip(meSats, { ...me?.privates })

--- a/components/user-header.js
+++ b/components/user-header.js
@@ -175,7 +175,7 @@ function NymEdit ({ user, setEditting }) {
 }
 
 function NymView ({ user, isMe, setEditting }) {
-  const me = useMe()
+  const { me } = useMe()
   return (
     <div className='d-flex align-items-center mb-2'>
       <div className={styles.username}>@{user.name}<Hat className='' user={user} badge /></div>
@@ -237,7 +237,7 @@ function SocialLink ({ name, id }) {
 }
 
 function HeaderHeader ({ user }) {
-  const me = useMe()
+  const { me } = useMe()
 
   const showModal = useShowModal()
   const toaster = useToast()

--- a/components/user-list.js
+++ b/components/user-list.js
@@ -12,6 +12,7 @@ import { useMe } from './me'
 import { MEDIA_URL } from '@/lib/constants'
 import { NymActionDropdown } from '@/components/user-header'
 import classNames from 'classnames'
+import CheckCircle from '@/svgs/checkbox-circle-fill.svg'
 
 // all of this nonsense is to show the stat we are sorting by first
 const Stacked = ({ user }) => (user.optional.stacked !== null && <span>{abbrNum(user.optional.stacked)} stacked</span>)
@@ -52,11 +53,11 @@ export function UserListRow ({ user, stats, className, onNymClick, showHat = tru
       <div className={`${styles.hunk} ${className}`}>
         <Link
           href={`/${user.name}`}
-          className={`${styles.title} d-inline-flex align-items-center text-reset ${selected ? 'fw-bold text-underline' : ''}`}
+          className={`d-inline-flex align-items-center text-reset ${selected ? 'fw-bold text-underline' : 'text-muted'}`}
           style={{ textUnderlineOffset: '0.25em' }}
           onClick={onNymClick}
         >
-          @{user.name}{showHat && <Hat className='ms-1 fill-grey' height={14} width={14} user={user} />}
+          @{user.name}{showHat && <Hat className='ms-1 fill-grey' height={14} width={14} user={user} />}{selected && <CheckCircle className='ms-3 fill-primary' height={14} width={14} />}
         </Link>
         {stats && (
           <div className={styles.other}>

--- a/components/user-list.js
+++ b/components/user-list.js
@@ -51,7 +51,7 @@ export function UserListRow ({ user, stats, className, onNymClick, showHat = tru
       </Link>
       <div className={`${styles.hunk} ${className}`}>
         <Link
-          href={`/${user.name}`} className={`${styles.title} d-inline-flex align-items-center text-reset`} onClick={onNymClick}
+          href={`/${user.name}`} className={`${styles.title} d-inline-flex align-items-center text-reset ${selected ? 'fw-bold' : ''}`} onClick={onNymClick}
         >
           @{user.name}{showHat && <Hat className='ms-1 fill-grey' height={14} width={14} user={user} />}
         </Link>

--- a/components/user-list.js
+++ b/components/user-list.js
@@ -40,12 +40,12 @@ function seperate (arr, seperator) {
   return arr.flatMap((x, i) => i < arr.length - 1 ? [x, seperator] : [x])
 }
 
-export function UserListRow ({ user, stats, className, onNymClick, showHat = true }) {
+export function UserListRow ({ user, stats, className, onNymClick, showHat = true, selected }) {
   return (
     <div className={`${styles.item} mb-2`} key={user.name}>
       <Link href={`/${user.name}`}>
         <Image
-          src={user.photoId ? `https://${process.env.NEXT_PUBLIC_MEDIA_DOMAIN}/${user.photoId}` : '/dorian400.jpg'} width='32' height='32'
+          src={user.photoId ? `${MEDIA_URL}/${user.photoId}` : '/dorian400.jpg'} width='32' height='32'
           className={`${userStyles.userimg} me-2`}
         />
       </Link>

--- a/components/user-list.js
+++ b/components/user-list.js
@@ -40,6 +40,31 @@ function seperate (arr, seperator) {
   return arr.flatMap((x, i) => i < arr.length - 1 ? [x, seperator] : [x])
 }
 
+export function UserListRow ({ user, stats, className, onNymClick, showHat = true }) {
+  return (
+    <div className={`${styles.item} mb-2`} key={user.name}>
+      <Link href={`/${user.name}`}>
+        <Image
+          src={user.photoId ? `https://${process.env.NEXT_PUBLIC_MEDIA_DOMAIN}/${user.photoId}` : '/dorian400.jpg'} width='32' height='32'
+          className={`${userStyles.userimg} me-2`}
+        />
+      </Link>
+      <div className={`${styles.hunk} ${className}`}>
+        <Link
+          href={`/${user.name}`} className={`${styles.title} d-inline-flex align-items-center text-reset`} onClick={onNymClick}
+        >
+          @{user.name}{showHat && <Hat className='ms-1 fill-grey' height={14} width={14} user={user} />}
+        </Link>
+        {stats && (
+          <div className={styles.other}>
+            {stats.map((Comp, i) => <Comp key={i} user={user} />)}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 export function UserBase ({ user, className, children, nymActionDropdown }) {
   return (
     <div className={classNames(styles.item, className)}>
@@ -63,7 +88,7 @@ export function UserBase ({ user, className, children, nymActionDropdown }) {
 }
 
 export function User ({ user, rank, statComps, className = 'mb-2', Embellish, nymActionDropdown = false }) {
-  const me = useMe()
+  const { me } = useMe()
   const showStatComps = statComps && statComps.length > 0
   return (
     <>

--- a/components/user-list.js
+++ b/components/user-list.js
@@ -51,7 +51,10 @@ export function UserListRow ({ user, stats, className, onNymClick, showHat = tru
       </Link>
       <div className={`${styles.hunk} ${className}`}>
         <Link
-          href={`/${user.name}`} className={`${styles.title} d-inline-flex align-items-center text-reset ${selected ? 'fw-bold' : ''}`} onClick={onNymClick}
+          href={`/${user.name}`}
+          className={`${styles.title} d-inline-flex align-items-center text-reset ${selected ? 'fw-bold text-underline' : ''}`}
+          style={{ textUnderlineOffset: '0.25em' }}
+          onClick={onNymClick}
         >
           @{user.name}{showHat && <Hat className='ms-1 fill-grey' height={14} width={14} user={user} />}
         </Link>

--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -112,7 +112,7 @@ const initIndexedDB = async (dbName, storeName) => {
 }
 
 export const WalletLoggerProvider = ({ children }) => {
-  const me = useMe()
+  const { me } = useMe()
   const [logs, setLogs] = useState([])
   let dbName = 'app:storage'
   if (me) {

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -124,7 +124,7 @@ export const SETTINGS_FIELDS = gql`
 
 export const SETTINGS = gql`
 ${SETTINGS_FIELDS}
-{
+query Settings {
   settings {
     ...SettingsFields
   }

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -320,8 +320,8 @@ export const USER_FULL = gql`
 
 export const USER = gql`
   ${USER_FIELDS}
-  query User($name: String!) {
-    user(name: $name) {
+  query User($id: ID, $name: String) {
+    user(id: $id, name: $name) {
       ...UserFields
     }
   }`

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -1,4 +1,4 @@
-import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client'
+import { ApolloClient, InMemoryCache, HttpLink, makeVar } from '@apollo/client'
 import { decodeCursor, LIMIT } from './cursor'
 import { SSR } from './constants'
 
@@ -24,6 +24,8 @@ export default function getApolloClient () {
     return window.apolloClient
   }
 }
+
+export const meAnonSats = {}
 
 function getClient (uri) {
   return new ApolloClient({
@@ -259,10 +261,23 @@ function getClient (uri) {
         Item: {
           fields: {
             meAnonSats: {
-              read (meAnonSats, { readField }) {
-                if (typeof window === 'undefined') return null
+              read (existingAmount, { readField }) {
+                if (SSR) return null
+
                 const itemId = readField('id')
-                return meAnonSats ?? Number(window.localStorage.getItem(`TIP-item:${itemId}`) || '0')
+
+                // we need to use reactive variables such that updates
+                // to local state propagate correctly
+                // see https://www.apollographql.com/docs/react/local-state/reactive-variables
+                let reactiveVar = meAnonSats[itemId]
+                if (!reactiveVar) {
+                  const storageKey = `TIP-item:${itemId}`
+                  const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
+                  reactiveVar = makeVar(existingAmount || 0)
+                  meAnonSats[itemId] = reactiveVar
+                }
+
+                return reactiveVar()
               }
             }
           }

--- a/middleware.js
+++ b/middleware.js
@@ -128,8 +128,6 @@ export const config = {
         { type: 'header', key: 'next-router-prefetch' },
         { type: 'header', key: 'purpose', value: 'prefetch' }
       ]
-    },
-    // account switching
-    '/api/graphql', '/_next/data/(.*)'
+    }
   ]
 }

--- a/middleware.js
+++ b/middleware.js
@@ -69,44 +69,6 @@ function referrerMiddleware (request) {
   return response
 }
 
-// TODO: use this middleware to switch between multiple auth accounts
-function multiAuthMiddleware (request) {
-  // switch next-auth session cookie with multi_auth cookie if cookie pointer present
-
-  // is there a cookie pointer?
-  const cookiePointerName = 'multi_auth.user-id'
-  const hasCookiePointer = request.cookies?.has(cookiePointerName)
-  // is there a session?
-  const sessionCookieName = request.secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
-  const hasSession = request.cookies?.has(sessionCookieName)
-
-  if (!hasCookiePointer || !hasSession) {
-    // no session or no cookie pointer. do nothing.
-    return NextResponse.next({ request })
-  }
-
-  const userId = request.cookies?.get(cookiePointerName)?.value
-  if (userId === 'anonymous') {
-    // user switched to anon. only delete session cookie.
-    request.cookies.delete(sessionCookieName)
-    return NextResponse.next({ request })
-  }
-
-  const userJWT = request.cookies.get(`multi_auth.${userId}`)?.value
-  if (!userJWT) {
-    // no multi auth JWT found
-    return NextResponse.next({ request })
-  }
-
-  if (userJWT) {
-    // multi auth JWT found in cookie that pointed to by cookie pointer that is different to current session cookie.
-    request.cookies.set(sessionCookieName, userJWT)
-    return NextResponse.next({ request })
-  }
-
-  return NextResponse.next({ request })
-}
-
 export function middleware (request) {
   const resp = referrerMiddleware(request)
 

--- a/middleware.js
+++ b/middleware.js
@@ -69,6 +69,44 @@ function referrerMiddleware (request) {
   return response
 }
 
+// TODO: use this middleware to switch between multiple auth accounts
+function multiAuthMiddleware (request) {
+  // switch next-auth session cookie with multi_auth cookie if cookie pointer present
+
+  // is there a cookie pointer?
+  const cookiePointerName = 'multi_auth.user-id'
+  const hasCookiePointer = request.cookies?.has(cookiePointerName)
+  // is there a session?
+  const sessionCookieName = request.secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
+  const hasSession = request.cookies?.has(sessionCookieName)
+
+  if (!hasCookiePointer || !hasSession) {
+    // no session or no cookie pointer. do nothing.
+    return NextResponse.next({ request })
+  }
+
+  const userId = request.cookies?.get(cookiePointerName)?.value
+  if (userId === 'anonymous') {
+    // user switched to anon. only delete session cookie.
+    request.cookies.delete(sessionCookieName)
+    return NextResponse.next({ request })
+  }
+
+  const userJWT = request.cookies.get(`multi_auth.${userId}`)?.value
+  if (!userJWT) {
+    // no multi auth JWT found
+    return NextResponse.next({ request })
+  }
+
+  if (userJWT) {
+    // multi auth JWT found in cookie that pointed to by cookie pointer that is different to current session cookie.
+    request.cookies.set(sessionCookieName, userJWT)
+    return NextResponse.next({ request })
+  }
+
+  return NextResponse.next({ request })
+}
+
 export function middleware (request) {
   const resp = referrerMiddleware(request)
 
@@ -128,6 +166,8 @@ export const config = {
         { type: 'header', key: 'next-router-prefetch' },
         { type: 'header', key: 'purpose', value: 'prefetch' }
       ]
-    }
+    },
+    // account switching
+    '/api/graphql', '/_next/data/(.*)'
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "canonical-json": "0.0.4",
         "classnames": "^2.5.1",
         "clipboard-copy": "^4.0.1",
+        "cookie": "^0.6.0",
         "cross-fetch": "^4.0.0",
         "csv-parser": "^3.0.0",
         "domino": "^2.1.6",
@@ -528,6 +529,15 @@
         "nodemailer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@auth/core/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@auth/prisma-adapter": {
@@ -7267,9 +7277,10 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/cookie": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
-      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9004,6 +9015,15 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -14750,6 +14770,15 @@
         "nodemailer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-auth/node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/next-plausible": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "canonical-json": "0.0.4",
     "classnames": "^2.5.1",
     "clipboard-copy": "^4.0.1",
+    "cookie": "^0.6.0",
     "cross-fetch": "^4.0.0",
     "csv-parser": "^3.0.0",
     "domino": "^2.1.6",

--- a/pages/[name]/index.js
+++ b/pages/[name]/index.js
@@ -86,7 +86,7 @@ export default function User ({ ssrData }) {
   const [create, setCreate] = useState(false)
   const [edit, setEdit] = useState(false)
   const router = useRouter()
-  const me = useMe()
+  const { me } = useMe()
 
   const { data } = useQuery(USER_FULL, { variables: { ...router.query } })
   if (!data && !ssrData) return <PageLoading />

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -22,6 +22,7 @@ import { ChainFeeProvider } from '@/components/chain-fee.js'
 import dynamic from 'next/dynamic'
 import { HasNewNotesProvider } from '@/components/use-has-new-notes'
 import WebLnProvider from '@/wallets/webln'
+import { AccountProvider } from '@/components/account'
 
 const PWAPrompt = dynamic(() => import('react-ios-pwa-prompt'), { ssr: false })
 
@@ -109,22 +110,24 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
                   <WalletLoggerProvider>
                     <WebLnProvider>
                       <ServiceWorkerProvider>
-                        <PriceProvider price={price}>
-                          <LightningProvider>
-                            <ToastProvider>
-                              <ShowModalProvider>
-                                <BlockHeightProvider blockHeight={blockHeight}>
-                                  <ChainFeeProvider chainFee={chainFee}>
-                                    <ErrorBoundary>
-                                      <Component ssrData={ssrData} {...otherProps} />
-                                      {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
-                                    </ErrorBoundary>
-                                  </ChainFeeProvider>
-                                </BlockHeightProvider>
-                              </ShowModalProvider>
-                            </ToastProvider>
-                          </LightningProvider>
-                        </PriceProvider>
+                        <AccountProvider>
+                          <PriceProvider price={price}>
+                            <LightningProvider>
+                              <ToastProvider>
+                                <ShowModalProvider>
+                                  <BlockHeightProvider blockHeight={blockHeight}>
+                                    <ChainFeeProvider chainFee={chainFee}>
+                                      <ErrorBoundary>
+                                        <Component ssrData={ssrData} {...otherProps} />
+                                        {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
+                                      </ErrorBoundary>
+                                    </ChainFeeProvider>
+                                  </BlockHeightProvider>
+                                </ShowModalProvider>
+                              </ToastProvider>
+                            </LightningProvider>
+                          </PriceProvider>
+                        </AccountProvider>
                       </ServiceWorkerProvider>
                     </WebLnProvider>
                   </WalletLoggerProvider>

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -137,9 +137,10 @@ function setMultiAuthCookies (req, res, { id, jwt, name, photoId }) {
 }
 
 async function pubkeyAuth (credentials, req, res, pubkeyColumnName) {
-  const { k1, pubkey, multiAuth: multiAuthParam } = credentials
-  // multiAuth query param is a string
-  const multiAuth = typeof multiAuthParam === 'string' ? multiAuthParam === 'true' : !!multiAuthParam
+  const { k1, pubkey } = credentials
+
+  const { body } = req.body
+  const multiAuth = typeof body.multiAuth === 'string' ? body.multiAuth === 'true' : !!body.multiAuth
 
   try {
     const lnauth = await prisma.lnAuth.findUnique({ where: { k1 } })

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -112,7 +112,7 @@ function getCallbacks (req, res) {
   }
 }
 
-function setMultiAuthCookies (req, res, { id, jwt, name, photoId, switchUser }) {
+function setMultiAuthCookies (req, res, { id, jwt, name, photoId }) {
   const b64Encode = obj => Buffer.from(JSON.stringify(obj)).toString('base64')
   const b64Decode = s => JSON.parse(Buffer.from(s, 'base64'))
 
@@ -138,10 +138,8 @@ function setMultiAuthCookies (req, res, { id, jwt, name, photoId, switchUser }) 
   }
   res.appendHeader('Set-Cookie', cookie.serialize('multi_auth', b64Encode(newMultiAuth), { ...cookieOptions, httpOnly: false }))
 
-  if (switchUser) {
-    // switch to user we just added
-    res.appendHeader('Set-Cookie', cookie.serialize('multi_auth.user-id', id, { ...cookieOptions, httpOnly: false }))
-  }
+  // switch to user we just added
+  res.appendHeader('Set-Cookie', cookie.serialize('multi_auth.user-id', id, { ...cookieOptions, httpOnly: false }))
 }
 
 async function pubkeyAuth (credentials, req, res, pubkeyColumnName) {
@@ -184,7 +182,7 @@ async function pubkeyAuth (credentials, req, res, pubkeyColumnName) {
         // update the cookies for multi-authentication.
         const secret = process.env.NEXTAUTH_SECRET
         const userJWT = await encodeJWT({ token: { id: user.id, name: user.name, email: user.email }, secret })
-        setMultiAuthCookies(req, res, { ...user, jwt: userJWT, switchUser: true })
+        setMultiAuthCookies(req, res, { ...user, jwt: userJWT })
         return token
       }
 

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -87,6 +87,7 @@ function multiAuthMiddleware (request) {
   // is there a cookie pointer?
   const cookiePointerName = 'multi_auth.user-id'
   const hasCookiePointer = !!request.cookies[cookiePointerName]
+
   // is there a session?
   const sessionCookieName = request.secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
   const hasSession = !!request.cookies[sessionCookieName]
@@ -105,12 +106,12 @@ function multiAuthMiddleware (request) {
 
   const userJWT = request.cookies[`multi_auth.${userId}`]
   if (!userJWT) {
-    // no multi auth JWT found
+    // no JWT for account switching found
     return request
   }
 
   if (userJWT) {
-    // multi auth JWT found in cookie that pointed to by cookie pointer that is different to current session cookie.
+    // use JWT found in cookie pointed to by cookie pointer
     request.cookies[sessionCookieName] = userJWT
     return request
   }

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -66,6 +66,7 @@ export default startServerAndCreateNextHandler(apolloServer, {
         session = { user: { ...sessionFields, apiKey: true } }
       }
     } else {
+      req = multiAuthMiddleware(req)
       session = await getServerSession(req, res, getAuthOptions(req))
     }
     return {
@@ -79,3 +80,40 @@ export default startServerAndCreateNextHandler(apolloServer, {
     }
   }
 })
+
+function multiAuthMiddleware (request) {
+  // switch next-auth session cookie with multi_auth cookie if cookie pointer present
+
+  // is there a cookie pointer?
+  const cookiePointerName = 'multi_auth.user-id'
+  const hasCookiePointer = !!request.cookies[cookiePointerName]
+  // is there a session?
+  const sessionCookieName = request.secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
+  const hasSession = !!request.cookies[sessionCookieName]
+
+  if (!hasCookiePointer || !hasSession) {
+    // no session or no cookie pointer. do nothing.
+    return request
+  }
+
+  const userId = request.cookies[cookiePointerName]
+  if (userId === 'anonymous') {
+    // user switched to anon. only delete session cookie.
+    delete request.cookies[sessionCookieName]
+    return request
+  }
+
+  const userJWT = request.cookies[`multi_auth.${userId}`]
+  if (!userJWT) {
+    // no multi auth JWT found
+    return request
+  }
+
+  if (userJWT) {
+    // multi auth JWT found in cookie that pointed to by cookie pointer that is different to current session cookie.
+    request.cookies[sessionCookieName] = userJWT
+    return request
+  }
+
+  return request
+}

--- a/pages/api/signout.js
+++ b/pages/api/signout.js
@@ -53,7 +53,7 @@ export default (req, res) => {
     cookie.serialize(sessionCookieName, newUserJWT, cookieOptions)
   ])
 
-  res.status(201).end()
+  res.status(302).end()
 }
 
 const b64Encode = obj => Buffer.from(JSON.stringify(obj)).toString('base64')

--- a/pages/api/signout.js
+++ b/pages/api/signout.js
@@ -10,12 +10,13 @@ export default (req, res) => {
   // is there a cookie pointer?
   const cookiePointerName = 'multi_auth.user-id'
   const userId = req.cookies[cookiePointerName]
+
   // is there a session?
   const sessionCookieName = req.secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
   const sessionJWT = req.cookies[sessionCookieName]
 
-  if (!userId || !sessionJWT) {
-    // no cookie pointer or no session cookie present. do nothing.
+  if (!userId && !sessionJWT) {
+    // no cookie pointer and no session cookie present. nothing to do.
     res.status(404).end()
     return
   }

--- a/pages/api/signout.js
+++ b/pages/api/signout.js
@@ -1,0 +1,60 @@
+import cookie from 'cookie'
+import { datePivot } from '../../lib/time'
+
+/**
+ * @param  {NextApiRequest}  req
+ * @param  {NextApiResponse} res
+ * @return {void}
+ */
+export default (req, res) => {
+  // is there a cookie pointer?
+  const cookiePointerName = 'multi_auth.user-id'
+  const userId = req.cookies[cookiePointerName]
+  // is there a session?
+  const sessionCookieName = req.secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
+  const sessionJWT = req.cookies[sessionCookieName]
+
+  if (!userId || !sessionJWT) {
+    // no cookie pointer or no session cookie present. do nothing.
+    res.status(404).end()
+    return
+  }
+
+  const cookies = []
+
+  const cookieOptions = {
+    path: '/',
+    secure: req.secure,
+    httpOnly: true,
+    sameSite: 'lax',
+    expires: datePivot(new Date(), { months: 1 })
+  }
+  // remove JWT pointed to by cookie pointer
+  cookies.push(cookie.serialize(`multi_auth.${userId}`, '', { ...cookieOptions, expires: 0, maxAge: 0 }))
+
+  // update multi_auth cookie and check if there are more accounts available
+  const oldMultiAuth = b64Decode(req.cookies.multi_auth)
+  const newMultiAuth = oldMultiAuth.filter(({ id }) => id !== Number(userId))
+  if (newMultiAuth.length === 0) {
+    // no next account available. cleanup: remove multi_auth + pointer cookie
+    cookies.push(cookie.serialize('multi_auth', '', { ...cookieOptions, httpOnly: false, expires: 0, maxAge: 0 }))
+    cookies.push(cookie.serialize('multi_auth.user-id', '', { ...cookieOptions, httpOnly: false, expires: 0, maxAge: 0 }))
+    res.setHeader('Set-Cookie', cookies)
+    res.status(204).end()
+    return
+  }
+  cookies.push(cookie.serialize('multi_auth', b64Encode(newMultiAuth), { ...cookieOptions, httpOnly: false }))
+
+  const newUserId = newMultiAuth[0].id
+  const newUserJWT = req.cookies[`multi_auth.${newUserId}`]
+  res.setHeader('Set-Cookie', [
+    ...cookies,
+    cookie.serialize(cookiePointerName, newUserId, { ...cookieOptions, httpOnly: false }),
+    cookie.serialize(sessionCookieName, newUserJWT, cookieOptions)
+  ])
+
+  res.status(201).end()
+}
+
+const b64Encode = obj => Buffer.from(JSON.stringify(obj)).toString('base64')
+const b64Decode = s => JSON.parse(Buffer.from(s, 'base64'))

--- a/pages/login.js
+++ b/pages/login.js
@@ -47,15 +47,6 @@ export async function getServerSideProps ({ req, res, query: { callbackUrl, mult
   }
 
   const providers = await getProviders()
-  if (multiAuth) {
-    // multi auth only supported for login with lightning and nostr
-    const multiAuthSupport = key => ['lightning', 'nostr'].includes(key)
-    Object.keys(providers).forEach(key => {
-      if (!multiAuthSupport(key)) {
-        delete providers[key]
-      }
-    })
-  }
 
   return {
     props: {

--- a/pages/login.js
+++ b/pages/login.js
@@ -7,7 +7,14 @@ import Login from '@/components/login'
 import { isExternal } from '@/lib/url'
 
 export async function getServerSideProps ({ req, res, query: { callbackUrl, multiAuth = false, error = null } }) {
-  const session = await getServerSession(req, res, getAuthOptions(req))
+  let session = await getServerSession(req, res, getAuthOptions(req))
+
+  // required to prevent infinite redirect loops if we switch to anon
+  // but are on a page that would redirect us to /signup.
+  // without this code, /signup would redirect us back to the callbackUrl.
+  if (req.cookies['multi_auth.user-id'] === 'anonymous') {
+    session = null
+  }
 
   // prevent open redirects. See https://github.com/stackernews/stacker.news/issues/264
   // let undefined urls through without redirect ... otherwise this interferes with multiple auth linking

--- a/pages/referrals/[when].js
+++ b/pages/referrals/[when].js
@@ -33,7 +33,7 @@ export const getServerSideProps = getGetServerSideProps({ query: REFERRALS, auth
 
 export default function Referrals ({ ssrData }) {
   const router = useRouter()
-  const me = useMe()
+  const { me } = useMe()
 
   const select = async values => {
     const { when, ...query } = values

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -101,14 +101,9 @@ export default function Settings ({ ssrData }) {
 
   const { data } = useQuery(SETTINGS)
   const { settings: { privates: settings } } = useMemo(() => data ?? ssrData, [data, ssrData])
-  if (!data && !ssrData) return <PageLoading />
 
-  // if we switched to anon, me is no longer defined
-  const router = useRouter()
-  if (!me) {
-    router.push('/login')
-    return null
-  }
+  // if we switched to anon, me is null before the page is reloaded
+  if ((!data && !ssrData) || !me) return <PageLoading />
 
   return (
     <Layout>

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -116,6 +116,7 @@ export default function Settings ({ ssrData }) {
         {hasOnlyOneAuthMethod(settings?.authMethods) && <AuthBanner />}
         <SettingsHeader />
         <Form
+          enableReinitialize
           initial={{
             tipDefault: settings?.tipDefault || 21,
             tipRandom: settings?.tipRandom,

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -84,7 +84,7 @@ export function SettingsHeader () {
 
 export default function Settings ({ ssrData }) {
   const toaster = useToast()
-  const me = useMe()
+  const { me } = useMe()
   const [setSettings] = useMutation(SET_SETTINGS, {
     update (cache, { data: { setSettings } }) {
       cache.modify({
@@ -96,13 +96,19 @@ export default function Settings ({ ssrData }) {
         }
       })
     }
-  }
-  )
+  })
   const logger = useServiceWorkerLogger()
 
   const { data } = useQuery(SETTINGS)
   const { settings: { privates: settings } } = useMemo(() => data ?? ssrData, [data, ssrData])
   if (!data && !ssrData) return <PageLoading />
+
+  // if we switched to anon, me is no longer defined
+  const router = useRouter()
+  if (!me) {
+    router.push('/login')
+    return null
+  }
 
   return (
     <Layout>
@@ -870,7 +876,7 @@ export function EmailLinkForm ({ callbackUrl }) {
 
 function ApiKey ({ enabled, apiKey }) {
   const showModal = useShowModal()
-  const me = useMe()
+  const { me } = useMe()
   const [generateApiKey] = useMutation(
     gql`
       mutation generateApiKey($id: ID!) {
@@ -996,7 +1002,7 @@ function ApiKeyModal ({ apiKey }) {
 }
 
 function ApiKeyDeleteObstacle ({ onClose }) {
-  const me = useMe()
+  const { me } = useMe()
   const [deleteApiKey] = useMutation(
     gql`
       mutation deleteApiKey($id: ID!) {

--- a/pages/wallet/index.js
+++ b/pages/wallet/index.js
@@ -61,7 +61,7 @@ export default function Wallet () {
 }
 
 function YouHaveSats () {
-  const me = useMe()
+  const { me } = useMe()
   const limitReached = me?.privates?.sats >= msatsToSats(BALANCE_LIMIT_MSATS)
   return (
     <h2 className={`${me ? 'visible' : 'invisible'} ${limitReached ? 'text-warning' : 'text-success'}`}>
@@ -108,7 +108,7 @@ export function WalletForm () {
 }
 
 export function FundForm () {
-  const me = useMe()
+  const { me } = useMe()
   const [showAlert, setShowAlert] = useState(true)
   const router = useRouter()
   const [createInvoice, { called, error }] = useMutation(gql`
@@ -211,7 +211,7 @@ export function SelectedWithdrawalForm () {
 
 export function InvWithdrawal () {
   const router = useRouter()
-  const me = useMe()
+  const { me } = useMe()
 
   const [createWithdrawl, { called, error }] = useMutation(CREATE_WITHDRAWL)
 
@@ -358,7 +358,7 @@ export function LnWithdrawal () {
 }
 
 export function LnAddrWithdrawal () {
-  const me = useMe()
+  const { me } = useMe()
   const router = useRouter()
   const [sendToLnAddr, { called, error }] = useMutation(SEND_TO_LNADDR)
   const defaultOptions = { min: 1 }

--- a/pages/withdrawals/[id].js
+++ b/pages/withdrawals/[id].js
@@ -123,7 +123,7 @@ function LoadWithdrawl () {
 function PrivacyOption ({ wd }) {
   if (!wd.bolt11) return
 
-  const me = useMe()
+  const { me } = useMe()
   const keepUntil = datePivot(new Date(wd.createdAt), { days: INVOICE_RETENTION_DAYS })
   const oldEnough = new Date() >= keepUntil
   if (!oldEnough) {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -251,6 +251,14 @@ $zindex-sticky: 900;
   justify-self: center;
 }
 
+svg {
+  fill: var(--bs-body-color);
+}
+
+.fill-primary {
+  fill: var(--bs-primary);
+}
+
 .text-primary svg {
   fill: var(--bs-primary);
 }

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -241,6 +241,10 @@ $zindex-sticky: 900;
   display: none;
 }
 
+.w-fit-content {
+  width: fit-content;
+}
+
 @media (display-mode: standalone) {
   .standalone {
     display: flex

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -22,7 +22,7 @@ export const Status = {
 }
 
 export function useWallet (name) {
-  const me = useMe()
+  const { me } = useMe()
   const showModal = useShowModal()
   const toaster = useToast()
   const [disableFreebies] = useMutation(gql`mutation { disableFreebies }`)
@@ -148,7 +148,7 @@ function extractServerConfig (fields, config) {
 }
 
 function useConfig (wallet) {
-  const me = useMe()
+  const { me } = useMe()
 
   const storageKey = getStorageKey(wallet?.name, me)
   const [clientConfig, setClientConfig, clearClientConfig] = useClientConfig(storageKey, {})
@@ -265,7 +265,7 @@ function isConfigured ({ fields, config }) {
 
 function useServerConfig (wallet) {
   const client = useApolloClient()
-  const me = useMe()
+  const { me } = useMe()
 
   const { data, refetch: refetchConfig } = useQuery(WALLET_BY_TYPE, { variables: { type: wallet?.walletType }, skip: !wallet?.walletType })
 


### PR DESCRIPTION
Closes #489

This PR implements account switching:

![2023-11-19-021317_1920x1080_scrot](https://github.com/stackernews/stacker.news/assets/27162016/3414e8ac-4c08-47a9-a5ea-ac90e08ec46d)

**Implementation details**

If a user wants to add an account, they are redirected to `/login` with `multiAuth` param set:

_components/switch-account.js:_
```js
const AddAccount = () => {
  const router = useRouter()
  return (
    <div className='d-flex flex-column me-2 my-1 text-center'>
      <Image
        width='135' height='135' src='https://imgs.search.brave.com/t8qv-83e1m_kaajLJoJ0GNID5ch0WvBGmy7Pkyr4kQY/rs:fit:860:0:0/g:ce/aHR0cHM6Ly91cGxv/YWQud2lraW1lZGlh/Lm9yZy93aWtpcGVk/aWEvY29tbW9ucy84/Lzg5L1BvcnRyYWl0/X1BsYWNlaG9sZGVy/LnBuZw' style={{ cursor: 'pointer' }} onClick={() => {
          router.push({
            pathname: '/login',
            query: { callbackUrl: window.location.origin + router.asPath, multiAuth: true }
          })
        }}
      />
      <div className='fst-italic'>+ add account</div>
    </div>
  )
}
```

With this param, a login flow within a session can be initiated. This param is checked in the backend to only set cookies without actually switching the user (`return token` instead of `return user`):

```js
if (multiAuth) {
  // we want to add a new account to 'switch accounts'
  const secret = process.env.NEXTAUTH_SECRET
  // default expiration for next-auth JWTs is in 1 month
  const expiresAt = datePivot(new Date(), { months: 1 })
  const cookieOptions = {
    path: '/',
    httpOnly: true,
    secure: true,
    sameSite: 'lax',
    expires: expiresAt
  }
  const userJWT = await encodeJWT({
    token: {
      id: user.id,
      name: user.name,
      email: user.email
    },
    secret
  })
  const me = await prisma.user.findUnique({ where: { id: token.id } })
  const tokenJWT = await encodeJWT({ token, secret })
  // NOTE: why can't I put this in a function with a for loop?!
  res.appendHeader('Set-Cookie', cookie.serialize(`multi_auth.${user.id}`, userJWT, cookieOptions))
  res.appendHeader('Set-Cookie', cookie.serialize(`multi_auth.${me.id}`, tokenJWT, cookieOptions))
  res.appendHeader('Set-Cookie',
    cookie.serialize('multi_auth',
      JSON.stringify([
        { id: user.id, name: user.name, photoId: user.photoId },
        { id: me.id, name: me.name, photoId: me.photoId }
      ]),
      { ...cookieOptions, httpOnly: false }))
  // don't switch accounts, we only want to add. switching is done in client via "pointer cookie"
  return token
}
return null
```

With these `multi_auth.*` cookies set, we can now show accounts to the user to which they can switch. The `multi_auth` 
cookie is not HTTP only since we want to access it from JS. This shouldn't be a problem since this is only for reading which accounts can be switched to and render this view:

![2023-11-19-022224_499x506_scrot](https://github.com/stackernews/stacker.news/assets/27162016/44b9dd87-1ebd-4163-8b35-410e309443ee)

On click, another cookie `multi_auth.user-id` is created via JS. This cookie is read inside a middleware in the backend to replace the session cookie that will be used to determine the user in the backend:

_middleware.js:_
```js
const multiAuthMiddleware = (request) => {
  // switch next-auth session cookie with multi_auth cookie if cookie pointer present
  const userId = request.cookies?.get('multi_auth.user-id')?.value
  const sessionCookieName = '__Secure-next-auth.session-token'
  const hasSession = request.cookies?.has(sessionCookieName)
  if (userId && hasSession) {
    const userJWT = request.cookies.get(`multi_auth.${userId}`)?.value
    if (userJWT) request.cookies.set(sessionCookieName, userJWT)
  }
  const response = NextResponse.next({ request })
  return response
}
```

**Showcase**


https://github.com/stackernews/stacker.news/assets/27162016/49f9ff4f-dc4a-4e46-bcd2-966be20fe66b



**TODO**

- [x] switching to anon
- [x] UI to go from anon back to session
- add `multiAuth` param to all login methods
  - [x] lightning auth
  - [x] nostr auth
  - [ ] ~~email auth~~ _(decided to remove this auth method, see https://github.com/stackernews/stacker.news/pull/644#issuecomment-1822106605)_
  - [ ] ~~github auth~~ _(decided to remove this auth method, see https://github.com/stackernews/stacker.news/pull/644#issuecomment-1822106605)_
  - [ ] ~~twitter auth~~ _(decided to remove this auth method, see https://github.com/stackernews/stacker.news/pull/644#issuecomment-1822106605)_
- [x] testing
- [x] replace hardcoded link for `add account` image
- [x] handle case where account is added which doesn't exist yet _(this will simply create a new account now but current account will never be updated if `multiAuth` is used)_
- [ ] ~~also refresh JWTs in `multi_auth.*`~~ (?) _(how?)_
- [x] think more about if using this "cookie pointer" approach is secure _(found an [article](https://connect2id.com/products/server/docs/guides/select-account) which also mentions "cookie pointers" - and I thought I invented that term, lol)_
- [x] middleware is now applied to all routes ... performance impact? _(nah, i think it's okay)_
- [x] [fix bug when looking at item and switching between anon and user](https://github.com/stackernews/stacker.news/pull/644#issuecomment-1820214123) _("fixed" in 0c8893c)_
- [x] on logout, only delete session token for current logged in account and move user to next available account