### PR TITLE
Fix QR scanner collapsed to no width

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -490,6 +490,9 @@ div[contenteditable]:disabled,
   align-self: center;
   width: fit-content;
 }
+.modal-body:has(video) {
+  width: 100%;
+}
 
 .nav-link:not(.text-success, .text-warning) {
   color: var(--theme-navLink) !important;


### PR DESCRIPTION
Fix #996

This was broken by my CSS changes in #670, #985.

https://github.com/stackernews/stacker.news/assets/27162016/ae78e413-2b42-4ec3-8330-23fa1d12aca1





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved the display of videos in modals by setting their width to 100%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->