### PR TITLE
More zap undo fixes

### DIFF
--- a/components/item-act.js
+++ b/components/item-act.js
@@ -83,7 +83,8 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
       let canceled
       const sats = values.amount
       const insufficientFunds = me?.privates?.sats < sats
-      if (insufficientFunds) throw new Error('insufficient funds')
+      const invoiceAttached = values.hash && values.hmac
+      if (insufficientFunds && !invoiceAttached) throw new Error('insufficient funds')
       // update function for optimistic UX
       const update = () => {
         const fragment = {

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -85,6 +85,9 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
       const insufficientFunds = me?.privates?.sats < sats
       const invoiceAttached = values.hash && values.hmac
       if (insufficientFunds && !invoiceAttached) throw new Error('insufficient funds')
+      // payments from external wallets already have their own flow
+      // and we don't want to show undo toasts for them
+      const skipToastFlow = invoiceAttached
       // update function for optimistic UX
       const update = () => {
         const fragment = {
@@ -109,10 +112,14 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
       }
       let undoUpdate
       return {
+        skipToastFlow,
         flowId,
         type: 'zap',
         pendingMessage: `${down ? 'down' : ''}zapped ${sats} sats`,
         onPending: async () => {
+          if (skipToastFlow) {
+            return onSubmit(values, { flowId, ...args, update: null })
+          }
           await strike()
           onClose()
           return new Promise((resolve, reject) => {

--- a/components/toast.js
+++ b/components/toast.js
@@ -180,7 +180,7 @@ export const ToastProvider = ({ children }) => {
                   </Button>
                 </div>
               </ToastBody>
-              {toast.delay > 0 && <div className={`${styles.progressBar} ${styles[toast.variant]}`} style={{ animationDelay }} />}
+              {toast.onUndo && toast.delay > 0 && <div className={`${styles.progressBar} ${styles[toast.variant]}`} style={{ animationDelay }} />}
             </Toast>
           )
         })}

--- a/components/toast.js
+++ b/components/toast.js
@@ -205,9 +205,12 @@ export const withToastFlow = (toaster) => flowFn => {
       onUndo,
       hideError,
       hideSuccess,
+      skipToastFlow,
       ...toastProps
     } = flowFn(...args)
     let canceled
+
+    if (skipToastFlow) return onPending()
 
     // XXX HACK this ends the flow by using flow toast which immediately closes itself
     const endFlow = () => toaster.warning('', { ...toastProps, delay: 0, autohide: true, flowId })

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -176,6 +176,12 @@ export default function Settings ({ ssrData }) {
                           <ul className='fw-bold'>
                             <li>An undo button is shown after every zap</li>
                             <li>The button is shown for 5 seconds</li>
+                            <li>
+                              The button is only shown for zaps from the custodial wallet
+                            </li>
+                            <li>
+                              Use a budget or manual approval with attached wallets
+                            </li>
                           </ul>
                         </Info>
                       </div>


### PR DESCRIPTION
TODO:

- [x] fix progress bar shown for toasts without undo (012c5dff)
- [x] fix "insufficient funds" shortcut error thrown on client even with invoice attached (484303fc)
- [x] fix zap undo shown after external payment success (88ec8d74)
- [x] mention that zap undos are limited to custodial zaps (2211d13c)
- [ ] fix missing progress bar for pending payment toasts