### PR TITLE
Fix container with empty name not found

### DIFF
--- a/sndev
+++ b/sndev
@@ -38,7 +38,7 @@ docker__sn_lnd() {
     t=""
   fi
 
-  docker__exec "$t" -u lnd sn_lnd lncli "$@"
+  docker__exec $t -u lnd sn_lnd lncli "$@"
 }
 
 docker__stacker_lnd() {
@@ -49,7 +49,7 @@ docker__stacker_lnd() {
     t=""
   fi
 
-  docker__exec "$t" -u lnd stacker_lnd lncli "$@"
+  docker__exec $t -u lnd stacker_lnd lncli "$@"
 }
 
 sndev__start() {


### PR DESCRIPTION
When I ran `sndev withdraw 1000`, I got the following error:

```
$ ./sndev withdraw 1000
Error: No such container:
```

By adding `set -x` at the top of the file, I saw the following command trace:

```
$ ./sndev withdraw 1000
+ call sndev__withdraw withdraw 1000
+ func=sndev__withdraw
+ type sndev__withdraw
+ case $3 in
+ shift
+ sndev__withdraw withdraw 1000
+ shift
+ docker__stacker_lnd addinvoice --amt 1000
+ t=addinvoice
+ '[' addinvoice = -t ']'
+ t=
+ docker__exec '' -u lnd stacker_lnd lncli addinvoice --amt 1000
+ jq -r .payment_request
++ command -v docker
+ '[' '!' -x /usr/bin/docker ']'
+ command docker exec -i '' -u lnd stacker_lnd lncli addinvoice --amt 1000
Error: No such container:
```

As can be seen in the last command, `docker exec` interpreted the `''` as the container name since `-i` does not require a value.

This PR fixes that by making sure that empty arguments to `docker__exec` are not interpreted as arguments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved variable handling in Docker-related functions for enhanced performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->