### PR TITLE
Use keyset pagination for notifications

### DIFF
--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -14,3 +14,10 @@ export function nextCursorEncoded (cursor, limit = LIMIT) {
   cursor.offset += limit
   return Buffer.from(JSON.stringify(cursor)).toString('base64')
 }
+
+export function nextNoteCursorEncoded (cursor, notifications = [], limit = LIMIT) {
+  // what we are looking for this oldest sort time for every table we are looking at
+  cursor.time = new Date(notifications.slice(-1).pop()?.sortTime ?? cursor.time)
+  cursor.offset += limit
+  return Buffer.from(JSON.stringify(cursor)).toString('base64')
+}


### PR DESCRIPTION
This improves pagination performance of notifications by using the last page's eldest `sortTime` as a filter for the next page. Previously we were using an offset method of pagination.

Given that `sortTime` is not guaranteed to be unique, there is a small probability we'll miss things between pages. This will only occur if two notifications happen at exactly the same millisecond which is likely to be incredibly rare globally:

```
stackernews=# select count(DISTINCT created_at), count(*) from "Item";
 count  | count  
--------+--------
 438562 | 438562
```

And is likely to be even more rare for the notifications of a single stacker. And even more rare that such a notification exists at a page boundary. 

So, this is not ideal, but it is likely more than good enough in practice.