### PR TITLE
Wallet Logs

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -529,7 +529,7 @@ export default {
   }
 }
 
-const addWalletLog = async ({ wallet, level, message }, { me, models }) => {
+export const addWalletLog = async ({ wallet, level, message }, { me, models }) => {
   try {
     await models.walletLog.create({ data: { userId: me.id, wallet, level, message } })
   } catch (err) {

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -304,6 +304,20 @@ export default {
         cursor: history.length === LIMIT ? nextCursorEncoded(decodedCursor) : null,
         facts: history
       }
+    },
+    walletLogs: async (parent, args, { me, models }) => {
+      if (!me) {
+        throw new GraphQLError('you must be logged in', { extensions: { code: 'FORBIDDEN' } })
+      }
+
+      return await models.walletLog.findMany({
+        where: {
+          userId: me.id
+        },
+        orderBy: {
+          createdAt: 'asc'
+        }
+      })
     }
   },
   WalletDetails: {
@@ -415,10 +429,11 @@ export default {
       data.macaroon = ensureB64(data.macaroon)
       data.cert = ensureB64(data.cert)
 
+      const wallet = 'walletLND'
       return await upsertWallet(
         {
           schema: LNDAutowithdrawSchema,
-          walletName: 'walletLND',
+          walletName: wallet,
           walletType: 'LND',
           testConnect: async ({ cert, macaroon, socket }) => {
             const { lnd } = await authenticatedLndGrpc({
@@ -426,24 +441,35 @@ export default {
               macaroon,
               socket
             })
-            return await createInvoice({
-              description: 'SN connection test',
-              lnd,
-              tokens: 0,
-              expires_at: new Date()
-            })
+            await addWalletLog({ wallet, level: 'SUCCESS', message: 'connected to LND node' }, { me, models })
+            try {
+              const inv = await createInvoice({
+                description: 'SN connection test',
+                lnd,
+                tokens: 0,
+                expires_at: new Date()
+              })
+              await addWalletLog({ wallet, level: 'SUCCESS', message: 'created test invoice' }, { me, models })
+              return inv
+            } catch (err) {
+              await addWalletLog({ wallet, level: 'ERROR', message: `could not create test invoice: ${err.message || err.toString?.()}` }, { me, models })
+              throw err
+            }
           }
         },
         { settings, data }, { me, models })
     },
     upsertWalletLNAddr: async (parent, { settings, ...data }, { me, models }) => {
+      const wallet = 'walletLightningAddress'
       return await upsertWallet(
         {
           schema: lnAddrAutowithdrawSchema,
-          walletName: 'walletLightningAddress',
+          walletName: wallet,
           walletType: 'LIGHTNING_ADDRESS',
           testConnect: async ({ address }) => {
-            return await lnAddrOptions(address)
+            const options = await lnAddrOptions(address)
+            await addWalletLog({ wallet, level: 'SUCCESS', message: 'fetched payment details' }, { me, models })
+            return options
           }
         },
         { settings, data }, { me, models })
@@ -453,7 +479,23 @@ export default {
         throw new GraphQLError('you must be logged in', { extensions: { code: 'UNAUTHENTICATED' } })
       }
 
-      await models.wallet.delete({ where: { userId: me.id, id: Number(id) } })
+      const wallet = await models.wallet.findUnique({ where: { userId: me.id, id: Number(id) } })
+      if (!wallet) {
+        throw new GraphQLError('wallet not found', { extensions: { code: 'BAD_INPUT' } })
+      }
+
+      // determine wallet name for logging
+      let walletName = ''
+      if (wallet.type === 'LND') {
+        walletName = 'walletLND'
+      } else if (wallet.type === 'LIGHTNING_ADDRESS') {
+        walletName = 'walletLightningAddress'
+      }
+
+      await models.$transaction([
+        models.wallet.delete({ where: { userId: me.id, id: Number(id) } }),
+        models.walletLog.create({ data: { userId: me.id, wallet: walletName, level: 'SUCCESS', message: 'wallet deleted' } })
+      ])
 
       return true
     }
@@ -487,6 +529,14 @@ export default {
   }
 }
 
+const addWalletLog = async ({ wallet, level, message }, { me, models }) => {
+  try {
+    await models.walletLog.create({ data: { userId: me.id, wallet, level, message } })
+  } catch (err) {
+    console.error('error creating wallet log:', err)
+  }
+}
+
 async function upsertWallet (
   { schema, walletName, walletType, testConnect }, { settings, data }, { me, models }) {
   if (!me) {
@@ -498,8 +548,9 @@ async function upsertWallet (
   if (testConnect) {
     try {
       await testConnect(data)
-    } catch (error) {
-      console.error(error)
+    } catch (err) {
+      console.error(err)
+      await addWalletLog({ wallet: walletName, level: 'ERROR', message: 'failed to attach wallet' }, { me, models })
       throw new GraphQLError('failed to connect to wallet', { extensions: { code: 'BAD_INPUT' } })
     }
   }
@@ -542,7 +593,9 @@ async function upsertWallet (
             }
           }
         }
-      }))
+      }),
+      models.walletLog.create({ data: { userId: me.id, wallet: walletName, level: 'SUCCESS', message: 'wallet updated' } })
+    )
   } else {
     txs.push(
       models.wallet.create({
@@ -554,7 +607,9 @@ async function upsertWallet (
             create: walletData
           }
         }
-      }))
+      }),
+      models.walletLog.create({ data: { userId: me.id, wallet: walletName, level: 'SUCCESS', message: 'wallet created' } })
+    )
   }
 
   await models.$transaction(txs)

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -436,25 +436,25 @@ export default {
           walletName: wallet,
           walletType: 'LND',
           testConnect: async ({ cert, macaroon, socket }) => {
-            const { lnd } = await authenticatedLndGrpc({
-              cert,
-              macaroon,
-              socket
-            })
-            await addWalletLog({ wallet, level: 'SUCCESS', message: 'connected to LND node' }, { me, models })
             try {
+              const { lnd } = await authenticatedLndGrpc({
+                cert,
+                macaroon,
+                socket
+              })
               const inv = await createInvoice({
                 description: 'SN connection test',
                 lnd,
                 tokens: 0,
                 expires_at: new Date()
               })
-              await addWalletLog({ wallet, level: 'SUCCESS', message: 'created test invoice' }, { me, models })
+              // we wrap both calls in one try/catch since connection attempts happen on RPC calls
+              await addWalletLog({ wallet, level: 'SUCCESS', message: 'connected to LND' }, { me, models })
               return inv
             } catch (err) {
               // LND errors are in this shape: [code, type, { err: { code, details, metadata } }]
               const details = err[2]?.err?.details || err.message || err.toString?.()
-              await addWalletLog({ wallet, level: 'ERROR', message: `could not create test invoice: ${details}` }, { me, models })
+              await addWalletLog({ wallet, level: 'ERROR', message: `could not connect to LND: ${details}` }, { me, models })
               throw err
             }
           }

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -452,7 +452,9 @@ export default {
               await addWalletLog({ wallet, level: 'SUCCESS', message: 'created test invoice' }, { me, models })
               return inv
             } catch (err) {
-              await addWalletLog({ wallet, level: 'ERROR', message: `could not create test invoice: ${err.message || err.toString?.()}` }, { me, models })
+              // LND errors are in this shape: [code, type, { err: { code, details, metadata } }]
+              const details = err[2]?.err?.details || err.message || err.toString?.()
+              await addWalletLog({ wallet, level: 'ERROR', message: `could not create test invoice: ${details}` }, { me, models })
               throw err
             }
           }

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -10,6 +10,7 @@ export default gql`
     wallets: [Wallet!]!
     wallet(id: ID!): Wallet
     walletByType(type: String!): Wallet
+    walletLogs: [WalletLog]!
   }
 
   extend type Mutation {
@@ -98,5 +99,13 @@ export default gql`
   type History {
     facts: [Fact!]!
     cursor: String
+  }
+
+  type WalletLog {
+    id: ID!
+    createdAt: Date!
+    wallet: ID!
+    level: String!
+    message: String!
   }
 `

--- a/components/log-message.js
+++ b/components/log-message.js
@@ -2,7 +2,8 @@ import { timeSince } from '@/lib/time'
 import styles from './log-message.module.css'
 
 export default function LogMessage ({ wallet, level, message, ts }) {
-  const levelClassName = level === 'ok' ? 'text-success' : level === 'error' ? 'text-danger' : level === 'info' ? 'text-info' : ''
+  level = level.toLowerCase()
+  const levelClassName = ['ok', 'success'].includes(level) ? 'text-success' : level === 'error' ? 'text-danger' : level === 'info' ? 'text-info' : ''
   return (
     <tr className={styles.line}>
       <td className={styles.timestamp}>{timeSince(new Date(ts))}</td>

--- a/components/log-message.js
+++ b/components/log-message.js
@@ -4,11 +4,11 @@ import styles from './log-message.module.css'
 export default function LogMessage ({ wallet, level, message, ts }) {
   const levelClassName = level === 'ok' ? 'text-success' : level === 'error' ? 'text-danger' : level === 'info' ? 'text-info' : ''
   return (
-    <div className={styles.line}>
-      <span className={styles.timestamp}>{timeSince(new Date(ts))}</span>
-      <span className='fw-bold mx-1'>[{wallet}]</span>
-      <span className={`fw-bold ${styles.level} ${levelClassName}`}>{level}</span>
-      <span>{message}</span>
-    </div>
+    <tr className={styles.line}>
+      <td className={styles.timestamp}>{timeSince(new Date(ts))}</td>
+      <td className={styles.wallet}>[{wallet}]</td>
+      <td className={`${styles.level} ${levelClassName}`}>{level}</td>
+      <td>{message}</td>
+    </tr>
   )
 }

--- a/components/log-message.js
+++ b/components/log-message.js
@@ -1,0 +1,14 @@
+import { timeSince } from '@/lib/time'
+import styles from './log-message.module.css'
+
+export default function LogMessage ({ wallet, level, message, ts }) {
+  const levelClassName = level === 'ok' ? 'text-success' : level === 'error' ? 'text-danger' : level === 'info' ? 'text-info' : ''
+  return (
+    <div className={styles.line}>
+      <span className={styles.timestamp}>{timeSince(new Date(ts))}</span>
+      <span className='fw-bold mx-1'>[{wallet}]</span>
+      <span className={`fw-bold ${styles.level} ${levelClassName}`}>{level}</span>
+      <span>{message}</span>
+    </div>
+  )
+}

--- a/components/log-message.module.css
+++ b/components/log-message.module.css
@@ -1,0 +1,18 @@
+.line {
+    font-family: monospace;
+    font-size: x-small;
+    color: var(--theme-grey) !important; /* .text-muted */
+}
+
+.timestamp {
+    text-align: end;
+    display: inline-block;
+    width: 25px;
+}
+
+.level {
+    text-transform: uppercase;
+    display: inline-block;
+    width: 40px;
+    margin: 0 0.25em;
+}

--- a/components/log-message.module.css
+++ b/components/log-message.module.css
@@ -19,5 +19,5 @@
     font-weight: bold;
     vertical-align: top;
     text-transform: uppercase;
-    margin-right: 0 0.25em;
+    padding-right: 0.5em;
 }

--- a/components/log-message.module.css
+++ b/components/log-message.module.css
@@ -1,18 +1,23 @@
 .line {
     font-family: monospace;
-    font-size: x-small;
     color: var(--theme-grey) !important; /* .text-muted */
 }
 
 .timestamp {
+    vertical-align: top;
     text-align: end;
-    display: inline-block;
-    width: 25px;
+    text-wrap: nowrap;
+    justify-self: first baseline;
+}
+
+.wallet {
+    vertical-align: top;
+    font-weight: bold;
 }
 
 .level {
+    font-weight: bold;
+    vertical-align: top;
     text-transform: uppercase;
-    display: inline-block;
-    width: 40px;
-    margin: 0 0.25em;
+    margin-right: 0 0.25em;
 }

--- a/components/logger.js
+++ b/components/logger.js
@@ -155,8 +155,6 @@ const initIndexedDB = async (storeName) => {
 }
 
 const WalletLoggerProvider = ({ children }) => {
-  // TODO: persist logs in local storage
-  // limit to last 24h?
   const [logs, setLogs] = useState([])
   const idbStoreName = 'wallet_logs'
   const idb = useRef()

--- a/components/qr.js
+++ b/components/qr.js
@@ -20,7 +20,7 @@ export default function Qr ({ asIs, value, webLn, statusVariant, description, st
       }
     }
     effect()
-  }, [provider?.enabled])
+  }, [provider])
 
   return (
     <>

--- a/components/qr.js
+++ b/components/qr.js
@@ -20,7 +20,7 @@ export default function Qr ({ asIs, value, webLn, statusVariant, description, st
       }
     }
     effect()
-  }, [provider])
+  }, [provider?.enabled])
 
   return (
     <>

--- a/components/serviceworker.js
+++ b/components/serviceworker.js
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react'
 import { Workbox } from 'workbox-window'
 import { gql, useMutation } from '@apollo/client'
-import { detectOS, useLogger } from './logger'
+import { detectOS, useServiceWorkerLogger } from './logger'
 
 const applicationServerKey = process.env.NEXT_PUBLIC_VAPID_PUBKEY
 
@@ -44,7 +44,7 @@ export const ServiceWorkerProvider = ({ children }) => {
           }
         }
       `)
