### PR TITLE
Enforce HTTPS for LNbits

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -48,7 +48,13 @@ addMethod(string, 'https', function () {
   return this.test({
     name: 'https',
     message: 'https required',
-    test: (url) => url.startsWith('https://')
+    test: (url) => {
+      try {
+        return new URL(url).protocol === 'https:'
+      } catch {
+        return false
+      }
+    }
   })
 })
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -44,6 +44,14 @@ addMethod(string, 'or', function (schemas, msg) {
   })
 })
 
+addMethod(string, 'https', function () {
+  return this.test({
+    name: 'https',
+    message: 'https required',
+    test: (url) => url.startsWith('https://')
+  })
+})
+
 const titleValidator = string().required('required').trim().max(
   MAX_TITLE_LENGTH,
   ({ max, value }) => `-${Math.abs(max - value.length)} characters remaining`
@@ -424,10 +432,10 @@ export const lnAddrSchema = ({ payerData, min, max, commentAllowed } = {}) =>
 
 export const lnbitsSchema = object({
   url: process.env.NODE_ENV === 'development'
-    ? string().or(
-      [string().matches(/^(http:\/\/)?localhost:\d+$/), string().url()],
-      'invalid url').required('required').trim()
-    : string().url().required('required').trim(),
+    ? string()
+      .or([string().matches(/^(http:\/\/)?localhost:\d+$/), string().url()], 'invalid url')
+      .required('required').trim().https()
+    : string().url().required('required').trim().https(),
   adminKey: string().length(32)
 })
 


### PR DESCRIPTION
Enforcing wss:// for relay URLs we need a bit more work since we need to parse the URL before we can give it to Yup object. 

Working on it but this can already be merged. Wanted to validate secrets anyway (make sure they are 32 characters in hex).