### PR TITLE
Fix alignment of info icon

### DIFF
--- a/components/info.js
+++ b/components/info.js
@@ -11,7 +11,7 @@ export default function Info ({ children, label, iconClassName = 'fill-theme-col
         e.preventDefault()
         showModal(onClose => children)
       }}
-      className='pointer'
+      className='d-flex align-items-center pointer'
     >
       <InfoIcon
         width={18} height={18} className={`${iconClassName} mx-1`}


### PR DESCRIPTION
The info icon was not vertically centered (see video), this PR fixes that.

https://github.com/stackernews/stacker.news/assets/27162016/6dc171bf-27db-497f-8d22-c05c88011b7d

