### PR TITLE
Rename HODL to JIT in frontend comments

### DIFF
--- a/components/invoice.js
+++ b/components/invoice.js
@@ -327,11 +327,11 @@ const waitForWebLNPayment = async ({ provider, invoice, pollInvoice, gqlCacheUpd
     return await new Promise((resolve, reject) => {
       // be optimistic and pretend zap was already successful for consistent zapping UX
       undoUpdate = gqlCacheUpdate?.()
-      // can't use await here since we might be paying HODL invoices
+      // can't use await here since we might be paying JIT invoices
       // and sendPaymentAsync is not supported yet.
       // see https://www.webln.guide/building-lightning-apps/webln-reference/webln.sendpaymentasync
       provider.sendPayment(invoice)
-        // WebLN payment will never resolve here for HODL invoices
+        // WebLN payment will never resolve here for JIT invoices
         // since they only get resolved after settlement which can't happen here
         .then(() => resolve({ webLn: true, gqlCacheUpdateUndo: undoUpdate }))
         .catch(err => {

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -87,7 +87,7 @@ function RawWebLNProvider ({ children }) {
       autohide: false,
       onCancel: async () => {
         try {
-          // hash and hmac are only passed for HODL invoices
+          // hash and hmac are only passed for JIT invoices
           if (hash && hmac) await cancelInvoice({ variables: { hash, hmac } })
           canceled = true
           toaster.warning('payment canceled')

--- a/worker/nostr.js
+++ b/worker/nostr.js
@@ -19,7 +19,7 @@ export async function nip57 ({ data: { hash }, boss, lnd, models }) {
     return
   }
 
-  // check if invoice still exists since HODL invoices get deleted after usage
+  // check if invoice still exists since JIT invoices get deleted after usage
   if (!inv) return
 
   try {

--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -127,7 +127,7 @@ async function checkInvoice ({ data: { hash }, boss, models, lnd }) {
       models.invoice.update({ where: { hash }, data: { confirmedIndex: inv.confirmed_index } })
     )
 
-    // don't send notifications for hodl invoices
+    // don't send notifications for JIT invoices
     if (dbInv.preimage) return
 
     sendUserNotification(dbInv.userId, {
@@ -140,7 +140,7 @@ async function checkInvoice ({ data: { hash }, boss, models, lnd }) {
   }
 
   if (inv.is_held) {
-    // First query makes sure that after payment, HODL invoices are settled
+    // First query makes sure that after payment, JIT invoices are settled
     // within 60 seconds or they will be canceled to minimize risk of
     // force closures or wallets banning us.
     // Second query is basically confirm_invoice without setting confirmed_at
@@ -286,7 +286,7 @@ export async function autoDropBolt11s ({ models, lnd }) {
   }
 }
 
-// The callback subscriptions above will NOT get called for HODL invoices that are already paid.
+// The callback subscriptions above will NOT get called for JIT invoices that are already paid.
 // So we manually cancel the HODL invoice here if it wasn't settled by user action
 export async function finalizeHodlInvoice ({ data: { hash }, models, lnd, ...args }) {
   const inv = await getInvoice({ id: hash, lnd })


### PR DESCRIPTION
For consistency reasons. JIT is a better name in the frontend since it describes the use case.