### PR TITLE
Do not remove orientation EXIF data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "page-metadata-parser": "^1.1.4",
         "pageres": "^7.1.0",
         "pg-boss": "^9.0.3",
+        "piexifjs": "^1.0.6",
         "prisma": "^5.4.2",
         "qrcode.react": "^3.1.0",
         "react": "^18.2.0",
@@ -12146,6 +12147,11 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/piexifjs": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/piexifjs/-/piexifjs-1.0.6.tgz",
+      "integrity": "sha512-0wVyH0cKohzBQ5Gi2V1BuxYpxWfxF3cSqfFXfPIpl5tl9XLS5z4ogqhUCD20AbHi0h9aJkqXNJnkVev6gwh2ag=="
     },
     "node_modules/pify": {
       "version": "2.3.0",
@@ -24885,6 +24891,11 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "piexifjs": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/piexifjs/-/piexifjs-1.0.6.tgz",
+      "integrity": "sha512-0wVyH0cKohzBQ5Gi2V1BuxYpxWfxF3cSqfFXfPIpl5tl9XLS5z4ogqhUCD20AbHi0h9aJkqXNJnkVev6gwh2ag=="
     },
     "pify": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "page-metadata-parser": "^1.1.4",
     "pageres": "^7.1.0",
     "pg-boss": "^9.0.3",
+    "piexifjs": "^1.0.6",
     "prisma": "^5.4.2",
     "qrcode.react": "^3.1.0",
     "react": "^18.2.0",


### PR DESCRIPTION
Fix #678 

Keeping this in draft until I confirmed this does indeed not strip orientation EXIF data - which I am going to do now.

