### PR TITLE
Remove leading dash to opt-in to being treated as vendor code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-docker/db/seed.sql -linguist-vendored
+docker/db/seed.sql linguist-vendored


### PR DESCRIPTION
Fixes #941 

I think we just have the wrong linguist vendor hint in the git-attributes file (opting out vs opting in)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated `.gitattributes` to adjust handling of database seed files for better project organization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->