### PR TITLE
Create Rehype Plugin to parse mentions

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -4,7 +4,7 @@ import YouTube from 'react-youtube'
 import gfm from 'remark-gfm'
 import { LightAsync as SyntaxHighlighter } from 'react-syntax-highlighter'
 import atomDark from 'react-syntax-highlighter/dist/cjs/styles/prism/atom-dark'
-import mention from '../lib/remark-mention'
+import { preprocessMentions, rehypeMentions } from '../lib/remark-mention'
 import sub from '../lib/remark-sub'
 import React, { useState, memo, useRef, useCallback, useMemo, useEffect } from 'react'
 import GithubSlugger from 'github-slugger'
@@ -33,11 +33,17 @@ export function SearchText ({ text }) {
 }
 
 // this is one of the slowest components to render
-export default memo(function Text ({ nofollow, imgproxyUrls, children, tab, itemId, ...outerProps }) {
+export default memo(function Text ({ nofollow, imgproxyUrls, children: _children, tab, itemId, ...outerProps }) {
+  const [children, setChildren] = useState(_children)
   const [overflowing, setOverflowing] = useState(false)
   const router = useRouter()
   const [show, setShow] = useState(false)
   const containerRef = useRef(null)
+
+  useEffect(() => {
+    const processedChildren = preprocessMentions(_children)
+    setChildren(processedChildren)
+  }, [_children])
 
   useEffect(() => {
     setShow(router.asPath.includes('#'))
@@ -221,8 +227,8 @@ export default memo(function Text ({ nofollow, imgproxyUrls, children, tab, item
           },
           img: Img
         }}
-        remarkPlugins={[gfm, mention, sub]}
-        rehypePlugins={[rehypeInlineCodeProperty]}
+        remarkPlugins={[gfm, sub]}
+        rehypePlugins={[rehypeInlineCodeProperty, rehypeMentions]}
       >
         {children}
       </ReactMarkdown>

--- a/lib/remark-mention.js
+++ b/lib/remark-mention.js
@@ -1,4 +1,5 @@
 import { findAndReplace } from 'mdast-util-find-and-replace'
+import { visit } from 'unist-util-visit'
 
 const userGroup = '[\\w_]+'
 
@@ -6,6 +7,40 @@ const mentionRegex = new RegExp(
   '@(' + userGroup + '(?:\\/' + userGroup + ')?)',
   'gi'
 )
+const placeholderRegex = /<!-- mention:(.+?) -->/
+
+// Replaces mentions with placeholder (<!-- mention:username -->)
+// to prevent markdown parsing
+export function preprocessMentions (text) {
+  if (placeholderRegex.test(text)) {
+    return text
+  }
+  return text.replace(mentionRegex, (_, username) => `<!-- mention:${username} -->`)
+}
+
+// Rehype plugin that replaces placeholders with mention links
+export function rehypeMentions () {
+  return function (tree) {
+    visit(tree, 'raw', function (node, index, parent) {
+      if (!placeholderRegex.test(node.value)) {
+        return
+      }
+      const usernameMatch = node.value.match(placeholderRegex)
+      const username = usernameMatch[1]
+      const newNode = {
+        type: 'element',
+        tagName: 'a',
+        properties: {
+          href: `/${username}`
+        },
+        children: [{ type: 'text', value: `@${username}` }]
+      }
+      if (parent) {
+        parent.children[index] = newNode
+      }
+    })
+  }
+}
 
 export default function mention (options) {
   return function transformer (tree) {


### PR DESCRIPTION
Fixes #663 

Took a few tries to figure out, but this strategy seems to be working.

Adds 2 step process for handling mention markup (ex. @username) that prevents unwanted markdown parsing.

1. Replace mentions with placeholder that won't get parsed into markdown. (i.e. an HTML comment)
2. After the text is parsed, rehype the placeholders with mention links.


Before: 
<img width="326" alt="image" src="https://github.com/stackernews/stacker.news/assets/43247027/213cec09-df29-4d90-9fd9-467ed7b86e36">

After:
<img width="260" alt="image" src="https://github.com/stackernews/stacker.news/assets/43247027/226093bb-5d3f-44a9-ae2c-3d6ea3d1d0d2">
