### PR TITLE
Make pins zappable

### DIFF
--- a/components/item-info.js
+++ b/components/item-info.js
@@ -57,7 +57,7 @@ export default function ItemInfo ({
 
   return (
     <div className={className || `${styles.other}`}>
-      {!item.position && !(!item.parentId && Number(item.user?.id) === AD_USER_ID) &&
+      {!(!item.parentId && Number(item.user?.id) === AD_USER_ID) &&
         <>
           <span title={`from ${numWithUnits(item.upvotes, {
               abbreviate: false,

--- a/components/item.js
+++ b/components/item.js
@@ -41,7 +41,7 @@ export default function Item ({ item, rank, belowTitle, right, full, children, s
         : <div />}
       <div className={`${styles.item} ${siblingComments ? 'pt-3' : ''}`}>
         {item.position
-          ? <Pin width={24} height={24} className={styles.pin} />
+          ? <UpVote item={item} className={styles.upvote} icon={<Pin width={24} height={24} className={styles.pin} />} />
           : item.meDontLikeSats > item.meSats
             ? <DownZap width={24} height={24} className={styles.dontLike} id={item.id} meDontLikeSats={item.meDontLikeSats} />
             : Number(item.user?.id) === AD_USER_ID

--- a/components/item.js
+++ b/components/item.js
@@ -41,7 +41,21 @@ export default function Item ({ item, rank, belowTitle, right, full, children, s
         : <div />}
       <div className={`${styles.item} ${siblingComments ? 'pt-3' : ''}`}>
         {item.position
-          ? <UpVote item={item} className={styles.upvote} icon={<Pin width={24} height={24} className={styles.pin} />} />
+          ? (
+            <UpVote item={item} className={styles.upvote}>
+              {({ meSats, color }) => (
+                <Pin
+                  width={24} height={24} className={styles.pin}
+                  style={meSats
+                    ? {
+                        fill: color,
+                        filter: `drop-shadow(0 0 6px ${color}90)`
+                      }
+                    : undefined}
+                />
+              )}
+            </UpVote>
+            )
           : item.meDontLikeSats > item.meSats
             ? <DownZap width={24} height={24} className={styles.dontLike} id={item.id} meDontLikeSats={item.meDontLikeSats} />
             : Number(item.user?.id) === AD_USER_ID

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -68,7 +68,7 @@ export function DropdownItemUpVote ({ item }) {
   )
 }
 
-export default function UpVote ({ item, className }) {
+export default function UpVote ({ item, className, icon }) {
   const showModal = useShowModal()
   const [voteShow, _setVoteShow] = useState(false)
   const [tipShow, _setTipShow] = useState(false)
@@ -179,22 +179,23 @@ export default function UpVote ({ item, className }) {
           <div
             className={`${disabled ? styles.noSelfTips : ''} ${styles.upvoteWrapper}`}
           >
-            <UpBolt
-              width={26}
-              height={26}
-              className={
+            {icon ||
+              <UpBolt
+                width={26}
+                height={26}
+                className={
                       `${styles.upvote}
                       ${className || ''}
                       ${disabled ? styles.noSelfTips : ''}
                       ${meSats ? styles.voted : ''}`
                     }
-              style={meSats
-                ? {
-                    fill: color,
-                    filter: `drop-shadow(0 0 6px ${color}90)`
-                  }
-                : undefined}
-            />
+                style={meSats
+                  ? {
+                      fill: color,
+                      filter: `drop-shadow(0 0 6px ${color}90)`
+                    }
+                  : undefined}
+              />}
           </div>
         </ActionTooltip>
       </LongPressable>

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -68,7 +68,7 @@ export function DropdownItemUpVote ({ item }) {
   )
 }
 
-export default function UpVote ({ item, className, icon }) {
+export default function UpVote ({ item, className, children }) {
   const showModal = useShowModal()
   const [voteShow, _setVoteShow] = useState(false)
   const [tipShow, _setTipShow] = useState(false)
@@ -179,23 +179,24 @@ export default function UpVote ({ item, className, icon }) {
           <div
             className={`${disabled ? styles.noSelfTips : ''} ${styles.upvoteWrapper}`}
           >
-            {icon ||
-              <UpBolt
-                width={26}
-                height={26}
-                className={
+            {children
+              ? children({ meSats, color })
+              : <UpBolt
+                  width={26}
+                  height={26}
+                  className={
                       `${styles.upvote}
                       ${className || ''}
                       ${disabled ? styles.noSelfTips : ''}
                       ${meSats ? styles.voted : ''}`
                     }
-                style={meSats
-                  ? {
-                      fill: color,
-                      filter: `drop-shadow(0 0 6px ${color}90)`
-                    }
-                  : undefined}
-              />}
+                  style={meSats
+                    ? {
+                        fill: color,
+                        filter: `drop-shadow(0 0 6px ${color}90)`
+                      }
+                    : undefined}
+                />}
           </div>
         </ActionTooltip>
       </LongPressable>


### PR DESCRIPTION
Follow-up to #767 

TODO:
- [x] be less lazy and color pins
- [x] show sats
- [x] saloon is also zappable now but i think this is no problem. we should handle saloon zaps like anon zaps.
- [x] testing (does this break stuff in the backend because of previous assumptions?)
- [x] ~only show pin icon where position is actually fixed~ _mhh, looking at the code, this isn't as trivial to change as I expected. But now I think it might actually be useful to see if an item is pinned even if it's not pinned on that particular page? I mentioned [here](https://stacker.news/items/407067) that I think both cases can be confusing since the pin icon also works as feedback that the item is well... pinned somewhere._
- [ ] add pin fees (100% reward pool if pinnee is OP else 50/50 pool/OP)