### PR TITLE
Use thresholds to trigger zap undos

### DIFF
--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -92,7 +92,7 @@ export default gql`
     nsfwMode: Boolean!
     tipDefault: Int!
     turboTipping: Boolean!
-    zapUndos: Boolean!
+    zapUndos: Int
     wildWestMode: Boolean!
     withdrawMaxFeeDefault: Int!
   }
@@ -157,7 +157,7 @@ export default gql`
     nsfwMode: Boolean!
     tipDefault: Int!
     turboTipping: Boolean!
-    zapUndos: Boolean!
+    zapUndos: Int
     wildWestMode: Boolean!
     withdrawMaxFeeDefault: Int!
     autoWithdrawThreshold: Int

--- a/components/dont-link-this.js
+++ b/components/dont-link-this.js
@@ -1,7 +1,7 @@
 import Dropdown from 'react-bootstrap/Dropdown'
 import { useShowModal } from './modal'
 import { useToast } from './toast'
-import ItemAct from './item-act'
+import ItemAct, { zapUndosThresholdReached } from './item-act'
 import AccordianItem from './accordian-item'
 import Flag from '@/svgs/flag-fill.svg'
 import { useMemo } from 'react'
@@ -32,12 +32,11 @@ function DownZapper ({ id, As, children }) {
         try {
           showModal(onClose =>
             <ItemAct
-              onClose={() => {
+              onClose={(amount) => {
                 onClose()
                 // undo prompt was toasted before closing modal if zap undos are enabled
                 // so an additional success toast would be confusing
-                const zapUndosEnabled = me && me?.privates?.zapUndos
-                if (!zapUndosEnabled) toaster.success('item downzapped')
+                if (!zapUndosThresholdReached(me, amount)) toaster.success('item downzapped')
               }} itemId={id} down
             >
               <AccordianItem

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -55,7 +55,7 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
 
   const [act, actUpdate] = useAct()
 
-  const onSubmit = useCallback(async ({ amount, hash, hmac }, { update }) => {
+  const onSubmit = useCallback(async ({ amount, hash, hmac }, { update, keepOpen }) => {
     if (!me) {
       const storageKey = `TIP-item:${itemId}`
       const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
@@ -75,7 +75,7 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
     // due to optimistic UX on zap undos
     if (!me || !me.privates.zapUndos) await strike()
     addCustomTip(Number(amount))
-    onClose()
+    if (!keepOpen) onClose()
   }, [me, act, down, itemId, strike])
 
   const onSubmitWithUndos = withToastFlow(toaster)(
@@ -128,7 +128,7 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
             undoUpdate = update()
             setTimeout(() => {
               if (canceled) return resolve()
-              onSubmit(values, { flowId, ...args, update: null })
+              onSubmit(values, { flowId, ...args, update: null, keepOpen: true })
                 .then(resolve)
                 .catch((err) => {
                   undoUpdate()

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -115,6 +115,7 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
       return {
         skipToastFlow,
         flowId,
+        tag: itemId,
         type: 'zap',
         pendingMessage: `${down ? 'down' : ''}zapped ${sats} sats`,
         onPending: async () => {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -531,7 +531,7 @@ export const settingsSchema = object({
   diagnostics: boolean(),
   noReferralLinks: boolean(),
   hideIsContributor: boolean(),
-  zapUndos: intValidator.required('required').min(0, 'must be greater or equal to 0')
+  zapUndos: intValidator.nullable().min(0, 'must be greater or equal to 0')
 })
 
 const warningMessage = 'If I logout, even accidentally, I will never be able to access my account again'

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -530,7 +530,8 @@ export const settingsSchema = object({
   hideWalletBalance: boolean(),
   diagnostics: boolean(),
   noReferralLinks: boolean(),
-  hideIsContributor: boolean()
+  hideIsContributor: boolean(),
+  zapUndos: intValidator.required('required').min(0, 'must be greater or equal to 0')
 })
 
 const warningMessage = 'If I logout, even accidentally, I will never be able to access my account again'

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -28,6 +28,7 @@ import { useMe } from '@/components/me'
 import { INVOICE_RETENTION_DAYS } from '@/lib/constants'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 import DeleteIcon from '@/svgs/delete-bin-line.svg'
+import { useField } from 'formik'
 
 export const getServerSideProps = getGetServerSideProps({ query: SETTINGS, authRequired: true })
 
@@ -65,7 +66,8 @@ export default function Settings ({ ssrData }) {
           initial={{
             tipDefault: settings?.tipDefault || 21,
             turboTipping: settings?.turboTipping,
-            zapUndos: settings?.zapUndos,
+            zapUndos: settings?.zapUndos || settings?.tipDefault || 0,
+            zapUndosEnabled: settings?.zapUndos !== null || false,
             fiatCurrency: settings?.fiatCurrency || 'USD',
             withdrawMaxFeeDefault: settings?.withdrawMaxFeeDefault,
             noteItemSats: settings?.noteItemSats,
@@ -98,7 +100,7 @@ export default function Settings ({ ssrData }) {
             noReferralLinks: settings?.noReferralLinks
           }}
           schema={settingsSchema}
-          onSubmit={async ({ tipDefault, withdrawMaxFeeDefault, nostrPubkey, nostrRelays, ...values }) => {
+          onSubmit={async ({ tipDefault, withdrawMaxFeeDefault, zapUndos, zapUndosEnabled, nostrPubkey, nostrRelays, ...values }) => {
             if (nostrPubkey.length === 0) {
               nostrPubkey = null
             } else {
@@ -116,6 +118,7 @@ export default function Settings ({ ssrData }) {
                   settings: {
                     tipDefault: Number(tipDefault),
                     withdrawMaxFeeDefault: Number(withdrawMaxFeeDefault),
+                    zapUndos: zapUndosEnabled ? Number(zapUndos) : null,
                     nostrPubkey,
                     nostrRelays: nostrRelaysFiltered,
                     ...values
@@ -171,25 +174,7 @@ export default function Settings ({ ssrData }) {
                     }
                     groupClassName='mb-0'
                   />
-                  <Checkbox
-                    name='zapUndos'
-                    label={
-                      <div className='d-flex align-items-center'>zap undos
-                        <Info>
-                          <ul className='fw-bold'>
-                            <li>An undo button is shown after every zap</li>
-                            <li>The button is shown for 5 seconds</li>
-                            <li>
-                              The button is only shown for zaps from the custodial wallet
-                            </li>
-                            <li>
-                              Use a budget or manual approval with attached wallets
-                            </li>
-                          </ul>
-                        </Info>
-                      </div>
-                    }
-                  />
+                  <ZapUndoField />
                 </>
               }
             />
@@ -918,5 +903,38 @@ I estimate that I will call the GraphQL API this many times (rough estimate is f
         </Info>
       </div>
     </>
+  )
+}
+
+const ZapUndoField = () => {
+  const [checkboxField] = useField({ name: 'zapUndosEnabled' })
+  return (
+    <div className='d-flex flex-row align-items-center'>
+      <Input
+        name='zapUndos'
+        disabled={!checkboxField.value}
+        label={
+          <Checkbox
+            name='zapUndosEnabled'
+            groupClassName='mb-0'
+            label={
+              <div className='d-flex align-items-center'>
+                zap undos
+                <Info>
+                  <ul className='fw-bold'>
+                    <li>An undo button is shown after every zap that exceeds or is equal to the threshold</li>
+                    <li>The button is shown for 5 seconds</li>
+                    <li>The button is only shown for zaps from the custodial wallet</li>
+                    <li>Use a budget or manual approval with attached wallets</li>
+                  </ul>
+                </Info>
+              </div>
+              }
+          />
+        }
+        append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
+        hint={<small className='text-muted'>threshold at which undo button is shown</small>}
+      />
+    </div>
   )
 }

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -66,7 +66,7 @@ export default function Settings ({ ssrData }) {
           initial={{
             tipDefault: settings?.tipDefault || 21,
             turboTipping: settings?.turboTipping,
-            zapUndos: settings?.zapUndos || settings?.tipDefault || 0,
+            zapUndos: settings?.zapUndos || settings?.tipDefault ? 100 * settings.tipDefault : 2100,
             zapUndosEnabled: settings?.zapUndos !== null,
             fiatCurrency: settings?.fiatCurrency || 'USD',
             withdrawMaxFeeDefault: settings?.withdrawMaxFeeDefault,

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -174,7 +174,7 @@ export default function Settings ({ ssrData }) {
                     }
                     groupClassName='mb-0'
                   />
-                  <ZapUndoField />
+                  <ZapUndosField />
                 </>
               }
             />
@@ -906,7 +906,7 @@ I estimate that I will call the GraphQL API this many times (rough estimate is f
   )
 }
 
-const ZapUndoField = () => {
+const ZapUndosField = () => {
   const [checkboxField] = useField({ name: 'zapUndosEnabled' })
   return (
     <div className='d-flex flex-row align-items-center'>

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -67,7 +67,7 @@ export default function Settings ({ ssrData }) {
             tipDefault: settings?.tipDefault || 21,
             turboTipping: settings?.turboTipping,
             zapUndos: settings?.zapUndos || settings?.tipDefault || 0,
-            zapUndosEnabled: settings?.zapUndos !== null || false,
+            zapUndosEnabled: settings?.zapUndos !== null,
             fiatCurrency: settings?.fiatCurrency || 'USD',
             withdrawMaxFeeDefault: settings?.withdrawMaxFeeDefault,
             noteItemSats: settings?.noteItemSats,

--- a/prisma/migrations/20240324192055_zap_undos_integer/migration.sql
+++ b/prisma/migrations/20240324192055_zap_undos_integer/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "users" ADD COLUMN "zapUndosTmp" INTEGER;
+UPDATE "users" SET "zapUndosTmp" = CASE WHEN "zapUndos" = false THEN NULL ELSE 0::INTEGER END;
+ALTER TABLE "users" DROP COLUMN "zapUndos";
+ALTER TABLE "users" RENAME COLUMN "zapUndosTmp" TO "zapUndos";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,7 +56,7 @@ model User {
   autoDropBolt11s           Boolean              @default(false)
   hideFromTopUsers          Boolean              @default(false)
   turboTipping              Boolean              @default(false)
-  zapUndos                  Boolean              @default(false)
+  zapUndos                  Int?
   imgproxyOnly              Boolean              @default(false)
   hideWalletBalance         Boolean              @default(false)
   referrerId                Int?


### PR DESCRIPTION
Based on #962 

This PR changes the type of `users.zapUndos` from boolean to integer. This integer is then used to determine if a zap should trigger the zap undo flow.

This should make this feature a lot more useful since one can set the threshold to an uncommon zap amount which could also be a miss click. Hence, the zap undo flow would only trigger when it's actually useful.

_input is disabled if checkbox not checked:_

![2024-03-25-020510_1920x1080_scrot](https://github.com/stackernews/stacker.news/assets/27162016/524ff36f-37f7-4193-87b9-779538c08af1)

_input is enabled if checkbox checked:_

![2024-03-25-020506_1920x1080_scrot](https://github.com/stackernews/stacker.news/assets/27162016/186e4270-7102-4137-8986-0336788082d6)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new threshold-based functionality for the `zapUndos` feature, enhancing user control over undo actions.
	- Added a `ZapUndoField` component in settings for better management of `zapUndos` thresholds.
- **Enhancements**
	- Improved toast management with a new `endFlow` function for more intuitive user notifications.
- **Bug Fixes**
	- Adjusted the `zapUndos` field from a Boolean to an Int type across the application for consistent data handling.
- **Refactor**
	- Streamlined the handling of undo actions in components with new logic and helper functions.
- **Database Changes**
	- Updated the "users" table to support integer values for `zapUndos`, facilitating the new threshold feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->