### PR TITLE
Fix missing setInitialized

### DIFF
--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -99,6 +99,7 @@ export function LNbitsProvider ({ children }) {
     const configStr = window.localStorage.getItem(storageKey)
     if (!configStr) {
       setEnabled(undefined)
+      setInitialized(true)
       return
     }
 

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -21,6 +21,7 @@ export function NWCProvider ({ children }) {
     const configStr = window.localStorage.getItem(storageKey)
     if (!configStr) {
       setEnabled(undefined)
+      setInitialized(true)
       return
     }
 


### PR DESCRIPTION
Payment methods were not marked as initialized if the local storage item did not exist on page load.

This lead to missing updates to the list of enabled providers since only initialized providers are considered.

And with no update to the list of enabled providers, a new payment method is in that case not automatically marked as the default if it's the only one.