### PR TITLE
Hash API keys with SHA-256 before storing them

### DIFF
--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -104,7 +104,7 @@ export default gql`
     github: Boolean!
     twitter: Boolean!
     email: String
-    apiKey: String
+    apiKey: Boolean!
   }
 
   type UserPrivates {

--- a/components/modal.js
+++ b/components/modal.js
@@ -61,7 +61,7 @@ export default function useModal () {
         dialogClassName={className}
         contentClassName={className}
       >
-        <div className='d-flex flex-row'>
+        <div className='d-flex flex-row align-self-end'>
           {modalOptions?.overflow &&
             <div className={'modal-btn modal-overflow ' + className}>
               <ActionDropdown>

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -767,7 +767,7 @@ export function EmailLinkForm ({ callbackUrl }) {
   )
 }
 
-export function ApiKey ({ enabled, apiKey }) {
+function ApiKey ({ enabled, apiKey }) {
   const showModal = useShowModal()
   const me = useMe()
   const [generateApiKey] = useMutation(

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -847,15 +847,15 @@ I estimate that I will call the GraphQL API this many times (rough estimate is f
               }}
             >Generate API key
             </Button>
-            {apiKey &&
-              <DeleteIcon
-                style={{ cursor: 'pointer' }} className='fill-danger mx-1' width={24} height={24}
-                onClick={async () => {
-                  showModal((onClose) => <ApiKeyDeleteObstacle onClose={onClose} />)
-                }}
-              />}
           </div>
         </OverlayTrigger>
+        {apiKey &&
+          <DeleteIcon
+            style={{ cursor: 'pointer' }} className='fill-danger mx-1' width={24} height={24}
+            onClick={async () => {
+              showModal((onClose) => <ApiKeyDeleteObstacle onClose={onClose} />)
+            }}
+          />}
         <Info>
           <ul className='fw-bold'>
             <li>use API keys with our <Link target='_blank' href='/api/graphql'>GraphQL API</Link> for authentication</li>

--- a/prisma/migrations/20240326181608_api_key_sha256/migration.sql
+++ b/prisma/migrations/20240326181608_api_key_sha256/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `apiKey` on the `users` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[apiKeyHash]` on the table `users` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "users.apikey_unique";
+
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "apiKey",
+ADD COLUMN     "apiKeyHash" CHAR(64);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users.apikeyhash_unique" ON "users"("apiKeyHash");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,7 +26,7 @@ model User {
   checkedNotesAt            DateTime?
   foundNotesAt              DateTime?
   pubkey                    String?              @unique(map: "users.pubkey_unique")
-  apiKey                    String?              @unique(map: "users.apikey_unique") @db.Char(32)
+  apiKeyHash                String?              @unique(map: "users.apikeyhash_unique") @db.Char(64)
   apiKeyEnabled             Boolean              @default(false)
   tipDefault                Int                  @default(100)
   bioId                     Int?

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -481,6 +481,10 @@ div[contenteditable]:disabled,
 .modal-content {
   background-color: var(--theme-inputBg);
   border-color: var(--theme-borderColor);
+  align-items: center;
+}
+.modal-body {
+  width: fit-content;
 }
 
 .nav-link:not(.text-success, .text-warning) {


### PR DESCRIPTION
As reported by @SatsAllDay, I stored API keys in plaintext in #915. This is bad since before #915, database leaks could not result in account takeovers. With API keys in plaintext, this is the case.

This PR fixes this by only storing SHA-256 hashes of API keys.

Additionally, the API key is only shown once to the user (obviously, since we literally cannot show it again).

https://github.com/stackernews/stacker.news/assets/27162016/fd5b8844-ec60-4fee-a8d4-3ee842e7c6a6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an enhanced API key management system, including generation, deletion, and verification of API keys using hashes for improved security.
	- Added new modal design adjustments for better alignment and presentation.

- **Bug Fixes**
	- Fixed user authentication flow to directly query the database for user information using API key hashes, enhancing the reliability of user sessions.

- **Refactor**
	- Updated the API key field in the user model from a string to a boolean to reflect its enabled status.
	- Improved the modal component's styling for better user interface consistency.

- **Database Changes**
	- Implemented database schema changes to support API key hashing, including dropping the old `apiKey` column and introducing `apiKeyHash` with a unique index.

- **Style**
	- Enhanced global modal styles for improved visual coherence across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->