### PR TITLE
Add a denormalized lastZapAt field to items for notifications performance

### DIFF
--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -220,12 +220,8 @@ export default {
           SELECT EXISTS(
             SELECT *
             FROM "Item"
-            JOIN "ItemAct" ON
-              "ItemAct"."itemId" = "Item".id
-              AND "ItemAct"."userId" <> "Item"."userId"
-            WHERE "ItemAct".created_at > $2
-            AND "Item"."userId" = $1
-            AND "ItemAct".act = 'TIP')`, me.id, lastChecked)
+            WHERE "Item"."lastZapAt" > $2
+            AND "Item"."userId" = $1)`, me.id, lastChecked)
         if (newSats.exists) {
           foundNotes()
           return true
@@ -296,15 +292,11 @@ export default {
         SELECT EXISTS(
           SELECT *
           FROM "Item"
-          JOIN "ItemAct" ON
-            "ItemAct"."itemId" = "Item".id
-            AND "ItemAct"."userId" <> "Item"."userId"
           JOIN "ItemForward" ON
             "ItemForward"."itemId" = "Item".id
             AND "ItemForward"."userId" = $1
-          WHERE "ItemAct".created_at > $2
-          AND "Item"."userId" <> $1
-          AND "ItemAct".act = 'TIP')`, me.id, lastChecked)
+          WHERE "Item"."lastZapAt" > $2
+          AND "Item"."userId" <> $1)`, me.id, lastChecked)
         if (newFwdSats.exists) {
           foundNotes()
           return true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build: ./docker/db
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "PGPASSWORD=${POSTGRES_PASSWORD} psql -U ${POSTGRES_USER} ${POSTGRES_DB} -c 'SELECT 1 FROM users LIMIT 1'"]
+      test: ["CMD-SHELL", "PGPASSWORD=${POSTGRES_PASSWORD} pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} -h 127.0.0.1 && psql -U ${POSTGRES_USER} ${POSTGRES_DB} -c 'SELECT 1 FROM users LIMIT 1'"]
       interval: 10s
       timeout: 10s
       retries: 10

--- a/prisma/migrations/20240324164838_last_zap_at/migration.sql
+++ b/prisma/migrations/20240324164838_last_zap_at/migration.sql
@@ -1,0 +1,45 @@
+-- AlterTable
+ALTER TABLE "Item" ADD COLUMN     "lastZapAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE INDEX "Item_lastZapAt_idx" ON "Item"("lastZapAt");
+
+-- CreateIndex
+CREATE INDEX "Reply_itemId_idx" ON "Reply"("itemId");
+
+-- CreateIndex
+CREATE INDEX "Reply_userId_idx" ON "Reply"("userId");
+
+
+-- when an item is zapped, update the lastZapAt field
+CREATE OR REPLACE FUNCTION sats_after_tip(item_id INTEGER, user_id INTEGER, tip_msats BIGINT) RETURNS INTEGER AS $$
+DECLARE
+    item "Item";
+BEGIN
+    SELECT * FROM "Item" WHERE id = item_id INTO item;
+    IF user_id <> 27 AND item."userId" = user_id THEN
+        RETURN 0;
+    END IF;
+
+    UPDATE "Item"
+    SET "msats" = "msats" + tip_msats,
+        "lastZapAt" = now()
+    WHERE id = item.id;
+
+    UPDATE "Item"
+    SET "commentMsats" = "commentMsats" + tip_msats
+    WHERE id <> item.id and path @> item.path;
+
+    RETURN 1;
+END;
+$$ LANGUAGE plpgsql;
+
+-- retrofit the lastZapAt field for all existing items
+UPDATE "Item" SET "lastZapAt" = "Zap".at
+FROM (
+    SELECT "ItemAct"."itemId", MAX("ItemAct"."created_at") AS at
+    FROM "ItemAct"
+    WHERE "ItemAct".act = 'TIP'
+    GROUP BY "ItemAct"."itemId"
+) AS "Zap"
+WHERE "Item"."id" = "Zap"."itemId";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -355,6 +355,7 @@ model Item {
   paidImgLink        Boolean               @default(false)
   commentMsats       BigInt                @default(0)
   lastCommentAt      DateTime?
+  lastZapAt          DateTime?
   ncomments          Int                   @default(0)
   msats              BigInt                @default(0)
   weightedDownVotes  Float                 @default(0)
@@ -393,6 +394,7 @@ model Item {
   Replies            Reply[]
 
   @@index([uploadId])
+  @@index([lastZapAt])
   @@index([bio], map: "Item.bio_index")
   @@index([createdAt], map: "Item.created_at_index")
   @@index([freebie], map: "Item.freebie_index")
@@ -428,6 +430,8 @@ model Reply {
 
   @@index([ancestorId])
   @@index([ancestorUserId])
+  @@index([itemId])
+  @@index([userId])
   @@index([level])
   @@index([createdAt])
 }


### PR DESCRIPTION
Prior we'd have to join and aggregate on `Item` and `ItemAct` to see if an `Item` had recent zaps. This gives us a more direct way to query for new zaps on an `Item`.

Bonus:
- removes reward islands from notifications query which were needed in another era

Bonus commit:
- adds `pg_isready` to existing healthcheck on the sndev db

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new sorting and filtering option based on the "lastZapAt" timestamp for more intuitive navigation of items.
- **Enhancements**
	- Streamlined notification retrieval process for improved performance and user experience.
	- Optimized item existence checks to enhance the accuracy and speed of query responses.
- **Database Updates**
	- Introduced a new column `lastZapAt` in the `Item` table to support enhanced sorting and filtering capabilities.
	- Implemented new indexes on `lastZapAt`, `itemId`, and `userId` to improve query efficiency and response times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->