### PR TITLE
Never notify on replies from self

### DIFF
--- a/api/resolvers/notifications.js
+++ b/api/resolvers/notifications.js
@@ -84,6 +84,7 @@ export default {
             '"ThreadSubscription"."userId" = $1',
             'r.created_at >= "ThreadSubscription".created_at',
             'r.created_at < $2',
+            'r."userId" <> $1',
             ...(meFull.noteAllDescendants ? [] : ['r.level = 1'])
           )}
           ORDER BY "sortTime" DESC


### PR DESCRIPTION
## Description

Fixes https://stacker.news/items/493271

In #958, we denormalized replies but don't store replies to self, see `p."userId" <> NEW."userId"` here:

https://github.com/stackernews/stacker.news/blob/15fb7f446b68611306e0dd0c5a0fa460834be991/prisma/migrations/20240323222903_replies/migration.sql#L70-L73

However, we missed that `ThreadSubscription` can still notify users about their own replies if the reply is in a thread to which they are subscribed.

This PR makes sure that we never notify 

## Additional context

Some discussion can be found here: https://github.com/stackernews/stacker.news/commit/a7b0272200c83a5d4c76b48460fc2aca084df3d7#r140575475

Push notifications were not affected since they actually still use old code with a `p."userId" <> $2` filter:

https://github.com/stackernews/stacker.news/blob/15fb7f446b68611306e0dd0c5a0fa460834be991/lib/webPush.js#L181-L199

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [ ] For frontend changes: Tested on mobile?
