### PR TITLE
fix: feetext defaults to free

### DIFF
--- a/components/fee-button.js
+++ b/components/fee-button.js
@@ -118,7 +118,7 @@ export default function FeeButton ({ ChildButton = SubmitButton, variant, text, 
     ? 'free'
     : total > 1
       ? numWithUnits(total, { abbreviate: false, format: true })
-      : undefined
+      : 'free'
   disabled ||= ctxDisabled
 
   return (

--- a/components/fee-button.js
+++ b/components/fee-button.js
@@ -118,7 +118,7 @@ export default function FeeButton ({ ChildButton = SubmitButton, variant, text, 
     ? 'free'
     : total > 1
       ? numWithUnits(total, { abbreviate: false, format: true })
-      : 'free'
+      : total === 1 ? undefined : 'free'
   disabled ||= ctxDisabled
 
   return (


### PR DESCRIPTION
## Description

closes #908

The tooltip text was defaulting to `undefined` when total <= 1. This PR changes it to "free"

<!--

A clear and concise description of what you changed and why.

Bullet points can be enough.

You can use the following PRs as inspiration:
  - https://github.com/stackernews/stacker.news/pull/227 (feature)
  - https://github.com/stackernews/stacker.news/pull/915 (feature)
  - https://github.com/stackernews/stacker.news/pull/871 (fix)
  - <your PR could be here>

Don't forget to mention which tickets this closes (if any).
Use following syntax to close them automatically on merge: closes #<NUMBER>

-->

## Screenshots

![Screenshot 2024-04-05 at 7 06 01 PM](https://github.com/stackernews/stacker.news/assets/6998593/1d90478f-f4d4-4ded-a726-fe9e84b013df)


<!--

If your changes are user facing, please add screenshots of the new UI.

You can also create a video to showcase your changes (useful to show UX).

-->

## Additional Context

<!--

You can mention here anything that you think is relevant for this PR. Some examples:

* You encountered something that you didn't understand while working on this PR
* You were not sure about something you did but did not find a better way
* You initially had a different approach but went with a different approach for some reason

-->

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [ ] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [ ] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [x] For frontend changes: Tested on mobile?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the `FeeButton` to consistently display 'free' when applicable, enhancing clarity for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->