### PR TITLE
Don't filter by pins in home

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -457,7 +457,8 @@ export default {
                     LEFT JOIN "Sub" ON "Sub"."name" = "Item"."subName"
                     ${joinZapRankPersonalView(me, models)}
                     ${whereClause(
-                      '"Item"."pinId" IS NULL',
+                      // in "home" (sub undefined), we want to show pinned items (but without the pin icon)
+                      sub ? '"Item"."pinId" IS NULL' : '',
                       '"Item"."deletedAt" IS NULL',
                       '"Item"."parentId" IS NULL',
                       '"Item".bio = false',


### PR DESCRIPTION
Was not able to reproduce since the query that I updated didn't return any items so the items were overridden by the query below it. Not sure why the query returns no items though. I thought it might be related to `zap_rank_personal_view` being empty for my user but we're using a `LEFT JOIN` so that shouldn't be it?

Anyway, looking at the code, I think this change is important.


https://github.com/stackernews/stacker.news/assets/27162016/c8e79336-0f9f-4f96-b6d9-88797c1ba175





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced item filtering to display pinned items differently based on subcategory presence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->