### PR TITLE
Refactor default payment method setting

### DIFF
--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -1,25 +1,23 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useState } from 'react'
 import { LNbitsProvider, useLNbits } from './lnbits'
 import { NWCProvider, useNWC } from './nwc'
 import { useToast } from '../toast'
 import { gql, useMutation } from '@apollo/client'
 
 const WebLNContext = createContext({})
-const storageKey = 'webln:providers'
 
-const paymentMethodHook = (methods, { name, enabled }) => {
-  let newMethods
-  if (enabled) {
-    newMethods = methods.includes(name) ? methods : [...methods, name]
-  } else {
-    newMethods = methods.filter(m => m !== name)
+const syncProvider = (array, provider) => {
+  const idx = array.findIndex(({ name }) => provider.name === name)
+  if (idx === -1) {
+    // add provider to end if enabled
+    return provider.enabled ? [...array, provider] : array
   }
-  savePaymentMethods(newMethods)
-  return newMethods
-}
-
-const savePaymentMethods = (methods) => {
-  window.localStorage.setItem(storageKey, JSON.stringify(methods))
+  return [
+    ...array.slice(0, idx),
+    // remove provider if not enabled
+    ...provider.enabled ? [provider] : [],
+    ...array.slice(idx + 1)
+  ]
 }
 
 function RawWebLNProvider ({ children }) {
@@ -27,21 +25,31 @@ function RawWebLNProvider ({ children }) {
   // since it gives full wallet access on XSS
   const lnbits = useLNbits()
   const nwc = useNWC()
-  const providers = [lnbits, nwc]
+  const [enabledProviders, setEnabledProviders] = useState([lnbits, nwc].filter(({ enabled }) => enabled))
+  // keep list in sync with underlying providers
+  useEffect(() => {
+    setEnabledProviders(providers => {
+      // Sync existing provider state with new provider state
+      // in the list while keeping the order they are in.
+      // If provider does not exist but is enabled, it is just added to the end of the list.
+      // This can be the case if we're syncing from a page reload
+      // where the providers are initially not enabled.
+      // If provider is no longer enabled, it is removed from the list.
+      const newProviders = [lnbits, nwc].reduce(syncProvider, providers)
+      return newProviders
+    })
+  }, [lnbits, nwc])
 
-  // TODO: Order of payment methods depends on user preference.
-  // Payment method at index 0 should be default,
-  // if that one fails we try the remaining ones in order as fallbacks.
-  // We should be able to implement this via dragging of cards.
-  // This list should then match the order in which the (payment) cards are rendered.
-  // eslint-disable-next-line no-unused-vars
-  const [paymentMethods, setPaymentMethods] = useState([])
-  const loadPaymentMethods = () => {
-    const methods = window.localStorage.getItem(storageKey)
-    if (!methods) return
-    setPaymentMethods(JSON.parse(methods))
+  // sanity check
+  for (const p of enabledProviders) {
+    if (!p.enabled) {
+      console.warn('Expected provider to be enabled but is not:', p.name)
+    }
   }
-  useEffect(loadPaymentMethods, [])
+
+  // first provider in list is the default provider
+  // TODO: implement fallbacks via provider priority
+  const provider = enabledProviders[0]
 
   const toaster = useToast()
   const [cancelInvoice] = useMutation(gql`
@@ -51,43 +59,6 @@ function RawWebLNProvider ({ children }) {
       }
     }
   `)
-
-  useEffect(() => {
-    setPaymentMethods(methods => paymentMethodHook(methods, nwc))
-    if (!nwc.enabled) nwc.setIsDefault(false)
-  }, [nwc.enabled])
-
-  useEffect(() => {
-    setPaymentMethods(methods => paymentMethodHook(methods, lnbits))
-    if (!lnbits.enabled) lnbits.setIsDefault(false)
-  }, [lnbits.enabled])
-
-  const setDefaultPaymentMethod = (provider) => {
-    for (const p of providers) {
-      if (p.name !== provider.name) {
-        p.setIsDefault(false)
-      }
-    }
-  }
-
-  useEffect(() => {
-    if (nwc.isDefault) setDefaultPaymentMethod(nwc)
-  }, [nwc.isDefault])
-
-  useEffect(() => {
-    if (lnbits.isDefault) setDefaultPaymentMethod(lnbits)
-  }, [lnbits.isDefault])
-
-  // TODO: implement numeric provider priority using paymentMethods list
-  // when we have more than two providers for sending
-  let provider = providers.filter(p => p.enabled && p.isDefault)[0]
-  if (!provider && providers.length > 0) {
-    // if no provider is the default, pick the first one and use that one as the default
-    provider = providers.filter(p => p.enabled)[0]
-    if (provider) {
-      provider.setIsDefault(true)
-    }
-  }
 
   const sendPaymentWithToast = function ({ bolt11, hash, hmac }) {
     let canceled = false
@@ -118,8 +89,21 @@ function RawWebLNProvider ({ children }) {
       })
   }
 
+  const setProvider = useCallback((defaultProvider) => {
+    // move provider to the start to set it as default
+    setEnabledProviders(providers => {
+      const idx = providers.findIndex(({ name }) => defaultProvider.name === name)
+      if (idx === -1) {
+        console.warn(`tried to set unenabled provider ${defaultProvider.name} as default`)
+        return providers
+      }
+      return [defaultProvider, ...providers.slice(0, idx), ...providers.slice(idx + 1)]
+    })
+  }, [setEnabledProviders])
+
+  const value = { provider: { ...provider, sendPayment: sendPaymentWithToast }, enabledProviders, setProvider }
   return (
-    <WebLNContext.Provider value={{ ...provider, sendPayment: sendPaymentWithToast }}>
+    <WebLNContext.Provider value={value}>
       {children}
     </WebLNContext.Provider>
   )
@@ -138,5 +122,10 @@ export function WebLNProvider ({ children }) {
 }
 
 export function useWebLN () {
+  const { provider } = useContext(WebLNContext)
+  return provider
+}
+
+export function useWebLNConfigurator () {
   return useContext(WebLNContext)
 }

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -64,7 +64,6 @@ export function LNbitsProvider ({ children }) {
   const [url, setUrl] = useState('')
   const [adminKey, setAdminKey] = useState('')
   const [enabled, setEnabled] = useState()
-  const [isDefault, setIsDefault] = useState()
 
   const name = 'LNbits'
   const storageKey = 'webln:provider:lnbits'
@@ -104,10 +103,9 @@ export function LNbitsProvider ({ children }) {
 
     const config = JSON.parse(configStr)
 
-    const { url, adminKey, isDefault } = config
+    const { url, adminKey } = config
     setUrl(url)
     setAdminKey(adminKey)
-    setIsDefault(isDefault)
 
     try {
       // validate config by trying to fetch wallet
@@ -124,7 +122,6 @@ export function LNbitsProvider ({ children }) {
     // immediately store config so it's not lost even if config is invalid
     setUrl(config.url)
     setAdminKey(config.adminKey)
-    setIsDefault(config.isDefault)
 
     // XXX This is insecure, XSS vulns could lead to loss of funds!
     //   -> check how mutiny encrypts their wallet and/or check if we can leverage web workers
@@ -153,7 +150,7 @@ export function LNbitsProvider ({ children }) {
     loadConfig().catch(console.error)
   }, [])
 
-  const value = { name, url, adminKey, saveConfig, clearConfig, enabled, isDefault, setIsDefault, getInfo, sendPayment }
+  const value = { name, url, adminKey, saveConfig, clearConfig, enabled, getInfo, sendPayment }
   return (
     <LNbitsContext.Provider value={value}>
       {children}

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -64,6 +64,7 @@ export function LNbitsProvider ({ children }) {
   const [url, setUrl] = useState('')
   const [adminKey, setAdminKey] = useState('')
   const [enabled, setEnabled] = useState()
+  const [initialized, setInitialized] = useState(false)
 
   const name = 'LNbits'
   const storageKey = 'webln:provider:lnbits'
@@ -115,6 +116,8 @@ export function LNbitsProvider ({ children }) {
       console.error('invalid LNbits config:', err)
       setEnabled(false)
       throw err
+    } finally {
+      setInitialized(true)
     }
   }, [])
 
@@ -150,7 +153,7 @@ export function LNbitsProvider ({ children }) {
     loadConfig().catch(console.error)
   }, [])
 
-  const value = { name, url, adminKey, saveConfig, clearConfig, enabled, getInfo, sendPayment }
+  const value = { name, url, adminKey, initialized, enabled, saveConfig, clearConfig, getInfo, sendPayment }
   return (
     <LNbitsContext.Provider value={value}>
       {children}

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -11,6 +11,7 @@ export function NWCProvider ({ children }) {
   const [relayUrl, setRelayUrl] = useState()
   const [secret, setSecret] = useState()
   const [enabled, setEnabled] = useState()
+  const [initialized, setInitialized] = useState(false)
   const [relay, setRelay] = useState()
 
   const name = 'NWC'
@@ -40,6 +41,8 @@ export function NWCProvider ({ children }) {
       console.error('invalid NWC config:', err)
       setEnabled(false)
       throw err
+    } finally {
+      setInitialized(true)
     }
   }, [])
 
@@ -171,7 +174,7 @@ export function NWCProvider ({ children }) {
     loadConfig().catch(console.error)
   }, [])
 
-  const value = { name, nwcUrl, relayUrl, walletPubkey, secret, saveConfig, clearConfig, enabled, getInfo, sendPayment }
+  const value = { name, nwcUrl, relayUrl, walletPubkey, secret, initialized, enabled, saveConfig, clearConfig, getInfo, sendPayment }
   return (
     <NWCContext.Provider value={value}>
       {children}

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -11,7 +11,6 @@ export function NWCProvider ({ children }) {
   const [relayUrl, setRelayUrl] = useState()
   const [secret, setSecret] = useState()
   const [enabled, setEnabled] = useState()
-  const [isDefault, setIsDefault] = useState()
   const [relay, setRelay] = useState()
 
   const name = 'NWC'
@@ -26,9 +25,8 @@ export function NWCProvider ({ children }) {
 
     const config = JSON.parse(configStr)
 
-    const { nwcUrl, isDefault } = config
+    const { nwcUrl } = config
     setNwcUrl(nwcUrl)
-    setIsDefault(isDefault)
 
     const params = parseWalletConnectUrl(nwcUrl)
     setRelayUrl(params.relayUrl)
@@ -47,9 +45,8 @@ export function NWCProvider ({ children }) {
 
   const saveConfig = useCallback(async (config) => {
     // immediately store config so it's not lost even if config is invalid
-    const { nwcUrl, isDefault } = config
+    const { nwcUrl } = config
     setNwcUrl(nwcUrl)
-    setIsDefault(isDefault)
     if (!nwcUrl) {
       setEnabled(undefined)
       return
@@ -174,7 +171,7 @@ export function NWCProvider ({ children }) {
     loadConfig().catch(console.error)
   }, [])
 
-  const value = { name, nwcUrl, relayUrl, walletPubkey, secret, saveConfig, clearConfig, enabled, isDefault, setIsDefault, getInfo, sendPayment }
+  const value = { name, nwcUrl, relayUrl, walletPubkey, secret, saveConfig, clearConfig, enabled, getInfo, sendPayment }
   return (
     <NWCContext.Provider value={value}>
       {children}


### PR DESCRIPTION
fix #802

* fixed warning about component update while rendering another component
* individual providers no longer need to know if they are the default or not
* default setting is now handled by `WebLNContext` -- the same context that returns the provider. this makes a lot more sense and is a lot easier to read (imo)
* default payment checkbox is now also disabled if there is only one enabled provider or if it is the default provider

https://github.com/stackernews/stacker.news/assets/27162016/b1f6411a-0dfe-4db3-936d-dcc4763f20e0

_and I really hate `useEffect` and loading stuff from local storage now, lol_
