### PR TITLE
first pass of a subscription management page under settings

### DIFF
--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -12,6 +12,7 @@ export default gql`
     searchUsers(q: String!, limit: Limit, similarity: Float): [User!]!
     userSuggestions(q: String, limit: Limit): [User!]!
     hasNewNotes: Boolean!
+    mySubscribedUsers(cursor: String): UsersNullable!
   }
 
   type UsersNullable {

--- a/components/user-list.js
+++ b/components/user-list.js
@@ -62,7 +62,7 @@ function User ({ user, rank, statComps, Embellish }) {
           <div className={styles.other}>
             {statComps.map((Comp, i) => <Comp key={i} user={user} />)}
           </div>
-          {Embellish && <Embellish rank={rank} />}
+          {Embellish && <Embellish rank={rank} user={user} />}
         </div>
       </div>
     </>
@@ -108,7 +108,7 @@ export function ListUsers ({ users, rank, statComps = seperate(STAT_COMPONENTS, 
   )
 }
 
-export default function UserList ({ ssrData, query, variables, destructureData, rank, footer = true }) {
+export default function UserList ({ ssrData, query, variables, destructureData, rank, footer = true, Embellish, statCompsProp }) {
   const { data, fetchMore } = useQuery(query, { variables })
   const dat = useData(data, ssrData)
   const [statComps, setStatComps] = useState(seperate(STAT_COMPONENTS, Seperator))
@@ -134,7 +134,7 @@ export default function UserList ({ ssrData, query, variables, destructureData, 
 
   return (
     <>
-      <ListUsers users={users} rank={rank} statComps={statComps} />
+      <ListUsers users={users} rank={rank} statComps={statCompsProp ?? statComps} Embellish={Embellish} />
       {footer &&
         <MoreFooter cursor={cursor} count={users?.length} fetchMore={fetchMore} Skeleton={UsersSkeleton} noMoreText='NO MORE' />}
     </>

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -206,6 +206,18 @@ export const USER_FIELDS = gql`
     }
   }`
 
+export const MY_SUBSCRIBED_USERS = gql`
+  ${USER_FIELDS}
+  query MySubscribedUsers($cursor: String) {
+    mySubscribedUsers(cursor: $cursor) {
+      users {
+        ...UserFields
+      }
+      cursor
+    }
+  }
+`
+
 export const TOP_USERS = gql`
   query TopUsers($cursor: String, $when: String, $from: String, $to: String, $by: String, ) {
     topUsers(cursor: $cursor, when: $when, from: $from, to: $to, by: $by) {

--- a/pages/settings/subscriptions/index.js
+++ b/pages/settings/subscriptions/index.js
@@ -1,0 +1,37 @@
+import { getGetServerSideProps } from '@/api/ssrApollo'
+import Layout from '@/components/layout'
+import UserList from '@/components/user-list'
+import { MY_SUBSCRIBED_USERS } from '@/fragments/users'
+import ActionDropdown from '@/components/action-dropdown'
+import MuteDropdownItem from '@/components/mute'
+import SubscribeUserDropdownItem from '@/components/subscribeUser'
+
+export const getServerSideProps = getGetServerSideProps({ query: MY_SUBSCRIBED_USERS, authRequired: true })
+
+export default function MySubscribedUsers ({ ssrData }) {
+  return (
+    <Layout>
+      <div className='pb-3 w-100 mt-2' style={{ maxWidth: '600px' }}>
+        <h2 className='mb-2 text-start'>settings</h2>
+        <h3 className='mb-2 text-start'>subscriptions</h3>
+        <UserList
+          ssrData={ssrData} query={MY_SUBSCRIBED_USERS}
+          destructureData={data => data.mySubscribedUsers}
+          rank
+          statCompsProp={[]}
+          Embellish={
+            ({ user }) =>
+              <div className='ms-2'>
+                <ActionDropdown>
+                  <SubscribeUserDropdownItem user={user} target='posts' />
+                  <SubscribeUserDropdownItem user={user} target='comments' />
+                  <MuteDropdownItem user={user} />
+                </ActionDropdown>
+              </div>
+            }
+        />
+      </div>
+    </Layout>
+
+  )
+}


### PR DESCRIPTION
**DRAFT**
**Description**

Closes #944 

Add a subscription management tab to the settings page - a tab where you can view all the stackers to whom you subscribe, and you can manage your subscriptions for each individually. The approach is as follows:

1. Add a new page at `/settings/subscriptions`
2. The above page is presented as a tab on the current settings page
3. Create a new user graphql query which returns all users to whom you subscribe to posts and/or comments
4. Displays a list of these users, in pages of 21
5. Each user in the list has an action overflow menu, where you can manage your subscription(s) to them, just like on the user profile page

**Screenshots**
Coming Soon ™️ 

**Additional Context**

**Checklist**

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [X] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [ ] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [ ] For frontend changes: Tested on mobile?
