### PR TITLE
Unified QR scanning

### DIFF
--- a/pages/wallet.js
+++ b/pages/wallet.js
@@ -29,6 +29,7 @@ import { useField } from 'formik'
 import { useToast } from '../components/toast'
 import { WalletLimitBanner } from '../components/banners'
 import Plug from '../svgs/plug.svg'
+import { decode } from 'bolt11'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
@@ -279,7 +280,13 @@ function InvoiceScanner ({ fieldName }) {
           return (
             <QrScanner
               onDecode={(result) => {
-                helpers.setValue(result.replace(/^lightning:/, '').toLowerCase())
+                if (result.split('lightning=')[1]) {
+                  helpers.setValue(result.split('lightning=')[1].split(/[&?]/)[0].toLowerCase())
+                } else if (decode(result.replace(/^lightning:/, ''))) {
+                  helpers.setValue(result.replace(/^lightning:/, '').toLowerCase())
+                } else {
+                  throw new Error('Not a proper lightning payment request')
+                }
                 onClose()
               }}
               onError={(error) => {
@@ -288,6 +295,7 @@ function InvoiceScanner ({ fieldName }) {
                 } else {
                   toaster.danger(error?.message || error?.toString?.())
                 }
+                onClose()
               }}
             />
           )


### PR DESCRIPTION
adds support for scanning bip21 qrs on withdrawal.

I didn't really make an attempt to add any substantial bip21 support as we only use it for finding the lightning param.

Closes #734 