### PR TITLE
Keep standard ports inside container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -265,9 +265,9 @@ services:
       - '--externalip=sn_lnd'
       - '--tlsextradomain=sn_lnd'
       - '--tlsextradomain=host.docker.internal'
-      - '--listen=0.0.0.0:${LND_P2P_PORT}'
-      - '--rpclisten=0.0.0.0:${LND_GRPC_PORT}'
-      - '--restlisten=0.0.0.0:${LND_REST_PORT}'
+      - '--listen=0.0.0.0:9735'
+      - '--rpclisten=0.0.0.0:10009'
+      - '--restlisten=0.0.0.0:8080'
       - '--bitcoin.active'
       - '--bitcoin.regtest'
       - '--bitcoin.node=bitcoind'
@@ -282,10 +282,10 @@ services:
       - '--bitcoin.defaultchanconfs=1'
       - '--maxpendingchannels=10'
     expose:
-      - "${LND_P2P_PORT}"
+      - "9735"
     ports:
-      - "${LND_REST_PORT}:${LND_REST_PORT}"
-      - "${LND_GRPC_PORT}:${LND_GRPC_PORT}"
+      - "${LND_REST_PORT}:8080"
+      - "${LND_GRPC_PORT}:10009"
     volumes:
       - sn_lnd:/home/lnd/.lnd
     labels:
@@ -329,9 +329,9 @@ services:
       - '--externalip=stacker_lnd'
       - '--tlsextradomain=stacker_lnd'
       - '--tlsextradomain=host.docker.internal'
-      - '--listen=0.0.0.0:${LND_P2P_PORT}'
-      - '--rpclisten=0.0.0.0:${LND_GRPC_PORT}'
-      - '--restlisten=0.0.0.0:${LND_REST_PORT}'
+      - '--listen=0.0.0.0:9735'
+      - '--rpclisten=0.0.0.0:10009'
+      - '--restlisten=0.0.0.0:8080'
       - '--bitcoin.active'
       - '--bitcoin.regtest'
       - '--bitcoin.node=bitcoind'
@@ -346,10 +346,10 @@ services:
       - '--bitcoin.defaultchanconfs=1'
       - '--maxpendingchannels=10'
     expose:
-      - "${LND_P2P_PORT}"
+      - "9735"
     ports:
-      - "${STACKER_LND_REST_PORT}:${LND_REST_PORT}"
-      - "${STACKER_LND_GRPC_PORT}:${LND_GRPC_PORT}"
+      - "${STACKER_LND_REST_PORT}:8080"
+      - "${STACKER_LND_GRPC_PORT}:10009"
     volumes:
       - stacker_lnd:/home/lnd/.lnd
     labels:


### PR DESCRIPTION
This makes it possible to continue to use `lncli` without `--rpcserver` inside the docker container even if the GRPC port exposed on the host machine is different.

This is the case on my machine since I am running a mainnet LND node on my machine so port 10009 is already used.

I could change the port to 20009 via `LND_GRPC_PORT` and `STACKER_LND_GRPC_PORT` (they can even have the same port) but then `lncli` inside the container needs to be aware of that which means that the sndev script would need to parse .env.development (or some other "magic") to know the GRPC port inside the container.

However, I decided that using standard ports inside the container is better to keep the sndev script simple at the cost of having to think about host vs container ports since they are different now.

One reason for that is that I think one even does not need to think about the host ports since they aren't even needed? But that's another topic.