### PR TITLE
Make territory billing period changeable

### DIFF
--- a/api/typeDefs/sub.js
+++ b/api/typeDefs/sub.js
@@ -36,6 +36,7 @@ export default gql`
     billingAutoRenew: Boolean!
     rankingType: String!
     billedLastAt: Date!
+    billPaidUntil: Date
     baseCost: Int!
     status: String!
     moderated: Boolean!

--- a/components/form.js
+++ b/components/form.js
@@ -804,7 +804,7 @@ export function Form ({
       const msg = err.message || err.toString?.()
       // handle errors from JIT invoices by ignoring them
       if (msg === 'modal closed' || msg === 'invoice canceled') return
-      toaster.danger('submit error:' + msg)
+      toaster.danger('submit error: ' + msg)
     }
   }, [onSubmit, feeButton?.total, toaster, clearLocalStorage, storageKeyPrefix])
 

--- a/components/territory-form.js
+++ b/components/territory-form.js
@@ -5,12 +5,12 @@ import FeeButton, { FeeButtonProvider } from './fee-button'
 import { gql, useApolloClient, useMutation } from '@apollo/client'
 import { useCallback, useMemo, useState } from 'react'
 import { useRouter } from 'next/router'
-import { MAX_TERRITORY_DESC_LENGTH, POST_TYPES, TERRITORY_BILLING_OPTIONS } from '../lib/constants'
+import { MAX_TERRITORY_DESC_LENGTH, POST_TYPES, TERRITORY_BILLING_OPTIONS, TERRITORY_PERIOD_COST } from '../lib/constants'
 import { territorySchema } from '../lib/validate'
 import { useMe } from './me'
 import Info from './info'
-import { consumedBilling, proratedBillingCost } from '../lib/territory'
 import { abbrNum } from '../lib/format'
+import { purchasedType } from '../lib/territory'
 
 export default function TerritoryForm ({ sub }) {
   const router = useRouter()
@@ -62,10 +62,11 @@ export default function TerritoryForm ({ sub }) {
 
     // we are changing billing type to something more expensive so prorate the change
     if (sub?.billingType?.toLowerCase() !== billing) {
-      lines.consumed = {
-        term: `- ${abbrNum(consumedBilling(sub))}`,
-        label: 'prorated credit',
-        modifier: cost => cost - consumedBilling(sub)
+      const alreadyBilled = TERRITORY_PERIOD_COST(purchasedType(sub))
+      lines.paid = {
+        term: `- ${abbrNum(alreadyBilled)} sats`,
+        label: 'already paid',
+        modifier: cost => cost - alreadyBilled
       }
       return lines
     }

--- a/components/territory-form.js
+++ b/components/territory-form.js
@@ -60,7 +60,7 @@ export default function TerritoryForm ({ sub }) {
     const lines = { territory: TERRITORY_BILLING_OPTIONS('first')[billing] }
     if (!sub) return lines
 
-    // we are changing billing type to something more expensive so prorate the change
+    // we are changing billing type so prorate the change
     if (sub?.billingType?.toLowerCase() !== billing) {
       const alreadyBilled = TERRITORY_PERIOD_COST(purchasedType(sub))
       lines.paid = {
@@ -172,10 +172,11 @@ export default function TerritoryForm ({ sub }) {
                 <span className='d-flex align-items-center'>billing
                   {sub && sub.billingType !== 'ONCE' &&
                     <Info>
-                      Changing your billing type will be prorated and go into effect immediately.
+                      You will be credited what you paid for your current billing period when you change your billing period to a longer duration.
+                      If you change from yearly to monthly, when your year ends, your monthly billing will begin.
                     </Info>}
                 </span>
-          }
+              }
               name='billing'
               groupClassName={billing !== 'once' ? 'mb-0' : ''}
             >

--- a/components/territory-payment-due.js
+++ b/components/territory-payment-due.js
@@ -8,7 +8,7 @@ import { LongCountdown } from './countdown'
 import { useCallback } from 'react'
 import { useApolloClient, useMutation } from '@apollo/client'
 import { SUB_PAY } from '../fragments/subs'
-import { nextBilling, nextBillingWithGrace } from '../lib/territory'
+import { nextBillingWithGrace } from '../lib/territory'
 
 export default function TerritoryPaymentDue ({ sub }) {
   const me = useMe()
@@ -78,7 +78,7 @@ export function TerritoryBillingLine ({ sub }) {
   const me = useMe()
   if (!sub || sub.userId !== Number(me?.id)) return null
 
-  const dueDate = nextBilling(sub)
+  const dueDate = sub.billPaidUntil && new Date(sub.billPaidUntil)
   const pastDue = dueDate && dueDate < new Date()
 
   return (

--- a/fragments/subs.js
+++ b/fragments/subs.js
@@ -12,6 +12,7 @@ export const SUB_FIELDS = gql`
     billingCost
     billingAutoRenew
     billedLastAt
