### PR TITLE
Territory post notifications

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -17,7 +17,7 @@ import uu from 'url-unshort'
 import { actSchema, advSchema, bountySchema, commentSchema, discussionSchema, jobSchema, linkSchema, pollSchema, ssValidate } from '../../lib/validate'
 import { sendUserNotification } from '../webPush'
 import { defaultCommentSort, isJob, deleteItemByAuthor, getDeleteCommand, hasDeleteCommand } from '../../lib/item'
-import { notifyItemParents, notifyUserSubscribers, notifyZapped } from '../../lib/push-notifications'
+import { notifyItemParents, notifyUserSubscribers, notifyZapped, notifyFounders } from '../../lib/push-notifications'
 import { datePivot, whenRange } from '../../lib/time'
 import { imageFeesInfo, uploadIdsFromText } from './image'
 import assertGofacYourself from './ofac'
@@ -1227,6 +1227,8 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
   await enqueueDeletionJob(item, models)
 
   notifyUserSubscribers({ models, item })
+
+  notifyFounders({ models, item })
 
   item.comments = []
   return item

--- a/api/resolvers/notifications.js
+++ b/api/resolvers/notifications.js
@@ -112,7 +112,7 @@ export default {
           `SELECT "Item".*, "Item".created_at AS "sortTime", 'TerritoryPost' AS type
             FROM "Item"
             JOIN "Sub" ON "Item"."subName" = "Sub".name
-            WHERE "Sub"."userId" = $1
+            WHERE "Sub"."userId" = $1 AND "Item"."userId" <> $1
             ORDER BY "sortTime" DESC
             LIMIT ${LIMIT}+$3`
         )

--- a/api/resolvers/notifications.js
+++ b/api/resolvers/notifications.js
@@ -107,6 +107,17 @@ export default {
           LIMIT ${LIMIT}+$3`
       )
 
+      if (meFull.noteTerritoryPosts) {
+        itemDrivenQueries.push(
+          `SELECT "Item".*, "Item".created_at AS "sortTime", 'TerritoryPost' AS type
+            FROM "Item"
+            JOIN "Sub" ON "Item"."subName" = "Sub".name
+            WHERE "Sub"."userId" = $1
+            ORDER BY "sortTime" DESC
+            LIMIT ${LIMIT}+$3`
+        )
+      }
+
       // mentions
       if (meFull.noteMentions) {
         itemDrivenQueries.push(
@@ -137,6 +148,7 @@ export default {
             WHEN type = 'Mention' THEN 1
             WHEN type = 'Reply' THEN 2
             WHEN type = 'FollowActivity' THEN 3
+            WHEN type = 'TerritoryPost' THEN 4
           END ASC
         )`
       )
@@ -346,6 +358,9 @@ export default {
     item: async (n, args, { models, me }) => getItem(n, { id: n.id }, { models, me })
   },
   FollowActivity: {
+    item: async (n, args, { models, me }) => getItem(n, { id: n.id }, { models, me })
+  },
+  TerritoryPost: {
     item: async (n, args, { models, me }) => getItem(n, { id: n.id }, { models, me })
   },
   JobChanged: {

--- a/api/typeDefs/notifications.js
+++ b/api/typeDefs/notifications.js
@@ -102,9 +102,15 @@ export default gql`
     sortTime: Date!
   }
 
+  type TerritoryPost {
+    id: ID!
+    item: Item!
+    sortTime: Date!
+  }
+
   union Notification = Reply | Votification | Mention
     | Invitification | Earn | JobChanged | InvoicePaid | Referral
-    | Streak | FollowActivity | ForwardedVotification | Revenue | SubStatus
+    | Streak | FollowActivity | ForwardedVotification | Revenue | SubStatus | TerritoryPost
 
   type Notifications {
     lastChecked: Date

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -69,6 +69,7 @@ export default gql`
     nostrPubkey: String
     nostrRelays: [String!]
     noteAllDescendants: Boolean!
+    noteTerritoryPosts: Boolean!
     noteCowboyHat: Boolean!
     noteDeposits: Boolean!
     noteEarning: Boolean!
@@ -125,6 +126,7 @@ export default gql`
     nostrPubkey: String
     nostrRelays: [String!]
     noteAllDescendants: Boolean!
+    noteTerritoryPosts: Boolean!
     noteCowboyHat: Boolean!
     noteDeposits: Boolean!
     noteEarning: Boolean!

--- a/api/webPush/index.js
+++ b/api/webPush/index.js
@@ -35,6 +35,7 @@ const createUserFilter = (tag) => {
   // filter users by notification settings
   const tagMap = {
     REPLY: 'noteAllDescendants',
+    TERRITORY_POST: 'noteTerritoryPosts',
     MENTION: 'noteMentions',
     TIP: 'noteItemSats',
     FORWARDEDTIP: 'noteForwardedSats',

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -47,7 +47,8 @@ function Notification ({ n, fresh }) {
         (type === 'JobChanged' && <JobChanged n={n} />) ||
         (type === 'Reply' && <Reply n={n} />) ||
         (type === 'SubStatus' && <SubStatus n={n} />) ||
-        (type === 'FollowActivity' && <FollowActivity n={n} />)
+        (type === 'FollowActivity' && <FollowActivity n={n} />) ||
+        (type === 'TerritoryPost' && <TerritoryPost n={n} />)
       }
     </NotificationLayout>
   )
@@ -415,6 +416,19 @@ function FollowActivity ({ n }) {
             </RootProvider>
           </div>
           )}
+    </>
+  )
+}
+
+function TerritoryPost ({ n }) {
+  return (
+    <>
+      <small className='fw-bold text-info ms-2'>
+        new post in ~{n.item.sub.name}
+      </small>
+      <div>
+        <Item item={n.item} />
+      </div>
     </>
   )
 }

--- a/fragments/notifications.js
+++ b/fragments/notifications.js
@@ -86,6 +86,14 @@ export const NOTIFICATIONS = gql`
             text
           }
         }
