### PR TITLE
Embed the login url as a qrcode into the html email

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -11,6 +11,8 @@ import { getToken } from 'next-auth/jwt'
 import { NodeNextRequest } from 'next/dist/server/base-http/node'
 import { schnorr } from '@noble/curves/secp256k1'
 import { notifyReferral } from '@/lib/webPush'
+import { renderToString } from 'react-dom/server'
+import QRCode from 'qrcode.react'
 
 /**
  * Stores userIds in user table
@@ -343,6 +345,8 @@ const newUserHtml = ({ url, site, email }) => {
   const mainBackgroundColor = '#ffffff'
   const buttonBackgroundColor = '#FADA5E'
 
+  const urlQrCode = renderToString(<QRCode value={url} renderAs='svg' size={256} />)
+
   return `
 <!doctype html>
 <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
@@ -502,6 +506,12 @@ const newUserHtml = ({ url, site, email }) => {
                             </td>
                           </tr>
                         </table>
+                      </td>
+                    </tr>
+                    <tr>
+                      <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                        <div style="font-family:Helvetica, Arial, sans-serif;font-size:14px;line-height:24px;text-align:center;color:#000000;">Or read this QRCode with your device:</div>
+                        ${urlQrCode}
                       </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
I own quite a few sn accounts (😅) and I use the *login with email* feature **a lot** to log on many devices both on sn's pwa and on my native client and this is a feature I always thought would be really nice to have :)

This makes it much easier to logon on different devices without needing to setup my email account to click the link or copy & paste it somewhere else so I can use it.

## Screenshots
![image](https://github.com/stackernews/stacker.news/assets/241271/b79ea5b6-82fe-4241-890b-d1b18cbf7145)

![image](https://github.com/stackernews/stacker.news/assets/241271/6cfa7a91-c6c0-4052-bd47-d913192fe136)

I covered the qrcode on purpose so I could take the screenshot

![image](https://github.com/stackernews/stacker.news/assets/241271/9bbaf8c9-2f08-4b30-be57-8f5859856119)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the authentication process by including a QR code in the HTML email template for improved security and user convenience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->