### PR TITLE
Fix invalid DOM property

### DIFF
--- a/pages/wallet.js
+++ b/pages/wallet.js
@@ -230,7 +230,7 @@ export function InvWithdrawal () {
   return (
     <>
       <Form
-        autocomplete='off'
+        autoComplete='off'
         initial={{
           invoice: '',
           maxFee: maxFeeDefault


### PR DESCRIPTION
Code works with `autocomplete` but it prints a warning in the console:

> Warning: Invalid DOM property `autocomplete`. Did you mean `autoComplete`?

Code also works with `autoComplete` as used in other parts in the code base.