### PR TITLE
Add founding date to territory header

### DIFF
--- a/components/territory-header.js
+++ b/components/territory-header.js
@@ -43,6 +43,8 @@ export function TerritoryInfo ({ sub }) {
           <Link href={`/${sub.user.name}`}>
             @{sub.user.name}<span> </span><Hat className='fill-grey' user={sub.user} height={12} width={12} />
           </Link>
+          <span>on </span>
+          <span className='fw-bold'>{new Date(sub.createdAt).toDateString()}</span>
         </div>
         <div className='text-muted'>
           <span>post cost </span>

--- a/fragments/subs.js
+++ b/fragments/subs.js
@@ -5,6 +5,7 @@ import { COMMENTS_ITEM_EXT_FIELDS } from './comments'
 export const SUB_FIELDS = gql`
   fragment SubFields on Sub {
     name
+    createdAt
     postTypes
     allowFreebies
     rankingType


### PR DESCRIPTION
## Description

This PR adds the founding date to the territory header.

## Screenshots

_desktop:_

![2024-04-03-011756_909x153_scrot](https://github.com/stackernews/stacker.news/assets/27162016/a6a6c262-0b0f-46c8-959d-f381f2d181bf)

_mobile:_

![localhost_3000_~Design(iPhone SE)](https://github.com/stackernews/stacker.news/assets/27162016/e44c7956-1fd6-48d4-ba38-551de7c528bd)

## Additional Context

I often wonder if a territory is new or I just haven't noticed it yet.

I think knowing which territories are new and which are old is interesting for all kind of reasons.

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?

verified that `createdAt` is a required column in the database

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [x] For frontend changes: Tested on mobile?
