### PR TITLE
Move the `AD` badge to be alongside other item info badges

### DIFF
--- a/components/item-info.js
+++ b/components/item-info.js
@@ -22,7 +22,7 @@ import MuteDropdownItem from './mute'
 export default function ItemInfo ({
   item, pendingSats, full, commentsText = 'comments',
   commentTextSingular = 'comment', className, embellishUser, extraInfo, onEdit, editText,
-  onQuoteReply, nofollow
+  onQuoteReply, nofollow, extraBadges
 }) {
   const editThreshold = new Date(item.createdAt).getTime() + 10 * 60000
   const me = useMe()
@@ -116,6 +116,7 @@ export default function ItemInfo ({
             {' '}<Badge className={styles.newComment} bg={null}>freebie</Badge>
           </Link>
         )}
+      {extraBadges}
       {canEdit && !item.deletedAt &&
         <>
           <span> \ </span>

--- a/components/item.js
+++ b/components/item.js
@@ -96,7 +96,7 @@ export default function Item ({ item, rank, belowTitle, right, full, children, s
             full={full} item={item} pendingSats={pendingSats}
             onQuoteReply={replyRef?.current?.quoteReply}
             nofollow={nofollow}
-            embellishUser={Number(item?.user?.id) === AD_USER_ID && <Badge className={styles.newComment} bg={null}>AD</Badge>}
+            extraBadges={Number(item?.user?.id) === AD_USER_ID && <Badge className={styles.newComment} bg={null}>AD</Badge>}
           />
           {belowTitle}
         </div>

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -55,6 +55,10 @@ async function main () {
     where: { name: 'anon' }
   })
 
+  const ad = await prisma.user.findUnique({
+    where: { name: 'ad' }
+  })
+
   await prisma.item.create({
     data: {
       title: 'System76 Developing “Cosmic” Desktop Environment',
@@ -168,6 +172,21 @@ async function main () {
       title: 'An anonymous post',
       url: 'https://www.google.com',
       userId: anon.id,
+      subName: 'bitcoin',
+      children: {
+        create: {
+          userId: anon.id,
+          text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+        }
+      }
+    }
+  })
+
+  await prisma.item.create({
+    data: {
+      title: 'An ad post',
+      url: 'https://www.google.com',
+      userId: ad.id,
       subName: 'bitcoin',
       children: {
         create: {


### PR DESCRIPTION
Closes #638 

Instead of using `embellishUser` for the `AD` badge, I introduced an `extraBadges` prop for `ItemInfo` and pass it there, allowing for better placement.

I also created an ad post in the seed file in this PR for easier testing.

<img width="319" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/0485c7fc-ebbd-467c-969c-31c598c175fb">
