### PR TITLE
Fix saloon comments hidden in profile due to nsfw filter

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -192,7 +192,7 @@ const activeOrMine = (me) => {
 export const muteClause = me =>
   me ? `NOT EXISTS (SELECT 1 FROM "Mute" WHERE "Mute"."muterId" = ${me.id} AND "Mute"."mutedId" = "Item"."userId")` : ''
 
-const HIDE_NSFW_CLAUSE = '"Sub"."nsfw" = FALSE'
+const HIDE_NSFW_CLAUSE = '("Sub"."nsfw" = FALSE OR "Sub"."nsfw" IS NULL)'
 
 export const nsfwClause = showNsfw => showNsfw ? '' : HIDE_NSFW_CLAUSE
 


### PR DESCRIPTION
I believe this doesn't break any assumption in #788. This should really only affect the saloon since only comments in the saloon have no sub.

Hence, even if a user has `nsfwSetting` disabled[^1], they will still see saloon comments in anyone's profile since they are never excluded.

[^1]: this double negation gets hard to keep track off