### PR TITLE
Handle space separated NWC info event

### DIFF
--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -214,7 +214,7 @@ async function getInfoWithRelay (relay, walletPubkey) {
     ], {
       onevent (event) {
         clearTimeout(timer)
-        const supported = event.content.split(',')
+        const supported = event.content.split(/[\s,]+/) // handle both spaces and commas
         supported.includes('pay_invoice') ? resolve() : reject(new Error('wallet does not support pay_invoice'))
         sub.close()
       },


### PR DESCRIPTION
Fixes: https://github.com/stackernews/stacker.news/pull/845#issuecomment-1951410455

The NIP defines separating by commas but seem alby guys did commas, this should handle both cases (according to chatgpt)