### PR TITLE
validate nym arg presence on `./sndev login` command

### DIFF
--- a/sndev
+++ b/sndev
@@ -318,6 +318,11 @@ USAGE
 
 sndev__login() {
   shift
+  if [ -z "$1" ]; then
+    echo "<nym> argument required"
+    sndev__help_login
+    exit 1
+  fi
   # hardcode token for which is the hex digest of the sha256 of
   # "SNDEV-TOKEN3_0W_PhDRZVanbeJsZZGIEljexkKoGbL6qGIqSwTjjI"
   # next-auth concats the token with the secret from env and then sha256's it


### PR DESCRIPTION
I ran into this locally because I didn't run the help command first, so I just executed `./sndev login`, thinking this would generate a random nym for me. This ended up creating a user with empty string as a name, which doesn't really seem like a good idea. Besides, it's not how the command was intended to work (AFAICT).

This PR checks to ensure that a nym is provided to the login command before proceeding. if omitted, echo an error message, display the help for the login command, then exit with a non-zero exit code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved input validation during login to ensure all required arguments are provided. If a required argument is missing, a helpful error message is now displayed to guide the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->