+    billPaidUntil
     baseCost
     userId
     desc

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -88,6 +88,17 @@ export const TERRITORY_BILLING_OPTIONS = (labelPrefix) => ({
   }
 })
 
+export const TERRITORY_PERIOD_COST = (billingType) => {
+  switch (billingType.toUpperCase()) {
+    case 'MONTHLY':
+      return TERRITORY_COST_MONTHLY
+    case 'YEARLY':
+      return TERRITORY_COST_YEARLY
+    case 'ONCE':
+      return TERRITORY_COST_ONCE
+  }
+}
+
 export const FOUND_BLURBS = [
   'The harsh frontier is no place for the unprepared. This hat will protect you from the sun, dust, and other elements Mother Nature throws your way.',
   'A cowboy is nothing without a cowboy hat. Take good care of it, and it will protect you from the sun, dust, and other elements on your journey.',

--- a/lib/territory.js
+++ b/lib/territory.js
@@ -1,14 +1,14 @@
 import { TERRITORY_GRACE_DAYS, TERRITORY_PERIOD_COST } from './constants'
 import { datePivot, diffDays } from './time'
 
-export function nextNextBilling (sub) {
-  if (!sub || sub.billingType === 'ONCE') return null
+export function nextBilling (relativeTo, billingType) {
+  if (!relativeTo || billingType === 'ONCE') return null
 
-  const pivot = sub.billingType === 'MONTHLY'
+  const pivot = billingType === 'MONTHLY'
     ? { months: 1 }
     : { years: 1 }
 
-  return datePivot(new Date(sub.billPaidUntil), pivot)
+  return datePivot(new Date(relativeTo), pivot)
 }
 
 export function purchasedType (sub) {

--- a/lib/territory.js
+++ b/lib/territory.js
@@ -16,22 +16,12 @@ export function purchasedType (sub) {
   return diffDays(new Date(sub.billedLastAt), new Date(sub.billPaidUntil)) >= 365 ? 'YEARLY' : 'MONTHLY'
 }
 
-export function consumedBilling (sub) {
-  if (!sub?.billPaidUntil) return null
-
-  const consumed = diffDays(new Date(sub.billedLastAt), new Date())
-  const purchased = diffDays(new Date(sub.billedLastAt), new Date(sub.billPaidUntil))
-
-  return TERRITORY_PERIOD_COST(purchasedType(sub)) -
-    Math.floor(TERRITORY_PERIOD_COST(purchasedType(sub)) * consumed / purchased)
-}
-
 export function proratedBillingCost (sub, newBillingType) {
   if (!sub ||
     sub.billingType === 'ONCE' ||
     sub.billingType === newBillingType.toUpperCase()) return null
 
-  return TERRITORY_PERIOD_COST(newBillingType) - consumedBilling(sub)
+  return TERRITORY_PERIOD_COST(newBillingType) - TERRITORY_PERIOD_COST(purchasedType(sub))
 }
 
 export function nextBillingWithGrace (sub) {

--- a/lib/territory.js
+++ b/lib/territory.js
@@ -1,28 +1,40 @@
-import { TERRITORY_GRACE_DAYS } from './constants'
-import { datePivot } from './time'
+import { TERRITORY_GRACE_DAYS, TERRITORY_PERIOD_COST } from './constants'
+import { datePivot, diffDays } from './time'
 
-export function nextBilling (sub) {
+export function nextNextBilling (sub) {
   if (!sub || sub.billingType === 'ONCE') return null
 
   const pivot = sub.billingType === 'MONTHLY'
     ? { months: 1 }
     : { years: 1 }
 
-  return datePivot(new Date(sub.billedLastAt), pivot)
+  return datePivot(new Date(sub.billPaidUntil), pivot)
 }
 
-export function nextNextBilling (sub) {
-  if (!sub || sub.billingType === 'ONCE') return null
+export function purchasedType (sub) {
+  if (!sub?.billPaidUntil) return 'ONCE'
+  return diffDays(new Date(sub.billedLastAt), new Date(sub.billPaidUntil)) >= 365 ? 'YEARLY' : 'MONTHLY'
+}
 
-  const pivot = sub.billingType === 'MONTHLY'
-    ? { months: 2 }
-    : { years: 2 }
+export function consumedBilling (sub) {
+  if (!sub?.billPaidUntil) return null
 
-  return datePivot(new Date(sub.billedLastAt), pivot)
+  const consumed = diffDays(new Date(sub.billedLastAt), new Date())
+  const purchased = diffDays(new Date(sub.billedLastAt), new Date(sub.billPaidUntil))
+
+  return TERRITORY_PERIOD_COST(purchasedType(sub)) -
+    Math.floor(TERRITORY_PERIOD_COST(purchasedType(sub)) * consumed / purchased)
+}
+
+export function proratedBillingCost (sub, newBillingType) {
+  if (!sub ||
+    sub.billingType === 'ONCE' ||
+    sub.billingType === newBillingType.toUpperCase()) return null
+
+  return TERRITORY_PERIOD_COST(newBillingType) - consumedBilling(sub)
 }
 
 export function nextBillingWithGrace (sub) {
-  const dueDate = nextBilling(sub)
   if (!sub) return null
-  return datePivot(dueDate, { days: TERRITORY_GRACE_DAYS })
+  return datePivot(new Date(sub.billPaidUntil), { days: TERRITORY_GRACE_DAYS })
 }

--- a/lib/time.js
+++ b/lib/time.js
@@ -33,6 +33,11 @@ export function datePivot (date,
   )
 }
 
+export function diffDays (date1, date2) {
+  const diffTime = Math.abs(date2 - date1)
+  return Math.floor(diffTime / (1000 * 60 * 60 * 24))
+}
+
 export const dayMonthYear = when => new Date(when).toISOString().slice(0, 10)
 export const dayMonthYearToDate = when => {
   const [year, month, day] = when.split('-')

--- a/prisma/migrations/20240216003921_territory_billing_trigger/migration.sql
+++ b/prisma/migrations/20240216003921_territory_billing_trigger/migration.sql
@@ -1,0 +1,48 @@
+-- AlterTable
+ALTER TABLE "Sub" ADD COLUMN     "billPaidUntil" TIMESTAMP(3);
+
+-- we want to denomalize billPaidUntil into a job so that the application
+-- doesn't have to concern itself too much with territory billing jobs
+-- and think about future state
+CREATE OR REPLACE FUNCTION update_territory_billing()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF (TG_OP = 'UPDATE') THEN
+        -- delete the old job
+        DELETE FROM pgboss.job
+            WHERE name = 'territoryBilling'
+            AND data->>'subName' = OLD."name";
+    END IF;
+
+    IF (NEW."billPaidUntil" IS NOT NULL) THEN
+        -- create a new job
+        INSERT INTO pgboss.job (name, data, startafter, keepuntil)
+            VALUES (
+                'territoryBilling',
+                jsonb_build_object('subName', NEW.name),
+                NEW."billPaidUntil",
+                NEW."billPaidUntil" + interval '1 day');
+    END IF;
+
+    RETURN NEW;
+EXCEPTION WHEN undefined_table THEN
+    return NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS update_territory_billing_trigger ON "Sub";
+CREATE TRIGGER update_territory_billing_trigger
+AFTER INSERT OR UPDATE ON "Sub"
+FOR EACH ROW
+WHEN (NEW.status = 'ACTIVE')
+EXECUTE PROCEDURE update_territory_billing();
+
+-- migrate existing data to have billPaidUntil
+UPDATE "Sub"
+SET "billPaidUntil" =
+    (CASE
+        WHEN "billingType" = 'MONTHLY' THEN "billedLastAt" + interval '1 month'
+        WHEN "billingType" = 'YEARLY' THEN "billedLastAt" + interval '1 year'
+        ELSE NULL
+    END);
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -476,6 +476,7 @@ model Sub {
   billingCost      Int
   billingAutoRenew Boolean     @default(false)
   billedLastAt     DateTime    @default(now())
+  billPaidUntil    DateTime?
   moderated        Boolean     @default(false)
   moderatedCount   Int         @default(0)
   nsfw             Boolean     @default(false)


### PR DESCRIPTION
closes #786 

This does what it says. It prorates, ie credits stackers, for the already paid billing period. e.g. If they're 15 days into a monthly billing cycle, upgrading to a year costs 900k sats.

This also makes the territory billing jobs a little more robust by maintaining how much time is already paid for in the `Sub` table and generating billing jobs off that column in a trigger (application doesn't need to concern itself with inserting/updating those jobs).

TODOs
- [x] test territory renewal
- [x] handle grace territory billing updates
- [x] test archive rehydration