### PR TITLE
less confusing expression for the hint of when the autowithdraw will be initiated

### DIFF
--- a/components/autowithdraw-shared.js
+++ b/components/autowithdraw-shared.js
@@ -43,9 +43,9 @@ export function AutowithdrawSettings ({ priority }) {
             name='autoWithdrawThreshold'
             onChange={(formik, e) => {
               const value = e.target.value
-              setSendThreshold(Math.max(Math.floor(value / 10), 1))
+              setSendThreshold(Math.max(Math.floor(value / 10 * 11), 1))
             }}
-            hint={isNumber(sendThreshold) ? `attempts to keep your balance no greater than ${numWithUnits(sendThreshold)} of this amount` : undefined}
+            hint={isNumber(sendThreshold) ? `will attempt auto-withdraw when your balance exceeds ${sendThreshold} sats` : undefined}
             append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
           />
           <Input

--- a/components/autowithdraw-shared.js
+++ b/components/autowithdraw-shared.js
@@ -3,7 +3,6 @@ import { Checkbox, Input } from './form'
 import { useMe } from './me'
 import { useEffect, useState } from 'react'
 import { isNumber } from 'mathjs'
-import { numWithUnits } from '@/lib/format'
 
 function autoWithdrawThreshold ({ me }) {
   return isNumber(me?.privates?.autoWithdrawThreshold) ? me?.privates?.autoWithdrawThreshold : 10000
@@ -45,7 +44,7 @@ export function AutowithdrawSettings ({ priority }) {
               const value = e.target.value
               setSendThreshold(Math.max(Math.floor(value / 10), 1))
             }}
-            hint={isNumber(sendThreshold) ? `will attempt auto-withdraw when your balance exceeds ${sendThreshold*11} sats` : undefined}
+            hint={isNumber(sendThreshold) ? `will attempt auto-withdraw when your balance exceeds ${sendThreshold * 11} sats` : undefined}
             append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
           />
           <Input

--- a/components/autowithdraw-shared.js
+++ b/components/autowithdraw-shared.js
@@ -43,9 +43,9 @@ export function AutowithdrawSettings ({ priority }) {
             name='autoWithdrawThreshold'
             onChange={(formik, e) => {
               const value = e.target.value
-              setSendThreshold(Math.max(Math.floor(value / 10 * 11), 1))
+              setSendThreshold(Math.max(Math.floor(value / 10), 1))
             }}
-            hint={isNumber(sendThreshold) ? `will attempt auto-withdraw when your balance exceeds ${sendThreshold} sats` : undefined}
+            hint={isNumber(sendThreshold) ? `will attempt auto-withdraw when your balance exceeds ${sendThreshold*11} sats` : undefined}
             append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
           />
           <Input


### PR DESCRIPTION
## Description

As hint, instead of giving the relative change, it gives the absolute value for the threshold at which the transfer will be initiated. I use the original value + this relative change by multiplying by showing 11/10 instead of 1/10 of the threshold value chosen by the user.

closes #1010

## Screenshots

I tested in works sndev mode and updates dynamically when the user changes the desired value:

<img width="1139" alt="Screenshot 2024-04-04 at 5 00 15 PM" src="https://github.com/stackernews/stacker.news/assets/11783268/3a3386fc-0225-4653-88c9-9c9c446df653">

## Checklist


- [x] Are your changes backwards compatible?
- [ ] Did you QA this? Could we deploy this straight to production?
- [ ] For frontend changes: Tested on mobile?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Adjusted the calculation of the auto-withdrawal trigger threshold for accuracy.
	- Updated hint text to clarify auto-withdrawal trigger conditions based on the balance exceeding the threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->