### PR TITLE
Enable readerView compatibility (issue #884)

### DIFF
--- a/components/item-full.js
+++ b/components/item-full.js
@@ -140,7 +140,7 @@ function TopLevelItem ({ item, noReply, ...props }) {
       belowTitle={item.forwards && item.forwards.length > 0 && <FwdUsers forwards={item.forwards} />}
       {...props}
     >
-      <div className={styles.fullItemContainer} ref={textRef}>
+      <article className={styles.fullItemContainer} ref={textRef}>
         {item.text && <ItemText item={item} />}
         {item.url && <ItemEmbed item={item} />}
         {item.poll && <Poll item={item} />}
@@ -157,7 +157,7 @@ function TopLevelItem ({ item, noReply, ...props }) {
                   {numWithUnits(item.bounty, { abbreviate: false, format: true })} bounty
                 </div>)}
           </div>}
-      </div>
+      </article>
       {!noReply &&
         <>
           <Reply item={item} replyOpen placeholder={item.ncomments > 3 ? 'fractions of a penny for your thoughts?' : 'early comments get more zaps'} onCancelQuote={cancelQuote} onQuoteReply={quoteReply} quote={quote} />


### PR DESCRIPTION
This PR implements the feature from issue https://github.com/stackernews/stacker.news/issues/884

fullItemContainer from ```div``` to ```article``` to make it compatible with browser's reader view

![image](https://github.com/stackernews/stacker.news/assets/241271/991e1ac0-b064-4d35-a8c6-3fb40dbc62fb)

![image](https://github.com/stackernews/stacker.news/assets/241271/8a81b14e-30e5-4eea-823d-90969fd873f2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Refactor**
	- Updated the HTML structure of the `TopLevelItem` component for better semantic clarity.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->