### PR TITLE
Enhance local dev env

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,16 +4,16 @@
 ############################################################################
 
 # github
-GITHUB_ID=<YOUR GITHUB ID>
-GITHUB_SECRET=<YOUR GITHUB SECRET>
+GITHUB_ID=
+GITHUB_SECRET=
 
 # twitter
-TWITTER_ID=<YOUR TWITTER ID>
-TWITTER_SECRET=<YOUR TWITTER SECRET>
+TWITTER_ID=
+TWITTER_SECRET=
 
 # email
-LOGIN_EMAIL_SERVER=smtp://<YOUR EMAIL>:<YOUR PASSWORD>@<YOUR SMTP DOMAIN>:587
-LOGIN_EMAIL_FROM=<YOUR FROM ALIAS>
+LOGIN_EMAIL_SERVER=
+LOGIN_EMAIL_FROM=
 LIST_MONK_AUTH=
 
 #####################################################################
@@ -48,16 +48,16 @@ OPENSEARCH_MODEL_ID=
 #######################################################
 
 # lnd
-LND_CERT=<YOUR LND HEX CERT>
-LND_MACAROON=<YOUR LND HEX MACAROON>
-LND_SOCKET=<YOUR LND GRPC HOST>:<YOUR LND GRPC PORT>
+LND_CERT=
+LND_MACAROON=
+LND_SOCKET=
 
 # lnurl
-LNAUTH_URL=<PUBLIC URL TO /api/lnauth>
-LNWITH_URL=<PUBLIC URL TO /api/lnwith>
+LNAUTH_URL=
+LNWITH_URL=
 
 # nostr (NIP-57 zap receipts)
-NOSTR_PRIVATE_KEY=<YOUR NOSTR PRIVATE KEY IN HEX>
+NOSTR_PRIVATE_KEY=
 
 ###############
 # LEAVE AS IS #

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ envbak
 .env.development.local
 .env.test.local
 .env.production.local
+.env.sndev
 
 # vercel
 .vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,6 @@ WORKDIR /app
 
 EXPOSE 3000
 
-CMD npm install --loglevel verbose --legacy-peer-deps; npx prisma migrate dev; npm run dev
+RUN npm install --loglevel verbose --legacy-peer-deps
+RUN npx prisma migrate dev
+CMD npm run dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,5 @@ WORKDIR /app
 
 EXPOSE 3000
 
-RUN npm install --loglevel verbose --legacy-peer-deps
-RUN npx prisma migrate dev
-CMD npm run dev
+RUN npm ci --loglevel verbose --legacy-peer-deps
+CMD npx prisma migrate dev && npm run dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,12 +9,19 @@ services:
     ports:
       - "5431:5432"
     env_file:
-      - ./.env.sample
+      - ./.env.sndev
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+        interval: 5s
+        timeout: 5s
+        retries: 5
     volumes:
+      - ./anon.sql:/docker-entrypoint-initdb.d/anon.sql
       - db:/var/lib/postgresql/data
   app:
     container_name: app
     build: ./
+    restart: always
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3000"]
       interval: 10s
@@ -22,9 +29,12 @@ services:
       retries: 10
       start_period: 1m30s
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     env_file:
-      - ./.env.sample
+      - ./.env.sndev
+    expose:
+      - "3000"
     ports:
       - "3000:3000"
     volumes:
@@ -35,13 +45,16 @@ services:
   worker:
     container_name: worker
     build: ./worker
+    restart: always
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy
       app:
         condition: service_healthy
+      opensearch:
+        condition: service_healthy
     env_file:
-      - ./.env.sample
+      - ./.env.sndev
     ports:
       - "8080:8080"
     volumes:
@@ -52,7 +65,7 @@ services:
       - opensearch
     entrypoint: ["/bin/sh", "-c"]
     command:
-      - npm run worker
+      - npm run worker:dev
   imgproxy:
     container_name: imgproxy
     image: darthsim/imgproxy:v3.18.1
@@ -63,7 +76,7 @@ services:
       retries: 3
     restart: always
     env_file:
-      - ./.env.sample
+      - ./.env.sndev
     expose:
       - "8080"
     ports:
@@ -73,6 +86,12 @@ services:
   opensearch:
     image: opensearchproject/opensearch:latest
     container_name: opensearch