-  const logger = useLogger()
+  const logger = useServiceWorkerLogger()
 
   // I am not entirely sure if this is needed since at least in Brave,
   // using `registration.pushManager.subscribe` also prompts the user.

--- a/components/wallet-logs.js
+++ b/components/wallet-logs.js
@@ -55,6 +55,8 @@ export default function WalletLogs ({ wallet, embedded }) {
     return () => tableRef.current?.removeEventListener('scroll', onScroll)
   }, [])
 
+  const filtered = logs.filter(l => !wallet || l.wallet === wallet)
+
   return (
     <>
       <Form initial={{ follow: true }}>
@@ -64,12 +66,11 @@ export default function WalletLogs ({ wallet, embedded }) {
         />
       </Form>
       <div ref={tableRef} className={`${styles.logTable} ${embedded ? styles.embedded : ''}`}>
+        <div className='w-100 text-center'>------ start of logs ------</div>
+        {filtered.length === 0 && <div className='w-100 text-center'>empty</div>}
         <table>
           <tbody>
-            <tr><td colSpan='4' className='text-center'>------ start of logs ------</td></tr>
-            {logs
-              .filter(l => !wallet || l.wallet === wallet)
-              .map((log, i) => <LogMessage key={i} {...log} />)}
+            {filtered.map((log, i) => <LogMessage key={i} {...log} />)}
           </tbody>
         </table>
       </div>

--- a/components/wallet-logs.js
+++ b/components/wallet-logs.js
@@ -1,0 +1,79 @@
+import { useRouter } from 'next/router'
+import LogMessage from './log-message'
+import { useWalletLogger } from './logger'
+import { useEffect, useRef, useState } from 'react'
+import { Checkbox, Form } from './form'
+import { useField } from 'formik'
+import styles from '@/styles/log.module.css'
+
+const FollowCheckbox = ({ value, ...props }) => {
+  const [,, helpers] = useField(props.name)
+
+  useEffect(() => {
+    helpers.setValue(value)
+  }, [value])
+
+  return (
+    <Checkbox {...props} />
+  )
+}
+
+export default function WalletLogs () {
+  const { logs } = useWalletLogger()
+
+  const router = useRouter()
+  const { follow: defaultFollow } = router.query
+  const [follow, setFollow] = useState(defaultFollow ?? true)
+  const tableRef = useRef()
+  const scrollY = useRef()
+  const tableEndRef = useRef()
+
+  useEffect(() => {
+    if (follow) {
+      tableEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    }
+  }, [logs, follow])
+
+  useEffect(() => {
+    function onScroll (e) {
+      const y = e.target.scrollTop
+
+      const down = y - scrollY.current >= -1
+      if (!!scrollY.current && !down) {
+        setFollow(false)
+      }
+
+      const maxY = e.target.scrollHeight - e.target.clientHeight
+      const dY = maxY - y
+      const isBottom = dY >= -1 && dY <= 1
+      if (isBottom) {
+        setFollow(true)
+      }
+
+      scrollY.current = y
+    }
+    tableRef.current?.addEventListener('scroll', onScroll)
+    return () => tableRef.current?.removeEventListener('scroll', onScroll)
+  }, [])
+
+  // TODO add filter by wallet
+  return (
+    <>
+      <Form initial={{ follow: true }}>
+        <FollowCheckbox
+          label='follow' name='follow' value={follow}
+          handleChange={setFollow}
+        />
+      </Form>
+      <div ref={tableRef} className={styles.logTable}>
+        <table>
+          <tbody>
+            <tr><td colSpan='4' className='text-center'>------ start of logs ------</td></tr>
+            {logs.map((log, i) => <LogMessage key={i} {...log} />)}
+            <tr><td colSpan='4' ref={tableEndRef} /></tr>
+          </tbody>
+        </table>
+      </div>
+    </>
+  )
+}

--- a/components/wallet-logs.js
+++ b/components/wallet-logs.js
@@ -55,7 +55,6 @@ export default function WalletLogs ({ wallet, embedded }) {
     return () => tableRef.current?.removeEventListener('scroll', onScroll)
   }, [])
 
-  // TODO add filter by wallet
   return (
     <>
       <Form initial={{ follow: true }}>

--- a/components/wallet-logs.js
+++ b/components/wallet-logs.js
@@ -18,7 +18,7 @@ const FollowCheckbox = ({ value, ...props }) => {
   )
 }
 
-export default function WalletLogs () {
+export default function WalletLogs ({ embedded }) {
   const { logs } = useWalletLogger()
 
   const router = useRouter()
@@ -61,11 +61,11 @@ export default function WalletLogs () {
     <>
       <Form initial={{ follow: true }}>
         <FollowCheckbox
-          label='follow' name='follow' value={follow}
+          label='follow logs' name='follow' value={follow}
           handleChange={setFollow}
         />
       </Form>
-      <div ref={tableRef} className={styles.logTable}>
+      <div ref={tableRef} className={`${styles.logTable} ${embedded ? styles.embedded : ''}`}>
         <table>
           <tbody>
             <tr><td colSpan='4' className='text-center'>------ start of logs ------</td></tr>

--- a/components/wallet-logs.js
+++ b/components/wallet-logs.js
@@ -1,6 +1,6 @@
 import { useRouter } from 'next/router'
 import LogMessage from './log-message'
-import { useWalletLogger } from './logger'
+import { useWalletLogs } from './logger'
 import { useEffect, useRef, useState } from 'react'
 import { Checkbox, Form } from './form'
 import { useField } from 'formik'
@@ -19,7 +19,7 @@ const FollowCheckbox = ({ value, ...props }) => {
 }
 
 export default function WalletLogs ({ wallet, embedded }) {
-  const { logs } = useWalletLogger()
+  const logs = useWalletLogs(wallet)
 
   const router = useRouter()
   const { follow: defaultFollow } = router.query
@@ -55,8 +55,6 @@ export default function WalletLogs ({ wallet, embedded }) {
     return () => tableRef.current?.removeEventListener('scroll', onScroll)
   }, [])
 
-  const filtered = logs.filter(l => !wallet || l.wallet === wallet)
-
   return (
     <>
       <Form initial={{ follow: true }}>
@@ -67,10 +65,10 @@ export default function WalletLogs ({ wallet, embedded }) {
       </Form>
       <div ref={tableRef} className={`${styles.logTable} ${embedded ? styles.embedded : ''}`}>
         <div className='w-100 text-center'>------ start of logs ------</div>
-        {filtered.length === 0 && <div className='w-100 text-center'>empty</div>}
+        {logs.length === 0 && <div className='w-100 text-center'>empty</div>}
         <table>
           <tbody>
-            {filtered.map((log, i) => <LogMessage key={i} {...log} />)}
+            {logs.map((log, i) => <LogMessage key={i} {...log} />)}
           </tbody>
         </table>
       </div>

--- a/components/wallet-logs.js
+++ b/components/wallet-logs.js
@@ -26,11 +26,10 @@ export default function WalletLogs ({ wallet, embedded }) {
   const [follow, setFollow] = useState(defaultFollow ?? true)
   const tableRef = useRef()
   const scrollY = useRef()
-  const tableEndRef = useRef()
 
   useEffect(() => {
     if (follow) {
-      tableEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+      tableRef.current?.scroll({ top: tableRef.current.scrollHeight, behavior: 'smooth' })
     }
   }, [logs, follow])
 
@@ -72,7 +71,6 @@ export default function WalletLogs ({ wallet, embedded }) {
             {logs
               .filter(l => !wallet || l.wallet === wallet)
               .map((log, i) => <LogMessage key={i} {...log} />)}
-            <tr><td colSpan='4' ref={tableEndRef} /></tr>
           </tbody>
         </table>
       </div>

--- a/components/wallet-logs.js
+++ b/components/wallet-logs.js
@@ -18,7 +18,7 @@ const FollowCheckbox = ({ value, ...props }) => {
   )
 }
 
-export default function WalletLogs ({ embedded }) {
+export default function WalletLogs ({ wallet, embedded }) {
   const { logs } = useWalletLogger()
 
   const router = useRouter()
@@ -69,7 +69,9 @@ export default function WalletLogs ({ embedded }) {
         <table>
           <tbody>
             <tr><td colSpan='4' className='text-center'>------ start of logs ------</td></tr>
-            {logs.map((log, i) => <LogMessage key={i} {...log} />)}
+            {logs
+              .filter(l => !wallet || l.wallet === wallet)
+              .map((log, i) => <LogMessage key={i} {...log} />)}
             <tr><td colSpan='4' ref={tableEndRef} /></tr>
           </tbody>
         </table>

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -92,19 +92,18 @@ export function LNbitsProvider ({ children }) {
   const sendPayment = useCallback(async (bolt11) => {
     const inv = lnpr.decode(bolt11)
     const hash = inv.tagsObject.payment_hash
-    // use short hash for logging to prevent x-overflow
-    const shortHash = `${hash.slice(0, 8)}..${hash.slice(-8)}`
-    logger.info('sending payment:', shortHash)
+    logger.info('sending payment:', `payment_hash=${hash}`)
     try {
       const response = await postPayment(url, adminKey, bolt11)
       const checkResponse = await getPayment(url, adminKey, response.payment_hash)
       if (!checkResponse.preimage) {
         throw new Error('No preimage')
       }
-      logger.ok('payment successful:', shortHash)
-      return { preimage: checkResponse.preimage }
+      const preimage = checkResponse.preimage
+      logger.ok('payment successful:', `payment_hash=${hash}`, `preimage=${preimage}`)
+      return { preimage }
     } catch (err) {
-      logger.error('payment failed:', shortHash, err.message || err.toString?.())
+      logger.error('payment failed:', `payment_hash=${hash}`, err.message || err.toString?.())
       throw err
     }
   }, [logger, url, adminKey])

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -1,4 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { useWalletLogger } from '../logger'
+import lnpr from 'bolt11'
 
 // Reference: https://github.com/getAlby/bitcoin-connect/blob/v3.2.0-alpha/src/connectors/LnbitsConnector.ts
 
@@ -65,6 +67,7 @@ export function LNbitsProvider ({ children }) {
   const [adminKey, setAdminKey] = useState('')
   const [enabled, setEnabled] = useState()
   const [initialized, setInitialized] = useState(false)
+  const logger = useWalletLogger('lnbits')
 
   const name = 'LNbits'
   const storageKey = 'webln:provider:lnbits'
@@ -87,19 +90,31 @@ export function LNbitsProvider ({ children }) {
   }, [url, adminKey])
 
   const sendPayment = useCallback(async (bolt11) => {
-    const response = await postPayment(url, adminKey, bolt11)
-    const checkResponse = await getPayment(url, adminKey, response.payment_hash)
-    if (!checkResponse.preimage) {
-      throw new Error('No preimage')
+    const inv = lnpr.decode(bolt11)
+    const hash = inv.tagsObject.payment_hash
+    // use short hash for logging to prevent x-overflow
+    const shortHash = `${hash.slice(0, 8)}..${hash.slice(-8)}`
+    logger.info('sending payment:', shortHash)
+    try {
+      const response = await postPayment(url, adminKey, bolt11)
+      const checkResponse = await getPayment(url, adminKey, response.payment_hash)
+      if (!checkResponse.preimage) {
+        throw new Error('No preimage')
+      }
+      logger.ok('payment successful:', shortHash)
+      return { preimage: checkResponse.preimage }
+    } catch (err) {
+      logger.error('payment failed:', shortHash, err.message)
+      throw err
     }
-    return { preimage: checkResponse.preimage }
-  }, [url, adminKey])
+  }, [logger, url, adminKey])
 
   const loadConfig = useCallback(async () => {
     const configStr = window.localStorage.getItem(storageKey)
     if (!configStr) {
       setEnabled(undefined)
       setInitialized(true)
+      logger.info('no existing config found')
       return
     }
 
@@ -109,18 +124,27 @@ export function LNbitsProvider ({ children }) {
     setUrl(url)
     setAdminKey(adminKey)
 
+    logger.info(
+      'loaded wallet config: ' +
+      'adminKey=****** ' +
+      `url=${url}`)
+
     try {
       // validate config by trying to fetch wallet
+      logger.info('trying to fetch wallet')
       await getWallet(url, adminKey)
+      logger.ok('wallet found')
       setEnabled(true)
+      logger.ok('wallet enabled')
     } catch (err) {
-      console.error('invalid LNbits config:', err)
+      logger.error('invalid config:', err)
       setEnabled(false)
+      logger.info('wallet disabled')
       throw err
     } finally {
       setInitialized(true)
     }
-  }, [])
+  }, [logger])
 
   const saveConfig = useCallback(async (config) => {
     // immediately store config so it's not lost even if config is invalid
@@ -132,15 +156,24 @@ export function LNbitsProvider ({ children }) {
     //   https://thenewstack.io/leveraging-web-workers-to-safely-store-access-tokens/
     window.localStorage.setItem(storageKey, JSON.stringify(config))
 
+    logger.info(
+      'saved wallet config: ' +
+      'adminKey=****** ' +
+      `url=${config.url}`)
+
     try {
       // validate config by trying to fetch wallet
+      logger.info('trying to fetch wallet')
       await getWallet(config.url, config.adminKey)
+      logger.ok('wallet found')
     } catch (err) {
-      console.error('invalid LNbits config:', err)
+      logger.error('invalid config:', err)
       setEnabled(false)
+      logger.info('wallet disabled')
       throw err
     }
     setEnabled(true)
+    logger.ok('wallet enabled')
   }, [])
 
   const clearConfig = useCallback(() => {

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -104,7 +104,7 @@ export function LNbitsProvider ({ children }) {
       logger.ok('payment successful:', shortHash)
       return { preimage: checkResponse.preimage }
     } catch (err) {
-      logger.error('payment failed:', shortHash, err.message)
+      logger.error('payment failed:', shortHash, err.message || err.toString?.())
       throw err
     }
   }, [logger, url, adminKey])

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -63,8 +63,6 @@ export function NWCProvider ({ children }) {
       `relay=${params.relayUrl}`
     )
 
-    logger.error('test error')
-
     try {
       logger.info(`requesting info event from ${params.relayUrl}`)
       await validateParams({ ...params, logger })

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -60,8 +60,7 @@ export function NWCProvider ({ children }) {
       'loaded wallet config: ' +
       'secret=****** ' +
       `pubkey=${params.walletPubkey.slice(0, 6)}..${params.walletPubkey.slice(-6)} ` +
-      `relay=${params.relayUrl}`
-    )
+      `relay=${params.relayUrl}`)
 
     try {
       logger.info(`requesting info event from ${params.relayUrl}`)

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -3,6 +3,8 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { Relay, finalizeEvent, nip04 } from 'nostr-tools'
 import { parseNwcUrl } from '@/lib/url'
+import { useWalletLogger } from '../logger'
+import lnpr from 'bolt11'
 
 const NWCContext = createContext()
 
@@ -13,6 +15,7 @@ export function NWCProvider ({ children }) {
   const [secret, setSecret] = useState()
   const [enabled, setEnabled] = useState()
   const [initialized, setInitialized] = useState(false)
+  const logger = useWalletLogger('nwc')
 
   const relayRef = useRef()
 
@@ -21,8 +24,14 @@ export function NWCProvider ({ children }) {
 
   const updateRelay = async (relayUrl) => {
     try {
-      relayRef.current?.close()
-      if (relayUrl) relayRef.current = await Relay.connect(relayUrl)
+      if (relayRef.current) {
+        relayRef.current.close()
+        logger.info('disconnected from', relayRef.current.url)
+      }
+      if (relayUrl) {
+        relayRef.current = await Relay.connect(relayUrl)
+        logger.ok(`connected to ${relayUrl}`)
+      }
     } catch (err) {
       console.error(err)
     }
@@ -33,6 +42,7 @@ export function NWCProvider ({ children }) {
     if (!configStr) {
       setEnabled(undefined)
       setInitialized(true)
+      logger.info('no existing config found')
       return
     }
 
@@ -46,18 +56,31 @@ export function NWCProvider ({ children }) {
     setWalletPubkey(params.walletPubkey)
     setSecret(params.secret)
 
+    logger.info(
+      'loaded wallet config: ' +
+      'secret=****** ' +
+      `pubkey=${params.walletPubkey.slice(0, 6)}..${params.walletPubkey.slice(-6)} ` +
+      `relay=${params.relayUrl}`
+    )
+
+    logger.error('test error')
+
     try {
-      await validateParams(params)
-      setEnabled(true)
+      logger.info(`requesting info event from ${params.relayUrl}`)
+      await validateParams({ ...params, logger })
+      logger.ok('info event received')
       await updateRelay(params.relayUrl)
+      setEnabled(true)
+      logger.ok('wallet enabled')
     } catch (err) {
-      console.error('invalid NWC config:', err)
+      logger.error('invalid config:', err)
       setEnabled(false)
+      logger.info('wallet disabled')
       throw err
     } finally {
       setInitialized(true)
     }
-  }, [])
+  }, [logger])
 
   const saveConfig = useCallback(async (config) => {
     // immediately store config so it's not lost even if config is invalid
@@ -77,16 +100,26 @@ export function NWCProvider ({ children }) {
     // this is definitely not ideal from a security perspective.
     window.localStorage.setItem(storageKey, JSON.stringify(config))
 
+    logger.info(
+      'saved wallet config: ' +
+      'secret=****** ' +
+      `pubkey=${params.walletPubkey.slice(0, 6)}..${params.walletPubkey.slice(-6)} ` +
+      `relay=${params.relayUrl}`)
+
     try {
-      await validateParams(params)
-      setEnabled(true)
+      logger.info(`requesting info event from ${params.relayUrl}`)
+      await validateParams({ ...params, logger })
+      logger.ok('info event received')
       await updateRelay(params.relayUrl)
+      setEnabled(true)
+      logger.ok('wallet enabled')
     } catch (err) {
-      console.error('invalid NWC config:', err)
+      logger.error('invalid config:', err)
       setEnabled(false)
+      logger.info('wallet disabled')
       throw err
     }
-  }, [])
+  }, [logger])
 
   const clearConfig = useCallback(() => {
     window.localStorage.removeItem(storageKey)
@@ -97,82 +130,94 @@ export function NWCProvider ({ children }) {
     setEnabled(undefined)
   }, [])
 
-  const sendPayment = useCallback((bolt11) => {
-    return new Promise(function (resolve, reject) {
-      const relay = relayRef.current
-      if (!relay) {
-        return reject(new Error('not connected to relay'))
-      }
-      (async function () {
+  const sendPayment = useCallback(async (bolt11) => {
+    const inv = lnpr.decode(bolt11)
+    const hash = inv.tagsObject.payment_hash
+    // use short hash for logging to prevent x-overflow
+    const shortHash = `${hash.slice(0, 8)}..${hash.slice(-8)}`
+    logger.info('sending payment:', shortHash)
+    try {
+      const ret = await new Promise(function (resolve, reject) {
+        const relay = relayRef.current
+        if (!relay) {
+          return reject(new Error('not connected to relay'))
+        }
+        (async function () {
         // XXX set this to mock NWC relays
-        const MOCK_NWC_RELAY = false
+          const MOCK_NWC_RELAY = false
 
-        // timeout since NWC is async (user needs to confirm payment in wallet)
-        // timeout is same as invoice expiry
-        const timeout = MOCK_NWC_RELAY ? 3000 : 180_000
-        let timer
-        const resetTimer = () => {
-          clearTimeout(timer)
-          timer = setTimeout(() => {
-            sub?.close()
-            if (MOCK_NWC_RELAY) {
-              const heads = Math.random() < 0.5
-              if (heads) {
-                return resolve({ preimage: null })
-              }
-              return reject(new Error('mock error'))
-            }
-            return reject(new Error('timeout'))
-          }, timeout)
-        }
-        if (MOCK_NWC_RELAY) return resetTimer()
-
-        const payload = {
-          method: 'pay_invoice',
-          params: { invoice: bolt11 }
-        }
-        const content = await nip04.encrypt(secret, walletPubkey, JSON.stringify(payload))
-        const request = finalizeEvent({
-          kind: 23194,
-          created_at: Math.floor(Date.now() / 1000),
-          tags: [['p', walletPubkey]],
-          content
-        }, secret)
-        await relay.publish(request)
-        resetTimer()
-
-        const filter = {
-          kinds: [23195],
-          authors: [walletPubkey],
-          '#e': [request.id]
-        }
-        const sub = relay.subscribe([filter], {
-          async onevent (response) {
-            resetTimer()
-            try {
-              const content = JSON.parse(await nip04.decrypt(secret, walletPubkey, response.content))
-              if (content.error) return reject(new Error(content.error.message))
-              if (content.result) return resolve({ preimage: content.result.preimage })
-            } catch (err) {
-              return reject(err)
-            } finally {
-              clearTimeout(timer)
-              sub.close()
-            }
-          },
-          onclose (reason) {
+          // timeout since NWC is async (user needs to confirm payment in wallet)
+          // timeout is same as invoice expiry
+          const timeout = MOCK_NWC_RELAY ? 3000 : 180_000
+          let timer
+          const resetTimer = () => {
             clearTimeout(timer)
-            reject(new Error(reason))
+            timer = setTimeout(() => {
+              sub?.close()
+              if (MOCK_NWC_RELAY) {
+                const heads = Math.random() < 0.5
+                if (heads) {
+                  return resolve({ preimage: null })
+                }
+                return reject(new Error('mock error'))
+              }
+              return reject(new Error('timeout'))
+            }, timeout)
           }
-        })
-      })().catch(reject)
-    })
-  }, [walletPubkey, secret])
+          if (MOCK_NWC_RELAY) return resetTimer()
+
+          const payload = {
+            method: 'pay_invoice',
+            params: { invoice: bolt11 }
+          }
+          const content = await nip04.encrypt(secret, walletPubkey, JSON.stringify(payload))
+          const request = finalizeEvent({
+            kind: 23194,
+            created_at: Math.floor(Date.now() / 1000),
+            tags: [['p', walletPubkey]],
+            content
+          }, secret)
+          await relay.publish(request)
+          resetTimer()
+
+          const filter = {
+            kinds: [23195],
+            authors: [walletPubkey],
+            '#e': [request.id]
+          }
+          const sub = relay.subscribe([filter], {
+            async onevent (response) {
+              resetTimer()
+              try {
+                const content = JSON.parse(await nip04.decrypt(secret, walletPubkey, response.content))
+                if (content.error) return reject(new Error(content.error.message))
+                if (content.result) return resolve({ preimage: content.result.preimage })
+              } catch (err) {
+                return reject(err)
+              } finally {
+                clearTimeout(timer)
+                sub.close()
+              }
+            },
+            onclose (reason) {
+              clearTimeout(timer)
+              reject(new Error(reason))
+            }
+          })
+        })().catch(reject)
+      })
+      logger.ok('payment successful:', shortHash)
+      return ret
+    } catch (err) {
+      logger.error('payment failed:', shortHash, err.message)
+      throw err
+    }
+  }, [walletPubkey, secret, logger])
 
   const getInfo = useCallback(() => getInfoWithRelay(relayRef?.current, walletPubkey), [relayRef?.current, walletPubkey])
 
   useEffect(() => {
-    loadConfig().catch(console.error)
+    loadConfig().catch(err => logger.error(err.message))
   }, [])
 
   const value = { name, nwcUrl, relayUrl, walletPubkey, secret, initialized, enabled, saveConfig, clearConfig, getInfo, sendPayment }
@@ -187,14 +232,16 @@ export function useNWC () {
   return useContext(NWCContext)
 }
 
-async function validateParams ({ relayUrl, walletPubkey, secret }) {
+async function validateParams ({ relayUrl, walletPubkey, secret, logger }) {
   let infoRelay
   try {
     // validate connection by fetching info event
     infoRelay = await Relay.connect(relayUrl)
-    return await getInfoWithRelay(infoRelay, walletPubkey)
+    logger.ok(`connected to ${relayUrl}`)
+    await getInfoWithRelay(infoRelay, walletPubkey, logger)
   } finally {
     infoRelay?.close()
+    logger.info(`closed connection to ${relayUrl}`)
   }
 }
 

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -130,9 +130,7 @@ export function NWCProvider ({ children }) {
   const sendPayment = useCallback(async (bolt11) => {
     const inv = lnpr.decode(bolt11)
     const hash = inv.tagsObject.payment_hash
-    // use short hash for logging to prevent x-overflow
-    const shortHash = `${hash.slice(0, 8)}..${hash.slice(-8)}`
-    logger.info('sending payment:', shortHash)
+    logger.info('sending payment:', `payment_hash=${hash}`)
     try {
       const ret = await new Promise(function (resolve, reject) {
         const relay = relayRef.current
@@ -203,10 +201,11 @@ export function NWCProvider ({ children }) {
           })
         })().catch(reject)
       })
-      logger.ok('payment successful:', shortHash)
+      const preimage = ret.preimage
+      logger.ok('payment successful:', `payment_hash=${hash}`, `preimage=${preimage}`)
       return ret
     } catch (err) {
-      logger.error('payment failed:', shortHash, err.message || err.toString?.())
+      logger.error('payment failed:', `payment_hash=${hash}`, err.message || err.toString?.())
       throw err
     }
   }, [walletPubkey, secret, logger])

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -267,7 +267,7 @@ async function getInfoWithRelay (relay, walletPubkey) {
       },
       onclose (reason) {
         clearTimeout(timer)
-        reject(new Error(reason))
+        reject(new Error(reason || 'connection closed: reason unknown'))
       },
       oneose () {
         clearTimeout(timer)

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -206,7 +206,7 @@ export function NWCProvider ({ children }) {
       logger.ok('payment successful:', shortHash)
       return ret
     } catch (err) {
-      logger.error('payment failed:', shortHash, err.message)
+      logger.error('payment failed:', shortHash, err.message || err.toString?.())
       throw err
     }
   }, [walletPubkey, secret, logger])
@@ -214,7 +214,7 @@ export function NWCProvider ({ children }) {
   const getInfo = useCallback(() => getInfoWithRelay(relayRef?.current, walletPubkey), [relayRef?.current, walletPubkey])
 
   useEffect(() => {
-    loadConfig().catch(err => logger.error(err.message))
+    loadConfig().catch(err => logger.error(err.message || err.toString?.()))
   }, [])
 
   const value = { name, nwcUrl, relayUrl, walletPubkey, secret, initialized, enabled, saveConfig, clearConfig, getInfo, sendPayment }

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -149,3 +149,15 @@ export const WALLETS = gql`
     }
   }
 `
+
+export const WALLET_LOGS = gql`
+  query WalletLogs {
+    walletLogs {
+      id
+      createdAt
+      wallet
+      level
+      message
+    }
+  }
+`

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -597,10 +597,9 @@ export const nwcSchema = object({
           throw new Error('pubkey must be 64 hex chars')
         }
         await string().required('pubkey required').trim().matches(NOSTR_PUBKEY_HEX, 'pubkey must be 64 hex chars').validate(walletPubkey)
-        await string().required('relay url required').trim().validate(relayUrl)
+        await string().required('relay url required').trim().wss('relay must use wss://').validate(relayUrl)
         await string().required('secret required').trim().matches(/^[0-9a-fA-F]{64}$/, 'secret must be 64 hex chars').validate(secret)
       } catch (err) {
-        console.error(err)
         return context.createError({ message: err.message })
       }
       return true

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -597,9 +597,10 @@ export const nwcSchema = object({
           throw new Error('pubkey must be 64 hex chars')
         }
         await string().required('pubkey required').trim().matches(NOSTR_PUBKEY_HEX, 'pubkey must be 64 hex chars').validate(walletPubkey)
-        await string().required('relay url required').trim().wss('relay must use wss://').validate(relayUrl)
+        await string().required('relay url required').trim().validate(relayUrl)
         await string().required('secret required').trim().matches(/^[0-9a-fA-F]{64}$/, 'secret must be 64 hex chars').validate(secret)
       } catch (err) {
+        console.error(err)
         return context.createError({ message: err.message })
       }
       return true

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -23,7 +23,7 @@ import { useShowModal } from '@/components/modal'
 import { authErrorMessage } from '@/components/login'
 import { NostrAuth } from '@/components/nostr-auth'
 import { useToast } from '@/components/toast'
-import { useLogger } from '@/components/logger'
+import { useServiceWorkerLogger } from '@/components/logger'
 import { useMe } from '@/components/me'
 import { INVOICE_RETENTION_DAYS } from '@/lib/constants'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
@@ -52,7 +52,7 @@ export default function Settings ({ ssrData }) {
     }
   }
   )
-  const logger = useLogger()
+  const logger = useServiceWorkerLogger()
 
   const { data } = useQuery(SETTINGS)
   const { settings: { privates: settings } } = useMemo(() => data ?? ssrData, [data, ssrData])

--- a/pages/settings/wallets/lightning-address.js
+++ b/pages/settings/wallets/lightning-address.js
@@ -3,7 +3,7 @@ import { Form, Input } from '@/components/form'
 import { CenterLayout } from '@/components/layout'
 import { useMe } from '@/components/me'
 import { WalletButtonBar, WalletCard } from '@/components/wallet-card'
-import { useMutation } from '@apollo/client'
+import { useApolloClient, useMutation } from '@apollo/client'
 import { useToast } from '@/components/toast'
 import { lnAddrAutowithdrawSchema } from '@/lib/validate'
 import { useRouter } from 'next/router'
@@ -18,8 +18,21 @@ export default function LightningAddress ({ ssrData }) {
   const me = useMe()
   const toaster = useToast()
   const router = useRouter()
-  const [upsertWalletLNAddr] = useMutation(UPSERT_WALLET_LNADDR, { refetchQueries: ['WalletLogs'] })
-  const [removeWallet] = useMutation(REMOVE_WALLET, { refetchQueries: ['WalletLogs'] })
+  const client = useApolloClient()
+  const [upsertWalletLNAddr] = useMutation(UPSERT_WALLET_LNADDR, {
+    refetchQueries: ['WalletLogs'],
+    onError: (err) => {
+      client.refetchQueries({ include: ['WalletLogs'] })
+      throw err
+    }
+  })
+  const [removeWallet] = useMutation(REMOVE_WALLET, {
+    refetchQueries: ['WalletLogs'],
+    onError: (err) => {
+      client.refetchQueries({ include: ['WalletLogs'] })
+      throw err
+    }
+  })
 
   const { walletByType: wallet } = ssrData || {}
 

--- a/pages/settings/wallets/lightning-address.js
+++ b/pages/settings/wallets/lightning-address.js
@@ -9,6 +9,7 @@ import { lnAddrAutowithdrawSchema } from '@/lib/validate'
 import { useRouter } from 'next/router'
 import { AutowithdrawSettings, autowithdrawInitial } from '@/components/autowithdraw-shared'
 import { REMOVE_WALLET, UPSERT_WALLET_LNADDR, WALLET_BY_TYPE } from '@/fragments/wallet'
+import WalletLogs from '@/components/wallet-logs'
 
 const variables = { type: 'LIGHTNING_ADDRESS' }
 export const getServerSideProps = getGetServerSideProps({ query: WALLET_BY_TYPE, variables, authRequired: true })
@@ -17,8 +18,8 @@ export default function LightningAddress ({ ssrData }) {
   const me = useMe()
   const toaster = useToast()
   const router = useRouter()
-  const [upsertWalletLNAddr] = useMutation(UPSERT_WALLET_LNADDR)
-  const [removeWallet] = useMutation(REMOVE_WALLET)
+  const [upsertWalletLNAddr] = useMutation(UPSERT_WALLET_LNADDR, { refetchQueries: ['WalletLogs'] })
+  const [removeWallet] = useMutation(REMOVE_WALLET, { refetchQueries: ['WalletLogs'] })
 
   const { walletByType: wallet } = ssrData || {}
 
@@ -74,6 +75,9 @@ export default function LightningAddress ({ ssrData }) {
           }}
         />
       </Form>
+      <div className='mt-3'>
+        <WalletLogs wallet='lnAddr' embedded />
+      </div>
     </CenterLayout>
   )
 }

--- a/pages/settings/wallets/lightning-address.js
+++ b/pages/settings/wallets/lightning-address.js
@@ -63,7 +63,6 @@ export default function LightningAddress ({ ssrData }) {
             router.push('/settings/wallets')
           } catch (err) {
             console.error(err)
-            toaster.danger('failed to attach: ' + err.message || err.toString?.())
           }
         }}
       >
@@ -83,7 +82,6 @@ export default function LightningAddress ({ ssrData }) {
               router.push('/settings/wallets')
             } catch (err) {
               console.error(err)
-              toaster.danger('failed to unattach:' + err.message || err.toString?.())
             }
           }}
         />

--- a/pages/settings/wallets/lightning-address.js
+++ b/pages/settings/wallets/lightning-address.js
@@ -86,7 +86,7 @@ export default function LightningAddress ({ ssrData }) {
           }}
         />
       </Form>
-      <div className='mt-3'>
+      <div className='mt-3 w-100'>
         <WalletLogs wallet='lnAddr' embedded />
       </div>
     </CenterLayout>

--- a/pages/settings/wallets/lnbits.js
+++ b/pages/settings/wallets/lnbits.js
@@ -8,6 +8,7 @@ import { useRouter } from 'next/router'
 import { useLNbits } from '@/components/webln/lnbits'
 import { WalletSecurityBanner } from '@/components/banners'
 import { useWebLNConfigurator } from '@/components/webln'
+import WalletLogs from '@/components/wallet-logs'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
@@ -76,6 +77,9 @@ export default function LNbits () {
           }}
         />
       </Form>
+      <div className='mt-3'>
+        <WalletLogs wallet='lnbits' embedded />
+      </div>
     </CenterLayout>
   )
 }

--- a/pages/settings/wallets/lnbits.js
+++ b/pages/settings/wallets/lnbits.js
@@ -77,7 +77,7 @@ export default function LNbits () {
           }}
         />
       </Form>
