### PR TITLE
allow pins to be zapped but not from pin position

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -369,7 +369,6 @@ export default {
               ${relationClause(type)}
               ${joinZapRankPersonalView(me, models)}
               ${whereClause(
-                '"Item"."pinId" IS NULL',
                 '"Item"."deletedAt" IS NULL',
                 subClause(sub, 5, subClauseTable(type), me),
                 typeClause(type),
@@ -389,7 +388,6 @@ export default {
               ${selectClause(type)}
               ${relationClause(type)}
               ${whereClause(
-                '"Item"."pinId" IS NULL',
                 '"Item"."deletedAt" IS NULL',
                 subClause(sub, 5, subClauseTable(type), me),
                 typeClause(type),

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -25,7 +25,7 @@ import { MuteSubDropdownItem, PinSubDropdownItem } from './territory-header'
 export default function ItemInfo ({
   item, full, commentsText = 'comments',
   commentTextSingular = 'comment', className, embellishUser, extraInfo, onEdit, editText,
-  onQuoteReply, nofollow, extraBadges, nested
+  onQuoteReply, nofollow, extraBadges, nested, pinnable
 }) {
   const editThreshold = new Date(item.createdAt).getTime() + 10 * 60000
   const me = useMe()
@@ -57,7 +57,7 @@ export default function ItemInfo ({
 
   return (
     <div className={className || `${styles.other}`}>
-      {!item.position && !(!item.parentId && Number(item.user?.id) === AD_USER_ID) &&
+      {!(item.position && (pinnable || !item.subName)) && !(!item.parentId && Number(item.user?.id) === AD_USER_ID) &&
         <>
           <span title={`from ${numWithUnits(item.upvotes, {
               abbreviate: false,

--- a/components/item.js
+++ b/components/item.js
@@ -24,7 +24,7 @@ export function SearchTitle ({ title }) {
   })
 }
 
-export default function Item ({ item, rank, belowTitle, right, full, children, siblingComments, onQuoteReply }) {
+export default function Item ({ item, rank, belowTitle, right, full, children, siblingComments, onQuoteReply, pinnable }) {
   const titleRef = useRef()
   const router = useRouter()
 
@@ -40,7 +40,7 @@ export default function Item ({ item, rank, belowTitle, right, full, children, s
           </div>)
         : <div />}
       <div className={`${styles.item} ${siblingComments ? 'pt-3' : ''}`}>
-        {item.position
+        {item.position && (pinnable || !item.subName)
           ? <Pin width={24} height={24} className={styles.pin} />
           : item.meDontLikeSats > item.meSats
             ? <DownZap width={24} height={24} className={styles.dontLike} id={item.id} meDontLikeSats={item.meDontLikeSats} />
@@ -95,6 +95,7 @@ export default function Item ({ item, rank, belowTitle, right, full, children, s
             full={full} item={item}
             onQuoteReply={onQuoteReply}
             nofollow={nofollow}
+            pinnable={pinnable}
             extraBadges={Number(item?.user?.id) === AD_USER_ID && <Badge className={styles.newComment} bg={null}>AD</Badge>}
           />
           {belowTitle}

--- a/components/items.js
+++ b/components/items.js
@@ -49,7 +49,7 @@ export default function Items ({ ssrData, variables = {}, query, destructureData
     <>
       <div className={styles.grid}>
         {itemsWithPins.filter(filter).map((item, i) => (
-          <ListItem key={item.id} item={item} rank={rank && i + 1} siblingComments={variables.includeComments} />
+          <ListItem key={item.id} item={item} rank={rank && i + 1} siblingComments={variables.includeComments} pinnable={pins?.length > 0} />
         ))}
       </div>
       <Foooter


### PR DESCRIPTION
This allows pins to be zapped and shown when they aren't pinned in the ranking for the page, eg in top, home, recent, or when visited directly.

This solves some of the issue presented in #773 and some the issues to be solved in #772 without introducing anything too new. It doesn't solve every corner of the issue but I think it might solve a goldilocks amount.

Merging immediately.