### PR TITLE
Add ranked territories to 'top' page

### DIFF
--- a/api/resolvers/growth.js
+++ b/api/resolvers/growth.js
@@ -46,6 +46,26 @@ export function viewGroup (range, view) {
   ) u`
 }
 
+export function subViewGroup (range) {
+  const unit = timeUnitForRange(range)
+  return `(
+    (SELECT *
+      FROM sub_stats_days
+      WHERE ${viewIntervalClause(range, 'sub_stats_days')})
+    UNION ALL
+    (SELECT *
+      FROM sub_stats_hours
+      WHERE ${viewIntervalClause(range, 'sub_stats_hours')}
+      ${unit === 'hour' ? '' : 'AND "sub_stats_hours".t >= date_trunc(\'day\', timezone(\'America/Chicago\', now()))'})
+    UNION ALL
+    (SELECT * FROM
+      sub_stats(
+      date_trunc('hour', timezone('America/Chicago', now())),
+      date_trunc('hour', timezone('America/Chicago', now())), '1 hour'::INTERVAL, 'hour')
+      WHERE "sub_stats".t >= date_trunc('${unit}', timezone('America/Chicago', $1)))
+  )`
+}
+
 export default {
   Query: {
     registrationGrowth: async (parent, { when, from, to }, { models }) => {

--- a/api/typeDefs/sub.js
+++ b/api/typeDefs/sub.js
@@ -5,6 +5,12 @@ export default gql`
     sub(name: String): Sub
     subLatestPost(name: String!): String
     subs: [Sub!]!
+    topSubs(cursor: String, when: String, from: String, to: String, by: String, limit: Limit): Subs
+  }
+
+  type Subs {
+    cursor: String
+    subs: [Sub!]!
   }
 
   extend type Mutation {
@@ -36,5 +42,18 @@ export default gql`
     moderatedCount: Int!
     meMuteSub: Boolean!
     nsfw: Boolean!
+    nposts(when: String, from: String, to: String): Int!
+    ncomments(when: String, from: String, to: String): Int!
+
+    optional: SubOptional!
+  }
+
+  type SubOptional {
+    """
+    conditionally private
+    """
+    stacked(when: String, from: String, to: String): Int
+    spent(when: String, from: String, to: String): Int
+    revenue(when: String, from: String, to: String): Int
   }
 `

--- a/components/territory-list.js
+++ b/components/territory-list.js
@@ -1,0 +1,98 @@
+import Link from 'next/link'
+import { abbrNum, numWithUnits } from '../lib/format'
+import styles from './item.module.css'
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery } from '@apollo/client'
+import MoreFooter from './more-footer'
+import { useData } from './use-data'
+
+// all of this nonsense is to show the stat we are sorting by first
+const Revenue = ({ sub }) => (sub.optional.revenue !== null && <span>{abbrNum(sub.optional.revenue)} revenue</span>)
+const Stacked = ({ sub }) => (sub.optional.stacked !== null && <span>{abbrNum(sub.optional.stacked)} stacked</span>)
+const Spent = ({ sub }) => (sub.optional.spent !== null && <span>{abbrNum(sub.optional.spent)} spent</span>)
+const Posts = ({ sub }) => (
+  <span>
+    {numWithUnits(sub.nposts, { unitSingular: 'post', unitPlural: 'posts' })}
+  </span>)
+const Comments = ({ sub }) => (
+  <span>
+    {numWithUnits(sub.ncomments, { unitSingular: 'comment', unitPlural: 'comments' })}
+  </span>)
+const Separator = () => (<span> \ </span>)
+
+const STAT_POS = {
+  stacked: 0,
+  revenue: 1,
+  spent: 2,
+  posts: 3,
+  comments: 4
+}
+const STAT_COMPONENTS = [Stacked, Revenue, Spent, Posts, Comments]
+
+function separate (arr, separator) {
+  return arr.flatMap((x, i) => i < arr.length - 1 ? [x, separator] : [x])
+}
+
+export default function TerritoryList ({ ssrData, query, variables, destructureData }) {
+  const { data, fetchMore } = useQuery(query, { variables })
+  const dat = useData(data, ssrData)
+  const [statComps, setStatComps] = useState(separate(STAT_COMPONENTS, Separator))
+
+  useEffect(() => {
+    // shift the stat we are sorting by to the front
+    const comps = [...STAT_COMPONENTS]
+    setStatComps(separate([...comps.splice(STAT_POS[variables?.by || 0], 1), ...comps], Separator))
+  }, [variables?.by])
+
+  const { subs, cursor } = useMemo(() => {
+    if (!dat) return {}
+    if (destructureData) {
+      return destructureData(dat)
+    } else {
+      return dat
+    }
+  }, [dat])
+
+  if (!dat) {
+    return <SubsSkeleton />
+  }
+
+  return (
+    <>
+      {subs?.map(sub => (
+        <div className={`${styles.item} mb-2`} key={sub.name}>
+          <div className={styles.hunk}>
+            <Link href={`/~${sub.name}`} className={`${styles.title} d-inline-flex align-items-center text-reset`}>
+              {sub.name}
+            </Link>
+            <div className={styles.other}>
+              {statComps.map((Comp, i) => <Comp key={i} sub={sub} />)}
+            </div>
+          </div>
+        </div>
+      ))}
+      <MoreFooter cursor={cursor} count={subs?.length} fetchMore={fetchMore} Skeleton={SubsSkeleton} noMoreText='NO MORE' />
+    </>
+  )
+}
+
+export function SubsSkeleton () {
+  const subs = new Array(21).fill(null)
+
+  return (
+    <div>{subs.map((_, i) => (
+      <div className={`${styles.item} ${styles.skeleton} mb-2`} key={i}>
+        <div className={styles.hunk}>
+          <div className={`${styles.name} clouds text-reset`} />
+          <div className={styles.other}>
+            <span className={`${styles.otherItem} clouds`} />
+            <span className={`${styles.otherItem} clouds`} />
+            <span className={`${styles.otherItem} ${styles.otherItemLonger} clouds`} />
+            <span className={`${styles.otherItem} ${styles.otherItemLonger} clouds`} />
+          </div>
+        </div>
+      </div>
+    ))}
+    </div>
+  )
+}

