### PR TITLE
Parse numeric strings as numbers

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -450,7 +450,8 @@ function InputInner ({
       if (draft) {
         // for some reason we have to turn off validation to get formik to
         // not assume this is invalid
-        helpers.setValue(draft, false)
+        const isNumeric = /^[0-9]+$/.test(draft)
+        helpers.setValue(isNumeric ? parseInt(draft) : draft, false)
         onChange && onChange(formik, { target: { value: draft } })
       }
     }

--- a/components/form.js
+++ b/components/form.js
@@ -451,7 +451,8 @@ function InputInner ({
         // for some reason we have to turn off validation to get formik to
         // not assume this is invalid
         const isNumeric = /^[0-9]+$/.test(draft)
-        helpers.setValue(isNumeric ? parseInt(draft) : draft, false)
+        const numericExpected = typeof field.value === 'number'
+        helpers.setValue(isNumeric && numericExpected ? parseInt(draft) : draft, false)
         onChange && onChange(formik, { target: { value: draft } })
       }
     }


### PR DESCRIPTION
If `baseCost` in the territory form was fetched from local storage, its type was string not number which broke GraphQL validation.

Unfortunately, I didn't find a way to additionally check that the input type was set to `number` via Formik's return value of [`useField`](https://formik.org/docs/api/useField). But I think this change shouldn't break anything. If somethings expects a string and it now receives a number, Javascript should do what it's infamous for: coercing values. So this might even fix other related bugs.

However, I additionally added a check such that this manual cast only happens if the current default value is also a number to be safe and meet developer expectations more closely.

https://github.com/stackernews/stacker.news/assets/27162016/a962c5e5-4aeb-478d-b36e-6a76f1459cc3

