### PR TITLE
Remove logging to browser

### DIFF
--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -20,8 +20,6 @@ let activeCount = 0
 
 const log = (message, level = 'info', context) => {
   messageChannelPort?.postMessage({ level, message, context })
-  if (level === 'error') console.error(message)
-  else console.log(message)
 }
 
 export function onPush (sw) {

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -60,7 +60,7 @@ export function onPush (sw) {
           log(`[sw:push] ${nid} - closing existing notifications`)
           notifications.filter(({ tag: nTag }) => nTag === tag).forEach(n => n.close())
         }
-        log(`[sw:push] ${nid} - show notification: ${payload.title} ${JSON.stringify(payload.options)}`)
+        log(`[sw:push] ${nid} - show notification with title "${payload.title}"`)
         return await sw.registration.showNotification(payload.title, payload.options)
       }
 
@@ -70,7 +70,7 @@ export function onPush (sw) {
         // incoming notification is first notification with this tag
         log(`[sw:push] ${nid} - no existing ${tag} notifications found`)
         setAppBadge(sw, ++activeCount)
-        log(`[sw:push] ${nid} - show notification: ${payload.title} ${JSON.stringify(payload.options)}`)
+        log(`[sw:push] ${nid} - show notification with title "${payload.title}"`)
         return await sw.registration.showNotification(payload.title, payload.options)
       }
 
@@ -162,7 +162,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
   }
 
   const options = { icon: payload.options?.icon, tag, data: { url: '/notifications', ...mergedPayload } }
-  log(`[sw:push] ${nid} - show notification: ${title} ${JSON.stringify(options)}`)
+  log(`[sw:push] ${nid} - show notification with title "${payload.title}"`)
   return await sw.registration.showNotification(title, options)
 }
 


### PR DESCRIPTION
I think I only added `console.log` and `console.error` for debugging during development.

Since we have problems with push notifications on iOS where we will not see the browser console anyway (or only using  USB debugging), we can remove these lines.

Also, the payload options weren't useful in the logs. They only add noise.

Related to #411 