### PR TITLE
Gracefully handle errors when fetching lnurlp .well-known info for ln addr withdrawals

### DIFF
--- a/lib/lnurl.js
+++ b/lib/lnurl.js
@@ -33,10 +33,19 @@ export async function lnAddrOptions (addr) {
     // support HTTP and HTTPS during development
     protocol = process.env.PUBLIC_URL.split('://')[0]
   }
-  const req = await fetch(`${protocol}://${domain}/.well-known/lnurlp/${name}`)
-  const res = await req.json()
+  const unexpectedErrorMessage = `An unexpected error occurred fetching the Lightning Address metadata for ${addr}. Check the address and try again.`
+  let res
+  try {
+    const req = await fetch(`${protocol}://${domain}/.well-known/lnurlp/${name}`)
+    res = await req.json()
+  } catch (err) {
+    // If `fetch` fails, or if `req.json` fails, catch it here and surface a reasonable error
+    console.log('Error fetching lnurlp', err)
+    throw new Error(unexpectedErrorMessage)
+  }
   if (res.status === 'ERROR') {
-    throw new Error(res.reason)
+    // if the response doesn't adhere to spec by providing a `reason` entry, returns a default error message
+    throw new Error(res.reason ?? unexpectedErrorMessage)
   }
 
   const { minSendable, maxSendable, ...leftOver } = res


### PR DESCRIPTION
Closes #735 

If `fetch` or `req.json` fails, catch those errors and return a default error to the user

If the res payload indicates error but doesn't return a `reason`, also return the same default error message to the user

Sample shown in the UI for various error reasons:
<img width="618" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/09f5a0c3-8c7e-4aa8-a504-2647e390b025">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for fetching Lightning Address metadata, ensuring more robust responses to fetch failures and JSON parsing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->