### PR TITLE
Fix image fees undefined and not enforced if logged in

### DIFF
--- a/api/resolvers/image.js
+++ b/api/resolvers/image.js
@@ -15,6 +15,8 @@ export function uploadIdsFromText (text, { models }) {
 }
 
 export async function imageFeesInfo (s3Keys, { models, me }) {
+  // returns info object in this format:
+  // { bytes24h: int, bytesUnpaid: int, nUnpaid: int, imageFeeMsats: BigInt }
   const [info] = await models.$queryRawUnsafe('SELECT * FROM image_fees_info($1::INTEGER, $2::INTEGER[])', me ? me.id : ANON_USER_ID, s3Keys)
   const imageFee = msatsToSats(info.imageFeeMsats)
   const totalFeesMsats = info.nUnpaid * Number(info.imageFeeMsats)

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1285,7 +1285,7 @@ export const updateItem = async (parent, { sub: subName, forward, options, ...it
   const fwdUsers = await getForwardUsers(models, forward)
 
   const uploadIds = uploadIdsFromText(item.text, { models })
-  const { fees: imgFees } = await imageFeesInfo(uploadIds, { models, me })
+  const { totalFees: imgFees } = await imageFeesInfo(uploadIds, { models, me })
 
   item = await serializeInvoicable(
     models.$queryRawUnsafe(`${SELECT} FROM update_item($1::JSONB, $2::JSONB, $3::JSONB, $4::INTEGER[]) AS "Item"`,
@@ -1321,7 +1321,7 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
   }
 
   const uploadIds = uploadIdsFromText(item.text, { models })
-  const { fees: imgFees } = await imageFeesInfo(uploadIds, { models, me })
+  const { totalFees: imgFees } = await imageFeesInfo(uploadIds, { models, me })
 
   let enforceFee = 0
   if (!me) {

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1323,7 +1323,7 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
   const uploadIds = uploadIdsFromText(item.text, { models })
   const { fees: imgFees } = await imageFeesInfo(uploadIds, { models, me })
 
-  let enforceFee
+  let enforceFee = 0
   if (!me) {
     if (item.parentId) {
       enforceFee = ANON_FEE_MULTIPLIER
@@ -1331,8 +1331,8 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
       const sub = await models.sub.findUnique({ where: { name: item.subName } })
       enforceFee = sub.baseCost * ANON_FEE_MULTIPLIER + (item.boost || 0)
     }
-    enforceFee += imgFees
   }
+  enforceFee += imgFees
 
   item = await serializeInvoicable(
     models.$queryRawUnsafe(


### PR DESCRIPTION
Mhh, interesting. Apparently, image fees were never properly applied if JIT invoices were used since I added image uploads in #576.

Image fees were still applied from the custodial wallet since the image fees are deducted inside the postgres functions `update_item` and `create_item`. We only calculate the image fees in the mutation manually so we can use it for `serializeInvoiceable` and `enforceFee`.

And this never broke since if `enforceFee` is undefined, we don't check if the fee was paid in full in `checkInvoice`, only that an invoice with any amount was paid. And if it's `NaN` which is the case if you add `undefined` (`imgFees`) to a number, the check inside `checkInvoice` also won't run since `NaN` is a falsy value.

