### PR TITLE
Add verbose logging in onPush listener

### DIFF
--- a/components/serviceworker.js
+++ b/components/serviceworker.js
@@ -58,6 +58,11 @@ export const ServiceWorkerProvider = ({ children }) => {
   })
 
   const subscribeToPushNotifications = async () => {
+    // serviceWorker.controller is null on forced refreshes
+    // see https://w3c.github.io/ServiceWorker/#navigator-service-worker-controller
+    if (!navigator.serviceWorker.controller) {
+      throw new Error('no active service worker found. try refreshing page.')
+    }
     const subscribeOptions = { userVisibleOnly: true, applicationServerKey }
     // Brave users must enable a flag in brave://settings/privacy first
     // see https://stackoverflow.com/a/69624651


### PR DESCRIPTION
This adds more logging so we can trace better where the service worker on iOS shows unexpected behavior.

My educated guess is that `Notification.close()` does not work but [according to MDN](https://developer.mozilla.org/en-US/docs/Web/API/Notification/close#browser_compatibility), it should work.

![2023-12-31-223109_789x531_scrot](https://github.com/stackernews/stacker.news/assets/27162016/4abf118b-b56d-4a0e-b1bb-81d57a953ae8)

But this wouldn't be the first but the second case where [MDN shows invalid data what a browser supports](https://github.com/mdn/browser-compat-data/issues/20305).

Related to #411