-      <div className='mt-3'>
+      <div className='mt-3 w-100'>
         <WalletLogs wallet='lnbits' embedded />
       </div>
     </CenterLayout>

--- a/pages/settings/wallets/lnd.js
+++ b/pages/settings/wallets/lnd.js
@@ -117,7 +117,7 @@ export default function LND ({ ssrData }) {
           }}
         />
       </Form>
-      <div className='mt-3'>
+      <div className='mt-3 w-100'>
         <WalletLogs wallet='lnd' embedded />
       </div>
     </CenterLayout>

--- a/pages/settings/wallets/lnd.js
+++ b/pages/settings/wallets/lnd.js
@@ -3,7 +3,7 @@ import { Form, Input } from '@/components/form'
 import { CenterLayout } from '@/components/layout'
 import { useMe } from '@/components/me'
 import { WalletButtonBar, WalletCard } from '@/components/wallet-card'
-import { useMutation } from '@apollo/client'
+import { useApolloClient, useMutation } from '@apollo/client'
 import { useToast } from '@/components/toast'
 import { LNDAutowithdrawSchema } from '@/lib/validate'
 import { useRouter } from 'next/router'
@@ -20,8 +20,21 @@ export default function LND ({ ssrData }) {
   const me = useMe()
   const toaster = useToast()
   const router = useRouter()
-  const [upsertWalletLND] = useMutation(UPSERT_WALLET_LND, { refetchQueries: ['WalletLogs'] })
-  const [removeWallet] = useMutation(REMOVE_WALLET, { refetchQueries: ['WalletLogs'] })
+  const client = useApolloClient()
+  const [upsertWalletLND] = useMutation(UPSERT_WALLET_LND, {
+    refetchQueries: ['WalletLogs'],
+    onError: (err) => {
+      client.refetchQueries({ include: ['WalletLogs'] })
+      throw err
+    }
+  })
+  const [removeWallet] = useMutation(REMOVE_WALLET, {
+    refetchQueries: ['WalletLogs'],
+    onError: (err) => {
+      client.refetchQueries({ include: ['WalletLogs'] })
+      throw err
+    }
+  })
 
   const { walletByType: wallet } = ssrData || {}
 

--- a/pages/settings/wallets/lnd.js
+++ b/pages/settings/wallets/lnd.js
@@ -69,7 +69,6 @@ export default function LND ({ ssrData }) {
             router.push('/settings/wallets')
           } catch (err) {
             console.error(err)
-            toaster.danger('failed to attach: ' + err.message || err.toString?.())
           }
         }}
       >
