### PR TITLE
Fix all known problems with invite and referral links

### DIFF
--- a/api/ssrApollo.js
+++ b/api/ssrApollo.js
@@ -111,7 +111,7 @@ export function getGetServerSideProps (
       }
 
       if (error || !data || (notFound && notFound(data, vars, me))) {
-        res.writeHead(301, {
+        res.writeHead(302, {
           Location: '/404'
         }).end()
       }

--- a/components/invite.js
+++ b/components/invite.js
@@ -21,7 +21,7 @@ export default function Invite ({ invite, active }) {
       <CopyInput
         groupClassName='mb-1'
         size='sm' type='text'
-        placeholder={`https://stacker.news/invites/${invite.id}`} readOnly noForm
+        placeholder={`${process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://stacker.news'}/invites/${invite.id}`} readOnly noForm
       />
       <div className={styles.other}>
         <span>{invite.gift} sat gift</span>

--- a/pages/invites/[id].js
+++ b/pages/invites/[id].js
@@ -36,7 +36,7 @@ export async function getServerSideProps ({ req, res, query: { id, error = null 
       // attempt to send gift
       // catch any errors and just ignore them for now
       await serialize(models,
-        models.$queryRawUnsafe('SELECT invite_drain($1::INTEGER, $2::INTEGER)', session.user.id, id))
+        models.$queryRawUnsafe('SELECT invite_drain($1::INTEGER, $2::TEXT)', session.user.id, id))
       const invite = await models.invite.findUnique({ where: { id } })
       notifyInvite(invite.userId)
     } catch (e) {

--- a/pages/invites/[id].js
+++ b/pages/invites/[id].js
@@ -26,9 +26,10 @@ export async function getServerSideProps ({ req, res, query: { id, error = null 
   })
 
   if (!data?.invite) {
-    res.writeHead(301, {
+    res.writeHead(302, {
       Location: '/404'
     }).end()
+    return { props: {} }
   }
 
   if (session && res) {
@@ -43,12 +44,10 @@ export async function getServerSideProps ({ req, res, query: { id, error = null 
       console.log(e)
     }
 
-    return {
-      redirect: {
-        destination: '/',
-        permanent: false
-      }
-    }
+    res.writeHead(302, {
+      Location: '/'
+    }).end()
+    return { props: {} }
   }
 
   return {


### PR DESCRIPTION
closes #1002 
closes #679 
closes #375 

- Invites have been broken since 7542dd6cc43f80eac6c29ee064bbab5c0ccb52a9 due to mismatching store procedure params. This fixed that.
- It also changes the redirection logic for invites which doesn't seem to work in more modern versions of nextjs.
    - bonus: we were doing permanent redirects in a few places where we shouldn't have been
- make referrals work for lnauth/nostr auth
    - these were broken because the callback we use to update referrals relied on next-auth telling us a user was new
    - however, from next-auth's perspective these users are never new because we create them before passing them to next-auth
    - solution: don't rely on the user being new, and update referrer on login/linking/signup too iff the user doesn't already have a referrer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated HTTP response status code from `301` to `302` for redirection, ensuring proper flow in case of errors or missing data.
- **New Features**
	- Enhanced invite link generation with conditional base URLs for improved flexibility.
- **Refactor**
	- Simplified authentication flow by adjusting user referral and newsletter signup logic.
	- Improved data handling in database queries and authentication methods for better efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->