### PR TITLE
Add tags and onCancel to toasts

### DIFF
--- a/components/toast.js
+++ b/components/toast.js
@@ -40,6 +40,7 @@ export const ToastProvider = ({ children }) => {
         variant: 'success',
         autohide: true,
         delay: 5000,
+        tag: options?.tag || body,
         ...options
       }
       return dispatchToast(toast)
@@ -50,6 +51,7 @@ export const ToastProvider = ({ children }) => {
         variant: 'warning',
         autohide: true,
         delay: 5000,
+        tag: options?.tag || body,
         ...options
       }
       return dispatchToast(toast)
@@ -59,6 +61,7 @@ export const ToastProvider = ({ children }) => {
         body,
         variant: 'danger',
         autohide: false,
+        tag: options?.tag || body,
         ...options
       }
       return dispatchToast(toast)

--- a/components/toast.module.css
+++ b/components/toast.module.css
@@ -21,6 +21,13 @@
   border-color: var(--bs-warning-border-subtle);
 }
 
+.toastCancel {
+  font-style: italic;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
 .toastClose {
   color: #fff;
   font-family: "lightning";

--- a/components/use-crossposter.js
+++ b/components/use-crossposter.js
@@ -27,7 +27,7 @@ export default function useCrossposter () {
 
   const relayError = (failedRelays) => {
     return new Promise(resolve => {
-      const { removeToast } = toast.danger(
+      const removeToast = toast.danger(
         <>
           Crossposting failed for {failedRelays.join(', ')} <br />
           <Button


### PR DESCRIPTION
I added tags to toasts in #749 for UX reasons. They work similar to how we merge push notifications in the service worker. So 2x `subscribed` becomes 1x `(2) subscribed`. This behavior is enabled by default since the body of a toast will be used as the tag by default and since I think this always makes sense to declutter the UI.

I figured that having this as a dedicated PR is easier to review. I will rebase #749 on this PR.

This also includes being able to attach an `onCancel` function to a toast. If a toast contains an `onCancel` function, it will not be closed on page navigation. This was also added in #749 to cancel async zaps (NWC) and can also be used to cancel custodial zaps in the near future, too.

Since toasts can have `onCancel` and the same tag (for example by simply having the same body), the `onCancel` of the most recent toast is shown. It that one is closed, the next uncanceled toast with same tag is shown.

I think that's better UX then the other way around (show `onCancel` of oldest toast with same tag) since you usually want to cancel your latest action.

https://github.com/stackernews/stacker.news/assets/27162016/931c998d-924c-4b22-aecd-b44c4ce0c2f6