@@ -114,7 +113,6 @@ export default function LND ({ ssrData }) {
               router.push('/settings/wallets')
             } catch (err) {
               console.error(err)
-              toaster.danger('failed to unattach:' + err.message || err.toString?.())
             }
           }}
         />

--- a/pages/settings/wallets/lnd.js
+++ b/pages/settings/wallets/lnd.js
@@ -11,6 +11,7 @@ import { AutowithdrawSettings, autowithdrawInitial } from '@/components/autowith
 import { REMOVE_WALLET, UPSERT_WALLET_LND, WALLET_BY_TYPE } from '@/fragments/wallet'
 import Info from '@/components/info'
 import Text from '@/components/text'
+import WalletLogs from '@/components/wallet-logs'
 
 const variables = { type: 'LND' }
 export const getServerSideProps = getGetServerSideProps({ query: WALLET_BY_TYPE, variables, authRequired: true })
@@ -19,8 +20,8 @@ export default function LND ({ ssrData }) {
   const me = useMe()
   const toaster = useToast()
   const router = useRouter()
-  const [upsertWalletLND] = useMutation(UPSERT_WALLET_LND)
-  const [removeWallet] = useMutation(REMOVE_WALLET)
+  const [upsertWalletLND] = useMutation(UPSERT_WALLET_LND, { refetchQueries: ['WalletLogs'] })
+  const [removeWallet] = useMutation(REMOVE_WALLET, { refetchQueries: ['WalletLogs'] })
 
   const { walletByType: wallet } = ssrData || {}
 
@@ -105,6 +106,9 @@ export default function LND ({ ssrData }) {
           }}
         />
       </Form>
