### PR TITLE
Fix wrong rewards in push notification

### DIFF
--- a/worker/earn.js
+++ b/worker/earn.js
@@ -217,7 +217,7 @@ function buildUserNotification (earnings) {
   if (earnings.POST) body += `#${earnings.POST.rank} among posts for ${fmt(earnings.POST.msats)}\n`
   if (earnings.COMMENT) body += `#${earnings.COMMENT.rank} among comments for ${fmt(earnings.COMMENT.msats)}\n`
   if (earnings.TIP_POST) body += `#${earnings.TIP_POST.rank} in post zapping for ${fmt(earnings.TIP_POST.msats)}\n`
-  if (earnings.TIP_COMMENT) body += `#${earnings.TIP_COMMENT.rank} in comment zapping for ${fmt(earnings.TIP_COMMENT.msats)}\n`
+  if (earnings.TIP_COMMENT) body += `#${earnings.TIP_COMMENT.rank} in comment zapping for ${fmt(earnings.TIP_COMMENT.msats)}`
 
   return { title, tag, body }
 }

--- a/worker/earn.js
+++ b/worker/earn.js
@@ -162,10 +162,25 @@ export async function earn ({ name, models }) {
       await serialize(models,
         models.$executeRaw`SELECT earn(${earner.userId}::INTEGER, ${earnings},
           ${now}::timestamp without time zone, ${earner.type}::"EarnType", ${earner.id}::INTEGER, ${earner.rank}::INTEGER)`)
+
+      const userN = notifications[earner.userId] || {}
+
+      // sum total
+      const prevMsats = userN.msats || 0
+      const msats = earnings + prevMsats
+
+      // sum total per earn type (POST, COMMENT, TIP_COMMENT, TIP_POST)
+      const prevEarnTypeMsats = userN[earner.type]?.msats || 0
+      const earnTypeMsats = earnings + prevEarnTypeMsats
+
+      // best (=lowest) rank per earn type
+      const prevEarnTypeBestRank = userN[earner.type]?.bestRank
+      const earnTypeBestRank = prevEarnTypeBestRank ? Math.min(prevEarnTypeBestRank, Number(earner.rank)) : Number(earner.rank)
+
       notifications[earner.userId] = {
-        ...notifications[earner.userId],
-        total: earnings + (notifications[earner.userId]?.total || 0),
-        [earner.type]: { msats: earnings, rank: earner.rank }
+        ...userN,
+        msats,
+        [earner.type]: { msats: earnTypeMsats, bestRank: earnTypeBestRank }
       }
     }
   }
@@ -211,13 +226,13 @@ async function territoryRevenue ({ models }) {
 function buildUserNotification (earnings) {
   const fmt = msats => numWithUnits(msatsToSats(msats, { abbreviate: false }))
 
-  const title = `you stacked ${fmt(earnings.total)} in rewards`
+  const title = `you stacked ${fmt(earnings.msats)} in rewards`
   const tag = 'EARN'
   let body = ''
-  if (earnings.POST) body += `#${earnings.POST.rank} among posts for ${fmt(earnings.POST.msats)}\n`
-  if (earnings.COMMENT) body += `#${earnings.COMMENT.rank} among comments for ${fmt(earnings.COMMENT.msats)}\n`
-  if (earnings.TIP_POST) body += `#${earnings.TIP_POST.rank} in post zapping for ${fmt(earnings.TIP_POST.msats)}\n`
-  if (earnings.TIP_COMMENT) body += `#${earnings.TIP_COMMENT.rank} in comment zapping for ${fmt(earnings.TIP_COMMENT.msats)}`
+  if (earnings.POST) body += `#${earnings.POST.bestRank} among posts with ${fmt(earnings.POST.msats)} in total\n`
+  if (earnings.COMMENT) body += `#${earnings.COMMENT.bestRank} among comments with ${fmt(earnings.COMMENT.msats)} in total\n`
+  if (earnings.TIP_POST) body += `#${earnings.TIP_POST.bestRank} in post zapping with ${fmt(earnings.TIP_POST.msats)} in total\n`
+  if (earnings.TIP_COMMENT) body += `#${earnings.TIP_COMMENT.bestRank} in comment zapping with ${fmt(earnings.TIP_COMMENT.msats)} in total`
 
   return { title, tag, body }
 }


### PR DESCRIPTION
Fix #661 

Essentially, this shows the best rank a stacker achieved per earn type and sums the sats per earn type instead of showing the last info per earn type.

Tested this by putting 141k into donations:

```sql
INSERT INTO "Donation"(created_at, sats, "userId")
VALUES (CURRENT_TIMESTAMP - '1 day'::interval, 141000, 14913);
```

and then assigning 16 random items to two accounts and pretending they were created yesterday:

```sql
UPDATE "Item"
SET created_at = date_trunc('second', CURRENT_TIMESTAMP - '1 day'::interval), "userId" = 14913
WHERE id IN (SELECT id FROM "Item" ORDER BY RANDOM() LIMIT 16);
UPDATE "Item"
SET created_at = date_trunc('second', CURRENT_TIMESTAMP - '1 day'::interval), "userId" = 14912
WHERE id IN (SELECT id FROM "Item" ORDER BY RANDOM() LIMIT 16);
```

This resulted in this output from the worker with the object being the push notification payload (if the coinflip resulted in posting being rewarded):

```
earn giving away 141000000 msats rewarding items
stacker 14913 earned 14521430 proportion 0.10298887189814242 rank 1n type COMMENT
stacker 14912 earned 13391912 proportion 0.09497810427830913 rank 2n type COMMENT
stacker 14913 earned 8790303 proportion 0.06234258097374948 rank 3n type COMMENT
stacker 14913 earned 7245061 proportion 0.05138341248328721 rank 4n type COMMENT
stacker 14913 earned 7245061 proportion 0.05138341248328721 rank 5n type COMMENT
stacker 14913 earned 5823796 proportion 0.04130352432877957 rank 6n type COMMENT
stacker 14912 earned 5582567 proportion 0.039592677327782884 rank 7n type COMMENT
stacker 14912 earned 3384558 proportion 0.024003958695498095 rank 8n type COMMENT
stacker 14913 earned 2262924 proportion 0.016049108692126703 rank 9n type COMMENT
stacker 14912 earned 2151900 proportion 0.01526170795160226 rank 10n type COMMENT
stacker 14913 earned 99099 proportion 0.0007028321602408267 rank 11n type COMMENT
stacker 14912 earned 1383 proportion 0.000009808727194188404 rank 12n type COMMENT
stacker 14913 earned 58022603 proportion 0.411507824169069 rank 1n type POST
stacker 14913 earned 11167688 proportion 0.07920346172530285 rank 2n type POST
stacker 14913 earned 1146073 proportion 0.008128183833526694 rank 3n type POST
stacker 14913 earned 95721 proportion 0.0006788772128439138 rank 4n type POST
stacker 14913 earned 67913 proportion 0.00048165305925754605 rank 5n type POST
14912 {
  title: 'you stacked 24.5k sats in rewards',
  tag: 'EARN',
  body: '#2 among comments for 24.5k sats in total\n'
}
14913 {
  title: 'you stacked 116.5k sats in rewards',
  tag: 'EARN',
  body: '#1 among posts with 70.5k sats in total\n' +
    '#1 among comments for 46k sats in total\n'
}
finished earn
```

and made sure that numbers add up: `24.5 + 70.5 + 46 = 141`