### PR TITLE
Fix silent push due to missing tag support in Safari on iOS

### DIFF
--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -19,7 +19,7 @@ export function onPush (sw) {
     if (!payload) return
     const { tag } = payload.options
     event.waitUntil((async () => {
-      if (immediatelyShowNotification(payload)) {
+      if (immediatelyShowNotification(tag)) {
         setAppBadge(sw, ++activeCount)
         // FIXME(iOS) this also doesn't work on iOS as expected. it displays multiple notifications with same tag.
         return await sw.registration.showNotification(payload.title, payload.options)
@@ -62,7 +62,7 @@ export function onPush (sw) {
 
 // if there is no tag or it's a TIP, FORWARDEDTIP or EARN notification
 // we don't need to merge notifications and thus the notification should be immediately shown using `showNotification`
-const immediatelyShowNotification = ({ options: { tag } }) => !tag || ['TIP', 'FORWARDEDTIP', 'EARN'].includes(tag.split('-')[0])
+const immediatelyShowNotification = (tag) => !tag || ['TIP', 'FORWARDEDTIP', 'EARN'].includes(tag.split('-')[0])
 
 const mergeAndShowNotification = async (sw, payload, currentNotifications, tag) => {
   // sanity check

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -104,15 +104,15 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag) 
   const { amount, followeeName, subType, sats } = mergedPayload
   let title = ''
   if (AMOUNT_TAGS.includes(compareTag)) {
-    if (tag === 'REPLY') {
+    if (compareTag === 'REPLY') {
       title = `you have ${amount} new replies`
-    } else if (tag === 'MENTION') {
+    } else if (compareTag === 'MENTION') {
       title = `you were mentioned ${amount} times`
-    } else if (tag === 'REFERRAL') {
+    } else if (compareTag === 'REFERRAL') {
       title = `${amount} stackers joined via your referral links`
-    } else if (tag === 'INVITE') {
+    } else if (compareTag === 'INVITE') {
       title = `your invite has been redeemed by ${amount} stackers`
-    } else if (tag === 'FOLLOW') {
+    } else if (compareTag === 'FOLLOW') {
       title = `@${followeeName} ${subType === 'POST' ? `created ${amount} posts` : `replied ${amount} times`}`
     }
   } else if (SUM_SATS_TAGS.includes(compareTag)) {

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -98,7 +98,6 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag) 
     }
     const newPayload = { ...data, amount: newAmount, sats: newSats }
     return newPayload
-    // we start with amount: 1 since we know the user agent already is showing one notification
   }, { ...incomingData, amount: initialAmount })
 
   // calculate title from merged payload

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -100,7 +100,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag) 
       newAmount = acc.amount + 1
     }
     if (SUM_SATS_TAGS.includes(compareTag)) {
-      newSats = acc.sats
+      newSats = acc.sats + data.sats
     }
     const newPayload = { ...data, amount: newAmount, sats: newSats }
     return newPayload

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -99,7 +99,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag) 
     const newPayload = { ...data, amount: newAmount, sats: newSats }
     return newPayload
     // we start with amount: 1 since we know the user agent already is showing one notification
-  }, { ...incomingData, sats: undefined, amount: initialAmount })
+  }, { ...incomingData, amount: initialAmount })
 
   // calculate title from merged payload
   const { amount, followeeName, subType, sats } = mergedPayload
@@ -115,9 +115,10 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag) 
       title = `your invite has been redeemed by ${amount} stackers`
     } else if (tag === 'FOLLOW') {
       title = `@${followeeName} ${subType === 'POST' ? `created ${amount} posts` : `replied ${amount} times`}`
-    } else if (tag === 'DEPOSIT') {
-      title = `${numWithUnits(sats, { abbreviate: false })} were deposited in your account`
     }
+  } else if (SUM_SATS_TAGS.includes(compareTag)) {
+    // there is only DEPOSIT in this array
+    title = `${numWithUnits(sats, { abbreviate: false })} were deposited in your account`
   }
 
   // close all current notifications before showing new one to "merge" notifications

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -94,7 +94,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag) 
   const SUM_SATS_TAGS = ['DEPOSIT']
   // this should reflect the amount of notifications that were already merged before
   const initialAmount = currentNotifications[0].data?.amount || 1
