### PR TITLE
Allow territory founders to pin items

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -496,7 +496,7 @@ export default {
                         ${whereClause(
                           '"pinId" IS NOT NULL',
                           '"parentId" IS NULL',
-                          sub ? '("subName" = $1 OR "subName" IS NULL)' : '"subName" IS NULL',
+                          sub ? '"subName" = $1' : '"subName" IS NULL',
                           muteClause(me))}
                     ) rank_filter WHERE RANK = 1`
                 }, ...subArr)

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -487,18 +487,21 @@ export default {
                   query: `
                     SELECT rank_filter.*
                       FROM (
-                        ${SELECT},
+                        ${SELECT}, position,
                         rank() OVER (
                             PARTITION BY "pinId"
                             ORDER BY "Item".created_at DESC
                         )
                         FROM "Item"
+                        JOIN "Pin" ON "Item"."pinId" = "Pin".id
                         ${whereClause(
                           '"pinId" IS NOT NULL',
                           '"parentId" IS NULL',
                           sub ? '"subName" = $1' : '"subName" IS NULL',
                           muteClause(me))}
-                    ) rank_filter WHERE RANK = 1`
+                    ) rank_filter WHERE RANK = 1
+                    ORDER BY position ASC`,
+                  orderBy: 'ORDER BY position ASC'
                 }, ...subArr)
               }
               break

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -662,7 +662,7 @@ export default {
           SET position = position - 1
           WHERE position > $1 AND id IN (
             SELECT "pinId" FROM "Item" i
-            ${whereClause('"pinId" IS NOT NULL', item.subName ? 'i."subName" = $1' : 'i."parentId" = $1')}
+            ${whereClause('"pinId" IS NOT NULL', item.subName ? 'i."subName" = $2' : 'i."parentId" = $2')}
           )
           `, ...args)
         )

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -26,6 +26,7 @@ export default gql`
 
   extend type Mutation {
     bookmarkItem(id: ID): Item
+    pinItem(id: ID): Item
     subscribeItem(id: ID): Item
     deleteItem(id: ID): Item
     upsertLink(id: ID, sub: String, title: String!, url: String!, text: String, boost: Int, forward: [ItemForwardInput], hash: String, hmac: String): Item!

--- a/components/comment.js
+++ b/components/comment.js
@@ -146,7 +146,7 @@ export default function Comment ({
           ? <Skull className={styles.dontLike} width={24} height={24} />
           : item.meDontLikeSats > item.meSats
             ? <DownZap width={24} height={24} className={styles.dontLike} id={item.id} meDontLikeSats={item.meDontLikeSats} />
-            : pin ? <Pin width={24} height={24} className={itemStyles.pinComment} /> : <UpVote item={item} className={styles.upvote} />}
+            : pin ? <Pin width={22} height={22} className={styles.pin} /> : <UpVote item={item} className={styles.upvote} />}
         <div className={`${itemStyles.hunk} ${styles.hunk}`}>
           <div className='d-flex align-items-center'>
             {item.user?.meMute && !includeParent && collapse === 'yep'

--- a/components/comment.js
+++ b/components/comment.js
@@ -24,6 +24,7 @@ import { useQuoteReply } from './use-quote-reply'
 import { DownZap } from './dont-link-this'
 import Skull from '../svgs/death-skull.svg'
 import { commentSubTreeRootId } from '../lib/item'
+import Pin from '../svgs/pushpin-fill.svg'
 
 function Parent ({ item, rootText }) {
   const root = useRoot()
@@ -92,7 +93,7 @@ export function CommentFlat ({ item, rank, siblingComments, ...props }) {
 
 export default function Comment ({
   item, children, replyOpen, includeParent, topLevel,
-  rootText, noComments, noReply, truncate, depth
+  rootText, noComments, noReply, truncate, depth, pin
 }) {
   const [edit, setEdit] = useState()
   const me = useMe()
@@ -145,7 +146,7 @@ export default function Comment ({
           ? <Skull className={styles.dontLike} width={24} height={24} />
           : item.meDontLikeSats > item.meSats
             ? <DownZap width={24} height={24} className={styles.dontLike} id={item.id} meDontLikeSats={item.meDontLikeSats} />
-            : <UpVote item={item} className={styles.upvote} />}
+            : pin ? <Pin width={24} height={24} className={itemStyles.pin} /> : <UpVote item={item} className={styles.upvote} />}
         <div className={`${itemStyles.hunk} ${styles.hunk}`}>
           <div className='d-flex align-items-center'>
             {item.user?.meMute && !includeParent && collapse === 'yep'

--- a/components/comment.js
+++ b/components/comment.js
@@ -146,7 +146,7 @@ export default function Comment ({
           ? <Skull className={styles.dontLike} width={24} height={24} />
           : item.meDontLikeSats > item.meSats
             ? <DownZap width={24} height={24} className={styles.dontLike} id={item.id} meDontLikeSats={item.meDontLikeSats} />
-            : pin ? <Pin width={24} height={24} className={itemStyles.pin} /> : <UpVote item={item} className={styles.upvote} />}
+            : pin ? <Pin width={24} height={24} className={itemStyles.pinComment} /> : <UpVote item={item} className={styles.upvote} />}
         <div className={`${itemStyles.hunk} ${styles.hunk}`}>
           <div className='d-flex align-items-center'>
             {item.user?.meMute && !includeParent && collapse === 'yep'

--- a/components/comment.module.css
+++ b/components/comment.module.css
@@ -10,6 +10,13 @@
     margin-right: 0rem;
 }
 
+.pin {
+    fill: #a5a5a5;
+    margin-left: .2rem;
+    margin-right: .3rem;
+    flex-shrink: 0;
+}
+
 .dontLike {
     fill: #a5a5a5;
     margin-right: .35rem;

--- a/components/comments.js
+++ b/components/comments.js
@@ -1,3 +1,4 @@
+import { Fragment } from 'react'
 import Comment, { CommentSkeleton } from './comment'
 import styles from './header.module.css'
 import Nav from 'react-bootstrap/Nav'
@@ -62,6 +63,8 @@ export function CommentsHeader ({ handleSort, pinned, bio, parentCreatedAt, comm
 export default function Comments ({ parentId, pinned, bio, parentCreatedAt, commentSats, comments, ...props }) {
   const router = useRouter()
 
+  const pins = comments?.filter(({ position }) => !!position).sort((a, b) => a.position - b.position)
+
   return (
     <>
       {comments?.length > 0
@@ -80,7 +83,12 @@ export default function Comments ({ parentId, pinned, bio, parentCreatedAt, comm
             }}
           />
         : null}
-      {comments.map(item => (
+      {pins.map(item => (
+        <Fragment key={item.id}>
+          <Comment depth={1} item={item} {...props} pin />
+        </Fragment>
+      ))}
+      {comments.filter(({ position }) => !position).map(item => (
         <Comment depth={1} key={item.id} item={item} {...props} />
       ))}
     </>

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -171,7 +171,7 @@ export default function ItemInfo ({
           </>}
         {me && !nested && sub &&
           <>
-            <hr className='dropdown-divider' />
+            {((!item.mine && Number(me.id) !== Number(sub.userId)) || Number(me.id) === Number(sub.userId)) && <hr className='dropdown-divider' />}
             {!item.mine && Number(me.id) !== Number(sub.userId) && <MuteSubDropdownItem item={item} sub={sub} />}
             {Number(me.id) === Number(sub.userId) && <PinSubDropdownItem item={item} />}
           </>}

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -153,7 +153,6 @@ export default function ItemInfo ({
         {(item.parentId || item.text) && onQuoteReply &&
           <Dropdown.Item onClick={onQuoteReply}>quote reply</Dropdown.Item>}
         {me && <BookmarkDropdownItem item={item} />}
-        {canPin && <PinSubDropdownItem item={item} />}
         {me && <SubscribeDropdownItem item={item} />}
         {item.otsHash &&
           <Link href={`/items/${item.id}/ots`} className='text-reset dropdown-item'>
@@ -164,15 +163,11 @@ export default function ItemInfo ({
             nostr note
           </Dropdown.Item>
         )}
-        {item?.mine && !item?.noteId &&
-          <CrosspostDropdownItem item={item} />}
         {me && !item.position &&
           !item.mine && !item.deletedAt &&
           (item.meDontLikeSats > meTotalSats
             ? <DropdownItemUpVote item={item} />
             : <DontLikeThisDropdownItem id={item.id} />)}
-        {item.mine && !item.position && !item.deletedAt && !item.bio &&
-          <DeleteDropdownItem itemId={item.id} type={item.title ? 'post' : 'comment'} />}
         {me && sub && !item.mine && !item.outlawed && Number(me.id) === Number(sub.userId) && sub.moderated &&
           <>
             <hr className='dropdown-divider' />
@@ -182,6 +177,18 @@ export default function ItemInfo ({
           <>
             <hr className='dropdown-divider' />
             <MuteSubDropdownItem item={item} sub={sub} />
+          </>}
+        {canPin &&
+          <>
+            <hr className='dropdown-divider' />
+            <PinSubDropdownItem item={item} />
+          </>}
+        {item?.mine && !item?.noteId &&
+          <CrosspostDropdownItem item={item} />}
+        {item.mine && !item.position && !item.deletedAt && !item.bio &&
+          <>
+            <hr className='dropdown-divider' />
+            <DeleteDropdownItem itemId={item.id} type={item.title ? 'post' : 'comment'} />
           </>}
         {me && !item.mine &&
           <>

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -47,6 +47,14 @@ export default function ItemInfo ({
     if (item) setMeTotalSats((item.meSats || 0) + (item.meAnonSats || 0))
   }, [item?.meSats, item?.meAnonSats])
 
+  // territory founders can pin any post in their territory
+  // and OPs can pin any root reply in their post
+  const isPost = !item.parentId
+  const mySub = (me && sub && Number(me.id) === sub.userId)
+  const myPost = (me && root && Number(me.id) === Number(root.user.id))
+  const rootReply = item.path.split('.').length === 2
+  const canPin = (isPost && mySub) || (myPost && rootReply)
+
   return (
     <div className={className || `${styles.other}`}>
       {!item.position && !(!item.parentId && Number(item.user?.id) === AD_USER_ID) &&
@@ -145,6 +153,7 @@ export default function ItemInfo ({
         {(item.parentId || item.text) && onQuoteReply &&
           <Dropdown.Item onClick={onQuoteReply}>quote reply</Dropdown.Item>}
         {me && <BookmarkDropdownItem item={item} />}
+        {canPin && <PinSubDropdownItem item={item} />}
         {me && <SubscribeDropdownItem item={item} />}
         {item.otsHash &&
           <Link href={`/items/${item.id}/ots`} className='text-reset dropdown-item'>
@@ -169,11 +178,10 @@ export default function ItemInfo ({
             <hr className='dropdown-divider' />
             <OutlawDropdownItem item={item} />
           </>}
-        {me && !nested && sub &&
+        {me && !nested && !item.mine && sub && Number(me.id) !== Number(sub.userId) &&
           <>
-            {((!item.mine && Number(me.id) !== Number(sub.userId)) || Number(me.id) === Number(sub.userId)) && <hr className='dropdown-divider' />}
-            {!item.mine && Number(me.id) !== Number(sub.userId) && <MuteSubDropdownItem item={item} sub={sub} />}
-            {Number(me.id) === Number(sub.userId) && <PinSubDropdownItem item={item} />}
+            <hr className='dropdown-divider' />
+            <MuteSubDropdownItem item={item} sub={sub} />
           </>}
         {me && !item.mine &&
           <>

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -20,7 +20,7 @@ import ActionDropdown from './action-dropdown'
 import MuteDropdownItem from './mute'
 import { DropdownItemUpVote } from './upvote'
 import { useRoot } from './root'
-import { MuteSubDropdownItem } from './territory-header'
+import { MuteSubDropdownItem, PinSubDropdownItem } from './territory-header'
 
 export default function ItemInfo ({
   item, full, commentsText = 'comments',
@@ -169,10 +169,11 @@ export default function ItemInfo ({
             <hr className='dropdown-divider' />
             <OutlawDropdownItem item={item} />
           </>}
-        {me && !nested && !item.mine && sub && Number(me.id) !== Number(sub.userId) &&
+        {me && !nested && sub &&
           <>
             <hr className='dropdown-divider' />
-            <MuteSubDropdownItem item={item} sub={sub} />
+            {!item.mine && Number(me.id) !== Number(sub.userId) && <MuteSubDropdownItem item={item} sub={sub} />}
+            {Number(me.id) === Number(sub.userId) && <PinSubDropdownItem item={item} />}
           </>}
         {me && !item.mine &&
           <>

--- a/components/item.module.css
+++ b/components/item.module.css
@@ -53,6 +53,12 @@ a.title:visited {
     flex-shrink: 0;
 }
 
+.pinComment {
+    fill: #a5a5a5;
+    margin-right: .4rem;
+    flex-shrink: 0;
+}
+
 .ad {
     fill: #a5a5a5ac;
     margin-right: .4rem;

--- a/components/item.module.css
+++ b/components/item.module.css
@@ -53,12 +53,6 @@ a.title:visited {
     flex-shrink: 0;
 }
 
-.pinComment {
-    fill: #a5a5a5;
-    margin-right: .4rem;
-    flex-shrink: 0;
-}
-
 .ad {
     fill: #a5a5a5ac;
     margin-right: .4rem;
@@ -104,6 +98,11 @@ a.link:visited {
 
 .other .dropdown svg {
     margin-top: -1px;
+}
+
+.other :global(.dropdown-item) {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
 }
 
 .item {

--- a/components/items.js
+++ b/components/items.js
@@ -24,11 +24,17 @@ export default function Items ({ ssrData, variables = {}, query, destructureData
     }
   }, [dat])
 
-  const pinMap = useMemo(() =>
-    pins?.reduce((a, p) => { a[p.position] = p; return a }, {}), [pins])
-
-  const remainingPins = useMemo(() =>
-    pins?.filter(p => p.position > items.length).sort((a, b) => a.position - b.position), [pins])
+  const itemsWithPins = useMemo(() => {
+    const res = [...items]
+    pins?.forEach(p => {
+      if (p.position <= res.length) {
+        res.splice(p.position - 1, 0, p)
+      } else {
+        res.push(p)
+      }
+    })
+    return res
+  }, [pins, items])
 
   const Skeleton = useCallback(() =>
     <ItemsSkeleton rank={rank} startRank={items?.length} limit={variables.limit} Footer={Foooter} />, [rank, items])
@@ -40,13 +46,9 @@ export default function Items ({ ssrData, variables = {}, query, destructureData
   return (
     <>
       <div className={styles.grid}>
-        {items.filter(filter).map((item, i) => (
-          <Fragment key={item.id}>
-            {pinMap && pinMap[i + 1] && <Item item={pinMap[i + 1]} />}
-            <ListItem item={item} rank={rank && i + 1} siblingComments={variables.includeComments} />
-          </Fragment>
+        {itemsWithPins.filter(filter).map((item, i) => (
+          <ListItem key={item.id} item={item} rank={rank && i + 1} siblingComments={variables.includeComments} />
         ))}
-        {remainingPins?.map(p => <Item key={p.id} item={p} />)}
       </div>
       <Foooter
         cursor={cursor} fetchMore={fetchMore} noMoreText={noMoreText}

--- a/components/items.js
+++ b/components/items.js
@@ -25,6 +25,8 @@ export default function Items ({ ssrData, variables = {}, query, destructureData
   }, [dat])
 
   const itemsWithPins = useMemo(() => {
+    if (!pins) return items
+
     const res = [...items]
     pins?.forEach(p => {
       if (p.position <= res.length) {

--- a/components/items.js
+++ b/components/items.js
@@ -27,6 +27,9 @@ export default function Items ({ ssrData, variables = {}, query, destructureData
   const pinMap = useMemo(() =>
     pins?.reduce((a, p) => { a[p.position] = p; return a }, {}), [pins])
 
+  const remainingPins = useMemo(() =>
+    pins?.filter(p => p.position > items.length).sort((a, b) => a.position - b.position), [pins])
+
   const Skeleton = useCallback(() =>
     <ItemsSkeleton rank={rank} startRank={items?.length} limit={variables.limit} Footer={Foooter} />, [rank, items])
 
@@ -34,41 +37,16 @@ export default function Items ({ ssrData, variables = {}, query, destructureData
     return <Skeleton />
   }
 
-  // keep track of pins
-  let remainingPins = pinMap ? Object.values(pinMap) : []
-
-  const mergePins = (item, i) => {
-    // we loop over unpinned items here.
-    // we will use this array to return pins together with the current item.
-    const items = []
-    // current position in feed (excluding pins)
-    let position = i + 1
-    let pin = pinMap?.[position]
-    // make sure this pin wasn't already inserted
-    let notInserted = pin ? remainingPins.some(({ id }) => id === pin?.id) : undefined
-    // insert all consecutive pins at this position
-    while (pin && notInserted) {
-      remainingPins = remainingPins.filter(({ id }) => id !== pin.id)
-      items.push(<Item key={`pin-${position}`} item={pin} />)
-      pin = pinMap[++position]
-      notInserted = pin ? remainingPins.some(({ id }) => id === pin.id) : undefined
-    }
-
-    // add "normal" item after pins
-    items.push(<ListItem key={`item-${item.id}`} item={item} rank={rank && i + 1} siblingComments={variables.includeComments} />)
-
-    return (
-      <Fragment key={item.id}>
-        {items}
-      </Fragment>
-    )
-  }
-
   return (
     <>
       <div className={styles.grid}>
-        {items.filter(filter).map(mergePins)}
-        {remainingPins.map((item, i) => <Item key={item.id} item={item} />)}
+        {items.filter(filter).map((item, i) => (
+          <Fragment key={item.id}>
+            {pinMap && pinMap[i + 1] && <Item item={pinMap[i + 1]} />}
+            <ListItem item={item} rank={rank && i + 1} siblingComments={variables.includeComments} />
+          </Fragment>
+        ))}
+        {remainingPins?.map(p => <Item key={p.id} item={p} />)}
       </div>
       <Foooter
         cursor={cursor} fetchMore={fetchMore} noMoreText={noMoreText}

--- a/components/territory-header.js
+++ b/components/territory-header.js
@@ -151,16 +151,8 @@ export function PinSubDropdownItem ({ item: { id, position } }) {
             position
         }
       }`, {
-      update (cache, { data: { pinItem } }) {
-        console.log(pinItem)
-        cache.modify({
-          id: `Item:${id}`,
-          fields: {
-            position: () => pinItem.position
-          }
-        })
-      },
-      refetchQueries: ['SubItems']
+      // refetch since position of other items might also have changed to fill gaps
+      refetchQueries: ['SubItems', 'Item']
     }
   )
   return (

--- a/components/territory-header.js
+++ b/components/territory-header.js
@@ -162,8 +162,7 @@ export function PinSubDropdownItem ({ item: { id, position } }) {
           await pinItem({ variables: { id } })
           toaster.success(position ? 'pin removed' : 'pin added')
         } catch (err) {
-          console.error(err)
-          toaster.danger(position ? 'failed to remove pin' : 'failed to pin')
+          toaster.danger(err.message)
         }
       }}
     >

--- a/components/territory-header.js
+++ b/components/territory-header.js
@@ -141,3 +141,41 @@ export function MuteSubDropdownItem ({ item, sub }) {
     </Dropdown.Item>
   )
 }
+
+export function PinSubDropdownItem ({ item: { id, position } }) {
+  const toaster = useToast()
+  const [pinItem] = useMutation(
+    gql`
+      mutation pinItem($id: ID!) {
+        pinItem(id: $id) {
+            position
+        }
+      }`, {
+      update (cache, { data: { pinItem } }) {
+        console.log(pinItem)
+        cache.modify({
+          id: `Item:${id}`,
+          fields: {
+            position: () => pinItem.position
+          }
+        })
+      },
+      refetchQueries: ['SubItems']
+    }
+  )
+  return (
+    <Dropdown.Item
+      onClick={async () => {
+        try {
+          await pinItem({ variables: { id } })
+          toaster.success(position ? 'pin removed' : 'pin added')
+        } catch (err) {
+          console.error(err)
+          toaster.danger(position ? 'failed to remove pin' : 'failed to pin')
+        }
+      }}
+    >
+      {position ? 'unpin item' : 'pin item'}
+    </Dropdown.Item>
+  )
+}

--- a/fragments/comments.js
+++ b/fragments/comments.js
@@ -3,6 +3,7 @@ import { gql } from '@apollo/client'
 export const COMMENT_FIELDS = gql`
   fragment CommentFields on Item {
     id
+    position
     parentId
     createdAt
     deletedAt

--- a/prisma/migrations/20240130165240_existing_pins_null_sub/migration.sql
+++ b/prisma/migrations/20240130165240_existing_pins_null_sub/migration.sql
@@ -1,0 +1,3 @@
+-- all existing pins shouldn't have a subName
+-- this only impacts old daily discussion threads
+update "Item" set "subName" = null where "pinId" is not null;


### PR DESCRIPTION
Closes #61 

TODO:
- [x] [bug] update cache for all items to move item to correct position after pin update
- [x] [bug] fix position bug for position > 1
- [x] [feature] implement pinning of comments _(optional)_
- [x] ~[ux] allow pinned items to get zapped _(requesting for comments, optional)_~ _MVP feature creep, let's get some user feedback first_
- [x] [ux] ~use usual sorting (`hot`) for posts pinned by users. currently, it uses `recent` like saloon~ _actually, `recent` makes a lot of sense for pinned posts, not only saloon_
- [x] [bug] fix horizontal layout shift when pinning replies (minimal but still visible)

Current state (b88080c4):

https://github.com/stackernews/stacker.news/assets/27162016/18f21a8f-e531-4f55-b874-63bd9c481000
