### PR TITLE
Refactor leaky abstraction of query vs array of queries for serialized queries

### DIFF
--- a/api/resolvers/serial.js
+++ b/api/resolvers/serial.js
@@ -91,7 +91,7 @@ export async function serializeInvoicable (query, { models, lnd, hash, hmac, me,
   }
 
   // if there is only one result, return it directly, else the array
-  results = results.flat(2)
+  results = Array.isArray(results) ? results.flat(2) : [results]
   return results.length > 1 ? results : results[0]
 }
 


### PR DESCRIPTION
Noticed while working on #897 that `serializeInvoiceable` threw this error if only a query was passed which wouldn't return an array:

> TypeError: results.flat is not a function

Example call:

```js
return await serializeInvoicable(
  models.sub.update({ where: { name }, data: { userId: me.id, status: 'ACTIVE' } }),
  { models, hash, hmac, me }
)
```

Seems like this was never the case so far. We either always used an array of queries or raw queries.