### PR TITLE
Fix toast progress bar desync

### DIFF
--- a/components/toast.js
+++ b/components/toast.js
@@ -160,7 +160,7 @@ export const ToastProvider = ({ children }) => {
           // a toast is unhidden if it was hidden before since it now gets rendered
           const unhidden = toast.hidden
           // we only need to start the animation at a different timing when it was hidden by another toast before.
-          // else the animation for rerendered toasts jumps and toast delay and animatino get out of sync.
+          // if we don't do this, the animation for rerendered toasts skips ahead and toast delay and animation get out of sync.
           const elapsed = (+new Date() - toast.createdAt)
           const animationDelay = unhidden ? `-${elapsed}ms` : undefined
           return (


### PR DESCRIPTION
If a toast gets rendered again with the same animation-delay, the negative animation-delay seems to get added which means that the animation skips ahead.

This commit fixes that by ensuring that animation-delay is only set if the toast was not rendered before.

Before:

_notice how the progress bar for `subscribed` gets out of sync when `unsubscribed` gets rendered for the first time and how `unsubscribed`'s progress bar gets out of sync when it gets rendered again due to `subscribed` disappearing. progress bar for toasts that were hidden before are not out of sync._

https://github.com/stackernews/stacker.news/assets/27162016/73d5d41c-b394-4bb1-8b2f-e12d555b7481

Now:

_no progress bar desyncs anymore._

https://github.com/stackernews/stacker.news/assets/27162016/29963650-d167-4f44-b74d-be5b7b317de0