+      <div className='mt-3'>
+        <WalletLogs wallet='lnd' embedded />
+      </div>
     </CenterLayout>
   )
 }

--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -8,6 +8,7 @@ import { useRouter } from 'next/router'
 import { useNWC } from '@/components/webln/nwc'
 import { WalletSecurityBanner } from '@/components/banners'
 import { useWebLNConfigurator } from '@/components/webln'
+import WalletLogs from '@/components/wallet-logs'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
@@ -68,6 +69,9 @@ export default function NWC () {
           }}
         />
       </Form>
+      <div className='mt-3'>
+        <WalletLogs embedded />
+      </div>
     </CenterLayout>
   )
 }

--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -70,7 +70,7 @@ export default function NWC () {
         />
       </Form>
       <div className='mt-3'>
-        <WalletLogs embedded />
+        <WalletLogs wallet='nwc' embedded />
       </div>
     </CenterLayout>
   )

--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -69,7 +69,7 @@ export default function NWC () {
           }}
         />
       </Form>
-      <div className='mt-3'>
+      <div className='mt-3 w-100'>
         <WalletLogs wallet='nwc' embedded />
       </div>
     </CenterLayout>

--- a/pages/wallet/index.js
+++ b/pages/wallet/index.js
@@ -6,7 +6,7 @@ import { gql, useMutation, useQuery } from '@apollo/client'
 import Qr, { QrSkeleton } from '@/components/qr'
 import { CenterLayout } from '@/components/layout'
 import InputGroup from 'react-bootstrap/InputGroup'
