### PR TITLE
Expose WebLN interface via React Context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ node_modules/
 .DS_Store
 *.pem
 /*.sql
+lnbits/
 
 # debug
 npm-debug.log*

--- a/components/banners.js
+++ b/components/banners.js
@@ -88,3 +88,20 @@ export function WalletLimitBanner () {
     </Alert>
   )
 }
+
+export function WalletSecurityBanner () {
+  return (
+    <Alert className={styles.banner} key='info' variant='warning'>
+      <Alert.Heading>
+        Wallet Security Disclaimer
+      </Alert.Heading>
+      <p className='mb-1'>
+        Your wallet's credentials are stored in the browser and never go to the server.<br />
+        However, you should definitely <strong>set a budget in your wallet</strong>.
+      </p>
+      <p>
+        Also, for the time being, you will have to reenter your credentials on other devices.
+      </p>
+    </Alert>
+  )
+}

--- a/components/form.js
+++ b/components/form.js
@@ -962,16 +962,21 @@ export function DatePicker ({ fromName, toName, noForm, onChange, when, from, to
   )
 }
 
-export function ClientInput ({ initialValue, ...props }) {
-  // This component can be used for Formik fields
-  // where the initial value is not available on first render.
-  // Example: value is stored in localStorage which is fetched
-  // after first render using an useEffect hook.
-  const [,, helpers] = useField(props)
+function Client (Component) {
+  return ({ initialValue, ...props }) => {
+    // This component can be used for Formik fields
+    // where the initial value is not available on first render.
+    // Example: value is stored in localStorage which is fetched
+    // after first render using an useEffect hook.
+    const [,, helpers] = useField(props)
 
-  useEffect(() => {
-    helpers.setValue(initialValue)
-  }, [initialValue])
+    useEffect(() => {
+      helpers.setValue(initialValue)
+    }, [initialValue])
 
-  return <Input {...props} />
+    return <Component {...props} />
+  }
 }
+
+export const ClientInput = Client(Input)
+export const ClientCheckbox = Client(Checkbox)

--- a/components/form.js
+++ b/components/form.js
@@ -961,3 +961,17 @@ export function DatePicker ({ fromName, toName, noForm, onChange, when, from, to
     />
   )
 }
+
+export function ClientInput ({ initialValue, ...props }) {
+  // This component can be used for Formik fields
+  // where the initial value is not available on first render.
+  // Example: value is stored in localStorage which is fetched
+  // after first render using an useEffect hook.
+  const [,, helpers] = useField(props)
+
+  useEffect(() => {
+    helpers.setValue(initialValue)
+  }, [initialValue])
+
+  return <Input {...props} />
+}

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -182,7 +182,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
   const showModal = useShowModal()
   const provider = useWebLN()
   const client = useApolloClient()
-  const pollInvoice = (id) => client.query({ query: INVOICE, variables: { id } })
+  const pollInvoice = (id) => client.query({ query: INVOICE, fetchPolicy: 'no-cache', variables: { id } })
 
   const onSubmitWrapper = useCallback(async (
     { cost, ...formValues },

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -230,7 +230,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
     const retry = () => onSubmit(
       { hash: inv.hash, hmac: inv.hmac, ...formValues },
       // unset update function since we already ran an cache update
-      { variables, update: null })
+      { variables })
     // first retry
     try {
       const ret = await retry()

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -269,7 +269,15 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
 const INVOICE_CANCELED_ERROR = 'invoice was canceled'
 const waitForPayment = async ({ invoice, showModal, provider, pollInvoice, updateCache, undoUpdate }) => {
   if (provider.enabled) {
-    return await waitForWebLNPayment({ provider, invoice, pollInvoice, updateCache })
+    try {
+      return await waitForWebLNPayment({ provider, invoice, pollInvoice, updateCache })
+    } catch (err) {
+      const INVOICE_CANCELED_ERROR = 'invoice was canceled'
+      // check for errors which mean that QR code will also fail
+      if (err.message === INVOICE_CANCELED_ERROR) {
+        throw err
+      }
+    }
   }
 
   // QR code as fallback
@@ -328,9 +336,7 @@ const waitForWebLNPayment = async ({ provider, invoice, pollInvoice, updateCache
     // undo attempt to make zapping UX consistent
     undoUpdate?.()
     console.error('WebLN payment failed:', err)
-    if (err.message === INVOICE_CANCELED_ERROR) {
-      throw err
-    }
+    throw err
   }
 }
 

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -244,7 +244,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
     }
 
     // wait until invoice is paid or modal is closed
-    const { modalClose, gqlCacheUpdateUndo } = await waitForPayment({
+    const { modalOnClose, gqlCacheUpdateUndo } = await waitForPayment({
       invoice: inv,
       showModal,
       provider,
@@ -261,7 +261,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
     // first retry
     try {
       const ret = await retry()
-      modalClose?.()
+      modalOnClose?.()
       return ret
     } catch (error) {
       gqlCacheUpdateUndo?.()
@@ -284,6 +284,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
             }}
             onRetry={async () => {
               resolve(await retry())
+              onClose()
             }}
           />
         )

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -224,7 +224,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
       provider,
       pollInvoice,
       updateCache: () => update?.(client.cache, { data: optimisticResponse }),
-      undoUpdate: () => update?.(client.cache, { data: { ...optimisticResponse, undo: true } })
+      undoUpdate: () => update?.(client.cache, { data: { ...optimisticResponse }, undo: true })
     })
 
     const retry = () => onSubmit(

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -221,7 +221,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
       provider,
       pollInvoice,
       updateCache: () => update?.(client.cache, { data: optimisticResponse }),
-      undoUpdate: () => update?.(client.cache, { data: optimisticResponse }, true)
+      undoUpdate: () => update?.(client.cache, { data: { ...optimisticResponse, undo: true } })
     })
     const { webLN, modalClose } = payment
 

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -252,10 +252,12 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
       gqlCacheUpdate: _update
     })
 
+    const webLnPayment = !!gqlCacheUpdateUndo
+
     const retry = () => onSubmit(
       { hash: inv.hash, hmac: inv.hmac, ...formValues },
-      // unset update function since we already ran an cache update
-      { variables })
+      // unset update function since we already ran an cache update if we paid using WebLN
+      { variables, update: webLnPayment ? null : undefined })
     // first retry
     try {
       const ret = await retry()

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -270,7 +270,7 @@ const INVOICE_CANCELED_ERROR = 'invoice was canceled'
 const waitForPayment = async ({ invoice, showModal, provider, pollInvoice, updateCache, undoUpdate }) => {
   if (provider.enabled) {
     try {
-      return await waitForWebLNPayment({ provider, invoice, pollInvoice, updateCache })
+      return await waitForWebLNPayment({ provider, invoice, pollInvoice, updateCache, undoUpdate })
     } catch (err) {
       const INVOICE_CANCELED_ERROR = 'invoice was canceled'
       // check for errors which mean that QR code will also fail

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -259,7 +259,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
         )
       }, { keepOpen: true, onClose: cancelAndReject })
     })
-  }, [onSubmit, createInvoice, !!me])
+  }, [onSubmit, provider, createInvoice, !!me])
 
   return onSubmitWrapper
 }

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -186,7 +186,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
 
   const onSubmitWrapper = useCallback(async (
     { cost, ...formValues },
-    { variables, optimisticResponse, update, ...apolloArgs }) => {
+    { variables, optimisticResponse, update, ...submitArgs }) => {
     // some actions require a session
     if (!me && options.requireSession) {
       throw new Error('you must be logged in')
@@ -201,7 +201,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
       try {
         const insufficientFunds = me?.privates.sats < cost
         return await onSubmit(formValues,
-          { variables, optimisticsResponse: insufficientFunds ? null : optimisticResponse, ...apolloArgs })
+          { ...submitArgs, variables, optimisticsResponse: insufficientFunds ? null : optimisticResponse })
       } catch (error) {
         if (!payOrLoginError(error) || !cost) {
           // can't handle error here - bail
@@ -255,7 +255,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
     const retry = () => onSubmit(
       { hash: inv.hash, hmac: inv.hmac, ...formValues },
       // unset update function since we already ran an cache update if we paid using WebLN
-      { variables, update: webLn ? null : undefined })
+      { ...submitArgs, variables, update: webLn ? null : undefined })
     // first retry
     try {
       const ret = await retry()

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -14,12 +14,15 @@ import PayerData from './payer-data'
 import Bolt11Info from './bolt11-info'
 import { useWebLN } from './webln'
 
-export function Invoice ({ invoice, modal, onPayment, info, successVerb }) {
+export function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn }) {
   const [expired, setExpired] = useState(new Date(invoice.expiredAt) <= new Date())
+
+  // if webLn was not passed, use true by default
+  if (webLn === undefined) webLn = true
 
   let variant = 'default'
   let status = 'waiting for you'
-  let webLn = true
+
   if (invoice.cancelled) {
     variant = 'failed'
     status = 'cancelled'
@@ -119,7 +122,7 @@ const JITInvoice = ({ invoice: { id, hash, hmac, expiresAt }, onPayment, onCance
 
   return (
     <>
-      <Invoice invoice={data.invoice} modal onPayment={onPayment} successVerb='received' />
+      <Invoice invoice={data.invoice} modal onPayment={onPayment} successVerb='received' webLn={false} />
       {retry
         ? (
           <>

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -172,8 +172,8 @@ export function useAct ({ onUpdate } = {}) {
 }
 
 export function useZap () {
-  const update = useCallback((cache, args, undo) => {
-    const { data: { act: { id, sats, path, amount } } } = args
+  const update = useCallback((cache, args) => {
+    const { data: { act: { id, sats, path, amount, undo } } } = args
 
     // determine how much we increased existing sats by by checking the
     // difference between result sats and meSats

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -257,6 +257,7 @@ export function useZap () {
     const insufficientFunds = me?.privates.sats < sats
     const optimisticResponse = { act: { path: item.path, ...variables } }
     try {
+      if (!insufficientFunds) strike()
       await zap({ variables, optimisticResponse: insufficientFunds ? null : optimisticResponse })
     } catch (error) {
       if (payOrLoginError(error)) {

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -106,8 +106,8 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
 export function useAct ({ onUpdate } = {}) {
   const me = useMe()
 
-  const update = useCallback((cache, args, undo) => {
-    const { data: { act: { id, sats, path, act, amount } } } = args
+  const update = useCallback((cache, args) => {
+    const { data: { act: { id, sats, path, act, amount } }, undo } = args
 
     cache.modify({
       id: `Item:${id}`,
@@ -173,7 +173,7 @@ export function useAct ({ onUpdate } = {}) {
 
 export function useZap () {
   const update = useCallback((cache, args) => {
-    const { data: { act: { id, sats, path, amount, undo } } } = args
+    const { data: { act: { id, sats, path, amount } }, undo } = args
 
     // determine how much we increased existing sats by by checking the
     // difference between result sats and meSats

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -107,14 +107,14 @@ export function useAct ({ onUpdate } = {}) {
   const me = useMe()
 
   const update = useCallback((cache, args) => {
-    const { data: { act: { id, sats, path, act, amount } }, undo } = args
+    const { data: { act: { id, sats, path, act } } } = args
 
     cache.modify({
       id: `Item:${id}`,
       fields: {
         sats (existingSats = 0) {
           if (act === 'TIP') {
-            return existingSats + (undo ? -amount : sats)
+            return existingSats + sats
           }
 
           return existingSats
@@ -122,7 +122,7 @@ export function useAct ({ onUpdate } = {}) {
         meSats: me
           ? (existingSats = 0) => {
               if (act === 'TIP') {
-                return existingSats + (undo ? -amount : sats)
+                return existingSats + sats
               }
 
               return existingSats
@@ -131,7 +131,7 @@ export function useAct ({ onUpdate } = {}) {
         meDontLikeSats: me
           ? (existingSats = 0) => {
               if (act === 'DONT_LIKE_THIS') {
-                return existingSats + (undo ? -amount : sats)
+                return existingSats + sats
               }
 
               return existingSats
@@ -148,7 +148,7 @@ export function useAct ({ onUpdate } = {}) {
           id: `Item:${aId}`,
           fields: {
             commentSats (existingCommentSats = 0) {
-              return existingCommentSats + (undo ? -amount : sats)
+              return existingCommentSats + sats
             }
           }
         })
@@ -173,7 +173,7 @@ export function useAct ({ onUpdate } = {}) {
 
 export function useZap () {
   const update = useCallback((cache, args) => {
-    const { data: { act: { id, sats, path, amount } }, undo } = args
+    const { data: { act: { id, sats, path } } } = args
 
     // determine how much we increased existing sats by by checking the
     // difference between result sats and meSats
@@ -191,15 +191,15 @@ export function useZap () {
 
     const satsDelta = sats - item.meSats
 
-    if (satsDelta >= 0) {
+    if (satsDelta > 0) {
       cache.modify({
         id: `Item:${id}`,
         fields: {
           sats (existingSats = 0) {
-            return existingSats + (undo ? -amount : satsDelta)
+            return existingSats + satsDelta
           },
           meSats: () => {
-            return undo ? sats - amount : sats
+            return sats
           }
         }
       })
@@ -211,7 +211,7 @@ export function useZap () {
           id: `Item:${aId}`,
           fields: {
             commentSats (existingCommentSats = 0) {
-              return existingCommentSats + (undo ? -amount : satsDelta)
+              return existingCommentSats + satsDelta
             }
           }
         })

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -199,7 +199,7 @@ export function useZap () {
             return existingSats + (undo ? -amount : satsDelta)
           },
           meSats: () => {
-            return sats
+            return undo ? sats - amount : sats
           }
         }
       })

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -235,11 +235,9 @@ export function useZap () {
   const [act] = useAct()
 
   const invoiceableAct = useInvoiceModal(
-    async ({ hash, hmac }, { variables, ...apolloArgs }, webLN) => {
+    async ({ hash, hmac }, { variables, ...apolloArgs }) => {
       await act({ variables: { ...variables, hash, hmac }, ...apolloArgs })
-      if (!strike({ webLN })) {
-        toaster.success('WebLN zap successful')
-      }
+      strike()
     }, [act, strike])
 
   return useCallback(async ({ item, me }) => {

--- a/components/lightning.js
+++ b/components/lightning.js
@@ -12,12 +12,12 @@ export class LightningProvider extends React.Component {
    * Strike lightning on the screen, if the user has the setting enabled
    * @returns boolean indicating whether the strike actually happened, based on user preferences
    */
