### PR TITLE
Fix territory transfer push notification sent to everyone

### DIFF
--- a/api/resolvers/sub.js
+++ b/api/resolvers/sub.js
@@ -367,7 +367,7 @@ export default {
       ].filter(q => !!q),
       { models, lnd, hash, hmac, me, enforceFee: billingCost })
 
-      if (oldSub.userId !== me.id) notifyTerritoryTransfer({ models, sub: newSub, to: me.id })
+      if (oldSub.userId !== me.id) notifyTerritoryTransfer({ models, sub: newSub, to: me })
     }
   },
   Sub: {


### PR DESCRIPTION
I did not test but pretty sure that's it.

Since I passed in `me.id` and not `me`, `to.id` was `undefined` in `notifyTerritoryTransfer` which meant that the query inside `sendUserNotification` selected every user and thus a push notification was sent out to every user with them enabled:

```js
export const notifyTerritoryTransfer = async ({ models, sub, to }) => {
  try {
    await sendUserNotification(to.id, {
      title: `~${sub.name} was transferred to you`,
      tag: `TERRITORY_TRANSFER-${sub.name}`
    })
  } catch (err) {
    console.error(err)
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the territory transfer notification system for enhanced accuracy in user identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->