### PR TITLE
sndev profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 Launch a fully featured SN development environment in a single command.
 
-```txt
+```sh
 $ ./sndev start
 ```
 
@@ -38,25 +38,32 @@ Go to [localhost:3000](http://localhost:3000).
 
 Start the development environment
 
-```txt
+```sh
 $ ./sndev start
 ```
 
-By default all will be run. If you only want to run specific services for specific features, set `COMPOSE_PROFILES` to use one or more of `minimal|images|search|payments`. To only run mininal services without images, search, or payments:
+By default all services will be run. If you want to exclude specific services from running, set `COMPOSE_PROFILES` to use one or more of `minimal|images|search|payments`. To only run mininal services without images, search, or payments:
 
-```txt
+```sh
 $ COMPOSE_PROFILES=minimal ./sndev start
+```
+
+Or, as I would recommend:
+
+```sh
+$ export COMPOSE_PROFILES=minimal
+$ ./sndev start
 ```
 
 To run with images and payments services:
 
-```txt
+```sh
 $ COMPOSE_PROFILES=images,payments ./sndev start
 ```
 
 View all available commands
 
-```txt
+```sh
 $ ./sndev help
 
                             888

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ Start the development environment
 $ ./sndev start
 ```
 
+By default all will be run. If you only want to run specific services for specific features, set `COMPOSE_PROFILES` to use one or more of `minimal|images|search|payments`. To only run mininal services without images, search, or payments:
+
+```txt
+$ COMPOSE_PROFILES=minimal ./sndev start
+```
+
+To run with images and payments services:
+
+```txt
+$ COMPOSE_PROFILES=images,payments ./sndev start
+```
+
 View all available commands
 
 ```txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,15 +39,6 @@ services:
       db:
         condition: service_healthy
         restart: true
-      opensearch:
-        condition: service_healthy
-        restart: true
-      sn_lnd:
-        condition: service_healthy
-        restart: true
-      # s3:
-      #   condition: service_healthy
-      #   restart: true
     env_file:
       - .env.development
     expose:
@@ -73,12 +64,6 @@ services:
       app:
         condition: service_healthy
         restart: true
-      opensearch:
-        condition: service_healthy
-        restart: true
-      sn_lnd:
-        condition: service_healthy
-        restart: true
     env_file:
       - .env.development
     volumes:
@@ -89,6 +74,8 @@ services:
   imgproxy:
     container_name: imgproxy
     image: darthsim/imgproxy:v3.23.0
+    profiles:
+      - images
     healthcheck:
       test: [ "CMD", "imgproxy", "health" ]
       interval: 10s
@@ -114,6 +101,8 @@ services:
     #   retries: 10
     #   start_period: 1m
     restart: unless-stopped
+    profiles:
+      - images
     env_file:
       - .env.development
     environment:
@@ -131,6 +120,8 @@ services:
   opensearch:
     image: opensearchproject/opensearch:2.12.0
     container_name: opensearch
+    profiles:
+      - search
     healthcheck:
       test: ["CMD-SHELL", "curl -ku admin:${OPENSEARCH_INITIAL_ADMIN_PASSWORD} --silent --fail localhost:9200/_cluster/health || exit 1"]
       interval: 10s
@@ -171,6 +162,8 @@ services:
     image: opensearchproject/opensearch-dashboards:2.12.0
     container_name: os-dashboard
     restart: unless-stopped
+    profiles:
+      - search
     depends_on:
       opensearch:
         condition: service_healthy
@@ -191,6 +184,8 @@ services:
     image: polarlightning/bitcoind:26.0
     container_name: bitcoin
     restart: unless-stopped
+    profiles:
+      - payments
     healthcheck:
       test: ["CMD-SHELL", "bitcoin-cli -chain=regtest -rpcport=${RPC_PORT} -rpcuser=${RPC_USER} -rpcpassword=${RPC_PASS} getblockchaininfo"]
       interval: 10s
@@ -248,6 +243,8 @@ services:
         - LN_NODE_FOR=sn
     container_name: sn_lnd
     restart: unless-stopped
+    profiles:
+      - payments
     healthcheck:
       test: ["CMD-SHELL", "lncli", "getinfo"]
       interval: 10s
@@ -310,6 +307,8 @@ services:
         - LN_NODE_FOR=stacker
     container_name: stacker_lnd
     restart: unless-stopped
+    profiles:
+      - payments
     healthcheck:
       test: ["CMD-SHELL", "lncli", "getinfo"]
       interval: 10s
@@ -368,6 +367,8 @@ services:
   channdler:
     image: mcuadros/ofelia:latest
     container_name: channdler
+    profiles:
+      - payments
     depends_on:
       - bitcoin
       - sn_lnd

