### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,54 @@
+**Description**
+
+<!--
+
+A clear and concise description of what you changed and why.
+
+Bullet points can be enough.
+
+You can use the following PRs as inspiration:
+  - https://github.com/stackernews/stacker.news/pull/227 (feature)
+  - https://github.com/stackernews/stacker.news/pull/915 (feature)
+  - https://github.com/stackernews/stacker.news/pull/871 (fix)
+  - <your PR could be here>
+
+Don't forget to mention which tickets this closes (if any).
+Use following syntax to close them automatically on merge: closes #<NUMBER>
+
+-->
+
+**Screenshots**
+
+<!--
+
+If your changes are user facing, please add screenshots of the new UI.
+
+You can also create a video to showcase your changes (useful to show UX).
+
+-->
+
+**Additional Context**
+
+<!--
+
+You can mention here anything that you think is relevant for this PR. Some examples:
+
+* You encountered something that you didn't understand while working on this PR
+* You were not sure about something you did but did not find a better way
+* You initially had a different approach but went with a different approach for some reason
+
+-->
+
+**Checklist**
+
+<!-- Examples for backwards incompatible changes:
+- dropping database columns
+- changing GraphQL type definitions to make a field mandatory -->
+- [ ] Are your changes backwards compatible?
+
+<!-- If your PR is not ready for review yet, please mark your PR as a draft.
+If changes were requested, request a new review when you incorporated the feedback. -->
+- [ ] Did you QA this? Could we deploy this straight to production?
+
+<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
+- [ ] For frontend changes: Tested on mobile?


### PR DESCRIPTION
With the checklist in this PR template, we should no longer be caught off by backwards incompatible changes like in #980 which cause downtime during deployments. The checklist is formulated intentionally in a way that if the box is not checked, the answer to the question is probably no.

This was partly inspired by the [PR template for the Alby browser extension](https://github.com/getAlby/lightning-browser-extension/blob/master/.github/pull_request_template.md). Are there other good templates that we could use as a reference?

I also added some examples of PRs that had good descriptions in my opinion. This list might be biased / opinionated though. Are there better examples? Are these examples useful?

This PR template also adds other useful information about the review process. Anything to add? For example, we could mention that we mark PRs as drafts ourselves when we request changes but we did not do this so far afaict. I think we simply mentioned to request a new review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Documentation**
	- Introduced a pull request template to standardize the descriptions for changes, enhancing clarity and consistency in project documentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->