### PR TITLE
Add setting for no referral links on copy

### DIFF
--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -64,6 +64,7 @@ export default gql`
   input SettingsInput {
     autoDropBolt11s: Boolean!
     diagnostics: Boolean!
+    noReferralLinks: Boolean!
     fiatCurrency: String!
     greeterMode: Boolean!
     hideBookmarks: Boolean!
@@ -128,6 +129,7 @@ export default gql`
     """
     autoDropBolt11s: Boolean!
     diagnostics: Boolean!
+    noReferralLinks: Boolean!
     fiatCurrency: String!
     greeterMode: Boolean!
     hideBookmarks: Boolean!

--- a/components/share.js
+++ b/components/share.js
@@ -9,7 +9,8 @@ import { commentSubTreeRootId } from '../lib/item'
 import { useRouter } from 'next/router'
 
 const referrurl = (ipath, me) => {
-  const path = `${ipath}${me ? `/r/${me.name}` : ''}`
+  const referral = me && !me.privates?.noReferralLinks
+  const path = `${ipath}${referral ? `/r/${me.name}` : ''}`
   if (!SSR) {
     return `${window.location.protocol}//${window.location.host}${path}`
   }

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -12,6 +12,7 @@ export const ME = gql`
       privates {
         autoDropBolt11s
         diagnostics
+        noReferralLinks
         fiatCurrency
         greeterMode
         hideCowboyHat
@@ -87,6 +88,7 @@ export const SETTINGS_FIELDS = gql`
       imgproxyOnly
       hideWalletBalance
       diagnostics
+      noReferralLinks
       nostrPubkey
       nostrCrossposting
       nostrRelays

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -531,6 +531,7 @@ export const settingsSchema = object({
   hideTwitter: boolean(),
   hideWalletBalance: boolean(),
   diagnostics: boolean(),
+  noReferralLinks: boolean(),
   hideIsContributor: boolean()
 })
 

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -94,7 +94,8 @@ export default function Settings ({ ssrData }) {
             hideBookmarks: settings?.hideBookmarks,
             hideWalletBalance: settings?.hideWalletBalance,
             diagnostics: settings?.diagnostics,
-            hideIsContributor: settings?.hideIsContributor
+            hideIsContributor: settings?.hideIsContributor,
+            noReferralLinks: settings?.noReferralLinks
           }}
           schema={settingsSchema}
           onSubmit={async ({ tipDefault, withdrawMaxFeeDefault, nostrPubkey, nostrRelays, ...values }) => {
@@ -410,6 +411,11 @@ export default function Settings ({ ssrData }) {
               </div>
             }
             name='diagnostics'
+            groupClassName='mb-0'
+          />
+          <Checkbox
+            label={<>don't create referral links on copy</>}
+            name='noReferralLinks'
           />
           <div className='form-label'>content</div>
           <Checkbox

--- a/prisma/migrations/20240317144736_referral_link_privacy_setting/migration.sql
+++ b/prisma/migrations/20240317144736_referral_link_privacy_setting/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "noReferralLinks" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -98,6 +98,7 @@ model User {
   hideGithub                Boolean              @default(true)
   hideNostr                 Boolean              @default(true)
   hideTwitter               Boolean              @default(true)
+  noReferralLinks           Boolean              @default(false)
   githubId                  String?
   twitterId                 String?
   followers                 UserSubscription[]   @relation("follower")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new setting to allow users to disable the creation of referral links on copy actions, enhancing privacy controls.

- **Database Changes**
	- Implemented a database migration to add a new boolean column `noReferralLinks` to the "users" table.

- **API Changes**
	- Added a new field `noReferralLinks` to various input types and GraphQL queries to support the new setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->