### PR TITLE
Fix NWC support detection

### DIFF
--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -214,7 +214,7 @@ async function getInfoWithRelay (relay, walletPubkey) {
     ], {
       onevent (event) {
         clearTimeout(timer)
-        const supported = event.content.split()
+        const supported = event.content.split(',')
         resolve(supported)
         sub.close()
       },

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -47,8 +47,8 @@ export function NWCProvider ({ children }) {
     setSecret(params.secret)
 
     try {
-      const supported = await validateParams(params)
-      setEnabled(supported.includes('pay_invoice'))
+      await validateParams(params)
+      setEnabled(true)
       await updateRelay(params.relayUrl)
     } catch (err) {
       console.error('invalid NWC config:', err)
@@ -78,8 +78,8 @@ export function NWCProvider ({ children }) {
     window.localStorage.setItem(storageKey, JSON.stringify(config))
 
     try {
-      const supported = await validateParams(params)
-      setEnabled(supported.includes('pay_invoice'))
+      await validateParams(params)
+      setEnabled(true)
       await updateRelay(params.relayUrl)
     } catch (err) {
       console.error('invalid NWC config:', err)
@@ -215,7 +215,7 @@ async function getInfoWithRelay (relay, walletPubkey) {
       onevent (event) {
         clearTimeout(timer)
         const supported = event.content.split(',')
-        resolve(supported)
+        supported.includes('pay_invoice') ? resolve() : reject(new Error('wallet does not support pay_invoice'))
         sub.close()
       },
       onclose (reason) {


### PR DESCRIPTION
It worked with Mutiny because Mutiny only supports `pay_invoice` so the resulting array only contained a single element with value `pay_invoice`.

With wallets that supported multiple methods, the single element no longer matched `pay_invoice`.

https://github.com/stackernews/stacker.news/assets/27162016/1ad2e5a2-e48c-419d-a099-a643ccf524d5

I think that's what every stacker encountered with red indicators but no error message since there is indeed no toast if `pay_invoice` support was not detected.

So I believe this fixes #821. I think the errors in the console are unrelated to NWC and that they are just ["CSP WTF reports"](https://github.com/nico3333fr/CSP-useful/tree/master/csp-wtf).