+    healthcheck:
+      test: ["CMD-SHELL", "curl -ku admin:admin --silent --fail localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+    restart: always
     environment:
       - discovery.type=single-node
       - plugins.security.disabled=true
@@ -81,7 +100,6 @@ services:
       - 9600:9600 # Performance Analyzer
     volumes:
       - os:/usr/share/opensearch/data
-      - ./:/app
     command: >
       bash -c '
         set -m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,17 +4,17 @@ services:
     container_name: db
     build: ./db
     restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sn -d stackernews"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     expose:
       - "5432"
     ports:
       - "5431:5432"
     env_file:
       - ./.env.sndev
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
-        interval: 5s
-        timeout: 5s
-        retries: 5
     volumes:
       - ./anon.sql:/docker-entrypoint-initdb.d/anon.sql
       - db:/var/lib/postgresql/data
@@ -31,6 +31,10 @@ services:
     depends_on:
       db:
         condition: service_healthy
+        restart: true
+      opensearch:
+        condition: service_healthy
+        restart: true
     env_file:
       - ./.env.sndev
     expose:
@@ -49,10 +53,13 @@ services:
     depends_on:
       db:
         condition: service_healthy
+        restart: true
       app:
         condition: service_healthy
+        restart: true
       opensearch:
         condition: service_healthy
+        restart: true
     env_file:
       - ./.env.sndev
     ports:
@@ -116,6 +123,11 @@ services:
   os-dashboard:
     image: opensearchproject/opensearch-dashboards:latest
     container_name: os-dashboard
+    restart: always
+    depends_on:
+      opensearch:
+        condition: service_healthy
+        restart: true
     environment:
       - opensearch.ssl.verificationMode=none
       - server.ssl.enabled=false

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "NODE_OPTIONS='--trace-warnings' next start -p $PORT --keepAliveTimeout 120000",
     "lint": "standard",
     "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
-    "worker": "tsx --trace-warnings worker/index.js"
+    "worker": "tsx --trace-warnings worker/index.js",
+    "worker:dev": "tsx --trace-warnings --watch worker/index.js"
   },
   "dependencies": {
     "@apollo/client": "^3.8.5",

--- a/sndev
+++ b/sndev
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+sndev__start() {
+  if [ ! -x "$(command -v docker-compose)" ]; then
+    echo "docker compose is not installed"
+    echo "installation instructions are here: https://docs.docker.com/desktop/"
+    exit 0
+  fi
+
+  if ! [ -f .env.sndev ]; then
+    echo ".env.sndev does not exist."
+    echo "creating from .env.sample"
+    cp .env.sample .env.sndev
+  fi
+
+  echo "Starting application"
+  docker compose up
+}
+
+sndev__stop() {
+  echo "Stopping application"
+  docker compose down
+}
+
+sndev__delete() {
+  echo "Deleting application"
+  docker compose down --volumes --remove-orphans
+}
+
+sndev__help() {
+    if [ $# -eq 3 ]; then
+        call "sndev__$1__$2__$3" "$@"
+    elif [ $# -eq 2 ]; then
+        call "sndev__$1__$2" "$@"
+    else
+        help="sndev manages a docker based stacker news development environment
+
+USAGE
+  $ sndev [COMMAND]
+
+COMMANDS
+  start   start env
+  stop    stop env
+  delete  delete env
+  help    display help for sndev
+"
+        echo "$help"
+    fi
+}
+
+call() {
+    func=$1
+    if type "$func" 1>/dev/null 2>&1; then
+        shift
+        "$func" "$@"  # invoke our named function w/ all remaining arguments
+    else
+        sndev__help
+        exit 1
+    fi
+}
+
+call "sndev__$1" "$@"


### PR DESCRIPTION
Just getting started on this, but so far:

- makes worker hot reload
- makes docker compose shituation more reliable with restart logic and stuff
- begins a `sndev` bash script for managing all the kinds of things one might want to do in our local dev
- uses are `.env.sndev` for env created from `.env.sample` when `sndev start` is run

TODO:
- [ ] finish up adding db seed (I've configured postgres to load it but I need to add to repo)
- [ ] add an lnd network to docker compose stuff with some kind of auto-mining
- [ ] have db seed also populate elasticsearch
- [ ] mock s3 on disk for imgproxy
- [ ] add remaining commands for `sndev`
    - [ ] `sndev login $nym`
    - [ ] `sndev makeinvoice $all_the_lnd_params`
    - [ ] `sndev payinvoice $all_the_lnd_params`
    - [ ] `sndev dbtimewarp`
- [ ] refine the crap out it with lots of helpful and encouraging messages
 
Am I missing anything? After this I'll try and see if I can get this all working in github codespaces.