### PR TITLE
Drop unused function signature of create_item

### DIFF
--- a/prisma/migrations/20240224220605_remove_unused_create_item_function/migration.sql
+++ b/prisma/migrations/20240224220605_remove_unused_create_item_function/migration.sql
@@ -1,0 +1,3 @@
+-- drop unused create_item function
+
+DROP FUNCTION IF EXISTS create_item(jsonb, jsonb, jsonb, interval);


### PR DESCRIPTION
We only use `create_item` at a single location:

https://github.com/stackernews/stacker.news/blob/a067a9fcf113954ca9a73ddc71db4220e9e801d6/api/resolvers/item.js#L1332-L1337

It uses the function signature with integer[] at the end.