### PR TITLE
Drop noteTerritoryPosts column

### DIFF
--- a/prisma/migrations/20240228031956_drop_note_territory_posts_column/migration.sql
+++ b/prisma/migrations/20240228031956_drop_note_territory_posts_column/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `noteTerritoryPosts` on the `users` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "noteTerritoryPosts";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,7 +41,6 @@ model User {
   noteItemSats              Boolean              @default(true)
   noteMentions              Boolean              @default(true)
   noteForwardedSats         Boolean              @default(true)
-  noteTerritoryPosts        Boolean              @default(true)
   lastCheckedJobs           DateTime?
   noteJobIndicator          Boolean              @default(true)
   photoId                   Int?


### PR DESCRIPTION
I've seen that I forgot to add the column back into the Prisma schema for backwards compatibility in https://github.com/stackernews/stacker.news/commit/cd4f24310611c936523bf317eab49b911b80483c but it should be safe to drop now.