### PR TITLE
Fix onSubmit not ignoring payment cancels from WebLN payments

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -802,7 +802,8 @@ export function Form ({
       }
     } catch (err) {
       const msg = err.message || err.toString?.()
-      // handle errors from JIT invoices by ignoring them
+      // ignore errors from JIT invoices or payments from attached wallets
+      // that mean that submit failed because user aborted the payment
       if (msg === 'modal closed' || msg === 'invoice canceled') return
       toaster.danger('submit error:' + msg)
     }

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -293,13 +293,12 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
   return onSubmitWrapper
 }
 
-const INVOICE_CANCELED_ERROR = 'invoice was canceled'
+const INVOICE_CANCELED_ERROR = 'invoice canceled'
 const waitForPayment = async ({ invoice, showModal, provider, pollInvoice, gqlCacheUpdate }) => {
   if (provider.enabled) {
     try {
       return await waitForWebLNPayment({ provider, invoice, pollInvoice, gqlCacheUpdate })
     } catch (err) {
-      const INVOICE_CANCELED_ERROR = 'invoice was canceled'
       // check for errors which mean that QR code will also fail
       if (err.message === INVOICE_CANCELED_ERROR) {
         throw err


### PR DESCRIPTION
If you had an wallet attached, wanted to pay an invoice with it ("payment pending") and then canceled it, the `onSubmit` handler didn't recognize this as the user aborting the action and toasted "submit error: invoice was canceled". This fixes this.

PS: We should probably put all (frontend) error messages into lib/constants.js to prevent such bugs. But wanted to keep this PR simple. And maybe there is a better way to match errors instead of matching by error message?