+        ... on TerritoryPost {
+          id
+          sortTime
+          item {
+            ...ItemFullFields
+            text
+          }
+        }
         ... on Invitification {
           id
           sortTime

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -23,6 +23,7 @@ export const ME = gql`
         lastCheckedJobs
         nostrCrossposting
         noteAllDescendants
+        noteTerritoryPosts
         noteCowboyHat
         noteDeposits
         noteEarning
@@ -57,6 +58,7 @@ export const SETTINGS_FIELDS = gql`
       noteItemSats
       noteEarning
       noteAllDescendants
+      noteTerritoryPosts
       noteMentions
       noteDeposits
       noteInvites

--- a/lib/push-notifications.js
+++ b/lib/push-notifications.js
@@ -100,9 +100,16 @@ export const notifyZapped = async ({ models, id }) => {
 export const notifyFounders = async ({ models, item }) => {
   try {
     const isPost = !!item.title
+
+    // only notify on posts in subs
     if (!isPost || !item.subName) return
+
     const author = await models.user.findUnique({ where: { id: item.userId } })
     const sub = await models.sub.findUnique({ where: { name: item.subName } })
+
+    // don't send notifications on own posts to founders
+    if (sub.userId === author.id) return
+
     const tag = `TERRITORY_POST-${sub.name}`
     await sendUserNotification(sub.userId, {
       title: `@${author.name} created a post in ~${sub.name}`,

--- a/lib/push-notifications.js
+++ b/lib/push-notifications.js
@@ -96,3 +96,20 @@ export const notifyZapped = async ({ models, id }) => {
     console.error(err)
   }
 }
+
+export const notifyFounders = async ({ models, item }) => {
+  try {
+    const isPost = !!item.title
+    if (!isPost || !item.subName) return
+    const author = await models.user.findUnique({ where: { id: item.userId } })
+    const sub = await models.sub.findUnique({ where: { name: item.subName } })
+    await sendUserNotification(sub.userId, {
+      title: `@${author.name} created a post in ~${sub.name}`,
+      body: item.title,
+      item,
+      tag: 'TERRITORY_POST'
+    })
+  } catch (err) {
+    console.error(err)
+  }
+}

--- a/lib/push-notifications.js
+++ b/lib/push-notifications.js
@@ -103,11 +103,13 @@ export const notifyFounders = async ({ models, item }) => {
     if (!isPost || !item.subName) return
     const author = await models.user.findUnique({ where: { id: item.userId } })
     const sub = await models.sub.findUnique({ where: { name: item.subName } })
+    const tag = `TERRITORY_POST-${sub.name}`
     await sendUserNotification(sub.userId, {
       title: `@${author.name} created a post in ~${sub.name}`,
       body: item.title,
       item,
-      tag: 'TERRITORY_POST'
+      data: { subName: sub.name },
+      tag
     })
   } catch (err) {
     console.error(err)

--- a/pages/settings.js
+++ b/pages/settings.js
@@ -68,6 +68,7 @@ export default function Settings ({ ssrData }) {
             noteItemSats: settings?.noteItemSats,
             noteEarning: settings?.noteEarning,
             noteAllDescendants: settings?.noteAllDescendants,
+            noteTerritoryPosts: settings?.noteTerritoryPosts,
             noteMentions: settings?.noteMentions,
             noteDeposits: settings?.noteDeposits,
             noteInvites: settings?.noteInvites,
@@ -194,6 +195,11 @@ export default function Settings ({ ssrData }) {
           <Checkbox
             label='someone replies to someone who replied to me'
             name='noteAllDescendants'
+            groupClassName='mb-0'
+          />
+          <Checkbox
+            label='someone writes a post in a territory I founded'
+            name='noteTerritoryPosts'
             groupClassName='mb-0'
           />
           <Checkbox

--- a/prisma/migrations/20240110195551_territory_posts_notifications/migration.sql
+++ b/prisma/migrations/20240110195551_territory_posts_notifications/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "noteTerritoryPosts" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model User {
   lastSeenAt            DateTime?
   stackedMsats          BigInt               @default(0)
   noteAllDescendants    Boolean              @default(true)
+  noteTerritoryPosts    Boolean              @default(true)
   noteDeposits          Boolean              @default(true)
   noteEarning           Boolean              @default(true)
   noteInvites           Boolean              @default(true)

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -113,7 +113,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
   // merge notifications into single notification payload
   // ---
   // tags that need to know the amount of notifications with same tag for merging
-  const AMOUNT_TAGS = ['REPLY', 'MENTION', 'REFERRAL', 'INVITE', 'FOLLOW']
+  const AMOUNT_TAGS = ['REPLY', 'MENTION', 'REFERRAL', 'INVITE', 'FOLLOW', 'TERRITORY_POST']
   // tags that need to know the sum of sats of notifications with same tag for merging
   const SUM_SATS_TAGS = ['DEPOSIT']
   // this should reflect the amount of notifications that were already merged before
@@ -148,6 +148,8 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
       title = `your invite has been redeemed by ${amount} stackers`
     } else if (compareTag === 'FOLLOW') {
       title = `@${followeeName} ${subType === 'POST' ? `created ${amount} posts` : `replied ${amount} times`}`
+    } else if (compareTag === 'TERRITORY_POST') {
+      title = `you have ${amount} new territory posts`
     }
   } else if (SUM_SATS_TAGS.includes(compareTag)) {
     // there is only DEPOSIT in this array

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -135,7 +135,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
   log(`[sw:push] ${nid} - merged payload: ${JSON.stringify(mergedPayload)}`)
 
   // calculate title from merged payload
-  const { amount, followeeName, subType, sats } = mergedPayload
+  const { amount, followeeName, subName, subType, sats } = mergedPayload
   let title = ''
   if (AMOUNT_TAGS.includes(compareTag)) {
     if (compareTag === 'REPLY') {
@@ -149,7 +149,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
     } else if (compareTag === 'FOLLOW') {
       title = `@${followeeName} ${subType === 'POST' ? `created ${amount} posts` : `replied ${amount} times`}`
     } else if (compareTag === 'TERRITORY_POST') {
-      title = `you have ${amount} new territory posts`
+      title = `you have ${amount} new posts in ~${subName}`
     }
   } else if (SUM_SATS_TAGS.includes(compareTag)) {
     // there is only DEPOSIT in this array


### PR DESCRIPTION
Close #681. This is based on #744 so #744 needs merging first.

TODO:

- [x] push notifications
- [x] add items to /notifications
- [x] don't notify on own posts

Territory post notifications look like this in /notifications:

![2024-01-11-033609_587x223_scrot](https://github.com/stackernews/stacker.news/assets/27162016/9eda1188-a482-4354-8d88-999353411a0b)

Push notifications keep territories separate:

![signal-2024-01-11-033509_003](https://github.com/stackernews/stacker.news/assets/27162016/d1407bfa-440a-415d-9f58-54d1824f7d38)

![signal-2024-01-11-033509_002](https://github.com/stackernews/stacker.news/assets/27162016/cd97ef7f-da42-4128-a1ad-a25c8f071ef7)

