### PR TITLE
Fix out of order undos for turbo zaps

### DIFF
--- a/components/item-act.js
+++ b/components/item-act.js
@@ -338,6 +338,7 @@ export function useZap () {
       let undoUpdate
       return {
         flowId,
+        tag: itemId,
         type: 'zap',
         pendingMessage: `zapped ${amount} sats`,
         onPending: () =>

--- a/components/toast.js
+++ b/components/toast.js
@@ -127,13 +127,12 @@ export const ToastProvider = ({ children }) => {
 
     // merge toasts with same tag
     const prevToast = toasts[idx]
-    let { rawBody, body, amount } = prevToast
-    rawBody ??= body
+    let { amount } = prevToast
     amount = amount ? amount + 1 : 2
-    body = `(${amount}) ${rawBody}`
+    const body = `(${amount}) ${toast.body}`
     return [
       ...toasts.slice(0, idx),
-      { ...toast, rawBody, amount, body },
+      { ...toast, amount, body },
       ...toasts.slice(idx + 1)
     ]
   }


### PR DESCRIPTION
Turbo zaps had different toast bodies so they weren't merged together. This gave stackers the option to undo these zaps out of order.

When zaps are undone out of order, the client cache can get in a bad state. Using the item id as a tag fixes that such that zaps for the same item will always get merged together.

This can be seen as a workaround for hacky zap undo code but I think it's also better UX so maybe we should do this anyway.