### PR TITLE
Remove ineffective guard against all caps

### DIFF
--- a/components/link-form.js
+++ b/components/link-form.js
@@ -146,10 +146,6 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
               variables: { title: e.target.value }
             })
           }
-          if (e.target.value === e.target.value.toUpperCase()) {
-            setTitleOverride(e.target.value.replace(/\w\S*/g, txt =>
-              txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()))
-          }
         }}
         maxLength={MAX_TITLE_LENGTH}
       />


### PR DESCRIPTION
With this PR, I am suggesting to remove the existing guard against all caps titles for the following reasons:

- it's ineffective since it only makes the second letter lower case
- there are ways to not make it trigger and thus still be able to post links with all caps
- it's unexpected and thus confusing
- there are legitimate use cases for using all caps in the first few letters. example: acronyms
- it only applied to link posts (inconsistent UX)

related to https://github.com/stackernews/stacker.news/issues/584, #590 