--- a/components/top-header.js
+++ b/components/top-header.js
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router'
 import { Form, Select, DatePicker } from './form'
-import { ITEM_SORTS, USER_SORTS, WHENS } from '../lib/constants'
+import { ITEM_SORTS, SUB_SORTS, USER_SORTS, WHENS } from '../lib/constants'
 import { whenToFrom } from '../lib/time'
 
 export default function TopHeader ({ sub, cat }) {
@@ -21,7 +21,8 @@ export default function TopHeader ({ sub, cat }) {
     if (typeof query.by !== 'undefined') {
       if (query.by === '' ||
           (what === 'stackers' && (query.by === 'stacked' || !USER_SORTS.includes(query.by))) ||
-          (what !== 'stackers' && (query.by === 'zaprank' || !ITEM_SORTS.includes(query.by)))) {
+          (what === 'territories' && (query.by === 'stacked' || !SUB_SORTS.includes(query.by))) ||
+          (['posts', 'comments'].includes(what) && (query.by === 'zaprank' || !ITEM_SORTS.includes(query.by)))) {
         delete query.by
       }
     }
@@ -54,7 +55,7 @@ export default function TopHeader ({ sub, cat }) {
               name='what'
               size='sm'
               overrideValue={what}
-              items={router?.query?.sub ? ['posts', 'comments'] : ['posts', 'comments', 'stackers', 'cowboys']}
+              items={router?.query?.sub ? ['posts', 'comments'] : ['posts', 'comments', 'stackers', 'cowboys', 'territories']}
             />
             {cat !== 'cowboys' &&
               <>
@@ -65,7 +66,7 @@ export default function TopHeader ({ sub, cat }) {
                   name='by'
                   size='sm'
                   overrideValue={by}
-                  items={cat === 'stackers' ? USER_SORTS : ITEM_SORTS}
+                  items={sortItemsForCategory(cat)}
                 />
                 for
                 <Select
@@ -98,4 +99,15 @@ export default function TopHeader ({ sub, cat }) {
       </Form>
     </div>
   )
+}
+
+function sortItemsForCategory (cat) {
+  switch (cat) {
+    case 'stackers':
+      return USER_SORTS
+    case 'territories':
+      return SUB_SORTS
+    default:
+      return ITEM_SORTS
+  }
 }

--- a/fragments/subs.js
+++ b/fragments/subs.js
@@ -114,3 +114,22 @@ export const SUB_PAY = gql`
       ...SubFullFields
     }
   }`
+
+export const TOP_SUBS = gql`
+  query TopSubs($cursor: String, $when: String, $from: String, $to: String, $by: String, ) {
+    topSubs(cursor: $cursor, when: $when, from: $from, to: $to, by: $by) {
+      subs {
+        name
+        ncomments(when: $when, from: $from, to: $to)
+        nposts(when: $when, from: $from, to: $to)
+
+        optional {
+          stacked(when: $when, from: $from, to: $to)
+          spent(when: $when, from: $from, to: $to)
+          revenue(when: $when, from: $from, to: $to)
+        }
+      }
+      cursor
+    }
+  }
+`

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -55,6 +55,19 @@ function getClient (uri) {
                 return incoming
               }
             },
+            topSubs: {
+              keyArgs: ['when', 'by', 'from', 'to', 'limit'],
+              merge (existing, incoming, { args }) {
+                if (isFirstPage(incoming.cursor, existing?.subs, args.limit)) {
+                  return incoming
+                }
+
+                return {
+                  cursor: incoming.cursor,
+                  subs: [...(existing?.subs || []), ...incoming.subs]
+                }
+              }
+            },
             topUsers: {
               keyArgs: ['when', 'by', 'from', 'to', 'limit'],
               merge (existing, incoming, { args }) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -44,6 +44,7 @@ export const DONT_LIKE_THIS_COST = 1
 export const COMMENT_TYPE_QUERY = ['comments', 'freebies', 'outlawed', 'borderland', 'all', 'bookmarks']
 export const USER_SORTS = ['stacked', 'spent', 'comments', 'posts', 'referrals']
 export const ITEM_SORTS = ['zaprank', 'comments', 'sats']
+export const SUB_SORTS = ['stacked', 'revenue', 'spent', 'posts', 'comments']
 export const WHENS = ['day', 'week', 'month', 'year', 'forever', 'custom']
 export const ITEM_TYPES_USER = ['all', 'posts', 'comments', 'bounties', 'links', 'discussions', 'polls', 'freebies', 'jobs', 'bookmarks']
 export const ITEM_TYPES = ['all', 'posts', 'comments', 'bounties', 'links', 'discussions', 'polls', 'freebies', 'bios', 'jobs']

--- a/pages/~/top/territories/[when].js
+++ b/pages/~/top/territories/[when].js
@@ -1,0 +1,25 @@
+import Layout from '../../../../components/layout'
+import { useRouter } from 'next/router'
+import { getGetServerSideProps } from '../../../../api/ssrApollo'
+import TopHeader from '../../../../components/top-header'
+import { TOP_SUBS } from '../../../../fragments/subs'
+import TerritoryList from '../../../../components/territory-list'
+
+export const getServerSideProps = getGetServerSideProps({ query: TOP_SUBS })
+
+export default function Index ({ ssrData }) {
+  const router = useRouter()
+  const variables = { ...router.query }
+
+  return (
+    <Layout>
+      <TopHeader cat='territories' />
+      <TerritoryList
+        ssrData={ssrData}
+        query={TOP_SUBS}
+        variables={variables}
+        destructureData={data => data.topSubs}
+      />
+    </Layout>
+  )
+}

--- a/prisma/migrations/20240212203105_add_sub_stats_views/migration.sql
+++ b/prisma/migrations/20240212203105_add_sub_stats_views/migration.sql
@@ -1,0 +1,53 @@
+CREATE OR REPLACE FUNCTION sub_stats(min TIMESTAMP(3), max TIMESTAMP(3), ival INTERVAL, date_part TEXT)
+RETURNS TABLE (
+    t TIMESTAMP(3), sub_name CITEXT, comments BIGINT, posts BIGINT,
+    msats_revenue BIGINT, msats_stacked BIGINT, msats_spent BIGINT)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    min_utc TIMESTAMP(3) := timezone('utc', min AT TIME ZONE 'America/Chicago');
+BEGIN
+    RETURN QUERY
+    SELECT period.t,
+        "subName" as sub_name,
+        (sum(quantity) FILTER (WHERE type = 'COMMENT'))::BIGINT as comments,
+        (sum(quantity) FILTER (WHERE type = 'POST'))::BIGINT as posts,
+        (sum(quantity) FILTER (WHERE type = 'REVENUE'))::BIGINT as msats_revenue,
+        (sum(quantity) FILTER (WHERE type = 'TIP'))::BIGINT as msats_stacked,
+        (sum(quantity) FILTER (WHERE type = 'BILLING'))::BIGINT as msats_spent
+    FROM generate_series(min, max, ival) period(t)
+    LEFT JOIN
+    ((SELECT "subName", "ItemAct"."msats" as quantity, act::TEXT as type, "ItemAct"."created_at"
+        FROM "ItemAct"
+        JOIN "Item" ON "Item"."id" = "ItemAct"."itemId"
+        WHERE "ItemAct"."created_at" >= min_utc)
+        UNION ALL
+    (SELECT "subName", 1 as quantity,
+        CASE WHEN "Item"."parentId" IS NULL THEN 'POST' ELSE 'COMMENT' END as type, created_at
+        FROM "Item"
+        WHERE created_at >= min_utc)
+        UNION ALL
+    (SELECT "subName", msats as quantity, type::TEXT as type, created_at
+        FROM "SubAct"
+        WHERE created_at >= min_utc)
+    ) u ON period.t = date_trunc(date_part, u.created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago')
+    GROUP BY "subName", period.t
+    ORDER BY period.t ASC;
+END;
+$$;
+
+DROP MATERIALIZED VIEW IF EXISTS sub_stats_hours;
+CREATE MATERIALIZED VIEW IF NOT EXISTS sub_stats_hours AS
+SELECT (sub_stats(min, max, '1 hour'::INTERVAL, 'hour')).* FROM last_24_hours;
+
+DROP MATERIALIZED VIEW IF EXISTS sub_stats_days;
+CREATE MATERIALIZED VIEW IF NOT EXISTS sub_stats_days AS
+SELECT (sub_stats(min, max, '1 day'::INTERVAL, 'day')).* FROM all_days;
+
+DROP MATERIALIZED VIEW IF EXISTS sub_stats_months;
+CREATE MATERIALIZED VIEW IF NOT EXISTS sub_stats_months AS
+SELECT (sub_stats(min, max, '1 month'::INTERVAL, 'month')).* FROM all_months;
+
+CREATE UNIQUE INDEX IF NOT EXISTS sub_stats_hours_idx ON sub_stats_hours(t, sub_name);
+CREATE UNIQUE INDEX IF NOT EXISTS sub_stats_days_idx ON sub_stats_days(t, sub_name);
+CREATE UNIQUE INDEX IF NOT EXISTS sub_stats_months_idx ON sub_stats_months(t, sub_name);

--- a/prisma/migrations/20240212203105_add_sub_stats_views/migration.sql
+++ b/prisma/migrations/20240212203105_add_sub_stats_views/migration.sql
@@ -14,31 +14,33 @@ BEGIN
         (sum(quantity) FILTER (WHERE type = 'POST'))::BIGINT as posts,
         (sum(quantity) FILTER (WHERE type = 'REVENUE'))::BIGINT as msats_revenue,
         (sum(quantity) FILTER (WHERE type = 'TIP'))::BIGINT as msats_stacked,
-        (sum(quantity) FILTER (WHERE type = 'BILLING'))::BIGINT as msats_spent
+        (sum(quantity) FILTER (WHERE type IN ('BOOST', 'TIP', 'FEE', 'STREAM', 'POLL', 'DONT_LIKE_THIS', 'VOTE')))::BIGINT as msats_spent
     FROM generate_series(min, max, ival) period(t)
-    LEFT JOIN
-    ((SELECT "subName", "ItemAct"."msats" as quantity, act::TEXT as type, "ItemAct"."created_at"
-        FROM "ItemAct"
-        JOIN "Item" ON "Item"."id" = "ItemAct"."itemId"
-        WHERE "ItemAct"."created_at" >= min_utc
-            AND "subName" IS NOT NULL
-            AND act = 'TIP')
-        UNION ALL
-    (SELECT "subName", 1 as quantity, 'POST' as type, created_at
-        FROM "Item"
-        WHERE created_at >= min_utc
-            AND "Item"."parentId" IS NULL
-            AND "subName" IS NOT NULL)
-        UNION ALL
-    (SELECT root."subName", 1 as quantity, 'COMMENT' as type, "Item"."created_at"
-        FROM "Item"
-        JOIN "Item" root ON "Item"."rootId" = root."id"
-        WHERE "Item"."created_at" >= min_utc
-            AND root."subName" IS NOT NULL)
-        UNION ALL
-    (SELECT "subName", msats as quantity, type::TEXT as type, created_at
-        FROM "SubAct"
-        WHERE created_at >= min_utc)
+    LEFT JOIN (
+        -- For msats_spent and msats_stacked
+        (SELECT "subName", "ItemAct"."msats" as quantity, act::TEXT as type, "ItemAct"."created_at"
+            FROM "ItemAct"
+            JOIN "Item" ON "Item"."id" = "ItemAct"."itemId"
+            WHERE "ItemAct"."created_at" >= min_utc
+                AND "subName" IS NOT NULL
+                AND act = 'TIP')
+            UNION ALL
+        (SELECT "subName", 1 as quantity, 'POST' as type, created_at
+            FROM "Item"
+            WHERE created_at >= min_utc
+                AND "Item"."parentId" IS NULL
+                AND "subName" IS NOT NULL)
+            UNION ALL
+        (SELECT root."subName", 1 as quantity, 'COMMENT' as type, "Item"."created_at"
+            FROM "Item"
+            JOIN "Item" root ON "Item"."rootId" = root."id"
+            WHERE "Item"."created_at" >= min_utc
+                AND root."subName" IS NOT NULL)
+            UNION ALL
+        -- For msats_revenue
+        (SELECT "subName", msats as quantity, type::TEXT as type, created_at
+            FROM "SubAct"
+            WHERE created_at >= min_utc)
     ) u ON period.t = date_trunc(date_part, u.created_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Chicago')
     GROUP BY "subName", period.t
     ORDER BY period.t ASC;

--- a/worker/views.js
+++ b/worker/views.js
@@ -1,7 +1,7 @@
 import { PrismaClient } from '@prisma/client'
 
 const viewPrefixes = ['reg_growth', 'spender_growth', 'item_growth', 'spending_growth',
-  'stackers_growth', 'stacking_growth', 'user_stats']
+  'stackers_growth', 'stacking_growth', 'user_stats', 'sub_stats']
 
 // this is intended to be run everyday after midnight CT
 export async function views ({ data: { period } = { period: 'days' } }) {


### PR DESCRIPTION
Closes https://github.com/stackernews/stacker.news/issues/796

- Adds `sub_stats_days`, `sub_stats_hours`, and `sub_stats_months` materialized views to aggregate stacked, revenue, spent, posts, and comments counts for each territory.
- Adds `territories` option to "top" select
- Adds new top territories page and `topSubs` GraphQL query

#### Screenshots

##### Added territories to "top" dropdown
<img width="508" alt="Screenshot 2024-02-13 at 3 54 24 PM" src="https://github.com/stackernews/stacker.news/assets/158518982/7f4b0861-79eb-466a-b504-e5b1809d922f">

##### Added territory-specific sort by options
<img width="442" alt="Screenshot 2024-02-13 at 3 54 31 PM" src="https://github.com/stackernews/stacker.news/assets/158518982/5a7d1d76-275a-4901-a7d4-eaef99d05270">

##### Added top territories page
<img width="956" alt="Screenshot 2024-02-14 at 11 06 16 AM" src="https://github.com/stackernews/stacker.news/assets/158518982/61038ef0-826b-49c0-9a97-4db88c5971be">
