### PR TITLE
Fix ToC due to repeated slug calls

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -80,8 +80,8 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
 
   const Heading = useCallback(({ children, node, ...props }) => {
     const [copied, setCopied] = useState(false)
-    const id = useMemo(() =>
-      noFragments ? undefined : slugger?.slug(toString(node).replace(/[^\w\-\s]+/gi, '')), [node, noFragments, slugger])
+    const nodeText = toString(node)
+    const id = useMemo(() => noFragments ? undefined : slugger?.slug(nodeText.replace(/[^\w\-\s]+/gi, '')), [nodeText, noFragments, slugger])
     const h = useMemo(() => {
       if (topLevel) {
         return node?.TagName


### PR DESCRIPTION
I noticed that the Table of Contents was broken in https://stacker.news/faq.

This PR fixes that by replacing `node` in the `useMemo` dependency array with the node text. This makes sure that the ids are only generated again if the node text is different between renders since the node itself is always different between renders.

https://github.com/stackernews/stacker.news/assets/27162016/b84b2987-6b29-41e9-944b-15e4c6326458

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the logic for generating the `id` attribute in the `Text` component for enhanced readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->