I got the tag value 0x0112 from [here](https://www.media.mit.edu/pia/Research/deepview/exif.html).

---

Okay, 21a9c3e does not work because we are actually deleting all EXIF data _at once_. So the loop is not _iterating_ over EXIF "tags". It's searching for the start of the EXIF data and then deleting it all at once. At least that is my current understanding which I am writing down here to not forget that this is my current "baseline of progress".

I think I need to dive deeper into the [EXIF spec](https://www.media.mit.edu/pia/Research/deepview/exif.html) to be able to do what [some tools](https://github.com/nathanpeck/exiftool) [can do on the CLI](https://stackoverflow.com/questions/37432580/how-to-remove-exif-data-from-image-but-keep-the-orientation) in JS using our existing approach.

[There](https://github.com/exif-js/exif-js) [are](https://github.com/hMatoba/piexifjs) libraries which handle EXIF data in JS but they seem to be either unmaintained, or not necessary. I also don't like new dependencies anymore. There is a way to do it within our code but ... might take me too long to pull it off. I'll keep trying for a few hours more at least :)

Worst case scenario, I have to look at the source code of these tools to see how they manage to keep orientation data.

---

Ok I stopped trying to get this to work without using a library since it is taking me too long and doing binary stuff in Javascript is definitely not my strength, lol. I am now trying to simply use [piexifjs](https://github.com/hMatoba/piexifjs) even though last update was from 4 years ago. But the EXIF spec seems to be from 1999 itself, so maybe the latest update doesn't matter? If I can get it to work with a library, maybe THEN I am able to do it without a library, lol.

I should learn to find the right order of doing things, lol. First try the simple thing so I at least have something working which I can fall back on when other things don't work out for whatever reason.

---

Tried to get [piexifjs](https://github.com/hMatoba/piexifjs) to work but somehow it didn't work. Didn't even get a real error message. Trying out sharp now because [it was mentioned as an alternative in a ticket](https://github.com/hMatoba/piexifjs/issues/78#issuecomment-933366351). Turns out that is super maintained since the last commit is literally from [15 hours ago](https://github.com/lovell/sharp/commit/c9e39960075ef84ba604896ada1c318d000a7bdf), lol.

So I think we should really go with this if possible.

---

Seems like it only runs on the server, not in the browser:

> It can be used with all JavaScript runtimes that provide support for Node-API v9, including Node.js >= 18.17.0, Deno and Bun.

---

[lol, I found another custom code just for orientation now.](https://stackoverflow.com/a/32490603/13555687) Going to try this now. If not, I can try [this SO code](https://stackoverflow.com/a/7585267/13555687) using the even older [exif-js](https://github.com/exif-js/exif-js) library but someone said:

> The JS lib in the question looks little bit outdated, but would probably work.

---

Okay, finally was able to read the orientation metadata with the custom code provided, lol

---

For some reason, struggling with the last step of putting the extracted orientation value back in after deleting everything else ...

![2023-12-14-085134_982x480_scrot](https://github.com/stackernews/stacker.news/assets/27162016/723142f3-0806-4da3-8f66-fca0b13185b6)

---

finding [this piece of documentation](https://piexifjs.readthedocs.io/en/latest/appendices.html#exif-data-in-piexifjs) was what i was missing all along. and it turns out, [using a simple int was right all along](https://piexifjs.readthedocs.io/en/latest/appendices.html) (as I initially tried), I just must have gotten confused that there was _still_ an error:

![2023-12-15-063740_983x451_scrot](https://github.com/stackernews/stacker.news/assets/27162016/80c25de3-d16d-4bea-a8bf-94b9b7b5bb90)

Looking at the code, the documentation and basically everything about this library: i guess this library **really only supports JPEG**, lol:

_documentation_:

> Insert exif into JPEG.
-- https://piexifjs.readthedocs.io/en/latest/functions.html#insert

_example_:

```js
var exifbytes = piexif.dump(exifObj)
var newJpeg = piexif.insert(exifbytes, jpegData)
```

_code_
```js
    that.insert = function (exif, jpeg) {
        var b64 = false;
        if (exif.slice(0, 6) != "\x45\x78\x69\x66\x00\x00") {
            throw new Error("Given data is not exif.");
        }
        if (jpeg.slice(0, 2) == "\xff\xd8") {
        } else if (jpeg.slice(0, 23) == "data:image/jpeg;base64," || jpeg.slice(0, 22) == "data:image/jpg;base64,") {
            jpeg = atob(jpeg.split(",")[1]);
            b64 = true;
        } else {
            throw new Error("Given data is not jpeg.");
        }

        var exifStr = "\xff\xe1" + pack(">H", [exif.length + 2]) + exif;
        var segments = splitIntoSegments(jpeg);
        var new_data = mergeSegments(segments, exifStr);
        if (b64) {
            new_data = "data:image/jpeg;base64," + btoa(new_data);
        }

        return new_data;
    };
```

mhh, but I think that's not a problem since there aren't other file formats we allow that can have EXIF data according to my research while working on [#634](https://github.com/stackernews/stacker.news/pull/634#issuecomment-1812980151). So I guess this is just another additional indicator that there are indeed no other _common_ image files that allow EXIF next to JPEG.

---

So I think the only stuff left to do is this (I am finally back with my TODOs in PR descriptions, lol):

- [x] make sure there are indeed no other image file types that allow orientation  values in EXIF but aren't supported by the library
- [x] map orientation values from output of `getOrientation` to required values for `piexifjs`. ~~I think~~ that's the cause that some JPEGs still throw `pack error` since there is a `val > 0` check in the library but `getOrientation` can return value < 0 _(ah, no mapping required, just filter for value < 0)_
- [x] fix JPEG detection since if there is no pack error, a "not JPEG" error comes up
- [x] ignore everything which is not JPEG ~~+ make sure there is indeed no EXIF with a sanity check~~
- [x] fix: JPEGs with orientation value > 0 throw an blank error if `img.src` is set to them

---

What the [spec](https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf) says on page 30 about the values for orientation:

![2023-12-15-141955_653x566_scrot](https://github.com/stackernews/stacker.news/assets/27162016/c9461e21-76d9-472d-9ea6-c9567f40b9a2)

![VGsAj](https://github.com/stackernews/stacker.news/assets/27162016/2c846eaf-8dfc-40a5-ad7a-b70693eca5d0)

[_source_](https://stackoverflow.com/a/32490603)