-  strike = ({ webLN } = {}) => {
+  strike = () => {
     const should = window.localStorage.getItem('lnAnimate') || 'yes'
     if (should === 'yes') {
       this.setState(state => {
         return {
-          bolts: [...state.bolts, <Lightning key={state.bolts.length} webLN={webLN} onDone={() => this.unstrike(state.bolts.length)} />]
+          bolts: [...state.bolts, <Lightning key={state.bolts.length} onDone={() => this.unstrike(state.bolts.length)} />]
         }
       })
       return true
@@ -49,7 +49,7 @@ export function useLightning () {
   return useContext(LightningContext)
 }
 
-export function Lightning ({ onDone, webLN }) {
+export function Lightning ({ onDone }) {
   const canvasRef = useRef(null)
 
   useEffect(() => {
@@ -67,8 +67,7 @@ export function Lightning ({ onDone, webLN }) {
       speed: 100,
       spread: 30,
       branches: 20,
-      onDone,
-      lineWidth: webLN ? 7 : 3
+      onDone
     })
     canvas.bolt.draw()
   }, [])
@@ -85,6 +84,7 @@ function Bolt (ctx, options) {
     spread: 50,
     branches: 10,
     maxBranches: 10,
+    lineWidth: 3,
     ...options
   }
   this.point = [this.options.startPoint[0], this.options.startPoint[1]]

--- a/components/qr.js
+++ b/components/qr.js
@@ -17,8 +17,8 @@ export default function Qr ({ asIs, value, webLn, statusVariant, description, st
         try {
           await provider.sendPayment(value)
         } catch (e) {
-          console.log(e.message)
-          toaster.danger(`${provider.name}: ${e.message}`)
+          console.log(e?.message)
+          toaster.danger(`${provider.name}: ${e?.message}`)
         }
       }
     }

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -10,7 +10,6 @@ import LongPressable from 'react-longpressable'
 import Overlay from 'react-bootstrap/Overlay'
 import Popover from 'react-bootstrap/Popover'
 import { useShowModal } from './modal'
-import { useLightning } from './lightning'
 import { numWithUnits } from '../lib/format'
 import { Dropdown } from 'react-bootstrap'
 
@@ -111,7 +110,6 @@ export default function UpVote ({ item, className }) {
 
   const [act] = useAct()
   const zap = useZap()
-  const strike = useLightning()
 
   const disabled = useMemo(() => item?.mine || item?.meForward || item?.deletedAt,
     [item?.mine, item?.meForward, item?.deletedAt])
@@ -167,8 +165,6 @@ export default function UpVote ({ item, className }) {
                 } else {
                   setTipShow(true)
                 }
-
-                strike()
 
                 zap({ item, me })
               }

--- a/components/wallet-card.js
+++ b/components/wallet-card.js
@@ -41,7 +41,7 @@ export function WalletButtonBar ({
   return (
     <div className={`mt-3 ${className}`}>
       <div className='d-flex justify-content-between'>
-        {enabled &&
+        {enabled !== undefined &&
           <Button onClick={onDelete} variant='grey-medium'>{deleteText}</Button>}
         {children}
         <div className='d-flex align-items-center ms-auto'>

--- a/components/wallet-card.js
+++ b/components/wallet-card.js
@@ -7,6 +7,7 @@ import CancelButton from './cancel-button'
 import { SubmitButton } from './form'
 
 export function WalletCard ({ title, badges, provider, enabled }) {
+  const isConfigured = enabled === true || enabled === false
   return (
     <Card className={styles.card}>
       <div className={`${styles.indicator} ${enabled === true ? styles.success : enabled === false ? styles.error : styles.disabled}`} />
@@ -23,7 +24,7 @@ export function WalletCard ({ title, badges, provider, enabled }) {
       {provider &&
         <Link href={`/settings/wallets/${provider}`}>
           <Card.Footer className={styles.attach}>
-            {enabled
+            {isConfigured
               ? <>configure<Gear width={14} height={14} /></>
               : <>attach<Plug width={14} height={14} /></>}
           </Card.Footer>

--- a/components/wallet-card.js
+++ b/components/wallet-card.js
@@ -9,7 +9,7 @@ import { SubmitButton } from './form'
 export function WalletCard ({ title, badges, provider, enabled }) {
   return (
     <Card className={styles.card}>
-      <div className={`${styles.indicator} ${enabled ? styles.success : styles.disabled}`} />
+      <div className={`${styles.indicator} ${enabled === true ? styles.success : enabled === false ? styles.error : styles.disabled}`} />
       <Card.Body>
         <Card.Title>{title}</Card.Title>
         <Card.Subtitle className='mt-2'>

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -1,64 +1,35 @@
-import { createContext, useCallback, useContext, useEffect, useState } from 'react'
-import LNbitsProvider from './lnbits'
-import NWCProvider from './nwc'
+import { createContext, useContext } from 'react'
+import { LNbitsProvider, useLNbits } from './lnbits'
+import { NWCProvider, useNWC } from './nwc'
 
 const WebLNContext = createContext({})
 
-const _providers = { lnbits: LNbitsProvider, nwc: NWCProvider }
+function RawWebLNProvider ({ children }) {
+  const lnbits = useLNbits()
+  const nwc = useNWC()
 
-export function WebLNProvider ({ children }) {
-  const [providers, setProviders] = useState(_providers)
-
-  useEffect(() => {
-    const initProvider = async key => {
-      const config = await _providers[key].load()
-      const pkey = _providers[key]
-      setProviders(p => ({
-        ...p,
-        [key]: {
-          config,
-          enabled: pkey.enabled,
-          sendPayment: pkey.sendPayment?.bind(pkey)
-        }
-      }))
-    }
-    // init providers on client
-    initProvider('lnbits')
-    initProvider('nwc')
-    // TODO support more WebLN providers
-  }, [])
-
-  const setConfig = useCallback(async (key, config) => {
-    await _providers[key].save(config)
-    const { enabled } = _providers[key]
-    setProviders(p => ({ ...p, [key]: { ...p[key], config, enabled } }))
-  }, [providers])
-
-  const clearConfig = useCallback(async (key) => {
-    await _providers[key].clear()
-    const { enabled } = _providers[key]
-    setProviders(p => ({ ...p, [key]: { ...p[key], config: null, enabled } }))
-  }, [providers])
+  // TODO: switch between providers based on user preference
+  const provider = nwc
 
   return (
-    <WebLNContext.Provider value={{ provider: providers, setConfig, clearConfig }}>
+    <WebLNContext.Provider value={provider}>
       {children}
     </WebLNContext.Provider>
   )
 }
 
-export function useWebLN (key) {
-  const { provider, setConfig: _setConfig, clearConfig: _clearConfig } = useContext(WebLNContext)
+export function WebLNProvider ({ children }) {
+  return (
+    <LNbitsProvider>
+      <NWCProvider>
+        <RawWebLNProvider>
+          {children}
+        </RawWebLNProvider>
+      </NWCProvider>
+    </LNbitsProvider>
+  )
+}
 
-  if (!key) {
-    // TODO pick preferred enabled WebLN provider here
-    key = 'nwc'
-  }
-
-  const p = provider[key]
-  const { config, enabled } = p
-  const setConfig = (config) => _setConfig(key, config)
-  const clearConfig = () => _clearConfig(key)
-
-  return { name: key, config, setConfig, clearConfig, enabled, sendPayment: p.sendPayment.bind(p) }
+export function useWebLN () {
+  return useContext(WebLNContext)
 }

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -52,7 +52,7 @@ export function useWebLN (key) {
 
   if (!key) {
     // TODO pick preferred enabled WebLN provider here
-    key = 'lnbits'
+    key = 'nwc'
   }
 
   const p = provider[key]
@@ -60,5 +60,5 @@ export function useWebLN (key) {
   const setConfig = (config) => _setConfig(key, config)
   const clearConfig = () => _clearConfig(key)
 
-  return { name: key, config, setConfig, clearConfig, enabled, sendPayment: p.sendPayment?.bind(p) }
+  return { name: key, config, setConfig, clearConfig, enabled, sendPayment: p.sendPayment.bind(p) }
 }

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -1,9 +1,10 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react'
 import LNbitsProvider from './lnbits'
+import NWCProvider from './nwc'
 
 const WebLNContext = createContext({})
 
-const _providers = { lnbits: LNbitsProvider }
+const _providers = { lnbits: LNbitsProvider, nwc: NWCProvider }
 
 export function WebLNProvider ({ children }) {
   const [providers, setProviders] = useState(_providers)
@@ -17,12 +18,13 @@ export function WebLNProvider ({ children }) {
         [key]: {
           config,
           enabled: pkey.enabled,
-          sendPayment: pkey.sendPayment.bind(pkey)
+          sendPayment: pkey.sendPayment?.bind(pkey)
         }
       }))
     }
     // init providers on client
     initProvider('lnbits')
+    initProvider('nwc')
     // TODO support more WebLN providers
   }, [])
 
@@ -58,5 +60,5 @@ export function useWebLN (key) {
   const setConfig = (config) => _setConfig(key, config)
   const clearConfig = () => _clearConfig(key)
 
-  return { name: key, config, setConfig, clearConfig, enabled, sendPayment: p.sendPayment.bind(p) }
+  return { name: key, config, setConfig, clearConfig, enabled, sendPayment: p.sendPayment?.bind(p) }
 }

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -22,7 +22,7 @@ function RawWebLNProvider ({ children }) {
   `)
 
   // TODO: switch between providers based on user preference
-  const provider = nwc
+  const provider = nwc.enabled ? nwc : lnbits
 
   const sendPaymentWithToast = function ({ bolt11, hash, hmac }) {
     let canceled = false

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -1,17 +1,47 @@
-import { createContext, useContext } from 'react'
+import { createContext, useContext, useEffect, useState } from 'react'
 import { LNbitsProvider, useLNbits } from './lnbits'
 import { NWCProvider, useNWC } from './nwc'
 import { useToast } from '../toast'
 import { gql, useMutation } from '@apollo/client'
 
 const WebLNContext = createContext({})
+const storageKey = 'webln:providers'
+
+const paymentMethodHook = (methods, { name, enabled }) => {
+  let newMethods
+  if (enabled) {
+    newMethods = methods.includes(name) ? methods : [...methods, name]
+  } else {
+    newMethods = methods.filter(m => m !== name)
+  }
+  savePaymentMethods(newMethods)
+  return newMethods
+}
+
+const savePaymentMethods = (methods) => {
+  window.localStorage.setItem(storageKey, JSON.stringify(methods))
+}
 
 function RawWebLNProvider ({ children }) {
   // LNbits should only be used during development
   // since it gives full wallet access on XSS
-  // eslint-disable-next-line no-unused-vars
   const lnbits = useLNbits()
   const nwc = useNWC()
+  const providers = [lnbits, nwc]
+
+  // order of payment methods depends on user preference:
+  // payment method at index 0 is default, if that one fails
+  // we try the remaining ones in order as fallbacks.
+  // -- TODO: implement fallback logic
+  // eslint-disable-next-line no-unused-vars
+  const [paymentMethods, setPaymentMethods] = useState([])
+  const loadPaymentMethods = () => {
+    const methods = window.localStorage.getItem(storageKey)
+    if (!methods) return
+    setPaymentMethods(JSON.parse(methods))
+  }
+  useEffect(loadPaymentMethods, [])
+
   const toaster = useToast()
   const [cancelInvoice] = useMutation(gql`
     mutation cancelInvoice($hash: String!, $hmac: String!) {
@@ -21,8 +51,42 @@ function RawWebLNProvider ({ children }) {
     }
   `)
 
-  // TODO: switch between providers based on user preference
-  const provider = nwc.enabled ? nwc : lnbits
+  useEffect(() => {
+    setPaymentMethods(methods => paymentMethodHook(methods, nwc))
+    if (!nwc.enabled) nwc.setIsDefault(false)
+  }, [nwc.enabled])
+
+  useEffect(() => {
+    setPaymentMethods(methods => paymentMethodHook(methods, lnbits))
+    if (!lnbits.enabled) lnbits.setIsDefault(false)
+  }, [lnbits.enabled])
+
+  const setDefaultPaymentMethod = (provider) => {
+    for (const p of providers) {
+      if (p.name !== provider.name) {
+        p.setIsDefault(false)
+      }
+    }
+  }
+
+  useEffect(() => {
+    if (nwc.isDefault) setDefaultPaymentMethod(nwc)
+  }, [nwc.isDefault])
+
+  useEffect(() => {
+    if (lnbits.isDefault) setDefaultPaymentMethod(lnbits)
+  }, [lnbits.isDefault])
+
+  // TODO: implement numeric provider priority
+  // when we have more than two providers for sending
+  let provider = providers.filter(p => p.enabled && p.isDefault)[0]
+  if (!provider && providers.length > 0) {
+    // if no provider is the default, pick the first one and use that one as the default
+    provider = providers.filter(p => p.enabled)[0]
+    if (provider) {
+      provider.setIsDefault(true)
+    }
+  }
 
   const sendPaymentWithToast = function ({ bolt11, hash, hmac }) {
     let canceled = false

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -29,10 +29,11 @@ function RawWebLNProvider ({ children }) {
   const nwc = useNWC()
   const providers = [lnbits, nwc]
 
-  // order of payment methods depends on user preference:
-  // payment method at index 0 is default, if that one fails
-  // we try the remaining ones in order as fallbacks.
-  // -- TODO: implement fallback logic
+  // TODO: Order of payment methods depends on user preference.
+  // Payment method at index 0 should be default,
+  // if that one fails we try the remaining ones in order as fallbacks.
+  // We should be able to implement this via dragging of cards.
+  // This list should then match the order in which the (payment) cards are rendered.
   // eslint-disable-next-line no-unused-vars
   const [paymentMethods, setPaymentMethods] = useState([])
   const loadPaymentMethods = () => {
@@ -77,7 +78,7 @@ function RawWebLNProvider ({ children }) {
     if (lnbits.isDefault) setDefaultPaymentMethod(lnbits)
   }, [lnbits.isDefault])
 
-  // TODO: implement numeric provider priority
+  // TODO: implement numeric provider priority using paymentMethods list
   // when we have more than two providers for sending
   let provider = providers.filter(p => p.enabled && p.isDefault)[0]
   if (!provider && providers.length > 0) {

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -7,6 +7,9 @@ import { gql, useMutation } from '@apollo/client'
 const WebLNContext = createContext({})
 
 function RawWebLNProvider ({ children }) {
+  // LNbits should only be used during development
+  // since it gives full wallet access on XSS
+  // eslint-disable-next-line no-unused-vars
   const lnbits = useLNbits()
   const nwc = useNWC()
   const toaster = useToast()

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -40,7 +40,7 @@ function RawWebLNProvider ({ children }) {
       .then(() => {
         if (canceled) return
         removeToast?.()
-        if (!canceled) toaster.success('zap successful')
+        toaster.success('zap successful')
       }).catch((err) => {
         if (canceled) return
         removeToast?.()

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -1,18 +1,57 @@
 import { createContext, useContext } from 'react'
 import { LNbitsProvider, useLNbits } from './lnbits'
 import { NWCProvider, useNWC } from './nwc'
+import { useToast } from '../toast'
+import { gql, useMutation } from '@apollo/client'
 
 const WebLNContext = createContext({})
 
 function RawWebLNProvider ({ children }) {
   const lnbits = useLNbits()
   const nwc = useNWC()
+  const toaster = useToast()
+  const [cancelInvoice] = useMutation(gql`
+    mutation cancelInvoice($hash: String!, $hmac: String!) {
+      cancelInvoice(hash: $hash, hmac: $hmac) {
+        id
+      }
+    }
+  `)
 
   // TODO: switch between providers based on user preference
   const provider = nwc
 
+  const sendPaymentWithToast = function ({ bolt11, hash, hmac }) {
+    let canceled = false
+    let removeToast = toaster.warning('zap pending', {
+      autohide: false,
+      onCancel: async () => {
+        try {
+          await cancelInvoice({ variables: { hash, hmac } })
+          canceled = true
+          toaster.warning('zap canceled')
+          removeToast = undefined
+        } catch (err) {
+          toaster.danger('failed to cancel zap')
+        }
+      }
+    })
+    return provider.sendPayment(bolt11)
+      .then(() => {
+        if (canceled) return
+        removeToast?.()
+        if (!canceled) toaster.success('zap successful')
+      }).catch((err) => {
+        if (canceled) return
+        removeToast?.()
+        const reason = err?.message?.toString().toLowerCase() || 'unknown reason'
+        toaster.danger(`zap failed: ${reason}`)
+        throw err
+      })
+  }
+
   return (
-    <WebLNContext.Provider value={provider}>
+    <WebLNContext.Provider value={{ ...provider, sendPayment: sendPaymentWithToast }}>
       {children}
     </WebLNContext.Provider>
   )

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -37,10 +37,10 @@ function RawWebLNProvider ({ children }) {
       }
     })
     return provider.sendPayment(bolt11)
-      .then(() => {
-        if (canceled) return
+      .then(({ preimage }) => {
         removeToast?.()
         toaster.success('zap successful')
+        return { preimage }
       }).catch((err) => {
         if (canceled) return
         removeToast?.()

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -26,29 +26,29 @@ function RawWebLNProvider ({ children }) {
 
   const sendPaymentWithToast = function ({ bolt11, hash, hmac }) {
     let canceled = false
-    let removeToast = toaster.warning('zap pending', {
+    let removeToast = toaster.warning('payment pending', {
       autohide: false,
       onCancel: async () => {
         try {
           await cancelInvoice({ variables: { hash, hmac } })
           canceled = true
-          toaster.warning('zap canceled')
+          toaster.warning('payment canceled')
           removeToast = undefined
         } catch (err) {
-          toaster.danger('failed to cancel zap')
+          toaster.danger('failed to cancel payment')
         }
       }
     })
     return provider.sendPayment(bolt11)
       .then(({ preimage }) => {
         removeToast?.()
-        toaster.success('zap successful')
+        toaster.success('payment successful')
         return { preimage }
       }).catch((err) => {
         if (canceled) return
         removeToast?.()
         const reason = err?.message?.toString().toLowerCase() || 'unknown reason'
-        toaster.danger(`zap failed: ${reason}`)
+        toaster.danger(`payment failed: ${reason}`)
         throw err
       })
   }

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -53,7 +53,6 @@ export function LNbitsProvider ({ children }) {
         'getInfo',
         'getBalance',
         'sendPayment'
-        // TODO: support makeInvoice and sendPaymentAsync
       ],
       version: '1.0',
       supports: ['lightning']

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -82,7 +82,7 @@ export function LNbitsProvider ({ children }) {
 
   const loadConfig = useCallback(() => {
     const config = window.localStorage.getItem(storageKey)
-    if (!config) return null
+    if (!config) return
     const configJSON = JSON.parse(config)
     setUrl(configJSON.url)
     setAdminKey(configJSON.adminKey)

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -9,6 +9,7 @@ export function LNbitsProvider ({ children }) {
   const [adminKey, setAdminKey] = useState()
   const [enabled, setEnabled] = useState()
 
+  const name = 'LNbits'
   const storageKey = 'webln:provider:lnbits'
 
   const request = useCallback(async (method, path, args) => {
@@ -122,7 +123,7 @@ export function LNbitsProvider ({ children }) {
 
   useEffect(loadConfig, [])
 
-  const value = { url, adminKey, saveConfig, clearConfig, enabled, sendPayment }
+  const value = { name, url, adminKey, saveConfig, clearConfig, enabled, sendPayment }
   return (
     <LNbitsContext.Provider value={value}>
       {children}

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -1,35 +1,45 @@
-export default {
-  storageKey: 'webln:provider:lnbits',
-  _url: null,
-  _adminKey: null,
-  enabled: false,
-  async load () {
-    const config = window.localStorage.getItem(this.storageKey)
-    if (!config) return null
-    const configJSON = JSON.parse(config)
-    this._url = configJSON.url
-    this._adminKey = configJSON.adminKey
-    await this._updateEnabled()
-    return configJSON
-  },
-  async save (config) {
-    this._url = config.url
-    this._adminKey = config.adminKey
-    await this._updateEnabled()
-    // XXX This is insecure, XSS vulns could lead to loss of funds!
-    //   -> check how mutiny encrypts their wallet and/or check if we can leverage web workers
-    //   https://thenewstack.io/leveraging-web-workers-to-safely-store-access-tokens/
-    window.localStorage.setItem(this.storageKey, JSON.stringify(config))
-  },
-  clear () {
-    window.localStorage.removeItem(this.storageKey)
-    this._url = null
-    this._adminKey = null
-    this.enabled = false
-  },
-  async getInfo () {
-    // https://github.com/getAlby/bitcoin-connect/blob/v3.2.0-alpha/src/connectors/LnbitsConnector.ts
-    const response = await this._request(
+import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+
+// Reference: https://github.com/getAlby/bitcoin-connect/blob/v3.2.0-alpha/src/connectors/LnbitsConnector.ts
+
+const LNbitsContext = createContext()
+
+export function LNbitsProvider ({ children }) {
+  const [url, setUrl] = useState()
+  const [adminKey, setAdminKey] = useState()
+  const [enabled, setEnabled] = useState()
+
+  const storageKey = 'webln:provider:lnbits'
+
+  const request = useCallback(async (method, path, args) => {
+    let body = null
+    const query = ''
+    const headers = new Headers()
+    headers.append('Accept', 'application/json')
+    headers.append('Content-Type', 'application/json')
+    headers.append('X-Api-Key', adminKey)
+
+    if (method === 'POST') {
+      body = JSON.stringify(args)
+    } else if (args !== undefined) {
+      throw new Error('TODO: support args in GET')
+      // query = ...
+    }
+    const url_ = url.replace(/\/+$/, '')
+    const res = await fetch(url_ + path + query, {
+      method,
+      headers,
+      body
+    })
+    if (!res.ok) {
+      const errBody = await res.json()
+      throw new Error(errBody.detail)
+    }
+    return (await res.json())
+  }, [url, adminKey])
+
+  const getInfo = useCallback(async () => {
+    const response = await request(
       'GET',
       '/api/v1/wallet'
     )
@@ -47,9 +57,10 @@ export default {
       version: '1.0',
       supports: ['lightning']
     }
-  },
-  async sendPayment (bolt11) {
-    const response = await this._request(
+  }, [request])
+
+  const sendPayment = useCallback(async (bolt11) => {
+    const response = await request(
       'POST',
       '/api/v1/payments',
       {
@@ -57,58 +68,65 @@ export default {
         out: true
       }
     )
-
-    const checkResponse = await this._request(
+    const checkResponse = await request(
       'GET',
       `/api/v1/payments/${response.payment_hash}`
     )
-
     if (!checkResponse.preimage) {
       throw new Error('No preimage')
     }
     return {
       preimage: checkResponse.preimage
     }
-  },
-  async _request (method, path, args) {
-    if (!(this._url && this._adminKey)) throw new Error('provider not configured')
-    // https://github.com/getAlby/bitcoin-connect/blob/v3.2.0-alpha/src/connectors/LnbitsConnector.ts
-    let body = null
-    const query = ''
-    const headers = new Headers()
-    headers.append('Accept', 'application/json')
-    headers.append('Content-Type', 'application/json')
-    headers.append('X-Api-Key', this._adminKey)
+  }, [request])
 
-    if (method === 'POST') {
-      body = JSON.stringify(args)
-    } else if (args !== undefined) {
-      throw new Error('TODO: support args in GET')
-      // query = ...
-    }
-    const url = this._url.replace(/\/+$/, '')
-    const res = await fetch(url + path + query, {
-      method,
-      headers,
-      body
-    })
-    if (!res.ok) {
-      const errBody = await res.json()
-      throw new Error(errBody.detail)
-    }
-    return (await res.json())
-  },
-  async _updateEnabled () {
-    if (!(this._url && this._adminKey)) {
-      this.enabled = false
-      return
-    }
-    try {
-      await this.getInfo()
-      this.enabled = true
-    } catch (err) {
-      console.error(err)
-      this.enabled = false
-    }
-  }
+  const loadConfig = useCallback(() => {
+    const config = window.localStorage.getItem(storageKey)
+    if (!config) return null
+    const configJSON = JSON.parse(config)
+    setUrl(configJSON.url)
+    setAdminKey(configJSON.adminKey)
+  }, [])
+
+  const saveConfig = useCallback(async (config) => {
+    setUrl(config.url)
+    setAdminKey(config.adminKey)
+    // XXX This is insecure, XSS vulns could lead to loss of funds!
+    //   -> check how mutiny encrypts their wallet and/or check if we can leverage web workers
+    //   https://thenewstack.io/leveraging-web-workers-to-safely-store-access-tokens/
+    window.localStorage.setItem(storageKey, JSON.stringify(config))
+  }, [])
+
+  const clearConfig = useCallback(() => {
+    window.localStorage.removeItem(storageKey)
+    setUrl(null)
+    setAdminKey(null)
+    setEnabled(false)
+  }, [])
+
+  useEffect(() => {
+    (async function () {
+      if (!(url && adminKey)) return setEnabled(false)
+      try {
+        await getInfo()
+        setEnabled(true)
+      } catch (err) {
+        console.error(err)
+        setEnabled(false)
+      }
+    })()
+  }, [url, adminKey, getInfo])
+
+  useEffect(loadConfig, [])
+
+  const value = { url, adminKey, saveConfig, clearConfig, enabled, sendPayment }
+  return (
+    <LNbitsContext.Provider value={value}>
+      {children}
+    </LNbitsContext.Provider>
+  )
+}
+
+export function useLNbits () {
+  return useContext(LNbitsContext)
 }

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -64,6 +64,7 @@ export function LNbitsProvider ({ children }) {
   const [url, setUrl] = useState('')
   const [adminKey, setAdminKey] = useState('')
   const [enabled, setEnabled] = useState()
+  const [isDefault, setIsDefault] = useState()
 
   const name = 'LNbits'
   const storageKey = 'webln:provider:lnbits'
@@ -103,9 +104,10 @@ export function LNbitsProvider ({ children }) {
 
     const config = JSON.parse(configStr)
 
-    const { url, adminKey } = config
+    const { url, adminKey, isDefault } = config
     setUrl(url)
     setAdminKey(adminKey)
+    setIsDefault(isDefault)
 
     try {
       // validate config by trying to fetch wallet
@@ -122,6 +124,7 @@ export function LNbitsProvider ({ children }) {
     // immediately store config so it's not lost even if config is invalid
     setUrl(config.url)
     setAdminKey(config.adminKey)
+    setIsDefault(config.isDefault)
 
     // XXX This is insecure, XSS vulns could lead to loss of funds!
     //   -> check how mutiny encrypts their wallet and/or check if we can leverage web workers
@@ -150,7 +153,7 @@ export function LNbitsProvider ({ children }) {
     loadConfig().catch(console.error)
   }, [])
 
-  const value = { name, url, adminKey, saveConfig, clearConfig, enabled, getInfo, sendPayment }
+  const value = { name, url, adminKey, saveConfig, clearConfig, enabled, isDefault, setIsDefault, getInfo, sendPayment }
   return (
     <LNbitsContext.Provider value={value}>
       {children}

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -5,8 +5,8 @@ import { createContext, useCallback, useContext, useEffect, useState } from 'rea
 const LNbitsContext = createContext()
 
 export function LNbitsProvider ({ children }) {
-  const [url, setUrl] = useState()
-  const [adminKey, setAdminKey] = useState()
+  const [url, setUrl] = useState('')
+  const [adminKey, setAdminKey] = useState('')
   const [enabled, setEnabled] = useState()
 
   const name = 'LNbits'
@@ -97,8 +97,8 @@ export function LNbitsProvider ({ children }) {
 
   const clearConfig = useCallback(() => {
     window.localStorage.removeItem(storageKey)
-    setUrl(null)
-    setAdminKey(null)
+    setUrl('')
+    setAdminKey('')
   }, [])
 
   useEffect(() => {

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -76,9 +76,7 @@ export function LNbitsProvider ({ children }) {
     if (!checkResponse.preimage) {
       throw new Error('No preimage')
     }
-    return {
-      preimage: checkResponse.preimage
-    }
+    return { preimage: checkResponse.preimage }
   }, [request])
 
   const loadConfig = useCallback(() => {

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -9,11 +9,7 @@ export default {
     const configJSON = JSON.parse(config)
     this._url = configJSON.url
     this._adminKey = configJSON.adminKey
-    try {
-      await this._updateEnabled()
-    } catch (err) {
-      console.error(err)
-    }
+    await this._updateEnabled()
     return configJSON
   },
   async save (config) {
@@ -107,7 +103,12 @@ export default {
       this.enabled = false
       return
     }
-    await this.getInfo()
-    this.enabled = true
+    try {
+      await this.getInfo()
+      this.enabled = true
+    } catch (err) {
+      console.error(err)
+      this.enabled = false
+    }
   }
 }

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -101,12 +101,15 @@ export function LNbitsProvider ({ children }) {
     window.localStorage.removeItem(storageKey)
     setUrl(null)
     setAdminKey(null)
-    setEnabled(false)
   }, [])
 
   useEffect(() => {
+    // update enabled
     (async function () {
-      if (!(url && adminKey)) return setEnabled(false)
+      if (!(url && adminKey)) {
+        setEnabled(undefined)
+        return
+      }
       try {
         await getInfo()
         setEnabled(true)

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -95,21 +95,27 @@ export function LNbitsProvider ({ children }) {
   }, [url, adminKey])
 
   const loadConfig = useCallback(async () => {
-    const config = window.localStorage.getItem(storageKey)
-    if (!config) return
-    const configJSON = JSON.parse(config)
-    setUrl(configJSON.url)
-    setAdminKey(configJSON.adminKey)
+    const configStr = window.localStorage.getItem(storageKey)
+    if (!configStr) {
+      setEnabled(undefined)
+      return
+    }
+
+    const config = JSON.parse(configStr)
+
+    const { url, adminKey } = config
+    setUrl(url)
+    setAdminKey(adminKey)
 
     try {
       // validate config by trying to fetch wallet
-      await getWallet(configJSON.url, configJSON.adminKey)
+      await getWallet(url, adminKey)
+      setEnabled(true)
     } catch (err) {
       console.error('invalid LNbits config:', err)
       setEnabled(false)
       throw err
     }
-    setEnabled(true)
   }, [])
 
   const saveConfig = useCallback(async (config) => {

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -51,7 +51,6 @@ export function NWCProvider ({ children }) {
         }
         const content = await nip04.encrypt(secret, walletPubkey, JSON.stringify(payload))
         const request = finalizeEvent({
-          pubkey: walletPubkey,
           kind: 23194,
           created_at: Math.floor(Date.now() / 1000),
           tags: [],

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -60,6 +60,8 @@ export function NWCProvider ({ children }) {
         const sub = relay.subscribe([
           {
             kinds: [23195],
+            // for some reason, 'authors' must be set in the filter else you will debug your code for hours.
+            // this doesn't seem to be documented in NIP-01 or NIP-47.
             authors: [walletPubkey],
             '#e': [request.id]
           }

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -40,7 +40,7 @@ export function NWCProvider ({ children }) {
         // need big timeout since NWC is async (user needs to confirm payment in wallet)
 
         // XXX set this to mock NWC relays
-        const MOCK_NWC_RELAY = true
+        const MOCK_NWC_RELAY = false
 
         const timeout = MOCK_NWC_RELAY ? 3000 : 60000
         let timer

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -53,7 +53,7 @@ export function NWCProvider ({ children }) {
         const request = finalizeEvent({
           kind: 23194,
           created_at: Math.floor(Date.now() / 1000),
-          tags: [],
+          tags: [['p', walletPubkey]],
           content
         }, secret)
         await relay.publish(request)

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -58,8 +58,9 @@ export function NWCProvider ({ children }) {
         // XXX set this to mock NWC relays
         const MOCK_NWC_RELAY = false
 
-        // need big timeout since NWC is async (user needs to confirm payment in wallet)
-        const timeout = MOCK_NWC_RELAY ? 3000 : 60000
+        // timeout since NWC is async (user needs to confirm payment in wallet)
+        // timeout is same as invoice expiry
+        const timeout = MOCK_NWC_RELAY ? 3000 : 180_000
         let timer
         const resetTimer = () => {
           clearTimeout(timer)

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -38,11 +38,24 @@ export function NWCProvider ({ children }) {
     return new Promise(function (resolve, reject) {
       (async function () {
         // need big timeout since NWC is async (user needs to confirm payment in wallet)
-        const timeout = 60000
+
+        // XXX set this to mock NWC relays
+        const MOCK_NWC_RELAY = 1
+
+        const timeout = MOCK_NWC_RELAY ? 3000 : 60000
         let timer
         const resetTimer = () => {
           clearTimeout(timer)
-          timer = setTimeout(() => reject(new Error('timeout')), timeout)
+          timer = setTimeout(() => {
+            if (MOCK_NWC_RELAY) {
+              const heads = Math.random() < 0.5
+              if (heads) {
+                return resolve()
+              }
+              return reject(new Error('mock error'))
+            }
+            return reject(new Error('timeout'))
+          }, timeout)
         }
 
         const relay = await Relay.connect(relayUrl)

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -12,6 +12,7 @@ export function NWCProvider ({ children }) {
   const [secret, setSecret] = useState()
   const [enabled, setEnabled] = useState()
 
+  const name = 'NWC'
   const storageKey = 'webln:provider:nwc'
 
   const loadConfig = useCallback(() => {
@@ -149,7 +150,7 @@ export function NWCProvider ({ children }) {
 
   useEffect(loadConfig, [])
 
-  const value = { nwcUrl, relayUrl, walletPubkey, secret, saveConfig, clearConfig, enabled, sendPayment }
+  const value = { name, nwcUrl, relayUrl, walletPubkey, secret, saveConfig, clearConfig, enabled, sendPayment }
   return (
     <NWCContext.Provider value={value}>
       {children}

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -140,16 +140,6 @@ export function NWCProvider ({ children }) {
             resolve(supported)
             sub.close()
           },
-          // some relays like nostr.mutinywallet.com don't support NIP-47 info events
-          // so we simply check that we received EOSE
-          oneose () {
-            clearTimeout(timer)
-            // we assume that pay_invoice is supported
-            // (which should be mandatory to support since it's described in NIP-47)
-            const supported = ['pay_invoice']
-            resolve(supported)
-            sub.close()
-          },
           onclose (reason) {
             clearTimeout(timer)
             reject(new Error(reason))

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -1,0 +1,33 @@
+// https://github.com/getAlby/js-sdk/blob/master/src/webln/NostrWeblnProvider.ts
+
+export default {
+  storageKey: 'webln:provider:nwc',
+  _nwcUrl: null,
+  enabled: false,
+  async load () {
+    const config = window.localStorage.getItem(this.storageKey)
+    if (!config) return null
+    const configJSON = JSON.parse(config)
+    this._nwcUrl = configJSON.nwcUrl
+    try {
+      await this._updateEnabled()
+    } catch (err) {
+      console.error(err)
+    }
+    return configJSON
+  },
+  async save (config) {
+    this._nwcUrl = config.nwcUrl
+    await this._updateEnabled()
+    window.localStorage.setItem(this.storageKey, JSON.stringify(config))
+  },
+  clear () {
+    window.localStorage.removeItem(this.storageKey)
+    this._nwcUrl = null
+    this.enabled = false
+  },
+  async _updateEnabled () {
+    // TODO: use proper check, for example relay connection
+    this.enabled = !!this._nwcUrl
+  }
+}

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -11,6 +11,7 @@ export function NWCProvider ({ children }) {
   const [relayUrl, setRelayUrl] = useState()
   const [secret, setSecret] = useState()
   const [enabled, setEnabled] = useState()
+  const [isDefault, setIsDefault] = useState()
   const [relay, setRelay] = useState()
 
   const name = 'NWC'
@@ -25,8 +26,9 @@ export function NWCProvider ({ children }) {
 
     const config = JSON.parse(configStr)
 
-    const { nwcUrl } = config
+    const { nwcUrl, isDefault } = config
     setNwcUrl(nwcUrl)
+    setIsDefault(isDefault)
 
     const params = parseWalletConnectUrl(nwcUrl)
     setRelayUrl(params.relayUrl)
@@ -45,8 +47,9 @@ export function NWCProvider ({ children }) {
 
   const saveConfig = useCallback(async (config) => {
     // immediately store config so it's not lost even if config is invalid
-    const { nwcUrl } = config
+    const { nwcUrl, isDefault } = config
     setNwcUrl(nwcUrl)
+    setIsDefault(isDefault)
     if (!nwcUrl) {
       setEnabled(undefined)
       return
@@ -171,7 +174,7 @@ export function NWCProvider ({ children }) {
     loadConfig().catch(console.error)
   }, [])
 
-  const value = { name, nwcUrl, relayUrl, walletPubkey, secret, saveConfig, clearConfig, enabled, getInfo, sendPayment }
+  const value = { name, nwcUrl, relayUrl, walletPubkey, secret, saveConfig, clearConfig, enabled, isDefault, setIsDefault, getInfo, sendPayment }
   return (
     <NWCContext.Provider value={value}>
       {children}

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -110,7 +110,10 @@ export function NWCProvider ({ children }) {
   useEffect(() => {
     // update enabled
     (async function () {
-      if (!(relayUrl && walletPubkey && secret)) return setEnabled(false)
+      if (!(relayUrl && walletPubkey && secret)) {
+        setEnabled(undefined)
+        return
+      }
       try {
         await getInfo()
         setEnabled(true)

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -50,7 +50,7 @@ export function NWCProvider ({ children }) {
             if (MOCK_NWC_RELAY) {
               const heads = Math.random() < 0.5
               if (heads) {
-                return resolve()
+                return resolve({ preimage: null })
               }
               return reject(new Error('mock error'))
             }
@@ -90,7 +90,7 @@ export function NWCProvider ({ children }) {
             try {
               const content = JSON.parse(await nip04.decrypt(secret, walletPubkey, response.content))
               if (content.error) return reject(new Error(content.error.message))
-              if (content.result) return resolve(content.result.preimage)
+              if (content.result) return resolve({ preimage: content.result.preimage })
             } catch (err) {
               return reject(err)
             } finally {

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -16,7 +16,7 @@ export function NWCProvider ({ children }) {
 
   const loadConfig = useCallback(() => {
     const config = window.localStorage.getItem(storageKey)
-    if (!config) return null
+    if (!config) return
     const configJSON = JSON.parse(config)
     setNwcUrl(configJSON.nwcUrl)
   }, [])

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -40,7 +40,7 @@ export function NWCProvider ({ children }) {
         // need big timeout since NWC is async (user needs to confirm payment in wallet)
 
         // XXX set this to mock NWC relays
-        const MOCK_NWC_RELAY = 1
+        const MOCK_NWC_RELAY = true
 
         const timeout = MOCK_NWC_RELAY ? 3000 : 60000
         let timer
@@ -57,6 +57,7 @@ export function NWCProvider ({ children }) {
             return reject(new Error('timeout'))
           }, timeout)
         }
+        if (MOCK_NWC_RELAY) return resetTimer()
 
         const relay = await Relay.connect(relayUrl)
 

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -70,6 +70,8 @@ export function NWCProvider ({ children }) {
         const sub = relay.subscribe([filter], {
           async onevent (response) {
             resetTimer()
+            // TODO: check if we need verification here. does nostr-tools verify events?
+            // can we trust the NWC relay to respect our filters?
             try {
               const content = JSON.parse(await nip04.decrypt(secret, walletPubkey, response.content))
               if (content.error) return reject(new Error(content.error.message))

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -77,8 +77,6 @@ export function NWCProvider ({ children }) {
 
         const filter = {
           kinds: [23195],
-          // for some reason, 'authors' must be set in the filter else you will debug your code for hours.
-          // this doesn't seem to be documented in NIP-01 or NIP-47.
           authors: [walletPubkey],
           '#e': [request.id]
         }

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -1,14 +1,40 @@
 // https://github.com/getAlby/js-sdk/blob/master/src/webln/NostrWeblnProvider.ts
 
+import { Relay, nip04 } from 'nostr-tools'
+
+function parseWalletConnectUrl (walletConnectUrl) {
+  walletConnectUrl = walletConnectUrl
+    .replace('nostrwalletconnect://', 'http://')
+    .replace('nostr+walletconnect://', 'http://') // makes it possible to parse with URL in the different environments (browser/node/...)
+  const url = new URL(walletConnectUrl)
+  const options = {}
+  options.walletPubkey = url.host
+  const secret = url.searchParams.get('secret')
+  const relayUrl = url.searchParams.get('relay')
+  if (secret) {
+    options.secret = secret
+  }
+  if (relayUrl) {
+    options.relayUrl = relayUrl
+  }
+  return options
+}
+
 export default {
   storageKey: 'webln:provider:nwc',
   _nwcUrl: null,
+  _walletPubkey: null,
+  _relayUrl: null,
+  _secret: null,
   enabled: false,
   async load () {
     const config = window.localStorage.getItem(this.storageKey)
     if (!config) return null
     const configJSON = JSON.parse(config)
     this._nwcUrl = configJSON.nwcUrl
+    this._walletPubkey = configJSON.walletPubkey
+    this._relayUrl = configJSON.relayUrl
+    this._secret = configJSON.secret
     try {
       await this._updateEnabled()
     } catch (err) {
@@ -18,6 +44,10 @@ export default {
   },
   async save (config) {
     this._nwcUrl = config.nwcUrl
+    const params = parseWalletConnectUrl(config.nwcUrl)
+    this._walletPubkey = config.walletPubkey = params.walletPubkey
+    this._relayUrl = config.relayUrl = params.relayUrl
+    this._secret = config.secret = params.secret
     await this._updateEnabled()
     window.localStorage.setItem(this.storageKey, JSON.stringify(config))
   },
@@ -27,7 +57,58 @@ export default {
     this.enabled = false
   },
   async _updateEnabled () {
-    // TODO: use proper check, for example relay connection
-    this.enabled = !!this._nwcUrl
+    try {
+      // FIXME: this doesn't work since relay responds with EOSE immediately
+      // await this.getInfo()
+      this.enabled = !!this._nwcUrl && !!this._walletPubkey && !!this._relayUrl && !!this._secret
+    } catch (err) {
+      console.error(err)
+      this.enabled = false
+    }
+  },
+  async encrypt (pubkey, content) {
+    if (!this.secret) {
+      throw new Error('Missing secret')
+    }
+    const encrypted = await nip04.encrypt(this._secret, pubkey, content)
+    return encrypted
+  },
+  async decrypt (pubkey, content) {
+    if (!this.secret) {
+      throw new Error('Missing secret')
+    }
+    const decrypted = await nip04.decrypt(this._secret, pubkey, content)
+    return decrypted
+  },
+  // WebLN compatible response
+  // TODO: use NIP-47 get_info call
+  async getInfo () {
+    const relayUrl = this._relayUrl
+    const walletPubkey = this._walletPubkey
+    return new Promise(function (resolve, reject) {
+      (async function () {
+        const timeout = 5000
+        const timer = setTimeout(() => reject(new Error('timeout')), timeout)
+        const relay = await Relay.connect(relayUrl)
+        const sub = relay.subscribe([
+          {
+            kinds: [13194],
+            authors: [walletPubkey]
+          }
+        ], {
+          onevent (event) {
+            clearTimeout(timer)
+            sub.close()
+            // TODO: verify event
+            resolve(event)
+          },
+          oneose () {
+            clearTimeout(timer)
+            sub.close()
+            reject(new Error('EOSE'))
+          }
+        })
+      })().catch(reject)
+    })
   }
 }

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -117,12 +117,20 @@ export function NWCProvider ({ children }) {
             authors: [walletPubkey]
           }
         ], {
+          onevent (event) {
+            console.log(event)
+            const supported = event.content.split()
+            resolve(supported)
+          },
           // some relays like nostr.mutinywallet.com don't support NIP-47 info events
           // so we simply check that we received EOSE
           oneose () {
             clearTimeout(timer)
             sub.close()
-            resolve()
+            // we assume that pay_invoice is supported
+            // (which should be mandatory to support since it's described in NIP-47)
+            const supported = ['pay_invoice']
+            resolve(supported)
           }
         })
       })().catch(reject)
@@ -137,8 +145,8 @@ export function NWCProvider ({ children }) {
         return
       }
       try {
-        await getInfo()
-        setEnabled(true)
+        const supported = await getInfo()
+        setEnabled(supported.includes('pay_invoice'))
       } catch (err) {
         console.error(err)
         setEnabled(false)

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -17,17 +17,16 @@ export function NWCProvider ({ children }) {
   const storageKey = 'webln:provider:nwc'
 
   const loadConfig = useCallback(async () => {
-    const config = window.localStorage.getItem(storageKey)
-    if (!config) return
-
-    const configJSON = JSON.parse(config)
-
-    const { nwcUrl } = configJSON
-    setNwcUrl(nwcUrl)
-    if (!nwcUrl) {
+    const configStr = window.localStorage.getItem(storageKey)
+    if (!configStr) {
       setEnabled(undefined)
       return
     }
+
+    const config = JSON.parse(configStr)
+
+    const { nwcUrl } = config
+    setNwcUrl(nwcUrl)
 
     const params = parseWalletConnectUrl(nwcUrl)
     setRelayUrl(params.relayUrl)

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -118,7 +118,6 @@ export function NWCProvider ({ children }) {
           }
         ], {
           onevent (event) {
-            console.log(event)
             const supported = event.content.split()
             resolve(supported)
           },

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -99,8 +99,6 @@ export function NWCProvider ({ children }) {
         const sub = relay.subscribe([filter], {
           async onevent (response) {
             resetTimer()
-            // TODO: check if we need verification here. does nostr-tools verify events?
-            // can we trust the NWC relay to respect our filters?
             try {
               const content = JSON.parse(await nip04.decrypt(secret, walletPubkey, response.content))
               if (content.error) return reject(new Error(content.error.message))

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -6,7 +6,7 @@ import { Relay, finalizeEvent, nip04 } from 'nostr-tools'
 const NWCContext = createContext()
 
 export function NWCProvider ({ children }) {
-  const [nwcUrl, setNwcUrl] = useState()
+  const [nwcUrl, setNwcUrl] = useState('')
   const [walletPubkey, setWalletPubkey] = useState()
   const [relayUrl, setRelayUrl] = useState()
   const [secret, setSecret] = useState()
@@ -32,7 +32,7 @@ export function NWCProvider ({ children }) {
 
   const clearConfig = useCallback(() => {
     window.localStorage.removeItem(storageKey)
-    setNwcUrl(null)
+    setNwcUrl('')
   }, [])
 
   useEffect(() => {

--- a/copilot/capture/manifest.yml
+++ b/copilot/capture/manifest.yml
@@ -31,8 +31,6 @@ count:
   cooldown:
     in: 60s  # Number of seconds to wait before scaling up.
     out: 60s # Number of seconds to wait before scaling down.
-  cpu_percentage: 50 # Percentage of CPU to target for autoscaling.
-  memory_percentage: 60 # Percentage of memory to target for autoscaling.
   response_time: 3s
 exec: true     # Enable running commands in your container.
 network:

--- a/docs/attach-lnbits.md
+++ b/docs/attach-lnbits.md
@@ -1,0 +1,81 @@
+# attach lnbits
+
+To test sending from an attached wallet, it's easiest to use [lnbits](https://lnbits.com/) hooked up to a [local lnd node](./local-lnd.md) in your regtest network.
+
+This will attempt to walk you through setting up lnbits with docker and connecting it to your local lnd node.
+
+🚨 this a dev guide. do not use this guide for real funds 🚨
+
+From [this guide](https://docs.lnbits.org/guide/installation.html#option-3-docker):
+
+## 1. pre-configuration
+
+Create a directory for lnbits, get the sample environment file, and create a shared data directory for lnbits to use:
+
+```bash
+mkdir lnbits
+cd lnbits
+wget https://raw.githubusercontent.com/lnbits/lnbits/main/.env.example -O .env
+mkdir data
+```
+
+## 2. configure
+
+To configure lnbits to use a [local lnd node](./local-lnd.md) in your regtest network, go to [polar](https://lightningpolar.com/) and click on the LND node you want to use as a funding source. Then click on `Connect`.
+
+In the `Connect` tab, click the `File paths` tab and copy the `TLS cert` and `Admin macaroon` files to the `data` directory you created earlier.
+
+```bash
+cp /path/to/tls.cert /path/to/admin.macaroon data/
+```
+
+Then, open the `.env` file you created and override the following values:
+
+```bash
+LNBITS_ADMIN_UI=true
+LNBITS_BACKEND_WALLET_CLASS=LndWallet
+LND_GRPC_ENDPOINT=host.docker.internal
+LND_GRPC_PORT=${Port from the polar connect page}
+LND_GRPC_CERT=data/tls.cert
+LND_GRPC_MACAROON=data/admin.macaroon
+```
+
+## 2. Install and run lnbits
+
+Pull the latest image:
+
+```bash
+docker pull lnbitsdocker/lnbits-legend
+docker run --detach --publish 5001:5000 --name lnbits --volume ${PWD}/.env:/app/.env --volume ${PWD}/data/:/app/data lnbitsdocker/lnbits-legend
+```
+
+Note: we make lnbits available on the host's port 5001 here (on Mac, 5000 is used by AirPlay), but you can change that to whatever you want.
+
+## 3. Accessing the admin wallet
+
+By enabling the [Admin UI](https://docs.lnbits.org/guide/admin_ui.html), lnbits creates a so called super_user. Get this super_user id by running:
+
+```bash
+cat data/.super_user
+```
+
+Open your browser and go to `http://localhost:5001/wallet?usr=${super_user id from above}`. LNBits will redirect you to a default wallet we will use called `LNBits wallet`.
+
+## 4. Fund the wallet
+
+To fund `LNBits wallet`, click the `+` next the wallet balance. Enter the number of sats you want to credit the wallet and hit enter.
+
+## 5. Attach the wallet to stackernews
+
+Open up your local stackernews, go to `http://localhost:3000/settings/wallets` and click on `attach` in the `lnbits` card.
+
+In the form, fill in `lnbits url` with `http://localhost:5001`.
+
+Back in lnbits click on `API Docs` in the right pane. Copy the Admin key and paste it into the `admin key` field in the form.
+
+Click `attach` and you should be good to go.
+
+## Debugging
+
+- you can view lnbits logs with `docker logs lnbits` or in `data/logs/` in the `data` directory you created earlier
+- with the [Admin UI](https://docs.lnbits.org/guide/admin_ui.html), you can modify LNBits in the GUI by clicking `Server` in left pane

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -422,7 +422,11 @@ export const lnAddrSchema = ({ payerData, min, max, commentAllowed } = {}) =>
   }, {})))
 
 export const lnbitsSchema = object({
-  url: string().url().required('required').trim(),
+  url: process.env.NODE_ENV === 'development'
+    ? string().or(
+      [string().matches(/^(http:\/\/)?localhost:\d+$/), string().url()],
+      'invalid url').required('required').trim()
+    : string().url().required('required').trim(),
   adminKey: string().length(32)
 })
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -426,6 +426,10 @@ export const lnbitsSchema = object({
   adminKey: string().length(32)
 })
 
+export const nwcSchema = object({
+  nwcUrl: string().required('required').trim().matches(/^nostr\+walletconnect:/)
+})
+
 export const bioSchema = object({
   bio: string().required('required').trim()
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "node-s3-url-encode": "^0.0.4",
         "nodemailer": "^6.9.6",
         "nostr": "^0.2.8",
+        "nostr-tools": "^2.1.5",
         "nprogress": "^0.2.0",
         "opentimestamps": "^0.4.9",
         "page-metadata-parser": "^1.1.4",
@@ -2654,6 +2655,14 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-0.2.0.tgz",
+      "integrity": "sha512-6YBxJDAapHSdd3bLDv6x2wRPwq4QFMUaB3HvljNBUTThDd12eSm7/3F+2lnfzx2jvM+S6Nsy0jEt9QbPqSwqRw==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
@@ -2959,6 +2968,64 @@
       },
       "peerDependencies": {
         "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.1.tgz",
+      "integrity": "sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A==",
+      "dependencies": {
+        "@noble/curves": "~1.1.0",
+        "@noble/hashes": "~1.3.1",
+        "@scure/base": "~1.1.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.1.0.tgz",
+      "integrity": "sha512-091oBExgENk/kGj3AZmtBDMpxQPDtxQABR2B9lb1JbVTs6ytdzZNwvhxQ4MWasRNEzlbEH8jCWFCwhF/Obj5AA==",
+      "dependencies": {
+        "@noble/hashes": "1.3.1"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "dependencies": {
+        "@noble/hashes": "~1.3.0",
+        "@scure/base": "~1.1.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -10314,6 +10381,47 @@
         "noble-secp256k1": "^1.2.14",
         "ws": "^8.8.1"
       }
+    },
+    "node_modules/nostr-tools": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/nostr-tools/-/nostr-tools-2.1.5.tgz",
+      "integrity": "sha512-Gug/j54YGQ0ewB09dZW3mS9qfXWFlcOQMlyb1MmqQsuNO/95mfNOQSBi+jZ61O++Y+jG99SzAUPFLopUsKf0MA==",
+      "dependencies": {
+        "@noble/ciphers": "0.2.0",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.1",
+        "@scure/base": "1.1.1",
+        "@scure/bip32": "1.3.1",
+        "@scure/bip39": "1.2.1"
+      },
+      "optionalDependencies": {
+        "nostr-wasm": "v0.1.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nostr-tools/node_modules/@noble/hashes": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.1.tgz",
+      "integrity": "sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/nostr-wasm": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/nostr-wasm/-/nostr-wasm-0.1.0.tgz",
+      "integrity": "sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==",
+      "optional": true
     },
     "node_modules/nprogress": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "node-s3-url-encode": "^0.0.4",
     "nodemailer": "^6.9.6",
     "nostr": "^0.2.8",
+    "nostr-tools": "^2.1.5",
     "nprogress": "^0.2.0",
     "opentimestamps": "^0.4.9",
     "page-metadata-parser": "^1.1.4",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -92,14 +92,14 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
       </Head>
       <ErrorBoundary>
         <PlausibleProvider domain='stacker.news' trackOutboundLinks>
-          <WebLNProvider>
-            <ApolloProvider client={client}>
-              <MeProvider me={me}>
-                <LoggerProvider>
-                  <ServiceWorkerProvider>
-                    <PriceProvider price={price}>
-                      <LightningProvider>
-                        <ToastProvider>
+          <ApolloProvider client={client}>
+            <MeProvider me={me}>
+              <LoggerProvider>
+                <ServiceWorkerProvider>
+                  <PriceProvider price={price}>
+                    <LightningProvider>
+                      <ToastProvider>
+                        <WebLNProvider>
                           <ShowModalProvider>
                             <BlockHeightProvider blockHeight={blockHeight}>
                               <ChainFeeProvider chainFee={chainFee}>
@@ -110,14 +110,14 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
                               </ChainFeeProvider>
                             </BlockHeightProvider>
                           </ShowModalProvider>
-                        </ToastProvider>
-                      </LightningProvider>
-                    </PriceProvider>
-                  </ServiceWorkerProvider>
-                </LoggerProvider>
-              </MeProvider>
-            </ApolloProvider>
-          </WebLNProvider>
+                        </WebLNProvider>
+                      </ToastProvider>
+                    </LightningProvider>
+                  </PriceProvider>
+                </ServiceWorkerProvider>
+              </LoggerProvider>
+            </MeProvider>
+          </ApolloProvider>
         </PlausibleProvider>
       </ErrorBoundary>
     </>

--- a/pages/settings/wallets/index.js
+++ b/pages/settings/wallets/index.js
@@ -4,6 +4,7 @@ import styles from '../../../styles/wallet.module.css'
 import { WalletCard } from '../../../components/wallet-card'
 import { LightningAddressWalletCard } from './lightning-address'
 import { LNbitsCard } from './lnbits'
+import { NWCCard } from './nwc'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
@@ -16,6 +17,7 @@ export default function Wallet () {
         <div className={styles.walletGrid}>
           <LightningAddressWalletCard />
           <LNbitsCard />
+          <NWCCard />
           <WalletCard title='coming soon' badges={['probably']} />
           <WalletCard title='coming soon' badges={['we hope']} />
           <WalletCard title='coming soon' badges={['tm']} />

--- a/pages/settings/wallets/lnbits.js
+++ b/pages/settings/wallets/lnbits.js
@@ -1,5 +1,5 @@
 import { getGetServerSideProps } from '../../../api/ssrApollo'
-import { Form, ClientInput } from '../../../components/form'
+import { Form, ClientInput, ClientCheckbox } from '../../../components/form'
 import { CenterLayout } from '../../../components/layout'
 import { WalletButtonBar, WalletCard } from '../../../components/wallet-card'
 import { lnbitsSchema } from '../../../lib/validate'
@@ -10,7 +10,7 @@ import { useLNbits } from '../../../components/webln/lnbits'
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
 export default function LNbits () {
-  const { url, adminKey, saveConfig, clearConfig, enabled } = useLNbits()
+  const { url, adminKey, saveConfig, clearConfig, enabled, isDefault } = useLNbits()
   const toaster = useToast()
   const router = useRouter()
 
@@ -21,7 +21,8 @@ export default function LNbits () {
       <Form
         initial={{
           url: url || '',
-          adminKey: adminKey || ''
+          adminKey: adminKey || '',
+          isDefault: isDefault || false
         }}
         schema={lnbitsSchema}
         onSubmit={async (values) => {
@@ -48,6 +49,12 @@ export default function LNbits () {
           autoComplete='false'
           label='admin key'
           name='adminKey'
+        />
+        <ClientCheckbox
+          disabled={!enabled}
+          initialValue={isDefault}
+          label='default payment method'
+          name='isDefault'
         />
         <WalletButtonBar
           enabled={enabled} onDelete={async () => {

--- a/pages/settings/wallets/lnbits.js
+++ b/pages/settings/wallets/lnbits.js
@@ -5,12 +5,12 @@ import { WalletButtonBar, WalletCard } from '../../../components/wallet-card'
 import { lnbitsSchema } from '../../../lib/validate'
 import { useToast } from '../../../components/toast'
 import { useRouter } from 'next/router'
-import { useWebLN } from '../../../components/webln'
+import { useLNbits } from '../../../components/webln/lnbits'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
 export default function LNbits () {
-  const { config, setConfig, clearConfig, enabled } = useWebLN('lnbits')
+  const { url, adminKey, saveConfig, clearConfig, enabled } = useLNbits()
   const toaster = useToast()
   const router = useRouter()
 
@@ -20,13 +20,13 @@ export default function LNbits () {
       <h6 className='text-muted text-center pb-3'>use lnbits for zapping</h6>
       <Form
         initial={{
-          url: config?.url || '',
-          adminKey: config?.adminKey || ''
+          url: url || '',
+          adminKey: adminKey || ''
         }}
         schema={lnbitsSchema}
         onSubmit={async (values) => {
           try {
-            await setConfig(values)
+            await saveConfig(values)
             toaster.success('saved settings')
             router.push('/settings/wallets')
           } catch (err) {
@@ -65,7 +65,7 @@ export default function LNbits () {
 }
 
 export function LNbitsCard () {
-  const { enabled } = useWebLN('lnbits')
+  const { enabled } = useLNbits()
   return (
     <WalletCard
       title='lnbits'

--- a/pages/settings/wallets/lnbits.js
+++ b/pages/settings/wallets/lnbits.js
@@ -17,8 +17,8 @@ export default function LNbits () {
 
   return (
     <CenterLayout>
-      <h2 className='pb-2'>lnbits</h2>
-      <h6 className='text-muted text-center pb-3'>use lnbits for zapping</h6>
+      <h2 className='pb-2'>LNbits</h2>
+      <h6 className='text-muted text-center pb-3'>use LNbits for payments</h6>
       <WalletSecurityBanner />
       <Form
         initial={{
@@ -79,7 +79,7 @@ export function LNbitsCard () {
   const { enabled } = useLNbits()
   return (
     <WalletCard
-      title='lnbits'
+      title='LNbits'
       badges={['send only', 'non-custodialish']}
       provider='lnbits'
       enabled={enabled}

--- a/pages/settings/wallets/lnbits.js
+++ b/pages/settings/wallets/lnbits.js
@@ -1,5 +1,5 @@
 import { getGetServerSideProps } from '../../../api/ssrApollo'
-import { Form, Input } from '../../../components/form'
+import { Form, ClientInput } from '../../../components/form'
 import { CenterLayout } from '../../../components/layout'
 import { WalletButtonBar, WalletCard } from '../../../components/wallet-card'
 import { lnbitsSchema } from '../../../lib/validate'
@@ -35,13 +35,15 @@ export default function LNbits () {
           }
         }}
       >
-        <Input
+        <ClientInput
+          initialValue={url}
           label='lnbits url'
           name='url'
           required
           autoFocus
         />
-        <Input
+        <ClientInput
+          initialValue={adminKey}
           type='password'
           autoComplete='false'
           label='admin key'

--- a/pages/settings/wallets/lnbits.js
+++ b/pages/settings/wallets/lnbits.js
@@ -6,6 +6,7 @@ import { lnbitsSchema } from '../../../lib/validate'
 import { useToast } from '../../../components/toast'
 import { useRouter } from 'next/router'
 import { useLNbits } from '../../../components/webln/lnbits'
+import { WalletSecurityBanner } from '../../../components/banners'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
@@ -18,6 +19,7 @@ export default function LNbits () {
     <CenterLayout>
       <h2 className='pb-2'>lnbits</h2>
       <h6 className='text-muted text-center pb-3'>use lnbits for zapping</h6>
+      <WalletSecurityBanner />
       <Form
         initial={{
           url: url || '',

--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -1,0 +1,70 @@
+import { getGetServerSideProps } from '../../../api/ssrApollo'
+import { Form, Input } from '../../../components/form'
+import { CenterLayout } from '../../../components/layout'
+import { WalletButtonBar, WalletCard } from '../../../components/wallet-card'
+import { nwcSchema } from '../../../lib/validate'
+import { useToast } from '../../../components/toast'
+import { useRouter } from 'next/router'
+import { useWebLN } from '../../../components/webln'
+
+export const getServerSideProps = getGetServerSideProps({ authRequired: true })
+
+export default function NWC () {
+  const { config, setConfig, clearConfig, enabled } = useWebLN('nwc')
+  const toaster = useToast()
+  const router = useRouter()
+
+  return (
+    <CenterLayout>
+      <h2 className='pb-2'>nwc</h2>
+      <h6 className='text-muted text-center pb-3'>use Nostr Wallet Connect for zapping</h6>
+      <Form
+        initial={{
+          nwcUrl: config?.nwcUrl || ''
+        }}
+        schema={nwcSchema}
+        onSubmit={async (values) => {
+          try {
+            await setConfig(values)
+            toaster.success('saved settings')
+            router.push('/settings/wallets')
+          } catch (err) {
+            console.error(err)
+            toaster.danger('failed to attach: ' + err.message || err.toString?.())
+          }
+        }}
+      >
+        <Input
+          label='connection'
+          name='nwcUrl'
+          required
+          autoFocus
+        />
+        <WalletButtonBar
+          enabled={enabled} onDelete={async () => {
+            try {
+              await clearConfig()
+              toaster.success('saved settings')
+              router.push('/settings/wallets')
+            } catch (err) {
+              console.error(err)
+              toaster.danger('failed to unattach: ' + err.message || err.toString?.())
+            }
+          }}
+        />
+      </Form>
+    </CenterLayout>
+  )
+}
+
+export function NWCCard () {
+  const { enabled } = useWebLN('nwc')
+  return (
+    <WalletCard
+      title='nwc'
+      badges={['send only', 'non-custodialish', 'async']}
+      provider='nwc'
+      enabled={enabled}
+    />
+  )
+}

--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -17,8 +17,8 @@ export default function NWC () {
 
   return (
     <CenterLayout>
-      <h2 className='pb-2'>nwc</h2>
-      <h6 className='text-muted text-center pb-3'>use Nostr Wallet Connect for zapping</h6>
+      <h2 className='pb-2'>Nostr Wallet Connect</h2>
+      <h6 className='text-muted text-center pb-3'>use Nostr Wallet Connect for payments</h6>
       <WalletSecurityBanner />
       <Form
         initial={{
@@ -71,7 +71,7 @@ export function NWCCard () {
   const { enabled } = useNWC()
   return (
     <WalletCard
-      title='nwc'
+      title='NWC'
       badges={['send only', 'non-custodialish', 'budgetable']}
       provider='nwc'
       enabled={enabled}

--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -1,5 +1,5 @@
 import { getGetServerSideProps } from '../../../api/ssrApollo'
-import { Form, ClientInput } from '../../../components/form'
+import { Form, ClientInput, ClientCheckbox } from '../../../components/form'
 import { CenterLayout } from '../../../components/layout'
 import { WalletButtonBar, WalletCard } from '../../../components/wallet-card'
 import { nwcSchema } from '../../../lib/validate'
@@ -10,7 +10,7 @@ import { useNWC } from '../../../components/webln/nwc'
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
 export default function NWC () {
-  const { nwcUrl, saveConfig, clearConfig, enabled } = useNWC()
+  const { nwcUrl, saveConfig, clearConfig, enabled, isDefault } = useNWC()
   const toaster = useToast()
   const router = useRouter()
 
@@ -20,7 +20,8 @@ export default function NWC () {
       <h6 className='text-muted text-center pb-3'>use Nostr Wallet Connect for zapping</h6>
       <Form
         initial={{
-          nwcUrl: nwcUrl || ''
+          nwcUrl: nwcUrl || '',
+          isDefault: isDefault || false
         }}
         schema={nwcSchema}
         onSubmit={async (values) => {
@@ -40,6 +41,12 @@ export default function NWC () {
           name='nwcUrl'
           required
           autoFocus
+        />
+        <ClientCheckbox
+          disabled={!enabled}
+          initialValue={isDefault}
+          label='default payment method'
+          name='isDefault'
         />
         <WalletButtonBar
           enabled={enabled} onDelete={async () => {

--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -63,7 +63,7 @@ export function NWCCard () {
   return (
     <WalletCard
       title='nwc'
-      badges={['send only', 'non-custodialish', 'async']}
+      badges={['send only', 'non-custodialish', 'budgetable']}
       provider='nwc'
       enabled={enabled}
     />

--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -1,5 +1,5 @@
 import { getGetServerSideProps } from '../../../api/ssrApollo'
-import { Form, Input } from '../../../components/form'
+import { Form, ClientInput } from '../../../components/form'
 import { CenterLayout } from '../../../components/layout'
 import { WalletButtonBar, WalletCard } from '../../../components/wallet-card'
 import { nwcSchema } from '../../../lib/validate'
@@ -34,7 +34,8 @@ export default function NWC () {
           }
         }}
       >
-        <Input
+        <ClientInput
+          initialValue={nwcUrl}
           label='connection'
           name='nwcUrl'
           required

--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -6,6 +6,7 @@ import { nwcSchema } from '../../../lib/validate'
 import { useToast } from '../../../components/toast'
 import { useRouter } from 'next/router'
 import { useNWC } from '../../../components/webln/nwc'
+import { WalletSecurityBanner } from '../../../components/banners'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
@@ -18,6 +19,7 @@ export default function NWC () {
     <CenterLayout>
       <h2 className='pb-2'>nwc</h2>
       <h6 className='text-muted text-center pb-3'>use Nostr Wallet Connect for zapping</h6>
+      <WalletSecurityBanner />
       <Form
         initial={{
           nwcUrl: nwcUrl || '',

--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -5,12 +5,12 @@ import { WalletButtonBar, WalletCard } from '../../../components/wallet-card'
 import { nwcSchema } from '../../../lib/validate'
 import { useToast } from '../../../components/toast'
 import { useRouter } from 'next/router'
-import { useWebLN } from '../../../components/webln'
+import { useNWC } from '../../../components/webln/nwc'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
 export default function NWC () {
-  const { config, setConfig, clearConfig, enabled } = useWebLN('nwc')
+  const { nwcUrl, saveConfig, clearConfig, enabled } = useNWC()
   const toaster = useToast()
   const router = useRouter()
 
@@ -20,12 +20,12 @@ export default function NWC () {
       <h6 className='text-muted text-center pb-3'>use Nostr Wallet Connect for zapping</h6>
       <Form
         initial={{
-          nwcUrl: config?.nwcUrl || ''
+          nwcUrl: nwcUrl || ''
         }}
         schema={nwcSchema}
         onSubmit={async (values) => {
           try {
-            await setConfig(values)
+            await saveConfig(values)
             toaster.success('saved settings')
             router.push('/settings/wallets')
           } catch (err) {
@@ -58,7 +58,7 @@ export default function NWC () {
 }
 
 export function NWCCard () {
-  const { enabled } = useWebLN('nwc')
+  const { enabled } = useNWC()
   return (
     <WalletCard
       title='nwc'

--- a/styles/wallet.module.css
+++ b/styles/wallet.module.css
@@ -48,6 +48,13 @@
   filter: drop-shadow(0 0 2px #20c997);
 }
 
+.indicator.error {
+  color: var(--bs-red) !important;
+  background-color: var(--bs-red) !important;
+  border: 1px solid var(--bs-danger);
+  filter: drop-shadow(0 0 2px #c92020);
+}
+
 .indicator.disabled {
   color: var(--theme-toolbarHover) !important;
   background-color: var(--theme-toolbarHover) !important;


### PR DESCRIPTION
Supersedes #715 Closes #533 Closes #490 Closes #75

Based on #753, #752, #777, #778

TODO:
- [x] [feature] LNbits
- [x] [feature] NWC
- [x] [bug] Fix occasional `NaN` in cache update
- [x] [UX] use optimistic cache updates to keep site "snappy" (see 463578c)
- [x] ~[UX] use second lightning strike as "thunder" or "confirmation" (similar to double check marks in messengers) for WebLN zaps by overlapping them~
- [x] ~[UX] adapt first lightning strike based on if payment is pending (WebLN) or done (custodial) - for example, make pending zaps slower, last longer, different color etc.~
- [x] ~[UX] investigate if it makes sense to not immediately generate invoices for async providers (NWC); essentially queueing or batching zaps. For example, we could show a notification on their wallet that when clicked shows that zaps are queued. Only when they are ready to pay, we will initiate a payment which they can approve in their wallet then. If zaps are queued, we could also batch them together and create a single invoice for all of them (needs some updates in the backend to allow hash reuse for acts).~ _not planned, too much for MVP_
- [x] [bug] fix empty fields on hard refresh on config page since configs not initialized on first render
- [x] [UX] show persistent toast while zap is pending
- [x] [bug] toast race condition: invoice cancelation poll vs NWC invoice paid / error on payment
- [x] ~[feature] switch between providers~ not needed yet if we only launch with NWC
- [x] testing
- [x] [bug] cache update is not always undone
- [x] [feature] allow switching between LNbits and NWC
- [x] [UX] warn users about risk with banner
- [ ] [UX] static checks for NWC secret key since it's not validated via info event on save