### PR TITLE
Remove useRef for NWC relay

### DIFF
--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -25,7 +25,11 @@ export function NWCProvider ({ children }) {
 
     let relay, sub
     try {
-      relay = await Relay.connect(relayUrl)
+      relay = await Relay.connect(relayUrl).catch((err) => {
+        logger.error(`failed to connect to ${relayUrl}`)
+        // NOTE: err is undefined for some reason
+        throw err
+      })
       logger.ok(`connected to ${relayUrl}`)
       return await new Promise((resolve, reject) => {
         const timeout = 5000
@@ -72,7 +76,7 @@ export function NWCProvider ({ children }) {
     } finally {
       // For some reason, websocket is already in CLOSING or CLOSED state.
       // relay?.close()
-      logger.info(`closed connection to ${relayUrl}`)
+      if (relay) logger.info(`closed connection to ${relayUrl}`)
     }
   }, [logger])
 
@@ -180,7 +184,11 @@ export function NWCProvider ({ children }) {
 
     let relay, sub
     try {
-      relay = await Relay.connect(relayUrl)
+      relay = await Relay.connect(relayUrl).catch((err) => {
+        logger.error(`failed to connect to ${relayUrl}`)
+        // NOTE: err is undefined for some reason
+        throw err
+      })
       logger.ok(`connected to ${relayUrl}`)
       const ret = await new Promise(function (resolve, reject) {
         (async function () {
@@ -241,7 +249,7 @@ export function NWCProvider ({ children }) {
     } finally {
       // For some reason, websocket is already in CLOSING or CLOSED state.
       // relay?.close()
-      logger.info(`closed connection to ${relayUrl}`)
+      if (relay) logger.info(`closed connection to ${relayUrl}`)
     }
   }, [walletPubkey, secret, logger])
 


### PR DESCRIPTION
## Description

I noticed that my payments in prod most likely fail due to using a relay connection that is already closed. I now open and close a relay connection for every payment. That should be more reliable.

Also changed other stuff as mentioned in the commit message:

> * connect to relay for every payment for more reliable payments
> * remove getInfoWithRelay method (no longer needed since we no longer use useRef)
> * fix 'WebSocket is already in CLOSING or CLOSED state.' errors
> * improve logging


## Video

https://github.com/stackernews/stacker.news/assets/27162016/b3cdf2fe-05d8-48e0-8d44-febcfa443f93

## Additional Context

<!--

You can mention here anything that you think is relevant for this PR. Some examples:

* You encountered something that you didn't understand while working on this PR
* You were not sure about something you did but did not find a better way
* You initially had a different approach but went with a different approach for some reason

-->

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [ ] For frontend changes: Tested on mobile?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced the `NWCProvider` component for better connection handling with the relay server, improved error handling, and increased reliability.
	- Introduced new functions for wallet information retrieval and parameter validation.
	- Adjusted logic for wallet enablement based on supported methods, including timeout enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->