### PR TITLE
Check userId set in sendUserNotification

### DIFF
--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -85,6 +85,9 @@ const sendNotification = (subscription, payload) => {
 
 async function sendUserNotification (userId, notification) {
   try {
+    if (!userId) {
+      throw new Error('user id is required')
+    }
     notification.data ??= {}
     if (notification.item) {
       notification.data.url ??= await createItemUrl(notification.item)


### PR DESCRIPTION
We never intend to call this function without a specific user id in mind.

This should prevent bugs like [this](https://stacker.news/items/473427) from happening again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in notifications by checking for the presence of a user ID before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->