### PR TITLE
Mix error messages to hide user balance

### DIFF
--- a/api/resolvers/serial.js
+++ b/api/resolvers/serial.js
@@ -3,8 +3,7 @@ import retry from 'async-retry'
 import Prisma from '@prisma/client'
 import { settleHodlInvoice } from 'ln-service'
 import { createHmac } from './wallet'
-import { msatsToSats, numWithUnits } from '../../lib/format'
-import { BALANCE_LIMIT_MSATS } from '../../lib/constants'
+import { msatsToSats } from '../../lib/format'
 
 export default async function serialize (models, ...calls) {
   return await retry(async bail => {
@@ -49,7 +48,7 @@ export default async function serialize (models, ...calls) {
         bail(new Error('too many pending invoices'))
       }
       if (error.message.includes('SN_INV_EXCEED_BALANCE')) {
-        bail(new Error(`pending invoices must not cause balance to exceed ${numWithUnits(msatsToSats(BALANCE_LIMIT_MSATS))}`))
+        bail(new Error('too many pending invoices'))
       }
       if (error.message.includes('40001') || error.code === 'P2034') {
         throw new Error('wallet balance serialization failure - try again')


### PR DESCRIPTION
One possible (temporary?) solution for #691 would be to not respond with a error message which tells that creating this invoice would exceed a limit.

By just responding with a different error message, the attacker cannot distinguish between "too many invoices" or "invoice would exceed limit". This isn't ideal but still a lot better imo.

~~I haven't tested this or checked if this would break something but if our code is good, we're not relying on error messages so this change should be fine.~~

edit: Okay, I will test this, don't want to rely on @huumn superhuman skills to know exactly the impact of every line of code changed just by looking at it, lol

TODO:

- [x] test

---

Okay, pretty sure this doesn't break anything. I searched for all kind of substrings of the previous error message, and tested depositing and withdrawing. All good.