### PR TITLE
Add context field to crossposted link if present

### DIFF
--- a/components/use-crossposter.js
+++ b/components/use-crossposter.js
@@ -24,10 +24,17 @@ async function discussionToEvent (item) {
 async function linkToEvent (item) {
   const createdAt = Math.floor(Date.now() / 1000)
 
+  let contentField
+  if (item.text) {
+    contentField = `${item.title}\n${item.url}\n\n${item.text}`
+  } else {
+    contentField = `${item.title}\n${item.url}`
+  }
+
   return {
     created_at: createdAt,
     kind: 1,
-    content: `${item.title} \n ${item.url}`,
+    content: contentField,
     tags: []
   }
 }


### PR DESCRIPTION
I missed the new context field when working on crossposting links initially so this PR adds the context field into the crossposted link event content IF present.

A crossposted link WITH the context field will be formatted like so:
```
`${item.title}\n${item.url}\n\n${item.text}`
```
<img width="740" alt="image" src="https://github.com/stackernews/stacker.news/assets/53542748/40d7e12f-ed20-4661-b1ec-2e5007ceab01">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved how event links are constructed in crossposts, now including item text when available for richer content sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->