### PR TITLE
Allow links to be fit to their content on the homepage

### DIFF
--- a/components/item.module.css
+++ b/components/item.module.css
@@ -35,6 +35,7 @@ a.title:visited {
     overflow: hidden;
     text-overflow: ellipsis;
     flex: 1 0 128px;
+    max-width: fit-content;
     margin-bottom: .15rem;
 }
 


### PR DESCRIPTION
Closes #923 

Before all links filled the rest of the remaining container with `flex: 1 0 128px;` now they are constrained by `max-width: fit-content;` while still expanding to fill the container.

![image](https://github.com/stackernews/stacker.news/assets/108441023/eb6741d8-3e95-4fc9-bdde-e16f5f546d74)
(Background added for effect)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
	- Improved the layout of visited items by setting a new `max-width` property with the value `fit-content` for the `a.title:visited` selector.
	- Adjusted the width of `.skeleton .otherItemLonger` to `60px` for a more consistent visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->