### PR TITLE
Fix missing timezone

### DIFF
--- a/api/resolvers/growth.js
+++ b/api/resolvers/growth.js
@@ -35,7 +35,7 @@ export function withClause (range) {
 export function intervalClause (range, table) {
   const unit = timeUnitForRange(range)
 
-  return `date_trunc('${unit}', "${table}".created_at)  >= date_trunc('${unit}', $1) AND date_trunc('${unit}', "${table}".created_at) <= date_trunc('${unit}', $2) `
+  return `date_trunc('${unit}', timezone('America/Chicago', "${table}".created_at))  >= date_trunc('${unit}', timezone('America/Chicago', $1)) AND date_trunc('${unit}', timezone('America/Chicago', "${table}".created_at)) <= date_trunc('${unit}', timezone('America/Chicago', $2)) `
 }
 
 export function viewIntervalClause (range, view) {


### PR DESCRIPTION
This might explain why I've been seeing different stats in the calendar vs when I count my posts using my profile.

It seems to calculate the stats using a different time zone then I am providing via the frontend (local dates get converted to unix timestamps) vs which time zone is used in the profile on the frontend. I don't think this necessarily fixes this issue but at least this PR gets the ball rolling regarding discussing this issue.

So I am not sure if we really want to fix the timezone here. But since it's code running on the server, it should have a fixed timezone anyway for everyone. So in the end, this shouldn't change anything? This time zone stuff is really confusing lol. Need to think more about this thus I'll keep this as a draft for now.

---

Additionally, `withClause` which is used for our charts also does not use `timezone($1)` but might make sense to keep it there as is since it's isolated and I am not aware of any existing confusion there.

---

I also found out that we're using data types with no time zone for our `Item` table because [that's the data type Prisma maps `DateTime` to by default.](https://www.prisma.io/docs/orm/reference/prisma-schema-reference#datetime).

I don't think that's what we want. I think one should always store timestamp with time zone (`timestamptz`).

```
                                              Table "public.Item"
      Column       |              Type              | Collation | Nullable |              Default
-------------------+--------------------------------+-----------+----------+------------------------------------
 id                | integer                        |           | not null | nextval('"Item_id_seq"'::regclass)
 created_at        | timestamp(3) without time zone |           | not null | CURRENT_TIMESTAMP
 updated_at        | timestamp(3) without time zone |           | not null | CURRENT_TIMESTAMP
```

_kind of using this pull request to summarize somewhere all confusing stuff I found related to time._