### PR TITLE
Toast flows

### DIFF
--- a/components/toast.js
+++ b/components/toast.js
@@ -13,13 +13,26 @@ export const ToastProvider = ({ children }) => {
   const [toasts, setToasts] = useState([])
   const toastId = useRef(0)
 
-  const dispatchToast = useCallback((toastConfig) => {
-    toastConfig = {
-      ...toastConfig,
+  const dispatchToast = useCallback((toast) => {
+    toast = {
+      ...toast,
       id: toastId.current++
     }
-    setToasts(toasts => [...toasts, toastConfig])
-    return () => removeToast(toastConfig)
+    const { flowId } = toast
+    setToasts(toasts => {
+      if (flowId) {
+        // replace previous toast with same flow id
+        const idx = toasts.findIndex(toast => toast.flowId === flowId)
+        if (idx === -1) return [...toasts, toast]
+        return [
+          ...toasts.slice(0, idx),
+          toast,
+          ...toasts.slice(idx + 1)
+        ]
+      }
+      return [...toasts, toast]
+    })
+    return () => removeToast(toast)
   }, [])
 
   const removeToast = useCallback(({ id, onCancel, tag }) => {

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -83,30 +83,29 @@ function RawWebLNProvider ({ children }) {
 
   const sendPaymentWithToast = function ({ bolt11, hash, hmac }) {
     let canceled = false
-    let removeToast = toaster.warning('payment pending', {
+    const flowId = hash
+    toaster.warning('payment pending', {
       autohide: false,
       onCancel: async () => {
         try {
           // hash and hmac are only passed for JIT invoices
           if (hash && hmac) await cancelInvoice({ variables: { hash, hmac } })
           canceled = true
-          toaster.warning('payment canceled')
-          removeToast = undefined
+          toaster.warning('payment canceled', { flowId })
         } catch (err) {
-          toaster.danger('failed to cancel payment')
+          toaster.danger('failed to cancel payment', { flowId })
         }
-      }
+      },
+      flowId
     })
     return provider.sendPayment(bolt11)
       .then(({ preimage }) => {
-        removeToast?.()
-        toaster.success('payment successful')
+        toaster.success('payment successful', { flowId })
         return { preimage }
       }).catch((err) => {
         if (canceled) return
-        removeToast?.()
         const reason = err?.message?.toString().toLowerCase() || 'unknown reason'
-        toaster.danger(`payment failed: ${reason}`)
+        toaster.danger(`payment failed: ${reason}`, { flowId })
         throw err
       })
   }

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react'
 import { LNbitsProvider, useLNbits } from './lnbits'
 import { NWCProvider, useNWC } from './nwc'
-import { useToast } from '../toast'
+import { useToast, withToastFlow } from '../toast'
 import { gql, useMutation } from '@apollo/client'
 
 const WebLNContext = createContext({})
@@ -81,34 +81,17 @@ function RawWebLNProvider ({ children }) {
     }
   `)
 
-  const sendPaymentWithToast = function ({ bolt11, hash, hmac }) {
-    let canceled = false
-    const flowId = hash
-    toaster.warning('payment pending', {
-      autohide: false,
-      onCancel: async () => {
-        try {
-          // hash and hmac are only passed for JIT invoices
-          if (hash && hmac) await cancelInvoice({ variables: { hash, hmac } })
-          canceled = true
-          toaster.warning('payment canceled', { flowId })
-        } catch (err) {
-          toaster.danger('failed to cancel payment', { flowId })
-        }
-      },
-      flowId
-    })
-    return provider.sendPayment(bolt11)
-      .then(({ preimage }) => {
-        toaster.success('payment successful', { flowId })
-        return { preimage }
-      }).catch((err) => {
-        if (canceled) return
-        const reason = err?.message?.toString().toLowerCase() || 'unknown reason'
-        toaster.danger(`payment failed: ${reason}`, { flowId })
-        throw err
-      })
-  }
+  const sendPaymentWithToast = withToastFlow(toaster)(
+    ({ bolt11, hash, hmac }) => {
+      return {
+        flowId: hash,
+        type: 'payment',
+        onPending: () => provider.sendPayment(bolt11),
+        // hash and hmac are only passed for JIT invoices
+        onCancel: () => hash && hmac ? cancelInvoice({ variables: { hash, hmac } }) : undefined
+      }
+    }
+  )
 
   const setProvider = useCallback((defaultProvider) => {
     // move provider to the start to set it as default


### PR DESCRIPTION
"Toast flows" are a group of toasts that should be shown after each other.

Before, such flows were implemented by manually removing previous toasts in the same flow.

Now `flowId` can be passed and `ToastProvider` will make sure that there always only exists one toast with the same flowId.

This is different to toast tags since tags don't replace toasts with the same tag, they only are shown "above" them.

Added a wrapper for such flows to reuse the logic for custodial zap cancellation.