### PR TITLE
Fix title from draft being dismissed (#718)

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -453,7 +453,8 @@ function InputInner ({
         const isNumeric = /^[0-9]+$/.test(draft)
         const numericExpected = typeof field.value === 'number'
         helpers.setValue(isNumeric && numericExpected ? parseInt(draft) : draft)
-        onChange && onChange(formik, { target: { value: draft } })
+        // draft means change event is from local storage
+        onChange && onChange(formik, { target: { value: draft, draft: true } })
       }
     }
   }, [overrideValue])

--- a/components/form.js
+++ b/components/form.js
@@ -453,8 +453,7 @@ function InputInner ({
         const isNumeric = /^[0-9]+$/.test(draft)
         const numericExpected = typeof field.value === 'number'
         helpers.setValue(isNumeric && numericExpected ? parseInt(draft) : draft)
-        // draft means change event is from local storage
-        onChange && onChange(formik, { target: { value: draft, draft: true } })
+        onChange && onChange(formik, { target: { value: draft } })
       }
     }
   }, [overrideValue])

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -172,7 +172,9 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
           ? <div className='text-muted fw-bold'><Countdown date={editThreshold} /></div>
           : null}
         onChange={async (formik, e) => {
-          if ((/^ *$/).test(formik?.values.title)) {
+          const isTitleEmpty = (/^ *$/).test(formik?.values.title)
+          const isDraftChange = e.target.draft
+          if (!isDraftChange && isTitleEmpty) {
             getPageTitleAndUnshorted({
               variables: { url: e.target.value }
             })

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -172,9 +172,9 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
           ? <div className='text-muted fw-bold'><Countdown date={editThreshold} /></div>
           : null}
         onChange={async (formik, e) => {
-          const isTitleEmpty = (/^ *$/).test(formik?.values.title)
-          const isDraftChange = e.target.draft
-          if (!isDraftChange && isTitleEmpty) {
+          const hasTitle = !!(formik?.values.title.trim().length > 0)
+          const hasDraftTitle = !!(window.localStorage.getItem('link-title')?.trim()?.length > 0)
+          if (!hasTitle && !hasDraftTitle) {
             getPageTitleAndUnshorted({
               variables: { url: e.target.value }
             })


### PR DESCRIPTION
Add a way to bypass the title generation query when the url change is from local storage (draft) and not user interaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced form input handling to recognize draft changes, improving the user experience for data auto-saved from local storage.
- **Refactor**
	- Improved logic in link form validation to accurately detect empty titles, especially for draft changes, ensuring more reliable form submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->