### PR TITLE
Fix ampersands wrongly parsed as &amp; for href

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -126,6 +126,9 @@ export default memo(function Text ({ nofollow, imgproxyUrls, children, tab, ...o
           p: P,
           code: Code,
           a: ({ node, href, children, ...props }) => {
+            // fix href passed with ampersands parsed as &amp; already for some reason
+            href = href.replace(/&amp;/g, '&')
+
             children = children ? Array.isArray(children) ? children : [children] : []
             // don't allow zoomable images to be wrapped in links
             if (children.some(e => e?.props?.node?.tagName === 'img')) {


### PR DESCRIPTION
No idea why this already comes in with `&` parsed as `&amp;` ....

I might actually need some sleep sooner than later, lol :)

close #673 

https://github.com/stackernews/stacker.news/assets/27162016/e659370f-69fc-4f91-a92b-76a7ac6f9cab

