### PR TITLE
Fix alignment in modal

### DIFF
--- a/components/modal.js
+++ b/components/modal.js
@@ -61,7 +61,7 @@ export default function useModal () {
         dialogClassName={className}
         contentClassName={className}
       >
-        <div className='d-flex flex-row align-self-end'>
+        <div className='d-flex flex-row'>
           {modalOptions?.overflow &&
             <div className={'modal-btn modal-overflow ' + className}>
               <ActionDropdown>

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -485,9 +485,9 @@ div[contenteditable]:disabled,
 .modal-content {
   background-color: var(--theme-inputBg);
   border-color: var(--theme-borderColor);
-  align-items: center;
 }
 .modal-body {
+  align-self: center;
   width: fit-content;
 }
 


### PR DESCRIPTION
In #980, I updated the CSS for modals to center the modal body and use `width: fit-content` such that it doesn't look like this:

![2024-03-28-171639_514x193_scrot](https://github.com/stackernews/stacker.news/assets/27162016/a71809ca-6d16-47b0-afbd-ee7475b9a13a)

but like this:

![2024-03-28-171710_510x196_scrot](https://github.com/stackernews/stacker.news/assets/27162016/383387a8-3ac3-43f7-b9e9-e6f1f82748c4)

But this caused this:

![2024-03-28-171036_523x571_scrot](https://github.com/stackernews/stacker.news/assets/27162016/02f33e1b-e63a-4425-a71b-7efb359343ec)

This PR fixes that to look like this while still keeping the modal body centered:

![2024-03-28-171101_520x577_scrot](https://github.com/stackernews/stacker.news/assets/27162016/aa08d759-6f4a-4a2e-8777-e215bcca9e4a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved alignment and layout of modal components for better visual appeal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->