### PR TITLE
Fix notification badges

### DIFF
--- a/lib/badge.js
+++ b/lib/badge.js
@@ -4,14 +4,15 @@ export const clearNotifications = () => navigator.serviceWorker?.controller?.pos
 
 const badgingApiSupported = (sw = window) => 'setAppBadge' in sw.navigator
 
-const permissionGranted = async (sw = window, name = 'notifications') => {
+const permissionGranted = async (sw = window) => {
+  const name = 'notifications'
   let permission
   try {
     permission = await sw.navigator.permissions.query({ name })
   } catch (err) {
     console.error('Failed to check permissions', err)
   }
-  return permission?.state === 'granted'
+  return permission?.state === 'granted' || sw.Notification?.permission === 'granted'
 }
 
 export const setAppBadge = async (sw = window, count) => {


### PR DESCRIPTION
I found that the permissions check was failing on iOS Safari PWA, which seems like why the badges weren't working for me.

Check both `navigator.permissions.query` and `Notification.permission` for permissions.

It seems these values are not kept in sync on iOS Safari, which may be the source of badges not working on iOS PWA. [Source](https://developer.apple.com/forums/thread/731412)

Side note: holiday weekends mean I have time for side projects :) 