### PR TITLE
Allow zap undo's for short period of time

### DIFF
--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -84,6 +84,7 @@ export default gql`
     nsfwMode: Boolean!
     tipDefault: Int!
     turboTipping: Boolean!
+    zapUndos: Boolean!
     wildWestMode: Boolean!
     withdrawMaxFeeDefault: Int!
   }
@@ -146,6 +147,7 @@ export default gql`
     nsfwMode: Boolean!
     tipDefault: Int!
     turboTipping: Boolean!
+    zapUndos: Boolean!
     wildWestMode: Boolean!
     withdrawMaxFeeDefault: Int!
     autoWithdrawThreshold: Int

--- a/components/dont-link-this.js
+++ b/components/dont-link-this.js
@@ -7,6 +7,7 @@ import Flag from '../svgs/flag-fill.svg'
 import { useMemo } from 'react'
 import getColor from '../lib/rainbow'
 import { gql, useMutation } from '@apollo/client'
+import { useMe } from './me'
 
 export function DownZap ({ id, meDontLikeSats, ...props }) {
   const style = useMemo(() => (meDontLikeSats
@@ -23,6 +24,7 @@ export function DownZap ({ id, meDontLikeSats, ...props }) {
 function DownZapper ({ id, As, children }) {
   const toaster = useToast()
   const showModal = useShowModal()
+  const me = useMe()
 
   return (
     <As
@@ -32,7 +34,10 @@ function DownZapper ({ id, As, children }) {
             <ItemAct
               onClose={() => {
                 onClose()
-                toaster.success('item downzapped')
+                // undo prompt was toasted before closing modal if zap undos are enabled
+                // so an additional success toast would be confusing
+                const zapUndosEnabled = me && me?.privates?.zapUndos
+                if (!zapUndosEnabled) toaster.success('item downzapped')
               }} itemId={id} down
             >
               <AccordianItem

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -192,6 +192,9 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
       throw new Error('you must be logged in')
     }
 
+    // id for toast flows
+    if (!flowId) flowId = (+new Date()).toString(16)
+
     // educated guesses where action might pass in the invoice amount
     // (field 'cost' has highest precedence)
     cost ??= formValues.amount
@@ -201,7 +204,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
       try {
         const insufficientFunds = me?.privates.sats < cost
         return await onSubmit(formValues,
-          { ...submitArgs, variables, optimisticsResponse: insufficientFunds ? null : optimisticResponse, update })
+          { ...submitArgs, flowId, variables, optimisticsResponse: insufficientFunds ? null : optimisticResponse, update })
       } catch (error) {
         if (!payOrLoginError(error) || !cost) {
           // can't handle error here - bail

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -201,7 +201,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
       try {
         const insufficientFunds = me?.privates.sats < cost
         return await onSubmit(formValues,
-          { ...submitArgs, variables, optimisticsResponse: insufficientFunds ? null : optimisticResponse })
+          { ...submitArgs, variables, optimisticsResponse: insufficientFunds ? null : optimisticResponse, update })
       } catch (error) {
         if (!payOrLoginError(error) || !cost) {
           // can't handle error here - bail
@@ -256,6 +256,7 @@ export const useInvoiceable = (onSubmit, options = defaultOptions) => {
     const retry = () => onSubmit(
       { hash: inv.hash, hmac: inv.hmac, ...formValues },
       // unset update function since we already ran an cache update if we paid using WebLN
+      // also unset update function if null was explicitly passed in
       { ...submitArgs, variables, update: webLn ? null : undefined })
     // first retry
     try {

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -143,7 +143,7 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
       }}
       schema={amountSchema}
       invoiceable
-      onSubmit={onSubmitWithUndos}
+      onSubmit={me?.privates?.zapUndos ? onSubmitWithUndos : onSubmit}
     >
       <Input
         label='amount'

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -261,7 +261,9 @@ export function useZap () {
           // we can't simply clear the timeout on cancel since
           // the onPending promise would never settle in that case
           canceled = true
-        }
+        },
+        // no error message for custodial zaps
+        hideError: true
       }
     }
   )

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -77,7 +77,7 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
     onClose()
   }, [me, act, down, itemId, strike])
 
-  const onSubmitWithToast = withToastFlow(toaster)(
+  const onSubmitWithUndos = withToastFlow(toaster)(
     (values, args) => {
       const delay = 5000
       let canceled
@@ -143,7 +143,7 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
       }}
       schema={amountSchema}
       invoiceable
-      onSubmit={onSubmitWithToast}
+      onSubmit={onSubmitWithUndos}
     >
       <Input
         label='amount'
@@ -305,7 +305,7 @@ export function useZap () {
       strike()
     }, [act, strike])
 
-  const zapWithToast = withToastFlow(toaster)(
+  const zapWithUndos = withToastFlow(toaster)(
     ({ variables, optimisticResponse, update, flowId }) => {
       const { id: itemId, amount } = variables
       const delay = 5000
@@ -379,7 +379,7 @@ export function useZap () {
       if (insufficientFunds) throw new Error('insufficient funds')
       strike()
       if (me?.privates?.zapUndos) {
-        await zapWithToast(zapArgs)
+        await zapWithUndos(zapArgs)
       } else {
         await zap(zapArgs)
       }

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -7,7 +7,7 @@ import UpBolt from '../svgs/bolt.svg'
 import { amountSchema } from '../lib/validate'
 import { gql, useApolloClient, useMutation } from '@apollo/client'
 import { payOrLoginError, useInvoiceModal } from './invoice'
-import { useToast, withToastFlow } from './toast'
+import { TOAST_DEFAULT_DELAY_MS, useToast, withToastFlow } from './toast'
 import { useLightning } from './lightning'
 
 const defaultTips = [100, 1000, 10000, 100000]
@@ -79,7 +79,6 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
 
   const onSubmitWithUndos = withToastFlow(toaster)(
     (values, args) => {
-      const delay = 5000
       const { flowId } = args
       let canceled
       const sats = values.amount
@@ -125,7 +124,7 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
                   undoUpdate()
                   reject(err)
                 })
-            }, delay)
+            }, TOAST_DEFAULT_DELAY_MS)
           })
         },
         onUndo: () => {
@@ -311,7 +310,6 @@ export function useZap () {
   const zapWithUndos = withToastFlow(toaster)(
     ({ variables, optimisticResponse, update, flowId }) => {
       const { id: itemId, amount } = variables
-      const delay = 5000
       let canceled
       // update function for optimistic UX
       const _update = () => {
@@ -345,7 +343,7 @@ export function useZap () {
                   reject(err)
                 })
               },
-              delay
+              TOAST_DEFAULT_DELAY_MS
             )
           }),
         onUndo: () => {

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -80,6 +80,7 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
   const onSubmitWithUndos = withToastFlow(toaster)(
     (values, args) => {
       const delay = 5000
+      const { flowId } = args
       let canceled
       const sats = values.amount
       // update function for optimistic UX
@@ -103,7 +104,6 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
         actUpdate(client.cache, { data: optimisticResponse })
         return () => client.cache.writeFragment({ ...fragment, data: item })
       }
-      const flowId = (+new Date()).toString(16)
       let undoUpdate
       return {
         flowId,

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -310,10 +310,15 @@ export function useZap () {
     const insufficientFunds = me?.privates.sats < sats
     const optimisticResponse = { act: { path: item.path, ...variables } }
     const flowId = (+new Date()).toString(16)
+    const zapArgs = { variables, optimisticResponse: insufficientFunds ? null : optimisticResponse, update, flowId }
     try {
       if (insufficientFunds) throw new Error('insufficient funds')
       strike()
-      await zapWithToast({ variables, optimisticResponse: insufficientFunds ? null : optimisticResponse, update, flowId })
+      if (me?.privates?.zapUndos) {
+        await zapWithToast(zapArgs)
+      } else {
+        await zap(zapArgs)
+      }
     } catch (error) {
       if (payOrLoginError(error)) {
         // call non-idempotent version

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -94,6 +94,7 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
             path
             sats
             meSats
+            meDontLikeSats
           }
         `
         }
@@ -110,7 +111,7 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
       return {
         flowId,
         type: 'zap',
-        pendingMessage: `zapped ${sats} sats`,
+        pendingMessage: `${down ? 'down' : ''}zapped ${sats} sats`,
         onPending: async () => {
           await strike()
           onClose()

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -286,7 +286,7 @@ export function useZap () {
           canceled = true
           undoUpdate?.()
         },
-        // no error message for custodial zaps
+        hideSuccess: true,
         hideError: true
       }
     }

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -243,7 +243,7 @@ export function useZap () {
 
   const zapWithToast = withToastFlow(toaster)(
     ({ variables, optimisticResponse, update, flowId }) => {
-      const itemId = variables.id
+      const { id: itemId, amount } = variables
       const delay = 5000
       let canceled
       // update function for optimistic UX
@@ -266,6 +266,7 @@ export function useZap () {
       return {
         flowId,
         type: 'zap',
+        pendingMessage: `zapped ${amount} sats`,
         onPending: () =>
           new Promise((resolve, reject) => {
             undoUpdate = _update()
@@ -305,7 +306,7 @@ export function useZap () {
       sats = meSats + sats
     }
 
-    const variables = { id: item.id, sats, act: 'TIP' }
+    const variables = { id: item.id, sats, act: 'TIP', amount: sats - meSats }
     const insufficientFunds = me?.privates.sats < sats
     const optimisticResponse = { act: { path: item.path, ...variables } }
     const flowId = (+new Date()).toString(16)

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -83,6 +83,8 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
       const { flowId } = args
       let canceled
       const sats = values.amount
+      const insufficientFunds = me?.privates?.sats < sats
+      if (insufficientFunds) throw new Error('insufficient funds')
       // update function for optimistic UX
       const update = () => {
         const fragment = {

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -286,7 +286,8 @@ export function useZap () {
     const optimisticResponse = { act: { path: item.path, ...variables } }
     const flowId = (+new Date()).toString(16)
     try {
-      if (!insufficientFunds) strike()
+      if (insufficientFunds) throw new Error('insufficient funds')
+      strike()
       await zapWithToast({ variables, optimisticResponse: insufficientFunds ? null : optimisticResponse, flowId })
     } catch (error) {
       if (payOrLoginError(error)) {

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -373,7 +373,7 @@ export function useZap () {
     }
 
     const variables = { id: item.id, sats, act: 'TIP', amount: sats - meSats }
-    const insufficientFunds = me?.privates.sats < sats
+    const insufficientFunds = me?.privates.sats < (sats - meSats)
     const optimisticResponse = { act: { path: item.path, ...variables } }
     const flowId = (+new Date()).toString(16)
     const zapArgs = { variables, optimisticResponse: insufficientFunds ? null : optimisticResponse, update, flowId }

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -280,7 +280,7 @@ export function useZap () {
               delay
             )
           }),
-        onCancel: () => {
+        onUndo: () => {
           // we can't simply clear the timeout on cancel since
           // the onPending promise would never settle in that case
           canceled = true

--- a/components/toast.js
+++ b/components/toast.js
@@ -8,6 +8,8 @@ import styles from './toast.module.css'
 
 const ToastContext = createContext(() => {})
 
+export const TOAST_DEFAULT_DELAY_MS = 5000
+
 export const ToastProvider = ({ children }) => {
   const router = useRouter()
   const [toasts, setToasts] = useState([])
@@ -62,7 +64,7 @@ export const ToastProvider = ({ children }) => {
         body,
         variant: 'success',
         autohide: true,
-        delay: 5000,
+        delay: TOAST_DEFAULT_DELAY_MS,
         tag: options?.tag || body,
         ...options
       }
@@ -73,7 +75,7 @@ export const ToastProvider = ({ children }) => {
         body,
         variant: 'warning',
         autohide: true,
-        delay: 5000,
+        delay: TOAST_DEFAULT_DELAY_MS,
         tag: options?.tag || body,
         ...options
       }
@@ -134,6 +136,7 @@ export const ToastProvider = ({ children }) => {
     <ToastContext.Provider value={toaster}>
       <ToastContainer className={`pb-3 pe-3 ${styles.toastContainer}`} position='bottom-end' containerPosition='fixed'>
         {visibleToasts.map(toast => {
+          console.log('variant', toast.variant)
           const textStyle = toast.variant === 'warning' ? 'text-dark' : ''
           const onClose = () => {
             toast.onUndo?.()
@@ -163,6 +166,7 @@ export const ToastProvider = ({ children }) => {
                   </Button>
                 </div>
               </ToastBody>
+              {toast.delay > 0 && <div className={`${styles.progressBar} ${styles[toast.variant]}`} />}
             </Toast>
           )
         })}

--- a/components/toast.js
+++ b/components/toast.js
@@ -136,7 +136,6 @@ export const ToastProvider = ({ children }) => {
     <ToastContext.Provider value={toaster}>
       <ToastContainer className={`pb-3 pe-3 ${styles.toastContainer}`} position='bottom-end' containerPosition='fixed'>
         {visibleToasts.map(toast => {
-          console.log('variant', toast.variant)
           const textStyle = toast.variant === 'warning' ? 'text-dark' : ''
           const onClose = () => {
             toast.onUndo?.()

--- a/components/toast.js
+++ b/components/toast.js
@@ -94,7 +94,7 @@ export const ToastProvider = ({ children }) => {
   // Only clear toasts with no cancel function on page navigation
   // since navigation should not interfere with being able to cancel an action.
   useEffect(() => {
-    const handleRouteChangeStart = () => setToasts(toasts => toasts.filter(({ onCancel }) => onCancel), [])
+    const handleRouteChangeStart = () => setToasts(toasts => toasts.filter(({ onCancel, onUndo }) => onCancel || onUndo), [])
     router.events.on('routeChangeStart', handleRouteChangeStart)
 
     return () => {

--- a/components/toast.js
+++ b/components/toast.js
@@ -175,7 +175,8 @@ export const withToastFlow = (toaster) => flowFn => {
       onPending,
       onSuccess,
       onCancel,
-      onError
+      onError,
+      hideError
     } = flowFn(...args)
     let canceled
     toaster.warning(`${t} pending`, {
@@ -202,7 +203,12 @@ export const withToastFlow = (toaster) => flowFn => {
       // ignore errors if canceled since they might be caused by cancellation
       if (canceled) return
       const reason = err?.message?.toString().toLowerCase() || 'unknown reason'
-      toaster.danger(`${t} failed: ${reason}`, { flowId })
+      if (hideError) {
+        // XXX HACK to end flow by using flow toast which immediately closes itself
+        toaster.warning('', { delay: 0, autohide: true, flowId })
+      } else {
+        toaster.danger(`${t} failed: ${reason}`, { flowId })
+      }
       await onError?.()
       throw err
     }

--- a/components/toast.js
+++ b/components/toast.js
@@ -142,7 +142,7 @@ export const ToastProvider = ({ children }) => {
             removeToast(toast)
           }
           const buttonElement = toast.onUndo
-            ? <div className={`${styles.toastUndo} ${textStyle}`}>[undo]</div>
+            ? <div className={`${styles.toastUndo} ${textStyle}`}>undo</div>
             : toast.onCancel
               ? <div className={`${styles.toastCancel} ${textStyle}`}>cancel</div>
               : <div className={`${styles.toastClose} ${textStyle}`}>X</div>

--- a/components/toast.js
+++ b/components/toast.js
@@ -18,6 +18,7 @@ export const ToastProvider = ({ children }) => {
   const dispatchToast = useCallback((toast) => {
     toast = {
       ...toast,
+      createdAt: +new Date(),
       id: toastId.current++
     }
     const { flowId } = toast
@@ -148,6 +149,7 @@ export const ToastProvider = ({ children }) => {
             : toast.onCancel
               ? <div className={`${styles.toastCancel} ${textStyle}`}>cancel</div>
               : <div className={`${styles.toastClose} ${textStyle}`}>X</div>
+          const elapsed = (+new Date() - toast.createdAt)
           return (
             <Toast
               key={toast.id} bg={toast.variant} show autohide={toast.autohide}
@@ -165,7 +167,7 @@ export const ToastProvider = ({ children }) => {
                   </Button>
                 </div>
               </ToastBody>
-              {toast.delay > 0 && <div className={`${styles.progressBar} ${styles[toast.variant]}`} />}
+              {toast.delay > 0 && <div className={`${styles.progressBar} ${styles[toast.variant]}`} style={{ animationDelay: `-${elapsed}ms` }} />}
             </Toast>
           )
         })}

--- a/components/toast.module.css
+++ b/components/toast.module.css
@@ -1,5 +1,5 @@
 .toastContainer {
-  transform: translate3d(0,0,0);
+  transform: translate3d(0, 0, 0);
 }
 
 .toast {
@@ -44,6 +44,38 @@
   cursor: pointer;
   display: flex;
   align-items: center;
+}
+
+.progressBar {
+  width: 0;
+  height: 5px;
+  filter: brightness(66%);
+  /* same duration as toast delay */
+  animation: progressBar 5s linear;
+}
+
+.progressBar.success {
+  background-color: var(--bs-success);
+}
+
+.progressBar.danger {
+  background-color: var(--bs-danger);
+}
+
+.progressBar.warning {
+  background-color: var(--bs-warning);
+}
+
+
+
+@keyframes progressBar {
+  0% {
+    width: 0;
+  }
+
+  100% {
+    width: 100%;
+  }
 }
 
 .toastClose:hover {

--- a/components/toast.module.css
+++ b/components/toast.module.css
@@ -21,6 +21,13 @@
   border-color: var(--bs-warning-border-subtle);
 }
 
+.toastUndo {
+  font-style: normal;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+
 .toastCancel {
   font-style: italic;
   cursor: pointer;

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -82,9 +82,9 @@ function RawWebLNProvider ({ children }) {
   `)
 
   const sendPaymentWithToast = withToastFlow(toaster)(
-    ({ bolt11, hash, hmac }) => {
+    ({ bolt11, hash, hmac, flowId }) => {
       return {
-        flowId: hash,
+        flowId: flowId || hash,
         type: 'payment',
         onPending: () => provider.sendPayment(bolt11),
         // hash and hmac are only passed for JIT invoices

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -39,6 +39,7 @@ export const ME = gql`
         tipDefault
         tipPopover
         turboTipping
+        zapUndos
         upvotePopover
         wildWestMode
         withdrawMaxFeeDefault
@@ -62,6 +63,7 @@ export const SETTINGS_FIELDS = gql`
     privates {
       tipDefault
       turboTipping
+      zapUndos
       fiatCurrency
       withdrawMaxFeeDefault
       noteItemSats

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -175,9 +175,8 @@ export default function Settings ({ ssrData }) {
                       <div className='d-flex align-items-center'>zap undos
                         <Info>
                           <ul className='fw-bold'>
-                            <li>A notification will be shown after every zap</li>
-                            <li>The notification includes a button to undo the zap</li>
-                            <li>The notification is only shown for 5 seconds</li>
+                            <li>An undo button is shown after every zap</li>
+                            <li>The button is shown for 5 seconds</li>
                           </ul>
                         </Info>
                       </div>

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -63,6 +63,7 @@ export default function Settings ({ ssrData }) {
           initial={{
             tipDefault: settings?.tipDefault || 21,
             turboTipping: settings?.turboTipping,
+            zapUndos: settings?.zapUndos,
             fiatCurrency: settings?.fiatCurrency || 'USD',
             withdrawMaxFeeDefault: settings?.withdrawMaxFeeDefault,
             noteItemSats: settings?.noteItemSats,
@@ -139,32 +140,51 @@ export default function Settings ({ ssrData }) {
             <AccordianItem
               show={settings?.turboTipping}
               header={<div style={{ fontWeight: 'bold', fontSize: '92%' }}>advanced</div>}
-              body={<Checkbox
-                name='turboTipping'
-                label={
-                  <div className='d-flex align-items-center'>turbo zapping
-                    <Info>
-                      <ul className='fw-bold'>
-                        <li>Makes every additional bolt click raise your total zap to another 10x multiple of your default zap</li>
-                        <li>e.g. if your zap default is 10 sats
-                          <ul>
-                            <li>1st click: 10 sats total zapped</li>
-                            <li>2nd click: 100 sats total zapped</li>
-                            <li>3rd click: 1000 sats total zapped</li>
-                            <li>4th click: 10000 sats total zapped</li>
-                            <li>and so on ...</li>
+              body={
+                <>
+                  <Checkbox
+                    name='turboTipping'
+                    label={
+                      <div className='d-flex align-items-center'>turbo zapping
+                        <Info>
+                          <ul className='fw-bold'>
+                            <li>Makes every additional bolt click raise your total zap to another 10x multiple of your default zap</li>
+                            <li>e.g. if your zap default is 10 sats
+                              <ul>
+                                <li>1st click: 10 sats total zapped</li>
+                                <li>2nd click: 100 sats total zapped</li>
+                                <li>3rd click: 1000 sats total zapped</li>
+                                <li>4th click: 10000 sats total zapped</li>
+                                <li>and so on ...</li>
+                              </ul>
+                            </li>
+                            <li>You can still custom zap via long press
+                              <ul>
+                                <li>the next bolt click rounds up to the next greatest 10x multiple of your default</li>
+                              </ul>
+                            </li>
                           </ul>
-                        </li>
-                        <li>You can still custom zap via long press
-                          <ul>
-                            <li>the next bolt click rounds up to the next greatest 10x multiple of your default</li>
+                        </Info>
+                      </div>
+                    }
+                    groupClassName='mb-0'
+                  />
+                  <Checkbox
+                    name='zapUndos'
+                    label={
+                      <div className='d-flex align-items-center'>zap undos
+                        <Info>
+                          <ul className='fw-bold'>
+                            <li>A notification will be shown after every zap</li>
+                            <li>The notification includes a button to undo the zap</li>
+                            <li>The notification is only shown for 5 seconds</li>
                           </ul>
-                        </li>
-                      </ul>
-                    </Info>
-                  </div>
-                  }
-                    />}
+                        </Info>
+                      </div>
+                    }
+                  />
+                </>
+              }
             />
           </div>
           <Select

--- a/prisma/migrations/20240219225338_zap_undos/migration.sql
+++ b/prisma/migrations/20240219225338_zap_undos/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "zapUndos" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,6 +55,7 @@ model User {
   autoDropBolt11s           Boolean              @default(false)
   hideFromTopUsers          Boolean              @default(false)
   turboTipping              Boolean              @default(false)
+  zapUndos                  Boolean              @default(false)
   imgproxyOnly              Boolean              @default(false)
   hideWalletBalance         Boolean              @default(false)
   referrerId                Int?


### PR DESCRIPTION
Based on #856 

This prepends a toast flow to the existing payment flow to allow zap cancellation: "zap undo's".

Zaps are not really undone but only get triggered after a few seconds. What undoing actually means is to abort the pending zap.

If a zap failed because of insufficient funds and a wallet for sending is attached, the flow continues with the attached wallet.

Current state (ef544d09):

https://github.com/stackernews/stacker.news/assets/27162016/5f2f180d-7020-4699-bc5d-c42cc1484cb9

TODO:

- [x] [UX] hide the "insufficient funds" error if it gets replaced by "payment pending" shortly after for UX reasons
- [x] [UX] immediately show the QR code if we already know the user has not enough funds and there is no wallet attached
- [x] [UX] optimistic UX - use cache updates with lightning strikes before zap is actually triggered and undo on cancel (similar to how optimistic UX is implemented in the WebLN payment flow). Rename "cancel" to "undo" then and make toast more compact.
- [x] [feature] also add undo to custom / long press zaps
- [x] [feature] add setting for this which is off by default
- [x] ~[bug] fix undo does not undo changes to ancestors~ _(unrelated to this PR, was already an issue, will do in following PR)_
- [x] ~[UX] also deduct sats from user balance during cache updates for optimistic UX~ _(unrelated to this PR, was already an issue, will do in following PR)_
- [x] ~[feature] also add undo to bounty zaps~ _(not needed imo, there is already a confirm prompt which prevents missclicks)_
- [x] ~[refactor] manual cache updates and undoing is implemented weird. also includes bugs (see "fix undo does not undo changes to ancestors" above) and duplicate code. is there better way to do the same thing? are there apollo features we could use for this ("local mutations")?~ _(unrelated to this PR, was already an issue, will do in following PR)_