-import { WithdrawlSkeleton } from './withdrawals/[id]'
+import { WithdrawlSkeleton } from '@/pages/withdrawals/[id]'
 import { useMe } from '@/components/me'
 import { useEffect, useState } from 'react'
 import { requestProvider } from 'webln'
@@ -78,9 +78,18 @@ function YouHaveSats () {
 
 function WalletHistory () {
   return (
-    <Link href='/satistics?inc=invoice,withdrawal' className='text-muted fw-bold text-underline'>
-      wallet history
-    </Link>
+    <div className='d-flex flex-column text-center'>
+      <div>
+        <Link href='/satistics?inc=invoice,withdrawal' className='text-muted fw-bold text-underline'>
+          wallet history
+        </Link>
+      </div>
+      <div>
+        <Link href='/wallet/logs' className='text-muted fw-bold text-underline'>
+          wallet logs
+        </Link>
+      </div>
+    </div>
   )
 }
 

--- a/pages/wallet/logs.js
+++ b/pages/wallet/logs.js
@@ -1,22 +1,43 @@
-import { createContext } from 'react'
+import { createContext, useEffect } from 'react'
 import { CenterLayout } from '@/components/layout'
 import LogMessage from '@/components/log-message'
 import { useWalletLogger } from '@/components/logger'
 import { getGetServerSideProps } from '@/api/ssrApollo'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { datePivot } from '@/lib/time'
 
 export const getServerSideProps = getGetServerSideProps({ query: null })
 
 export const WalletLogsContext = createContext()
 
+const SKIP_BACK = { minutes: -5 }
+
 export default function WalletLogs () {
-  const { logs } = useWalletLogger()
+  const { logs, loadLogs } = useWalletLogger()
+
+  const router = useRouter()
   // TODO add filter by wallet, add sort by timestamp
+  const since = router.query.since ? parseInt(router.query.since, 10) : +datePivot(new Date(), SKIP_BACK)
+  const sinceRounded = Math.floor(since / 60e3) * 60e3
+  const earlierTs = +datePivot(new Date(since), SKIP_BACK)
+
+  useEffect(() => {
+    loadLogs(sinceRounded)
+  }, [sinceRounded])
+
   return (
     <>
       <CenterLayout>
         <h2 className='text-center'>wallet logs</h2>
         <div>
-          {logs.map((log, i) => <LogMessage key={i} {...log} />)}
+          <div>
+            <Link href={`/wallet/logs?since=${earlierTs}`} className='mx-3 text-muted text-underline'>show earlier logs</Link>
+          </div>
+          <div>
+            <div className='mx-3 text-muted' suppressHydrationWarning>{new Date(sinceRounded).toLocaleTimeString()}</div>
+            {logs.map((log, i) => <LogMessage key={i} {...log} />)}
+          </div>
         </div>
       </CenterLayout>
     </>

--- a/pages/wallet/logs.js
+++ b/pages/wallet/logs.js
@@ -12,7 +12,9 @@ export const getServerSideProps = getGetServerSideProps({ query: null })
 export const WalletLogsContext = createContext()
 
 export default function WalletLogs () {
-  const { logs, loadLogs } = useWalletLogger()
+  const { logs, loadLogs, logStart } = useWalletLogger()
+
+  const more = logs.length > 0 ? logStart < logs[0].ts : false
 
   const router = useRouter()
   // TODO add filter by wallet, add sort by timestamp
@@ -38,7 +40,8 @@ export default function WalletLogs () {
             <Link href={`/wallet/logs?since=${earlierTs6h}`} className='mx-1 text-muted text-underline'>6h</Link>
           </div>
           <div>
-            <div className='mx-3 text-muted' suppressHydrationWarning>{new Date(sinceRounded).toLocaleTimeString()}</div>
+            {!more && <div className='mx-3 text-muted'>------ end of logs ------</div>}
+            <div className='mx-3 text-muted' suppressHydrationWarning>{new Date(more ? sinceRounded : logStart).toLocaleTimeString()}</div>
             {logs.map((log, i) => <LogMessage key={i} {...log} />)}
           </div>
         </div>

--- a/pages/wallet/logs.js
+++ b/pages/wallet/logs.js
@@ -11,16 +11,16 @@ export const getServerSideProps = getGetServerSideProps({ query: null })
 
 export const WalletLogsContext = createContext()
 
-const SKIP_BACK = { minutes: -5 }
-
 export default function WalletLogs () {
   const { logs, loadLogs } = useWalletLogger()
 
   const router = useRouter()
   // TODO add filter by wallet, add sort by timestamp
-  const since = router.query.since ? parseInt(router.query.since, 10) : +datePivot(new Date(), SKIP_BACK)
+  const since = router.query.since ? parseInt(router.query.since, 10) : +datePivot(new Date(), { minutes: -5 })
   const sinceRounded = Math.floor(since / 60e3) * 60e3
-  const earlierTs = +datePivot(new Date(since), SKIP_BACK)
+  const earlierTs5m = +datePivot(new Date(since), { minutes: -5 })
+  const earlierTs1h = +datePivot(new Date(since), { hours: -1 })
+  const earlierTs6h = +datePivot(new Date(since), { hours: -6 })
 
   useEffect(() => {
     loadLogs(sinceRounded)
@@ -31,8 +31,11 @@ export default function WalletLogs () {
       <CenterLayout>
         <h2 className='text-center'>wallet logs</h2>
         <div>
-          <div>
-            <Link href={`/wallet/logs?since=${earlierTs}`} className='mx-3 text-muted text-underline'>show earlier logs</Link>
+          <div className='ms-3 text-muted'>
+            <span>show earlier logs:</span>
+            <Link href={`/wallet/logs?since=${earlierTs5m}`} className='mx-1 text-muted text-underline'>5m</Link>
+            <Link href={`/wallet/logs?since=${earlierTs1h}`} className='mx-1 text-muted text-underline'>1h</Link>
+            <Link href={`/wallet/logs?since=${earlierTs6h}`} className='mx-1 text-muted text-underline'>6h</Link>
           </div>
           <div>
             <div className='mx-3 text-muted' suppressHydrationWarning>{new Date(sinceRounded).toLocaleTimeString()}</div>

--- a/pages/wallet/logs.js
+++ b/pages/wallet/logs.js
@@ -6,6 +6,7 @@ import { getGetServerSideProps } from '@/api/ssrApollo'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { datePivot } from '@/lib/time'
+import styles from '@/styles/log.module.css'
 
 export const getServerSideProps = getGetServerSideProps({ query: null })
 
@@ -33,15 +34,15 @@ export default function WalletLogs () {
       <CenterLayout>
         <h2 className='text-center'>wallet logs</h2>
         <div>
-          <div className='ms-3 text-muted'>
+          <div className={styles.header}>
             <span>show earlier logs:</span>
             <Link href={`/wallet/logs?since=${earlierTs5m}`} className='mx-1 text-muted text-underline'>5m</Link>
             <Link href={`/wallet/logs?since=${earlierTs1h}`} className='mx-1 text-muted text-underline'>1h</Link>
             <Link href={`/wallet/logs?since=${earlierTs6h}`} className='mx-1 text-muted text-underline'>6h</Link>
+            <span className='mx-1 text-muted' suppressHydrationWarning>{new Date(more ? sinceRounded : logStart).toLocaleTimeString()}</span>
           </div>
-          <div>
-            {!more && <div className='mx-3 text-muted'>------ end of logs ------</div>}
-            <div className='mx-3 text-muted' suppressHydrationWarning>{new Date(more ? sinceRounded : logStart).toLocaleTimeString()}</div>
+          <div className={styles.logBox}>
+            {!more && <div className={styles.eol}>------ end of logs ------</div>}
             {logs.map((log, i) => <LogMessage key={i} {...log} />)}
           </div>
         </div>

--- a/pages/wallet/logs.js
+++ b/pages/wallet/logs.js
@@ -1,0 +1,24 @@
+import { createContext } from 'react'
+import { CenterLayout } from '@/components/layout'
+import LogMessage from '@/components/log-message'
+import { useWalletLogger } from '@/components/logger'
+import { getGetServerSideProps } from '@/api/ssrApollo'
+
+export const getServerSideProps = getGetServerSideProps({ query: null })
+
+export const WalletLogsContext = createContext()
+
+export default function WalletLogs () {
+  const { logs } = useWalletLogger()
+  // TODO add filter by wallet, add sort by timestamp
+  return (
+    <>
+      <CenterLayout>
+        <h2 className='text-center'>wallet logs</h2>
+        <div>
+          {logs.map((log, i) => <LogMessage key={i} {...log} />)}
+        </div>
+      </CenterLayout>
+    </>
+  )
+}

--- a/pages/wallet/logs.js
+++ b/pages/wallet/logs.js
@@ -20,9 +20,9 @@ export default function WalletLogs () {
   // TODO add filter by wallet, add sort by timestamp
   const since = router.query.since ? parseInt(router.query.since, 10) : +datePivot(new Date(), { minutes: -5 })
   const sinceRounded = Math.floor(since / 60e3) * 60e3
-  const earlierTs5m = +datePivot(new Date(since), { minutes: -5 })
-  const earlierTs1h = +datePivot(new Date(since), { hours: -1 })
-  const earlierTs6h = +datePivot(new Date(since), { hours: -6 })
+  const earlierTs5m = more ? +datePivot(new Date(since), { minutes: -5 }) : logStart
+  const earlierTs1h = more ? +datePivot(new Date(since), { hours: -1 }) : logStart
+  const earlierTs6h = more ? +datePivot(new Date(since), { hours: -6 }) : logStart
 
   useEffect(() => {
     loadLogs(sinceRounded)

--- a/pages/wallet/logs.js
+++ b/pages/wallet/logs.js
@@ -39,11 +39,14 @@ export default function WalletLogs () {
             <Link href={`/wallet/logs?since=${earlierTs5m}`} className='mx-1 text-muted text-underline'>5m</Link>
             <Link href={`/wallet/logs?since=${earlierTs1h}`} className='mx-1 text-muted text-underline'>1h</Link>
             <Link href={`/wallet/logs?since=${earlierTs6h}`} className='mx-1 text-muted text-underline'>6h</Link>
-            <span className='mx-1 text-muted' suppressHydrationWarning>{new Date(more ? sinceRounded : logStart).toLocaleTimeString()}</span>
           </div>
-          <div className={styles.logBox}>
-            {!more && <div className={styles.eol}>------ end of logs ------</div>}
-            {logs.map((log, i) => <LogMessage key={i} {...log} />)}
+          <div className={styles.logTable}>
+            <table>
+              <tbody>
+                {!more && <tr><td colSpan='4' className='text-center'>------ start of logs ------</td></tr>}
+                {logs.map((log, i) => <LogMessage key={i} {...log} />)}
+              </tbody>
+            </table>
           </div>
         </div>
       </CenterLayout>

--- a/pages/wallet/logs.js
+++ b/pages/wallet/logs.js
@@ -1,87 +1,15 @@
-import { createContext, useEffect, useRef, useState } from 'react'
 import { CenterLayout } from '@/components/layout'
-import LogMessage from '@/components/log-message'
-import { useWalletLogger } from '@/components/logger'
 import { getGetServerSideProps } from '@/api/ssrApollo'
-import styles from '@/styles/log.module.css'
-import { Checkbox, Form } from '@/components/form'
-import { useRouter } from 'next/router'
-import { useField } from 'formik'
+import WalletLogs from '@/components/wallet-logs'
 
 export const getServerSideProps = getGetServerSideProps({ query: null })
 
-export const WalletLogsContext = createContext()
-
-const FollowCheckbox = ({ value, ...props }) => {
-  const [,, helpers] = useField(props.name)
-
-  useEffect(() => {
-    helpers.setValue(value)
-  }, [value])
-
-  return (
-    <Checkbox {...props} />
-  )
-}
-
-export default function WalletLogs () {
-  const { logs } = useWalletLogger()
-
-  const router = useRouter()
-  const { follow: defaultFollow } = router.query
-  const [follow, setFollow] = useState(defaultFollow ?? true)
-  const tableRef = useRef()
-  const scrollY = useRef()
-  const tableEndRef = useRef()
-
-  useEffect(() => {
-    if (follow) {
-      tableEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-    }
-  }, [logs, follow])
-
-  useEffect(() => {
-    function onScroll (e) {
-      const y = e.target.scrollTop
-
-      const down = y - scrollY.current >= -1
-      if (!!scrollY.current && !down) {
-        setFollow(false)
-      }
-
-      const maxY = e.target.scrollHeight - e.target.clientHeight
-      const dY = maxY - y
-      const isBottom = dY >= -1 && dY <= 1
-      if (isBottom) {
-        setFollow(true)
-      }
-
-      scrollY.current = y
-    }
-    tableRef.current?.addEventListener('scroll', onScroll)
-    return () => tableRef.current?.removeEventListener('scroll', onScroll)
-  }, [])
-
-  // TODO add filter by wallet
+export default function () {
   return (
     <>
       <CenterLayout>
         <h2 className='text-center'>wallet logs</h2>
-        <Form initial={{ follow: true }}>
-          <FollowCheckbox
-            label='follow' name='follow' value={follow}
-            handleChange={setFollow}
-          />
-        </Form>
-        <div ref={tableRef} className={styles.logTable}>
-          <table>
-            <tbody>
-              <tr><td colSpan='4' className='text-center'>------ start of logs ------</td></tr>
-              {logs.map((log, i) => <LogMessage key={i} {...log} />)}
-              <tr><td colSpan='4' ref={tableEndRef} /></tr>
-            </tbody>
-          </table>
-        </div>
+        <WalletLogs />
       </CenterLayout>
     </>
   )

--- a/pages/wallet/logs.js
+++ b/pages/wallet/logs.js
@@ -1,11 +1,8 @@
-import { createContext, useEffect } from 'react'
+import { createContext } from 'react'
 import { CenterLayout } from '@/components/layout'
 import LogMessage from '@/components/log-message'
 import { useWalletLogger } from '@/components/logger'
 import { getGetServerSideProps } from '@/api/ssrApollo'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
-import { datePivot } from '@/lib/time'
 import styles from '@/styles/log.module.css'
 
 export const getServerSideProps = getGetServerSideProps({ query: null })
@@ -13,37 +10,18 @@ export const getServerSideProps = getGetServerSideProps({ query: null })
 export const WalletLogsContext = createContext()
 
 export default function WalletLogs () {
-  const { logs, loadLogs, logStart } = useWalletLogger()
+  const { logs } = useWalletLogger()
 
-  const more = logs.length > 0 ? logStart < logs[0].ts : false
-
-  const router = useRouter()
-  // TODO add filter by wallet, add sort by timestamp
-  const since = router.query.since ? parseInt(router.query.since, 10) : +datePivot(new Date(), { minutes: -5 })
-  const sinceRounded = Math.floor(since / 60e3) * 60e3
-  const earlierTs5m = more ? +datePivot(new Date(since), { minutes: -5 }) : logStart
-  const earlierTs1h = more ? +datePivot(new Date(since), { hours: -1 }) : logStart
-  const earlierTs6h = more ? +datePivot(new Date(since), { hours: -6 }) : logStart
-
-  useEffect(() => {
-    loadLogs(sinceRounded)
-  }, [sinceRounded])
-
+  // TODO add filter by wallet
   return (
     <>
       <CenterLayout>
         <h2 className='text-center'>wallet logs</h2>
         <div>
-          <div className={styles.logNav}>
-            <span>show earlier logs:</span>
-            <Link href={`/wallet/logs?since=${earlierTs5m}`} className='mx-1 text-muted text-underline'>5m</Link>
-            <Link href={`/wallet/logs?since=${earlierTs1h}`} className='mx-1 text-muted text-underline'>1h</Link>
-            <Link href={`/wallet/logs?since=${earlierTs6h}`} className='mx-1 text-muted text-underline'>6h</Link>
-          </div>
           <div className={styles.logTable}>
             <table>
               <tbody>
-                {!more && <tr><td colSpan='4' className='text-center'>------ start of logs ------</td></tr>}
+                <tr><td colSpan='4' className='text-center'>------ start of logs ------</td></tr>
                 {logs.map((log, i) => <LogMessage key={i} {...log} />)}
               </tbody>
             </table>

--- a/pages/wallet/logs.js
+++ b/pages/wallet/logs.js
@@ -34,7 +34,7 @@ export default function WalletLogs () {
       <CenterLayout>
         <h2 className='text-center'>wallet logs</h2>
         <div>
-          <div className={styles.header}>
+          <div className={styles.logNav}>
             <span>show earlier logs:</span>
             <Link href={`/wallet/logs?since=${earlierTs5m}`} className='mx-1 text-muted text-underline'>5m</Link>
             <Link href={`/wallet/logs?since=${earlierTs1h}`} className='mx-1 text-muted text-underline'>1h</Link>

--- a/prisma/migrations/20240403013755_wallet_logs/migration.sql
+++ b/prisma/migrations/20240403013755_wallet_logs/migration.sql
@@ -1,0 +1,20 @@
+-- AlterEnum
+ALTER TYPE "LogLevel" ADD VALUE 'SUCCESS';
+
+-- CreateTable
+CREATE TABLE "WalletLog" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "userId" INTEGER NOT NULL,
+    "wallet" TEXT NOT NULL,
+    "level" "LogLevel" NOT NULL,
+    "message" TEXT NOT NULL,
+
+    CONSTRAINT "WalletLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WalletLog_userId_created_at_idx" ON "WalletLog"("userId", "created_at");
+
+-- AddForeignKey
+ALTER TABLE "WalletLog" ADD CONSTRAINT "WalletLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,6 +122,7 @@ model User {
   TerritoryReceives         TerritoryTransfer[]  @relation("TerritoryTransfer_newUser")
   AncestorReplies           Reply[]              @relation("AncestorReplyUser")
   Replies                   Reply[]
+  walletLogs                WalletLog[]
 
   @@index([photoId])
   @@index([createdAt], map: "users.created_at_index")
@@ -155,6 +156,18 @@ model Wallet {
   walletLND              WalletLND?
 
   @@index([userId])
+}
+
+model WalletLog {
+  id        Int @id @default(autoincrement())
+  createdAt DateTime @default(now()) @map("created_at")
+  userId    Int
+  user      User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  wallet    String
+  level     LogLevel
+  message   String
+
+  @@index([userId, createdAt])
 }
 
 model WalletLightningAddress {
@@ -874,4 +887,5 @@ enum LogLevel {
   INFO
   WARN
   ERROR
+  SUCCESS
 }

--- a/styles/log.module.css
+++ b/styles/log.module.css
@@ -1,4 +1,4 @@
-.header {
+.logNav {
     text-align: center;
     color: var(--theme-grey) !important; /* .text-muted */
 }

--- a/styles/log.module.css
+++ b/styles/log.module.css
@@ -4,10 +4,10 @@
 }
 
 .logTable {
+    width: 100%;
     max-height: 60svh;
     overflow-y: auto;
-    margin: 0.5em 0;
-    padding: 0 1em;
+    padding-right: 1em;
     font-size: x-small;
     font-family: monospace;
     color: var(--theme-grey) !important; /* .text-muted */

--- a/styles/log.module.css
+++ b/styles/log.module.css
@@ -1,0 +1,25 @@
+.header {
+    text-align: center;
+    color: var(--theme-grey) !important; /* .text-muted */
+}
+
+.eol {
+    font-family: monospace;
+    font-size: x-small;
+    text-align: center;
+    color: var(--theme-grey) !important; /* .text-muted */
+}
+
+.logBox {
+    width: 100%;
+    padding: 0 1em;
+    overflow-y: auto;
+    margin: 0.5em 0;
+    max-height: 60svh;
+}
+
+@media screen and (min-width: 768px) {
+    .logBox {
+        max-height: 70svh;
+    }
+}

--- a/styles/log.module.css
+++ b/styles/log.module.css
@@ -13,16 +13,12 @@
     color: var(--theme-grey) !important; /* .text-muted */
 }
 
-.embedded {
-    max-height: 30svh;
-}
-
 @media screen and (min-width: 768px) {
     .logTable {
         max-height: 70svh;
     }
 
     .embedded {
-        max-height: 15svh;
+        max-height: 30svh;
     }
 }

--- a/styles/log.module.css
+++ b/styles/log.module.css
@@ -13,8 +13,16 @@
     color: var(--theme-grey) !important; /* .text-muted */
 }
 
+.embedded {
+    max-height: 30svh;
+}
+
 @media screen and (min-width: 768px) {
     .logTable {
         max-height: 70svh;
+    }
+
+    .embedded {
+        max-height: 15svh;
     }
 }

--- a/styles/log.module.css
+++ b/styles/log.module.css
@@ -3,23 +3,18 @@
     color: var(--theme-grey) !important; /* .text-muted */
 }
 
-.eol {
-    font-family: monospace;
+.logTable {
+    max-height: 60svh;
+    overflow-y: auto;
+    margin: 0.5em 0;
+    padding: 0 1em;
     font-size: x-small;
-    text-align: center;
+    font-family: monospace;
     color: var(--theme-grey) !important; /* .text-muted */
 }
 
-.logBox {
-    width: 100%;
-    padding: 0 1em;
-    overflow-y: auto;
-    margin: 0.5em 0;
-    max-height: 60svh;
-}
-
 @media screen and (min-width: 768px) {
-    .logBox {
+    .logTable {
         max-height: 70svh;
     }
 }

--- a/worker/autowithdraw.js
+++ b/worker/autowithdraw.js
@@ -69,10 +69,12 @@ export async function autoWithdraw ({ data: { id }, models, lnd }) {
       return
     } catch (error) {
       console.error(error)
+      // LND errors are in this shape: [code, type, { err: { code, details, metadata } }]
+      const details = error[2]?.err?.details || error.message || error.toString?.()
       await addWalletLog({
         wallet: wallet.type === 'LND' ? 'walletLND' : 'walletLightningAddress',
         level: 'ERROR',
-        message: 'autowithdrawal failed: ' + (error.message || error.toString?.())
+        message: 'autowithdrawal failed: ' + details
       })
     }
   }


### PR DESCRIPTION
## Description

Close #823 

This PR adds a new React context: `WalletLoggerContext`

This context can be used with `useWalletLogger` to show wallet logs at /wallet/logs.

## Screenshots

<details>
<summary>desktop (72ca7417)</summary>

![2024-04-03-175341_1920x1080_scrot](https://github.com/stackernews/stacker.news/assets/27162016/57d12205-4d55-488a-9e84-10e34a5d730b)

![2024-04-03-175328_1920x1080_scrot](https://github.com/stackernews/stacker.news/assets/27162016/8633ec43-66e0-4c21-a274-28862d2ad453)

</details>

<details>
<summary>mobile (72ca7417)</summary>

![localhost_3000_wallet_logs(iPhone SE) (4)](https://github.com/stackernews/stacker.news/assets/27162016/e7987583-6aa4-414c-97c4-e2d32d9e4a35)

![localhost_3000_wallet_logs(iPhone SE) (5)](https://github.com/stackernews/stacker.news/assets/27162016/a0c2d6d6-6cc3-4e48-80c6-a06433802708)

</details>

<details>
<summary>UX video (72ca7417)</summary>

https://github.com/stackernews/stacker.news/assets/27162016/83c796a0-994f-41e0-943e-9af78c7f7858

</details>

## How to test

### Sending via NWC

1. Clone and build [`nostr-wallet-connect-lnd`](https://github.com/benthecarman/nostr-wallet-connect-lnd)
2. Copy TLS certificate and admin macaroon from `stacker_lnd` container:
```
$ docker cp stacker_lnd:/home/lnd/.lnd/tls.cert tls.cert
$ docker cp stacker_lnd:/home/lnd/.lnd/data/chain/bitcoin/regtest/admin.macaroon admin.macaroon
```
3. Run `nostr-wallet-connect-lnd`:
```
$ RUST_LOG=info nostr-wallet-connect-lnd \
  --relay wss://relay.damus.io --network regtest \
  --lnd-host 127.0.0.1 --lnd-port 20010 \
  --cert-file stacker_lnd_tls.cert --macaroon-file stacker_lnd_admin.macaroon \
  --keys-file $(pwd)/keys.json
```

4. Copy and paste `nostr+walletconnect://` URL

### Receiving via LND

Use `stacker_lnd:10009` and `xxd -p -c0` on invoice.macaroon and tls.cert from container.

## Open Questions

### 1. Where should link to full logs be?


It's currently at /wallet below `wallet history`:
<details>
<summary>click to show screenshot</summary>

![localhost_3000_wallet_logs(iPhone SE) (2)](https://github.com/stackernews/stacker.news/assets/27162016/6059f058-eaf6-46ea-8b00-f9376aa68baa)

</details>

I thought about putting it into `attached wallets` since it's logs about attached wallets but that's too many clicks imo

**update:** Just saw that you mentioned it to be on the wallet attach page in #823:

> When on a wallet attach page display or link to the log for the wallet.

However, I planned to have all logs for every wallet at the same page with an optional dropdown filter to filter for specific wallets instead of having individual pages with no option to see all logs together. I think it's useful to see all interaction with attached wallets at one place (send + receive). When we have wallet fallbacks, that will be even more useful. What do you think @huumn?

**update:** I think I could _also_ link to /wallet/logs on every wallet attach page with a query param to immediately filter the logs by that wallet.

**update:** Added embedded logs and skipped adding a filter. You can just go to the individual page.

### 2. Show full payment hash in logs + more info like payment preimage?

The hash was truncated because of overflow issues and not sure how relevant the full hash is.

**update:** I think it's useful for debugging to be able to easily copy-paste payment hashes etc.

I now show the full hash + preimage in the logs with a horizontal scrollbar on x-overflow.

### 3 . Font size too small?

I am using `x-small` as the font size since it makes it easy to look at a lot of logs at the same time (good overview)

### 4. Expose secret in logs but don't persist it?

The original wallet logs screenshots show that the first and last 6 characters of the secret are shown in the log. I originally planned to not persist the secret in the logs so for loaded logs, the secret would show `******`.

**update:** I decided against that now since it's probably confusing. Secret is now never shown in the logs.

### 5. Delete logs on server for privacy reasons?

I shortly considered to delete all logs about a wallet if it was unattached but that might be confusing behavior.

I think we can keep this out of this PR and do it later.

---

TODO:

- [x] [feature] log statements for LNbits
- [x] [feature] fetch autowithdrawal logs from server
- [x] [feature] persist logs in local storage or IndexedDB | only store last 24h or more if unbounded client-side storage amount is actually not a problem
- [x] [feature] ~ability to sort logs by recent: if we store a lot of logs, I don't think one is interested in the oldest logs first.~ autoscroll is better
- [x] [refactor] fetching all logs from IndexedDB at once and then using `Array.filter` for pagination should make the code less complex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new component for displaying log messages in a styled manner.
	- Added comprehensive logging functionality across various components and pages, including service workers and wallets.
	- Implemented a new `WalletLogs` component for real-time log following, filtering, and display in wallet settings.
	- Enhanced error handling and logging for wallet transactions and settings adjustments.
	- Added a new GraphQL query for fetching wallet logs.
- **Enhancements**
	- Improved the logging mechanism by introducing context providers for service workers and wallets.
	- Modified existing components to utilize the new logging contexts for better clarity and error reporting.
- **Bug Fixes**
	- Removed unnecessary validation check for `wss://` protocol in relay URLs to prevent false errors.
- **Refactor**
	- Updated various components to use the enhanced logging functionalities and contexts.
- **Style**
	- Added new styles for log message display, navigation, and table formatting.
- **Chores**
	- Updated the database schema to support wallet logs.
	- Enhanced the auto withdrawal process with better logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->