### PR TITLE
Withdrawal notifications

### DIFF
--- a/api/resolvers/notifications.js
+++ b/api/resolvers/notifications.js
@@ -1,7 +1,7 @@
 import { GraphQLError } from 'graphql'
 import { decodeCursor, LIMIT, nextNoteCursorEncoded } from '@/lib/cursor'
 import { getItem, filterClause, whereClause, muteClause } from './item'
-import { getInvoice, getWithdrawal } from './wallet'
+import { getInvoice } from './wallet'
 import { pushSubscriptionSchema, ssValidate } from '@/lib/validate'
 import { replyToSubscription } from '@/lib/webPush'
 import { getSub } from './sub'
@@ -442,9 +442,6 @@ export default {
   },
   InvoicePaid: {
     invoice: async (n, args, { me, models }) => getInvoice(n, { id: n.id }, { me, models })
-  },
-  WithdrawlPaid: {
-    withdrawl: async (n, args, { me, models }) => getWithdrawal(n, { id: n.id }, { me, models })
   },
   Invitification: {
     invite: async (n, args, { models }) => {

--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -353,6 +353,22 @@ export default {
         }
       }
 
+      if (user.noteWithdrawals) {
+        const wdrwl = await models.withdrawl.findFirst({
+          where: {
+            userId: me.id,
+            status: 'CONFIRMED',
+            updatedAt: {
+              gt: lastChecked
+            }
+          }
+        })
+        if (wdrwl) {
+          foundNotes()
+          return true
+        }
+      }
+
       // check if new invites have been redeemed
       if (user.noteInvites) {
         const [newInvites] = await models.$queryRawUnsafe(`

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -53,31 +53,6 @@ export async function getInvoice (parent, { id }, { me, models, lnd }) {
   return inv
 }
 
-export async function getWithdrawal (parent, { id }, { me, models }) {
-  if (!me) {
-    throw new GraphQLError('you must be logged in', { extensions: { code: 'FORBIDDEN' } })
-  }
-
-  const wdrwl = await models.withdrawl.findUnique({
-    where: {
-      id: Number(id)
-    },
-    include: {
-      user: true
-    }
-  })
-
-  if (!wdrwl) {
-    throw new GraphQLError('withdrawal not found', { extensions: { code: 'BAD_INPUT' } })
-  }
-
-  if (wdrwl.user.id !== me.id) {
-    throw new GraphQLError('not ur withdrawal', { extensions: { code: 'FORBIDDEN' } })
-  }
-
-  return wdrwl
-}
-
 export function createHmac (hash) {
   const key = Buffer.from(process.env.INVOICE_HMAC_KEY, 'hex')
   return crypto.createHmac('sha256', key).update(Buffer.from(hash, 'hex')).digest('hex')
@@ -122,7 +97,30 @@ export default {
         }
       })
     },
-    withdrawl: getWithdrawal,
+    withdrawl: async (parent, { id }, { me, models }) => {
+      if (!me) {
+        throw new GraphQLError('you must be logged in', { extensions: { code: 'FORBIDDEN' } })
+      }
+
+      const wdrwl = await models.withdrawl.findUnique({
+        where: {
+          id: Number(id)
+        },
+        include: {
+          user: true
+        }
+      })
+
+      if (!wdrwl) {
+        throw new GraphQLError('withdrawal not found', { extensions: { code: 'BAD_INPUT' } })
+      }
+
+      if (wdrwl.user.id !== me.id) {
+        throw new GraphQLError('not ur withdrawal', { extensions: { code: 'FORBIDDEN' } })
+      }
+
+      return wdrwl
+    },
     numBolt11s: async (parent, args, { me, models, lnd }) => {
       if (!me) {
         throw new GraphQLError('you must be logged in', { extensions: { code: 'FORBIDDEN' } })

--- a/api/typeDefs/notifications.js
+++ b/api/typeDefs/notifications.js
@@ -91,6 +91,13 @@ export default gql`
     sortTime: Date!
   }
 
+  type WithdrawlPaid {
+    id: ID!
+    earnedSats: Int!
+    withdrawl: Withdrawl!
+    sortTime: Date!
+  }
+
   type Referral {
     id: ID!
     sortTime: Date!
@@ -115,7 +122,7 @@ export default gql`
   }
 
   union Notification = Reply | Votification | Mention
-    | Invitification | Earn | JobChanged | InvoicePaid | Referral
+    | Invitification | Earn | JobChanged | InvoicePaid | WithdrawlPaid | Referral
     | Streak | FollowActivity | ForwardedVotification | Revenue | SubStatus
     | TerritoryPost | TerritoryTransfer
 

--- a/api/typeDefs/notifications.js
+++ b/api/typeDefs/notifications.js
@@ -94,7 +94,6 @@ export default gql`
   type WithdrawlPaid {
     id: ID!
     earnedSats: Int!
-    withdrawl: Withdrawl!
     sortTime: Date!
   }
 

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -82,7 +82,8 @@ export default gql`
     nostrRelays: [String!]
     noteAllDescendants: Boolean!
     noteCowboyHat: Boolean!
-    noteDeposits: Boolean!
+    noteDeposits: Boolean!,
+    noteWithdrawals: Boolean!,
     noteEarning: Boolean!
     noteForwardedSats: Boolean!
     noteInvites: Boolean!
@@ -148,6 +149,7 @@ export default gql`
     noteAllDescendants: Boolean!
     noteCowboyHat: Boolean!
     noteDeposits: Boolean!
+    noteWithdrawals: Boolean!
     noteEarning: Boolean!
     noteForwardedSats: Boolean!
     noteInvites: Boolean!

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -40,6 +40,7 @@ function Notification ({ n, fresh }) {
         (type === 'Revenue' && <RevenueNotification n={n} />) ||
         (type === 'Invitification' && <Invitification n={n} />) ||
         (type === 'InvoicePaid' && (n.invoice.nostr ? <NostrZap n={n} /> : <InvoicePaid n={n} />)) ||
+        (type === 'WithdrawlPaid' && <WithdrawlPaid n={n} />) ||
         (type === 'Referral' && <Referral n={n} />) ||
         (type === 'Streak' && <Streak n={n} />) ||
         (type === 'Votification' && <Votification n={n} />) ||
@@ -95,6 +96,7 @@ const defaultOnClick = n => {
   if (type === 'SubStatus') return { href: `/~${n.sub.name}` }
   if (type === 'Invitification') return { href: '/invites' }
   if (type === 'InvoicePaid') return { href: `/invoices/${n.invoice.id}` }
+  if (type === 'WithdrawlPaid') return { href: `/withdrawals/${n.withdrawl.id}` }
   if (type === 'Referral') return { href: '/referrals/month' }
   if (type === 'Streak') return {}
   if (type === 'TerritoryTransfer') return { href: `/~${n.sub.name}` }
@@ -273,6 +275,15 @@ function InvoicePaid ({ n }) {
           <Text>{n.invoice.comment}</Text>
           {payerSig}
         </small>}
+    </div>
+  )
+}
+
+function WithdrawlPaid ({ n }) {
+  return (
+    <div className='fw-bold text-info ms-2 py-1'>
+      <Check className='fill-info me-1' />{numWithUnits(n.earnedSats, { abbreviate: false, unitSingular: 'sat was', unitPlural: 'sats were' })} withdrawn from your account
+      <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.sortTime))}</small>
     </div>
   )
 }

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -96,7 +96,7 @@ const defaultOnClick = n => {
   if (type === 'SubStatus') return { href: `/~${n.sub.name}` }
   if (type === 'Invitification') return { href: '/invites' }
   if (type === 'InvoicePaid') return { href: `/invoices/${n.invoice.id}` }
-  if (type === 'WithdrawlPaid') return { href: `/withdrawals/${n.withdrawl.id}` }
+  if (type === 'WithdrawlPaid') return { href: `/withdrawals/${n.id}` }
   if (type === 'Referral') return { href: '/referrals/month' }
   if (type === 'Streak') return {}
   if (type === 'TerritoryTransfer') return { href: `/~${n.sub.name}` }

--- a/fragments/notifications.js
+++ b/fragments/notifications.js
@@ -133,6 +133,15 @@ export const NOTIFICATIONS = gql`
             lud18Data
           }
         }
+        ... on WithdrawlPaid {
+          id
+          sortTime
+          earnedSats
+          withdrawl {
+            id
+            satsPaid
+          }
+        }
       }
     }
   } `

--- a/fragments/notifications.js
+++ b/fragments/notifications.js
@@ -137,10 +137,6 @@ export const NOTIFICATIONS = gql`
           id
           sortTime
           earnedSats
-          withdrawl {
-            id
-            satsPaid
-          }
         }
       }
     }

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -30,6 +30,7 @@ export const ME = gql`
         noteAllDescendants
         noteCowboyHat
         noteDeposits
+        noteWithdrawals
         noteEarning
         noteForwardedSats
         noteInvites
@@ -72,6 +73,7 @@ export const SETTINGS_FIELDS = gql`
       noteAllDescendants
       noteMentions
       noteDeposits
+      noteWithdrawals
       noteInvites
       noteJobIndicator
       noteCowboyHat

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -308,7 +308,7 @@ export async function notifyEarner (userId, earnings) {
 export async function notifyDeposit (userId, invoice) {
   try {
     await sendUserNotification(userId, {
-      title: `${numWithUnits(msatsToSats(invoice.received_mtokens), { abbreviate: false })} were deposited in your account`,
+      title: `${numWithUnits(msatsToSats(invoice.received_mtokens), { abbreviate: false, unitSingular: 'sat was', unitPlural: 'sats were' })} deposited in your account`,
       body: invoice.comment || undefined,
       tag: 'DEPOSIT',
       data: { sats: msatsToSats(invoice.received_mtokens) }
@@ -321,7 +321,7 @@ export async function notifyDeposit (userId, invoice) {
 export async function notifyWithdrawal (userId, wdrwl) {
   try {
     await sendUserNotification(userId, {
-      title: `${numWithUnits(msatsToSats(wdrwl.payment.mtokens), { abbreviate: false })} were withdrawn from your account`,
+      title: `${numWithUnits(msatsToSats(wdrwl.payment.mtokens), { abbreviate: false, unitSingular: 'sat was', unitPlural: 'sats were' })} withdrawn from your account`,
       tag: 'WITHDRAWAL',
       data: { sats: msatsToSats(wdrwl.payment.mtokens) }
     })

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -318,6 +318,18 @@ export async function notifyDeposit (userId, invoice) {
   }
 }
 
+export async function notifyWithdrawal (userId, wdrwl) {
+  try {
+    await sendUserNotification(userId, {
+      title: `${numWithUnits(msatsToSats(wdrwl.payment.mtokens), { abbreviate: false })} were withdrawn from your account`,
+      tag: 'WITHDRAWAL',
+      data: { sats: msatsToSats(wdrwl.payment.mtokens) }
+    })
+  } catch (err) {
+    console.error(err)
+  }
+}
+
 export async function notifyNewStreak (userId, streak) {
   const index = streak.id % FOUND_BLURBS.length
   const blurb = FOUND_BLURBS[index]

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -43,6 +43,7 @@ const createUserFilter = (tag) => {
     INVITE: 'noteInvites',
     EARN: 'noteEarning',
     DEPOSIT: 'noteDeposits',
+    WITHDRAWAL: 'noteWithdrawals',
     STREAK: 'noteCowboyHat'
   }
   const key = tagMap[tag.split('-')[0]]

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -75,6 +75,7 @@ export default function Settings ({ ssrData }) {
             noteAllDescendants: settings?.noteAllDescendants,
             noteMentions: settings?.noteMentions,
             noteDeposits: settings?.noteDeposits,
+            noteWithdrawals: settings?.noteWithdrawals,
             noteInvites: settings?.noteInvites,
             noteJobIndicator: settings?.noteJobIndicator,
             noteCowboyHat: settings?.noteCowboyHat,
@@ -221,6 +222,11 @@ export default function Settings ({ ssrData }) {
           <Checkbox
             label='sats are deposited in my account'
             name='noteDeposits'
+            groupClassName='mb-0'
+          />
+          <Checkbox
+            label='sats are withdrawn from my account'
+            name='noteWithdrawals'
             groupClassName='mb-0'
           />
           <Checkbox

--- a/prisma/migrations/20240325114003_withdrawal_notifications/migration.sql
+++ b/prisma/migrations/20240325114003_withdrawal_notifications/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "noteWithdrawals" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/migrations/20240325114003_withdrawal_notifications/migration.sql
+++ b/prisma/migrations/20240325114003_withdrawal_notifications/migration.sql
@@ -1,2 +1,29 @@
 -- AlterTable
 ALTER TABLE "users" ADD COLUMN     "noteWithdrawals" BOOLEAN NOT NULL DEFAULT true;
+
+CREATE OR REPLACE FUNCTION confirm_withdrawl(wid INTEGER, msats_paid BIGINT, msats_fee_paid BIGINT)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    msats_fee_paying BIGINT;
+    user_id INTEGER;
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    IF EXISTS (SELECT 1 FROM "Withdrawl" WHERE id = wid AND status IS NULL) THEN
+        SELECT "msatsFeePaying", "userId" INTO msats_fee_paying, user_id
+        FROM "Withdrawl" WHERE id = wid AND status IS NULL;
+
+        UPDATE "Withdrawl"
+        SET status = 'CONFIRMED', "msatsPaid" = msats_paid,
+        "msatsFeePaid" = msats_fee_paid, updated_at = now_utc()
+        WHERE id = wid AND status IS NULL;
+
+        UPDATE users SET msats = msats + (msats_fee_paying - msats_fee_paid) WHERE id = user_id;
+        RETURN 0;
+    END IF;
+
+    RETURN 1;
+END;
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model User {
   stackedMsats              BigInt               @default(0)
   noteAllDescendants        Boolean              @default(true)
   noteDeposits              Boolean              @default(true)
+  noteWithdrawals           Boolean              @default(true)
   noteEarning               Boolean              @default(true)
   noteInvites               Boolean              @default(true)
   noteItemSats              Boolean              @default(true)

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -154,9 +154,9 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
     }
   } else if (SUM_SATS_TAGS.includes(compareTag)) {
     if (compareTag === 'DEPOSIT') {
-      title = `${numWithUnits(sats, { abbreviate: false })} were deposited in your account`
+      title = `${numWithUnits(sats, { abbreviate: false, unitSingular: 'sat was', unitPlural: 'sats were' })} deposited in your account`
     } else if (compareTag === 'WITHDRAWAL') {
-      title = `${numWithUnits(sats, { abbreviate: false })} were withdrawn from your account`
+      title = `${numWithUnits(sats, { abbreviate: false, unitSingular: 'sat was', unitPlural: 'sats were' })} withdrawn from your account`
     }
   }
   log(`[sw:push] ${nid} - calculated title: ${title}`)

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -116,7 +116,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
   // tags that need to know the amount of notifications with same tag for merging
   const AMOUNT_TAGS = ['REPLY', 'MENTION', 'REFERRAL', 'INVITE', 'FOLLOW', 'TERRITORY_POST']
   // tags that need to know the sum of sats of notifications with same tag for merging
-  const SUM_SATS_TAGS = ['DEPOSIT']
+  const SUM_SATS_TAGS = ['DEPOSIT', 'WITHDRAWAL']
   // this should reflect the amount of notifications that were already merged before
   let initialAmount = currentNotifications[0]?.data?.amount || 1
   if (iOS()) initialAmount = 1
@@ -153,8 +153,11 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
       title = `you have ${amount} new posts in ~${subName}`
     }
   } else if (SUM_SATS_TAGS.includes(compareTag)) {
-    // there is only DEPOSIT in this array
-    title = `${numWithUnits(sats, { abbreviate: false })} were deposited in your account`
+    if (compareTag === 'DEPOSIT') {
+      title = `${numWithUnits(sats, { abbreviate: false })} were deposited in your account`
+    } else if (compareTag === 'WITHDRAWAL') {
+      title = `${numWithUnits(sats, { abbreviate: false })} were withdrawn from your account`
+    }
   }
   log(`[sw:push] ${nid} - calculated title: ${title}`)
 


### PR DESCRIPTION
This PR adds notifications for successful withdrawals:

![2024-03-26-005104_1920x1080_scrot](https://github.com/stackernews/stacker.news/assets/27162016/24cc484e-35ae-4243-913d-95392d853108)

I think having notifications for failed (auto)withdrawals would also be useful but going to do this in a different PR.

_Wanted to add video to show off push notification merging but for some reason suddenly all my channels are inactive and I see this in the logs (maybe related, not sure if that was there before):_

> stacker_lnd   | 2024-03-26 01:38:53.004 [ERR] CMGR: Can't accept connection: unable to accept connection from 172.19.0.10:47790: chacha20poly1305: message authentication failed

_Will check tomorrow what's going on but keeping this PR ready for review since I tested the code before and it worked._