### PR TITLE
Fix image rerender jitter and layout shift

### DIFF
--- a/components/block-height.js
+++ b/components/block-height.js
@@ -20,7 +20,7 @@ export const BlockHeightProvider = ({ blockHeight, children }) => {
   })
   const value = useMemo(() => ({
     height: data?.blockHeight ?? blockHeight ?? 0
-  }), [data, blockHeight])
+  }), [data?.blockHeight, blockHeight])
   return (
     <BlockHeightContext.Provider value={value}>
       {children}

--- a/components/chain-fee.js
+++ b/components/chain-fee.js
@@ -20,7 +20,7 @@ export const ChainFeeProvider = ({ chainFee, children }) => {
   })
   const value = useMemo(() => ({
     fee: Math.floor(data?.chainFee ?? chainFee ?? 0)
-  }), [data, chainFee])
+  }), [data?.chainFee, chainFee])
   return (
     <ChainFeeContext.Provider value={value}>
       {children}

--- a/components/text.js
+++ b/components/text.js
@@ -20,6 +20,7 @@ import { Button } from 'react-bootstrap'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { UNKNOWN_LINK_REL } from '../lib/constants'
+import isEqual from 'lodash/isEqual'
 
 export function SearchText ({ text }) {
   return (
@@ -34,7 +35,7 @@ export function SearchText ({ text }) {
 }
 
 // this is one of the slowest components to render
-export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, outlawed, ...outerProps }) {
+export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, outlawed, topLevel, noFragments }) {
   const [overflowing, setOverflowing] = useState(false)
   const router = useRouter()
   const [show, setShow] = useState(false)
@@ -79,7 +80,6 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
 
   const Heading = useCallback(({ children, node, ...props }) => {
     const [copied, setCopied] = useState(false)
-    const { noFragments, topLevel } = outerProps
     const id = useMemo(() =>
       noFragments ? undefined : slugger?.slug(toString(node).replace(/[^\w\-\s]+/gi, '')), [node, noFragments, slugger])
     const h = useMemo(() => {
@@ -114,7 +114,7 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
           </a>}
       </span>
     )
-  }, [outerProps, slugger.current])
+  }, [topLevel, noFragments, slugger.current])
 
   const Table = useCallback(({ node, ...props }) =>
     <span className='table-responsive'>
@@ -144,8 +144,8 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
       return url
     }
     const srcSet = imgproxyUrls?.[url]
-    return <ZoomableImage srcSet={srcSet} tab={tab} src={src} rel={rel ?? UNKNOWN_LINK_REL} {...props} {...outerProps} />
-  }, [imgproxyUrls, outerProps, tab])
+    return <ZoomableImage srcSet={srcSet} tab={tab} src={src} rel={rel ?? UNKNOWN_LINK_REL} {...props} topLevel />
+  }, [imgproxyUrls, topLevel, tab])
 
   return (
     <div className={`${styles.text} ${show ? styles.textUncontained : overflowing ? styles.textContained : ''}`} ref={containerRef}>
@@ -208,7 +208,7 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
             const youtube = href.match(/(https?:\/\/)?((www\.)?(youtube(-nocookie)?|youtube.googleapis)\.com.*(v\/|v=|vi=|vi\/|e\/|embed\/|user\/.*\/u\/\d+\/)|youtu\.be\/)(?<id>[_0-9a-z-]+)((?:\?|&)(?:t|start)=(?<start>\d+))?/i)
             if (youtube?.groups?.id) {
               return (
-                <div style={{ maxWidth: outerProps.topLevel ? '640px' : '320px', paddingRight: '15px', margin: '0.5rem 0' }}>
+                <div style={{ maxWidth: topLevel ? '640px' : '320px', paddingRight: '15px', margin: '0.5rem 0' }}>
                   <YouTube
                     videoId={youtube.groups.id} className={styles.youtubeContainer} opts={{
                       playerVars: {
@@ -236,4 +236,4 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
         </Button>}
     </div>
   )
-})
+}, isEqual)

--- a/components/text.module.css
+++ b/components/text.module.css
@@ -129,22 +129,26 @@
 }
 
 .text img {
+    --height: 35vh;
+    --width: 100%;
     display: block;
     margin-top: .5rem;
     margin-bottom: .5rem;
     width: auto;
-    max-width: 100%;
+    max-width: min(var(--width), 100%);
     cursor: zoom-in;
-    max-height: 25vh;
+    height: auto;
+    max-height: min(var(--height), 25vh);
     object-fit: contain;
     object-position: left top;
     min-width: 50%;
+    aspect-ratio: var(--aspect-ratio);
 }
 
 .text img.topLevel {
     margin-top: .75rem;
     margin-bottom: .75rem;
-    max-height: 35vh;
+    max-height: min(var(--height), 35vh);
 }
 
 img.fullScreen {


### PR DESCRIPTION
closes #850 

This does a few things:

- use the imgproxy info api to get image dimensions
- take the above and set an aspect ratio on images and reserve layout space for it
- prevents rerendering of image by making sure the image itself is `memo`ed
- prevents imgproxyUrls from triggering rerenders of `Text` by `memo`ing with `_.isEqual`
    - memoing is always a bit more hacky than I'd like but doing it where there are known issues seems okay
    - this could be avoided by taking more care with non-primitive props generally
- prevents non-updates to blockheight and fee providers causing tree to rerender