### PR TITLE
Disable billing autorenew on transfer

### DIFF
--- a/api/resolvers/sub.js
+++ b/api/resolvers/sub.js
@@ -308,7 +308,7 @@ export default {
 
       const [, updatedSub] = await models.$transaction([
         models.territoryTransfer.create({ data: { subName, oldUserId: me.id, newUserId: user.id } }),
-        models.sub.update({ where: { name: subName }, data: { userId: user.id } })
+        models.sub.update({ where: { name: subName }, data: { userId: user.id, billingAutoRenew: false } })
       ])
 
       notifyTerritoryTransfer({ models, sub, to: user })


### PR DESCRIPTION
To prevent unintended automated billing, I suggest we should disable automated billing on territory transfer.

related: https://stacker.news/items/473525

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Bug Fixes**
	- Updated subscription settings to disable auto-renew by default.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->