### PR TITLE
Show founded territories on profile

### DIFF
--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -698,6 +698,23 @@ export default {
         }
       })
     },
+    nterritories: async (user, { when, from, to }, { models }) => {
+      if (typeof user.nterritories !== 'undefined') {
+        return user.nterritories
+      }
+
+      const [gte, lte] = whenRange(when, from, to)
+      return await models.sub.count({
+        where: {
+          userId: user.id,
+          status: 'ACTIVE',
+          createdAt: {
+            gte,
+            lte
+          }
+        }
+      })
+    },
     bio: async (user, args, { models, me }) => {
       return getItem(user, { id: user.bioId }, { models, me })
     }

--- a/api/typeDefs/sub.js
+++ b/api/typeDefs/sub.js
@@ -6,6 +6,7 @@ export default gql`
     subLatestPost(name: String!): String
     subs: [Sub!]!
     topSubs(cursor: String, when: String, from: String, to: String, by: String, limit: Limit): Subs
+    userSubs(name: String!, cursor: String, when: String, from: String, to: String, by: String, limit: Limit): Subs
   }
 
   type Subs {

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -39,6 +39,7 @@ export default gql`
     name: String
     nitems(when: String, from: String, to: String): Int!
     nposts(when: String, from: String, to: String): Int!
+    nterritories(when: String, from: String, to: String): Int!
     ncomments(when: String, from: String, to: String): Int!
     bio: Item
     bioId: Int

--- a/components/user-header.js
+++ b/components/user-header.js
@@ -32,21 +32,25 @@ import TwitterIcon from '../svgs/twitter-fill.svg'
 export default function UserHeader ({ user }) {
   const router = useRouter()
 
+  const pathParts = router.asPath.split('/')
+  const activeKey = pathParts[2] === 'territories' ? 'territories' : pathParts.length === 2 ? 'bio' : 'items'
+  const showTerritoriesTab = activeKey === 'territories' || user.nterritories > 0
+
   return (
     <>
       <HeaderHeader user={user} />
       <Nav
         className={styles.nav}
-        activeKey={!!router.asPath.split('/')[2]}
+        activeKey={activeKey}
       >
         <Nav.Item>
           <Link href={'/' + user.name} passHref legacyBehavior>
-            <Nav.Link eventKey={false}>bio</Nav.Link>
+            <Nav.Link eventKey='bio'>bio</Nav.Link>
           </Link>
         </Nav.Item>
         <Nav.Item>
           <Link href={'/' + user.name + '/all'} passHref legacyBehavior>
-            <Nav.Link eventKey>
+            <Nav.Link eventKey='items'>
               {numWithUnits(user.nitems, {
                 abbreviate: false,
                 unitSingular: 'item',
@@ -55,6 +59,19 @@ export default function UserHeader ({ user }) {
             </Nav.Link>
           </Link>
         </Nav.Item>
+        {showTerritoriesTab && (
+          <Nav.Item>
+            <Link href={'/' + user.name + '/territories'} passHref legacyBehavior>
+              <Nav.Link eventKey='territories'>
+                {numWithUnits(user.nterritories, {
+                  abbreviate: false,
+                  unitSingular: 'territory',
+                  unitPlural: 'territories'
+                })}
+              </Nav.Link>
+            </Link>
+          </Nav.Item>
+        )}
       </Nav>
     </>
   )

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -1,6 +1,7 @@
 import { gql } from '@apollo/client'
 import { COMMENTS, COMMENTS_ITEM_EXT_FIELDS } from './comments'
 import { ITEM_FIELDS, ITEM_FULL_FIELDS } from './items'
+import { SUB_FULL_FIELDS } from './subs'
 
 export const ME = gql`
   {
@@ -282,3 +283,26 @@ export const USER_WITH_ITEMS = gql`
       }
     }
   }`
+
+export const USER_WITH_SUBS = gql`
+    ${USER_FIELDS}
+    ${SUB_FULL_FIELDS}
+    query UserWithSubs($name: String!, $cursor: String, $type: String, $when: String, $from: String, $to: String, $by: String) {
+      user(name: $name) {
+        ...UserFields
+      }
+      userSubs(name: $name, cursor: $cursor) {
+        cursor
+        subs {
+          ...SubFullFields
+          ncomments(when: "forever")
+          nposts(when: "forever")
+
+          optional {
+            stacked(when: "forever")
+            spent(when: "forever")
+            revenue(when: "forever")
+          }
+        }
+      }
+    }`

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -182,6 +182,7 @@ export const USER_FIELDS = gql`
     since
     photoId
     nitems
+    nterritories
     meSubscriptionPosts
     meSubscriptionComments
     meMute

--- a/pages/[name]/territories.js
+++ b/pages/[name]/territories.js
@@ -1,0 +1,33 @@
+import { getGetServerSideProps } from '../../api/ssrApollo'
+import { useRouter } from 'next/router'
+import { USER, USER_WITH_SUBS } from '../../fragments/users'
+import { useQuery } from '@apollo/client'
+import PageLoading from '../../components/page-loading'
+import { UserLayout } from '.'
+import TerritoryList from '../../components/territory-list'
+
+export const getServerSideProps = getGetServerSideProps({ query: USER_WITH_SUBS })
+
+export default function UserTerritories ({ ssrData }) {
+  const router = useRouter()
+  const variables = { ...router.query }
+
+  const { data } = useQuery(USER, { variables })
+  if (!data && !ssrData) return <PageLoading />
+
+  const { user } = data || ssrData
+
+  return (
+    <UserLayout user={user}>
+      <div className='mt-2'>
+        <TerritoryList
+          ssrData={ssrData}
+          query={USER_WITH_SUBS}
+          variables={variables}
+          destructureData={data => data.userSubs}
+          rank
+        />
+      </div>
+    </UserLayout>
+  )
+}


### PR DESCRIPTION
Closes https://github.com/stackernews/stacker.news/issues/847

- Shows "territories" tab on profile if user founded any active territories
- User territories page lists active territories founded by the user, ordered by stacked

<details>
<summary>Screenshots</summary>

#### Territories tab hidden if user hasn't founded territories
<img width="722" alt="Screenshot 2024-02-21 at 2 42 40 PM" src="https://github.com/stackernews/stacker.news/assets/158518982/d2f4f54e-4d25-4e50-815b-93cbd47b585a">

#### User territories page if user has founded territories
<img width="943" alt="Screenshot 2024-02-21 at 2 42 08 PM" src="https://github.com/stackernews/stacker.news/assets/158518982/6e039dd0-aec3-43f9-b007-b62164437b25">

</details>