### PR TITLE
Fix zap undo wrong default value shown

### DIFF
--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -66,7 +66,7 @@ export default function Settings ({ ssrData }) {
           initial={{
             tipDefault: settings?.tipDefault || 21,
             turboTipping: settings?.turboTipping,
-            zapUndos: settings?.zapUndos || settings?.tipDefault ? 100 * settings.tipDefault : 2100,
+            zapUndos: settings?.zapUndos || (settings?.tipDefault ? 100 * settings.tipDefault : 2100),
             zapUndosEnabled: settings?.zapUndos !== null,
             fiatCurrency: settings?.fiatCurrency || 'USD',
             withdrawMaxFeeDefault: settings?.withdrawMaxFeeDefault,


### PR DESCRIPTION
The correct value for `zapUndos` was stored in the database but we were always showing `100 * tipDefault` due to operator precedence: [`||` is evaluated before `?`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_precedence).

I must have forgotten to retest this logic after https://github.com/stackernews/stacker.news/pull/965/commits/81502f8645e6781c39edf469b1b71632a1e7c93f which was my last commit in #965.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the logic for setting preferences related to undo actions in the Settings menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->