### PR TITLE
Add index to make unique key props on territory options

### DIFF
--- a/components/sub-select.js
+++ b/components/sub-select.js
@@ -25,7 +25,7 @@ export function useSubs ({ prependSubs = [], sub, filterSubs = () => true, appen
 
   const [subs, setSubs] = useState([
     ...prependSubs.filter(s => s !== sub),
-    sub,
+    ...(sub ? [sub] : []),
     ...appendSubs.filter(s => s !== sub)])
   useEffect(() => {
     if (!data) return


### PR DESCRIPTION
Just a code cleanup PR. I was getting a react key prop warning on the `/post` route and I think the issue was that there was some duplicate items being used as keys so I added an index and subIndex for the `optgroup` and `option` to prevent any duplicate keys for siblings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the key assignment for list items in forms to ensure unique and accurate tracking.
	- Updated the `Select` function within `components/form.js` to enhance the rendering logic for better performance.
	- Enhanced the logic in the `useSubs` function of `components/sub-select.js` to optimize the inclusion of sub items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->