--- a/sndev
+++ b/sndev
@@ -74,12 +74,30 @@ EOF
     fi
   fi
 
-  if [ $# -eq 0 ]; then
-    docker__compose up --build
-    exit 0
+  profile=''
+  args='--build'
+  while test $# -gt 0; do
+    case "$1" in
+      --profile)
+        profile="$profile --profile $2"
+        shift
+        shift
+        ;;
+      *)
+        args="$args $1"
+        shift
+        ;;
+    esac
+  done
+
+
+  if [ -z "$profile" ]; then
+    if [ -z "$COMPOSE_PROFILES" ]; then
+      profile="--profile images --profile search --profile payments"
+    fi
   fi
 
-  docker__compose up "$@"
+  docker__compose $profile up $args
 }
 
 sndev__help_start() {
@@ -89,7 +107,8 @@ start the sndev env
 USAGE
   $ sndev start [OPTIONS]
 
-OPTIONS"
+OPTIONS
+      --profile stringArray       Set the profile of services to start (\"base\"|$(docker__compose config --profiles | awk '{ printf "%s\"%s\"", (NR==1? "" : "|"), $0} END{ print "" }')) (default all)"
 
   echo "$help"
   docker__compose up --help | awk '/Options:/{y=1;next}y'
@@ -107,7 +126,8 @@ stop the sndev env
 USAGE
   $ sndev stop [OPTIONS]
 
-OPTIONS"
+OPTIONS
+      --profile stringArray Set the profile of services to start ($(docker__compose config --profiles | awk '{ printf "%s\"%s\"", (NR==1? "" : "|"), $0} END{ print "" }')) (default \"*\")"
 
   echo "$help"
   docker__compose down --help | awk '/Options:/{y=1;next}y'

--- a/sndev
+++ b/sndev
@@ -9,7 +9,11 @@ docker__compose() {
     exit 0
   fi
 
-  CURRENT_UID=$(id -u) CURRENT_GID=$(id -g) command docker compose --env-file .env.development "$@"
+  if [ -z "$COMPOSE_PROFILES" ]; then
+    COMPOSE_PROFILES="images,search,payments"
+  fi
+
+  CURRENT_UID=$(id -u) CURRENT_GID=$(id -g) COMPOSE_PROFILES=$COMPOSE_PROFILES command docker compose --env-file .env.development "$@"
 }
 
 docker__exec() {
@@ -74,30 +78,12 @@ EOF
     fi
   fi
 
-  profile=''
-  args='--build'
-  while test $# -gt 0; do
-    case "$1" in
-      --profile)
-        profile="$profile --profile $2"
-        shift
-        shift
-        ;;
-      *)
-        args="$args $1"
-        shift
-        ;;
-    esac
-  done
-
-
-  if [ -z "$profile" ]; then
-    if [ -z "$COMPOSE_PROFILES" ]; then
-      profile="--profile images --profile search --profile payments"
-    fi
+  if [ $# -eq 0 ]; then
+    docker__compose up --build
+    exit 0
   fi
 
-  docker__compose $profile up $args
+  docker__compose up "$@"
 }
 
 sndev__help_start() {
@@ -107,8 +93,7 @@ start the sndev env
 USAGE
   $ sndev start [OPTIONS]
 
-OPTIONS
-      --profile stringArray       Set the profile of services to start (\"base\"|$(docker__compose config --profiles | awk '{ printf "%s\"%s\"", (NR==1? "" : "|"), $0} END{ print "" }')) (default all)"
+OPTIONS"
 
   echo "$help"
   docker__compose up --help | awk '/Options:/{y=1;next}y'
@@ -126,8 +111,7 @@ stop the sndev env
 USAGE
   $ sndev stop [OPTIONS]
 
-OPTIONS
-      --profile stringArray Set the profile of services to start ($(docker__compose config --profiles | awk '{ printf "%s\"%s\"", (NR==1? "" : "|"), $0} END{ print "" }')) (default \"*\")"
+OPTIONS"
 
   echo "$help"
   docker__compose down --help | awk '/Options:/{y=1;next}y'


### PR DESCRIPTION
fixes #928 by using [docker compose profiles](https://docs.docker.com/compose/profiles/).

By default all will be run. If you only want to run specific services for specific features, set `COMPOSE_PROFILES` to use one or more of `minimal|images|search|payments`. To only run mininal services without images, search, or payments:

```txt
$ COMPOSE_PROFILES=minimal ./sndev start
```

To run with images and payments services:

```txt
$ COMPOSE_PROFILES=images,payments ./sndev start
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the development environment setup by introducing the ability to run specific services (`minimal`, `images`, `search`, `payments`) using `COMPOSE_PROFILES`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->