### PR TITLE
Only close notifications manually on iOS

### DIFF
--- a/components/logger.js
+++ b/components/logger.js
@@ -11,7 +11,7 @@ const generateFancyName = () => {
   return `${adj}-${noun}-${id}`
 }
 
-function detectOS () {
+export function detectOS () {
   if (!window.navigator) return ''
 
   const userAgent = window.navigator.userAgent

--- a/components/serviceworker.js
+++ b/components/serviceworker.js
@@ -1,11 +1,14 @@
 import { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react'
 import { Workbox } from 'workbox-window'
 import { gql, useMutation } from '@apollo/client'
-import { useLogger } from './logger'
+import { detectOS, useLogger } from './logger'
 
 const applicationServerKey = process.env.NEXT_PUBLIC_VAPID_PUBKEY
 
 const ServiceWorkerContext = createContext()
+
+// message types for communication between app and service worker
+export const STORE_OS = 'STORE_OS'
 
 export const ServiceWorkerProvider = ({ children }) => {
   const [registration, setRegistration] = useState(null)
@@ -146,6 +149,7 @@ export const ServiceWorkerProvider = ({ children }) => {
     // see https://medium.com/@madridserginho/how-to-handle-webpush-api-pushsubscriptionchange-event-in-modern-browsers-6e47840d756f
     navigator?.serviceWorker?.controller?.postMessage?.({ action: 'SYNC_SUBSCRIPTION' })
     logger.info('sent SYNC_SUBSCRIPTION to service worker')
+    navigator?.serviceWorker?.controller?.postMessage?.({ action: STORE_OS, os: detectOS() })
   }, [registration])
 
   const contextValue = useMemo(() => ({

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -13,6 +13,7 @@ let actionChannelPort
 
 // operating system. the value will be received via a STORE_OS message from app since service workers don't have access to window.navigator
 let os = ''
+const iOS = () => os === 'iOS'
 
 // current push notification count for badge purposes
 let activeCount = 0
@@ -31,7 +32,7 @@ export function onPush (sw) {
         // close them and then we display the notification.
         const notifications = await sw.registration.getNotifications({ tag })
         // we only close notifications manually on iOS because we don't want to degrade android UX just because iOS is behind in their support.
-        if (os === 'iOS') notifications.filter(({ tag: nTag }) => nTag === tag).forEach(n => n.close())
+        if (iOS()) notifications.filter(({ tag: nTag }) => nTag === tag).forEach(n => n.close())
         return await sw.registration.showNotification(payload.title, payload.options)
       }
 
@@ -132,7 +133,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag) 
 
   // close all current notifications before showing new one to "merge" notifications
   // we only do this on iOS because we don't want to degrade android UX just because iOS is behind in their support.
-  if (os === 'iOS') currentNotifications.forEach(n => n.close()) && console.log('closing notifications')
+  if (iOS()) currentNotifications.forEach(n => n.close()) && console.log('closing notifications')
   const options = { icon: payload.options?.icon, tag, data: { url: '/notifications', ...mergedPayload } }
   return await sw.registration.showNotification(title, options)
 }


### PR DESCRIPTION
Related to #411 

I didn't notice a difference testing locally but I am pretty sure this will revert back to the Android UX that we had before #719 since the only problem was that it was noticeable that notifications are closed instead of only replaced using `tag`.