### PR TITLE
Add a ctrl + click eventListener to open notifications in new tab

### DIFF
--- a/components/notifications.js
+++ b/components/notifications.js
@@ -79,10 +79,7 @@ function NotificationLayout ({ children, n, href, as, fresh }) {
         }, router.asPath, { ...router.options, shallow: true })
         if (e.ctrlKey) {
           e.preventDefault()
-          const anchor = document.createElement('a')
-          anchor.href = n.item.parentId ? as + '?commentId=' + n.id : as
-          anchor.target = '_blank'
-          anchor.click()
+          window.open(n.item.parentId ? as + '?commentId=' + n.id : as, '_blank')
         } else {
           router.push(href, as)
         }


### PR DESCRIPTION
## Description

Adds a new `ctrl + click` event listener to the entire notification div to allow users to decide whether theywant to go directly to the notification or for it to be opened in a new tab

<!--

A clear and concise description of what you changed and why.

Bullet points can be enough.

You can use the following PRs as inspiration:
  - https://github.com/stackernews/stacker.news/pull/227 (feature)
  - https://github.com/stackernews/stacker.news/pull/915 (feature)
  - https://github.com/stackernews/stacker.news/pull/871 (fix)
  - <your PR could be here>

Don't forget to mention which tickets this closes (if any).
Use following syntax to close them automatically on merge: closes #<NUMBER>

-->

## Additional Context

There was some discussion about playing with `a` tags but only a select few notification types have `a` tags in the main body at the moment so to implement this would require redesigning all the notification objects. Also, to allow link-nesting we would have to really play with the css as html does not allow an `a` tag inside of an `a` tag. As a result this current change will not allow users to go the `right click` -> `open in new tab` route

*** Because this is adding a popup with `window.open()` this does create a pop-up permission since we are working within a `div` and it does not have traditional `a` tag functionality. I'm not totally sure if there is a way around this as it is not technically "clicking" a link (I tried with creating an anchor tag in [3d87012](https://github.com/stackernews/stacker.news/pull/1032/commits/3d8701226d4de2885e85034ec220555e6483703c) but this has the same problem)

<!--

You can mention here anything that you think is relevant for this PR. Some examples:

* You encountered something that you didn't understand while working on this PR
* You were not sure about something you did but did not find a better way
* You initially had a different approach but went with a different approach for some reason

-->

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?
* I did test with several notification types but not all of them!
is there any situation where we would want a different query type than `?commentId=` and is there a situation where this ternary `n.item.parentId ? as + '?commentId=' + n.id : as` breaks down?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [x] For frontend changes: Tested on mobile?
* I don't think this is a behavior we really want on mobile, while some users might* want this on a longpress or something I think we should avoid having stacker news be open in 100+ mobile tabs, also mobile browsers are pretty strict security wise so this would result in users having to check pop-up boxes regularly
