### PR TITLE
Fix duplicate deposit push messages sent

### DIFF
--- a/prisma/migrations/20240319153857_create_invoice_return_success/migration.sql
+++ b/prisma/migrations/20240319153857_create_invoice_return_success/migration.sql
@@ -1,0 +1,21 @@
+-- return integer based on update
+CREATE OR REPLACE FUNCTION confirm_invoice(lnd_id TEXT, lnd_received BIGINT)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    user_id INTEGER;
+    confirmed_at TIMESTAMP;
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    SELECT "userId", "confirmedAt" INTO user_id, confirmed_at FROM "Invoice" WHERE hash = lnd_id;
+    IF confirmed_at IS NULL THEN
+        UPDATE "Invoice" SET "msatsReceived" = lnd_received, "confirmedAt" = now_utc(), updated_at = now_utc()
+        WHERE hash = lnd_id;
+        UPDATE users SET msats = msats + lnd_received WHERE id = user_id;
+        RETURN 0;
+    END IF;
+    RETURN 1;
+END;
+$$;


### PR DESCRIPTION
Fix #763 

I was not able to find the reason why the `invoice_updated` listener is called multiple times for a single update.

The worker logs @huumn  sent me were suggesting that is indeed what is happening but they didn't explain why that is the case. We are running the worker once per app instance and there are four app instances so we would except four calls per update but that doesn't match what I saw in the logs.

For example, I found two calls from two instances for a total 4 calls (and not one call from each instance)  for payment hash `1725b9f15018c683e69904095cf12765f13afd0d1ba3800bab08521ac27e94c5` and a lot of calls from all four instances for `cc55d8c63a432de558ae57e367f3ac77222472c47dd0248e6f87e070b0e51509` where the push notification ended up showing 101k sats for a 1k sats deposit.

So no idea what is going on but this doesn't seem to cause any problem except #763.

This PR fixes #763 by using the database as the source of which update was the first and only sending a push message in that case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a backend update to enhance invoice processing and user data management.
- **Bug Fixes**
	- Improved notification handling in invoice verification to ensure users receive notifications only when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->