### PR TITLE
Fix territory form label clicks not toggling correct input

### DIFF
--- a/components/territory-form.js
+++ b/components/territory-form.js
@@ -172,6 +172,7 @@ export default function TerritoryForm ({ sub }) {
               label='100k sats/month'
               value='MONTHLY'
               name='billingType'
+              id='monthly-checkbox'
               readOnly={!!sub}
               handleChange={checked => checked && setBilling('monthly')}
               groupClassName='ms-1 mb-0'
@@ -182,6 +183,7 @@ export default function TerritoryForm ({ sub }) {
               label='1m sats/year'
               value='YEARLY'
               name='billingType'
+              id='yearly-checkbox'
               readOnly={!!sub}
               handleChange={checked => checked && setBilling('yearly')}
               groupClassName='ms-1 mb-0'
@@ -192,6 +194,7 @@ export default function TerritoryForm ({ sub }) {
               label='3m sats once'
               value='ONCE'
               name='billingType'
+              id='once-checkbox'
               readOnly={!!sub}
               handleChange={checked => checked && setBilling('once')}
               groupClassName='ms-1 mb-0'

--- a/components/territory-form.js
+++ b/components/territory-form.js
@@ -109,6 +109,7 @@ export default function TerritoryForm ({ sub }) {
                 label='links'
                 value='LINK'
                 name='postTypes'
+                id='links-checkbox'
                 groupClassName='ms-1 mb-0'
               />
             </Col>
@@ -118,6 +119,7 @@ export default function TerritoryForm ({ sub }) {
                 label='discussions'
                 value='DISCUSSION'
                 name='postTypes'
+                id='discussions-checkbox'
                 groupClassName='ms-1 mb-0'
               />
             </Col>
@@ -127,6 +129,7 @@ export default function TerritoryForm ({ sub }) {
                 label='bounties'
                 value='BOUNTY'
                 name='postTypes'
+                id='bounties-checkbox'
                 groupClassName='ms-1 mb-0'
               />
             </Col>
@@ -136,6 +139,7 @@ export default function TerritoryForm ({ sub }) {
                 label='polls'
                 value='POLL'
                 name='postTypes'
+                id='polls-checkbox'
                 groupClassName='ms-1 mb-0'
               />
             </Col>


### PR DESCRIPTION
On the territory form, clicking on the labels of the "post types" or "billing" options don't toggle the correct input:


https://github.com/stackernews/stacker.news/assets/158518982/991f675f-5dd8-4b5b-bbeb-02c521baa81d

All the labels within each group were being assigned the same html "id" since we were falling back to the "name" prop. We need to keep the "name" prop the same because that's how the form associates the value with the correct form field. Fix is to assign explicit "id" prop to each checkbox so that the label toggles the correct input.


https://github.com/stackernews/stacker.news/assets/158518982/9fa631b1-9c0c-4264-b865-a1f9286ae143

