### PR TITLE
Add missing space in front of founding date

### DIFF
--- a/components/territory-header.js
+++ b/components/territory-header.js
@@ -43,7 +43,7 @@ export function TerritoryInfo ({ sub }) {
           <Link href={`/${sub.user.name}`}>
             @{sub.user.name}<span> </span><Hat className='fill-grey' user={sub.user} height={12} width={12} />
           </Link>
-          <span>on </span>
+          <span> on </span>
           <span className='fw-bold'>{new Date(sub.createdAt).toDateString()}</span>
         </div>
         <div className='text-muted'>


### PR DESCRIPTION
## Description

Forgot a space in #1008 such that spacing was broken for users with cowboy hats.

## Screenshots

Before:

![2024-04-05-180711_290x57_scrot](https://github.com/stackernews/stacker.news/assets/27162016/7081c563-68c7-48ed-90d5-8a5047cf0b32)

After:

![2024-04-05-180733_299x58_scrot](https://github.com/stackernews/stacker.news/assets/27162016/6688f363-2a16-423b-94fe-0cf5c2df3c5a)

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [x] For frontend changes: Tested on mobile?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Style**
	- Improved readability in the territory information display by adjusting text spacing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->