### PR TITLE
Fix yewtube links showing up as dupes of each other

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -568,6 +568,9 @@ export default {
         // extract id and create both links
         const matches = url.match(/(https?:\/\/)?((www\.)?(youtube(-nocookie)?|youtube.googleapis)\.com.*(v\/|v=|vi=|vi\/|e\/|embed\/|user\/.*\/u\/\d+\/)|youtu\.be\/)(?<id>[_0-9a-z-]+)/i)
         similar = `(http(s)?://)?((www.|m.)?youtube.com/(watch\\?v=|v/|live/)${matches?.groups?.id}|youtu.be/${matches?.groups?.id})((\\?|&|#)%)?`
+      } else if (urlObj.hostname === 'yewtu.be') {
+        const matches = url.match(/(https?:\/\/)?yewtu\.be.*(v=|embed\/)(?<id>[_0-9a-z-]+)/i)
+        similar = `(http(s)?://)?yewtu.be/(watch\\?v=|embed/)${matches?.groups?.id}((\\?|&|#)%)?`
       } else {
         similar += '((\\?|#)%)?'
       }

--- a/contributors.txt
+++ b/contributors.txt
@@ -6,3 +6,4 @@ rleed
 bitcoinplebdev
 benthecarman
 stargut
+mz


### PR DESCRIPTION
Fixes https://github.com/stackernews/stacker.news/issues/642

This updates the `item#dupes` resolver to correctly extract the yewtube video ID and find similar links based on that ID. I only found one hostname for yewtube (no mobile site) and this should match across normal yewtube links (/watch?v=ID) and embed links (/embed/ID). 