### PR TITLE
Fix 404 for territories in profile

### DIFF
--- a/api/resolvers/sub.js
+++ b/api/resolvers/sub.js
@@ -186,6 +186,7 @@ export default {
 
       const subs = await models.$queryRawUnsafe(`
           SELECT "Sub".*,
+            "Sub".created_at as "createdAt",
             COALESCE(floor(sum(msats_revenue)/1000), 0) as revenue,
             COALESCE(floor(sum(msats_stacked)/1000), 0) as stacked,
             COALESCE(floor(sum(msats_spent)/1000), 0) as spent,


### PR DESCRIPTION
## Description

This fixes 404 for https://stacker.news/ek/territories.

## Additional context

Looking for similar bugs.

**Update**

Maybe this is a better fix since more generic?

```diff
diff --git a/api/resolvers/sub.js b/api/resolvers/sub.js
index 32328387..a9961816 100644
--- a/api/resolvers/sub.js
+++ b/api/resolvers/sub.js
@@ -394,7 +394,8 @@ export default {
     },
     meSubscription: async (sub, args, { me, models }) => {
       return sub.meSubscription || sub.SubSubscription?.length > 0
-    }
+    },
+    createdAt: sub => sub.createdAt || sub.created_at
   }
 }
```

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [ ] For frontend changes: Tested on mobile?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Enhanced the "Sub" entity query result with a clearer timestamp representation by adding a "createdAt" field.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->