### PR TITLE
prevent context providers causing rerenders

### DIFF
--- a/components/modal.js
+++ b/components/modal.js
@@ -35,19 +35,20 @@ export default function useModal () {
     setModalStack(modalStack.slice(0, -1))
     modalOptions?.onClose?.()
     return setModalContent(previousModalContent)
-  }, [modalStack, setModalStack])
+  }, [modalStack, setModalStack, modalOptions?.onClose])
 
+  // this is called on every navigation due to below useEffect
   const onClose = useCallback(() => {
     setModalContent(null)
-    setModalStack([])
+    setModalStack(ms => ms.length > 0 ? [] : ms)
     modalOptions?.onClose?.()
-  }, [modalOptions?.onClose])
+  }, [setModalStack, setModalContent, modalOptions?.onClose])
 
   const router = useRouter()
   useEffect(() => {
     router.events.on('routeChangeStart', onClose)
     return () => router.events.off('routeChangeStart', onClose)
-  }, [router, onClose])
+  }, [router.events, onClose])
 
   const modal = useMemo(() => {
     if (modalContent === null) {
@@ -76,7 +77,7 @@ export default function useModal () {
         </Modal.Body>
       </Modal>
     )
-  }, [modalContent, onClose])
+  }, [modalContent, onClose, modalOptions, onBack, modalStack])
 
   const showModal = useCallback(
     (getContent, options) => {

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -531,7 +531,7 @@ export default function Notifications ({ ssrData }) {
         }
       }, router.asPath, { ...router.options, shallow: true })
     }
-  }, [router, lastChecked])
+  }, [router?.query?.checkedAt, lastChecked])
 
   if (!dat) return <CommentsFlatSkeleton />
 
@@ -540,7 +540,7 @@ export default function Notifications ({ ssrData }) {
       {notifications.map(n =>
         <Notification
           n={n} key={nid(n)}
-          fresh={new Date(n.sortTime) > new Date(router?.query?.checkedAt)}
+          fresh={new Date(n.sortTime) > new Date(router?.query?.checkedAt ?? lastChecked)}
         />)}
       <MoreFooter cursor={cursor} count={notifications?.length} fetchMore={fetchMore} Skeleton={CommentsFlatSkeleton} noMoreText='NO MORE' />
     </>


### PR DESCRIPTION
We had some context providers that were setting the state to new references (of identical state) on every page navigation which was causing multiple unnecessary rerenders, e.g. `setState([])`. This was causing new notifications to occasionally not be highlighted.

This checks if the state is already empty and sets the state to the same reference, e.g. `setState(s => s.length > 0 ? [] : s)`.

This also did a pass over hook deps making sure they were correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced modal stack management and navigation handling in modals.
	- Improved notification freshness checks and dependency management.
	- Optimized toast creation and removal processes for better performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->