### PR TITLE
Fix logged title

### DIFF
--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -165,7 +165,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
   }
 
   const options = { icon: payload.options?.icon, tag, data: { url: '/notifications', ...mergedPayload } }
-  log(`[sw:push] ${nid} - show notification with title "${payload.title}"`)
+  log(`[sw:push] ${nid} - show notification with title "${title}"`)
   return await sw.registration.showNotification(title, options)
 }
 


### PR DESCRIPTION
I could swear I fixed this exact same thing before. Couldn't find a similar commit during my shallow git history search though. Maybe I force pushed it over or bad rebase or something.

This is related to a deposit push notification bug that can be seen in our logs.

For some reason, I receive a "4 sats were deposited in your account" when someone sends me 1 sat on SN.

I also received "2400 sats were deposited in your account" when someone send me 400 sats a few days ago.

Not sure what is going on, wasn't able to reproduce locally yet and the logs didn't fully explain what is going on.