-  const mergedPayload = currentNotifications.reduce((acc, { tag, data }) => {
+  const mergedPayload = currentNotifications.reduce((acc, { data }) => {
     let newAmount, newSats
     if (AMOUNT_TAGS.includes(compareTag)) {
       newAmount = acc.amount + 1

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -21,11 +21,10 @@ export function onPush (sw) {
     event.waitUntil((async () => {
       if (immediatelyShowNotification(tag)) {
         setAppBadge(sw, ++activeCount)
-        // FIXME(iOS) this also doesn't work on iOS as expected. it displays multiple notifications with same tag.
-        //   due to missing proper tag support in Safari on iOS, we can't rely on the tag property to replace notifications.
-        //   see https://bugs.webkit.org/show_bug.cgi?id=258922 for more information
-        //   we therefore fetch all notifications with the same tag (+ manual filter),
-        //   close them and then we display the notification.
+        // due to missing proper tag support in Safari on iOS, we can't rely on the tag property to replace notifications.
+        // see https://bugs.webkit.org/show_bug.cgi?id=258922 for more information
+        // we therefore fetch all notifications with the same tag (+ manual filter),
+        // close them and then we display the notification.
         const notifications = await sw.registration.getNotifications({ tag })
         notifications.filter(({ tag: nTag }) => nTag === tag).forEach(n => n.close())
         return await sw.registration.showNotification(payload.title, payload.options)

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -22,6 +22,12 @@ export function onPush (sw) {
       if (immediatelyShowNotification(tag)) {
         setAppBadge(sw, ++activeCount)
         // FIXME(iOS) this also doesn't work on iOS as expected. it displays multiple notifications with same tag.
+        //   due to missing proper tag support in Safari on iOS, we can't rely on the tag property to replace notifications.
+        //   see https://bugs.webkit.org/show_bug.cgi?id=258922 for more information
+        //   we therefore fetch all notifications with the same tag (+ manual filter),
+        //   close them and then we display the notification.
+        const notifications = await sw.registration.getNotifications({ tag })
+        notifications.filter(({ tag: nTag }) => nTag === tag).forEach(n => n.close())
         return await sw.registration.showNotification(payload.title, payload.options)
       }
 

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -62,7 +62,7 @@ export function onPush (sw) {
 
 // if there is no tag or it's a TIP, FORWARDEDTIP or EARN notification
 // we don't need to merge notifications and thus the notification should be immediately shown using `showNotification`
-const immediatelyShowNotification = (tag) => !tag || ['TIP', 'FORWARDEDTIP', 'EARN'].includes(tag.split('-')[0])
+const immediatelyShowNotification = (tag) => !tag || ['TIP', 'FORWARDEDTIP', 'EARN', 'STREAK'].includes(tag.split('-')[0])
 
 const mergeAndShowNotification = async (sw, payload, currentNotifications, tag) => {
   // sanity check

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -21,28 +21,41 @@ export function onPush (sw) {
     event.waitUntil((async () => {
       if (immediatelyShowNotification(payload)) {
         setAppBadge(sw, ++activeCount)
+        // FIXME(iOS) this also doesn't work on iOS as expected. it displays multiple notifications with same tag.
         return await sw.registration.showNotification(payload.title, payload.options)
       }
 
       // fetch existing notifications with same tag
-      const notifications = await sw.registration.getNotifications({ tag })
+      let notifications = await sw.registration.getNotifications({ tag })
 
-      // since we used a tag filter, there should only be zero or one notification
-      if (notifications.length > 1) {
-        const message = `[sw:push] more than one notification with tag ${tag} found`
-        messageChannelPort?.postMessage({ level: 'error', message })
-        console.error(message)
-        return null
-      }
-
+      // according to the spec, there should only be zero or one notification since we used a tag filter
+      // handle zero case here
       if (notifications.length === 0) {
         // incoming notification is first notification with this tag
         setAppBadge(sw, ++activeCount)
         return await sw.registration.showNotification(payload.title, payload.options)
       }
 
-      const currentNotification = notifications[0]
-      return await mergeAndShowNotification(sw, payload, currentNotification)
+      // handle unexpected case here
+      if (notifications.length > 1) {
+        const message = `[sw:push] more than one notification with tag ${tag} found`
+        messageChannelPort?.postMessage({ level: 'error', message })
+        console.error(message)
+        // due to missing proper tag support in Safari on iOS,
+        // we only acknowledge this error in our logs and don't bail here anymore
+        // see https://bugs.webkit.org/show_bug.cgi?id=258922 for more information
+        const message2 = '[sw:push] skip bail -- merging notifications manually'
+        messageChannelPort?.postMessage({ level: 'info', message: message2 })
+        console.log(message2)
+        // return null
+      }
+
+      // we manually filter notifications by their tag since iOS doesn't properly support tag
+      // and we're not sure if the built-in tag filter actually filters by tag on iOS
+      // or if it just returns all currently displayed notifications.
+      notifications = notifications.filter(({ tag: nTag }) => nTag === tag)
+
+      return await mergeAndShowNotification(sw, payload, notifications, tag)
     })())
   }
 }
@@ -51,40 +64,66 @@ export function onPush (sw) {
 // we don't need to merge notifications and thus the notification should be immediately shown using `showNotification`
 const immediatelyShowNotification = ({ options: { tag } }) => !tag || ['TIP', 'FORWARDEDTIP', 'EARN'].includes(tag.split('-')[0])
 
-const mergeAndShowNotification = async (sw, payload, currentNotification) => {
-  const { data: incomingData } = payload.options
-  const { tag, data: currentData } = currentNotification
-
-  // how many notification with this tag are there already?
-  // (start from 2 and +1 to include incoming notification)
-  const amount = currentNotification.data?.amount ? currentNotification.data.amount + 1 : 2
-
-  let title = ''
-  let newData = {}
-  if (tag === 'REPLY') {
-    title = `you have ${amount} new replies`
-  } else if (tag === 'MENTION') {
-    title = `you were mentioned ${amount} times`
-  } else if (tag === 'REFERRAL') {
-    title = `${amount} stackers joined via your referral links`
-  } else if (tag === 'INVITE') {
-    title = `your invite has been redeemed by ${amount} stackers`
-  } else if (tag === 'DEPOSIT') {
-    const currentSats = currentData.sats
-    const incomingSats = incomingData.sats
-    const newSats = currentSats + incomingSats
-    title = `${numWithUnits(newSats, { abbreviate: false })} were deposited in your account`
-    newData.sats = newSats
-  } else if (tag.split('-')[0] === 'FOLLOW') {
-    const { followeeName, subType } = incomingData
-    title = `@${followeeName} ${subType === 'POST' ? `created ${amount} posts` : `replied ${amount} times`}`
-    newData = incomingData
+const mergeAndShowNotification = async (sw, payload, currentNotifications, tag) => {
+  // sanity check
+  const otherTagNotifications = currentNotifications.filter(({ tag: nTag }) => nTag !== tag)
+  if (otherTagNotifications.length > 0) {
+    // we can't recover from this here. bail.
+    const message = `[sw:push] more than one notification with tag ${tag} after filter`
+    messageChannelPort?.postMessage({ level: 'error', message })
+    console.error(message)
+    return
   }
 
-  // close current notification before showing new one to "merge" notifications
-  currentNotification.close()
-  const newNotificationOptions = { icon: currentNotification.icon, tag, data: { url: '/notifications', amount, ...newData } }
-  return await sw.registration.showNotification(title, newNotificationOptions)
+  const { data: incomingData } = payload.options
+
+  // we can ignore everything after the first dash in the tag for our control flow
+  const compareTag = tag.split('-')[0]
+
+  // merge notifications into single notification payload
+  // ---
+  // tags that need to know the amount of notifications with same tag for merging
+  const AMOUNT_TAGS = ['REPLY', 'MENTION', 'REFERRAL', 'INVITE', 'FOLLOW']
+  // tags that need to know the sum of sats of notifications with same tag for merging
+  const SUM_SATS_TAGS = ['DEPOSIT']
+  // this should reflect the amount of notifications that were already merged before
+  const initialAmount = currentNotifications[0].data?.amount || 1
+  const mergedPayload = currentNotifications.reduce((acc, { tag, data }) => {
+    let newAmount, newSats
+    if (AMOUNT_TAGS.includes(compareTag)) {
+      newAmount = acc.amount + 1
+    }
+    if (SUM_SATS_TAGS.includes(compareTag)) {
+      newSats = acc.sats
+    }
+    const newPayload = { ...data, amount: newAmount, sats: newSats }
+    return newPayload
+    // we start with amount: 1 since we know the user agent already is showing one notification
+  }, { ...incomingData, sats: undefined, amount: initialAmount })
+
+  // calculate title from merged payload
+  const { amount, followeeName, subType, sats } = mergedPayload
+  let title = ''
+  if (AMOUNT_TAGS.includes(compareTag)) {
+    if (tag === 'REPLY') {
+      title = `you have ${amount} new replies`
+    } else if (tag === 'MENTION') {
+      title = `you were mentioned ${amount} times`
+    } else if (tag === 'REFERRAL') {
+      title = `${amount} stackers joined via your referral links`
+    } else if (tag === 'INVITE') {
+      title = `your invite has been redeemed by ${amount} stackers`
+    } else if (tag === 'FOLLOW') {
+      title = `@${followeeName} ${subType === 'POST' ? `created ${amount} posts` : `replied ${amount} times`}`
+    } else if (tag === 'DEPOSIT') {
+      title = `${numWithUnits(sats, { abbreviate: false })} were deposited in your account`
+    }
+  }
+
+  // close all current notifications before showing new one to "merge" notifications
+  currentNotifications.forEach(n => n.close())
+  const options = { icon: payload.options?.icon, tag, data: { url: '/notifications', ...mergedPayload } }
+  return await sw.registration.showNotification(title, options)
 }
 
 export function onNotificationClick (sw) {


### PR DESCRIPTION
Related to #411 

|       | Chrome (Blink) | Firefox (Gecko) | Safari (WebKit) |
| ----------- | ----------- |----------- |----------- |
| Desktop      | :white_check_mark:  [video for Brave on desktop](https://files.ekzyis.com/public/sn/web_push_test.mp4)  |  :white_check_mark: Firefox on desktop: tested zaps, replies and mentions| 
| Mobile   |   :white_check_mark: Brave on Android: tested zaps, replies and mentions      | _did not test but pretty sure this will work, too._ |

For faster testing on desktop (not E2E), we can use the serviceworker tools provided by some browsers:

![2023-12-29-203101_518x39_scrot](https://github.com/stackernews/stacker.news/assets/27162016/b191d036-5b8f-4f24-aef0-b53577cedad9)

Payload for replies:

```
{"title": "@anon replied to you", "options": { "tag": "REPLY", "icon": "/icons/icon_x96.png" }}
```

Payload for zaps (_does not use new merge logic_):

```
{"title": "your post stacked 21 sats", "options": { "tag": "TIP-328105", "icon": "/icons/icon_x96.png", "body": "testme"  }}
```

Payload for follows:

```
{"title": "@anon created a post", "options": { "tag": "FOLLOW-27-POST", "icon": "/icons/icon_x96.png", "body": "post title", "data": { "followeeName": "anon", "subType": "POST" } } }
```

Payload for forwarded zaps (_does not use new merge logic_):

```
{"title": "you were forwarded 21 sats", "options": { "tag": "FORWARDEDTIP-328105", "icon": "/icons/icon_x96.png", "body": "post title" } }
```

Payload for deposits:

```
{"title": "100 sats were deposited in your account", "options": { "tag": "DEPOSIT", "icon": "/icons/icon_x96.png", "data": { "sats": 100 } } }
```

Payload for mentions:

```
{"title": "you were mentioned", "options": { "tag": "MENTION", "icon": "/icons/icon_x96.png", "body": "post title" } }
```

Payload for referrals:

```
{ "title": "someone joined via one of your referral links", "options": { "tag": "REFERRAL", "icon": "/icons/icon_x96.png" } }
```

Payload for invites:

```
{ "title": "your invite has been redeemed", "options": { "tag": "INVITE", "icon": "/icons/icon_x96.png" } }
```

Payload for rewards (_does not use new merge logic_):

```
{ "title": "you stacked 1000 sats in rewards", "options": { "tag": "EARN", "icon": "/icons/icon_x96.png" } }
```

Payload for streaks:

```
{ "title": "you found a cowboy hat", "options": { "tag": "STREAK-FOUND", "icon": "/icons/icon_x96.png", "body": "blurb" } }
```