### PR TITLE
Mute Management Settings Page

### DIFF
--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -161,6 +161,26 @@ export default {
         users
       }
     },
+    myMutedUsers: async (parent, { cursor }, { models, me }) => {
+      if (!me) {
+        throw new GraphQLError('You must be logged in to view subscribed users', { extensions: { code: 'UNAUTHENTICATED' } })
+      }
+
+      const decodedCursor = decodeCursor(cursor)
+      const users = await models.$queryRaw`
+        SELECT users.*
+        FROM "Mute"
+        JOIN users ON "Mute"."mutedId" = users.id
+        WHERE "Mute"."muterId" = ${me.id}
+        OFFSET ${decodedCursor.offset}
+        LIMIT ${LIMIT}
+      `
+
+      return {
+        cursor: users.length === LIMIT ? nextCursorEncoded(decodedCursor) : null,
+        users
+      }
+    },
     topCowboys: async (parent, { cursor }, { models, me }) => {
       const decodedCursor = decodeCursor(cursor)
       const range = whenRange('forever')

--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -163,7 +163,7 @@ export default {
     },
     myMutedUsers: async (parent, { cursor }, { models, me }) => {
       if (!me) {
-        throw new GraphQLError('You must be logged in to view subscribed users', { extensions: { code: 'UNAUTHENTICATED' } })
+        throw new GraphQLError('You must be logged in to view muted users', { extensions: { code: 'UNAUTHENTICATED' } })
       }
 
       const decodedCursor = decodeCursor(cursor)

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -13,6 +13,7 @@ export default gql`
     userSuggestions(q: String, limit: Limit): [User!]!
     hasNewNotes: Boolean!
     mySubscribedUsers(cursor: String): Users!
+    myMutedUsers(cursor: String): Users!
   }
 
   type UsersNullable {

--- a/components/mute.js
+++ b/components/mute.js
@@ -1,10 +1,26 @@
+import { createContext, useContext } from 'react'
 import { useMutation } from '@apollo/client'
 import { gql } from 'graphql-tag'
 import Dropdown from 'react-bootstrap/Dropdown'
 import { useToast } from './toast'
 
+const MuteUserContext = createContext(() => ({
+  refetchQueries: []
+}))
+
+export const MuteUserContextProvider = ({ children, value }) => {
+  return (
+    <MuteUserContext.Provider value={value}>
+      {children}
+    </MuteUserContext.Provider>
+  )
+}
+
+export const useMuteUserContext = () => useContext(MuteUserContext)
+
 export default function MuteDropdownItem ({ user: { name, id, meMute } }) {
   const toaster = useToast()
+  const { refetchQueries } = useMuteUserContext()
   const [toggleMute] = useMutation(
     gql`
       mutation toggleMute($id: ID!) {
@@ -12,6 +28,7 @@ export default function MuteDropdownItem ({ user: { name, id, meMute } }) {
           meMute
         }
       }`, {
+      refetchQueries,
       update (cache, { data: { toggleMute } }) {
         cache.modify({
           id: `User:${id}`,

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -226,6 +226,26 @@ export const MY_SUBSCRIBED_USERS = gql`
   }
 `
 
+export const MY_MUTED_USERS = gql`
+  query MyMutedUsers($cursor: String) {
+    myMutedUsers(cursor: $cursor) {
+      users {
+        id
+        name
+        photoId
+        meSubscriptionPosts
+        meSubscriptionComments
+        meMute
+
+        optional {
+          streak
+        }
+      }
+      cursor
+    }
+  }
+`
+
 export const TOP_USERS = gql`
   query TopUsers($cursor: String, $when: String, $from: String, $to: String, $by: String, ) {
     topUsers(cursor: $cursor, when: $when, from: $from, to: $to, by: $by) {

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -99,6 +99,19 @@ function getClient (uri) {
                 }
               }
             },
+            myMutedUsers: {
+              keyArgs: false,
+              merge (existing, incoming) {
+                if (isFirstPage(incoming.cursor, existing?.users)) {
+                  return incoming
+                }
+
+                return {
+                  cursor: incoming.cursor,
+                  users: [...(existing?.users || []), ...incoming.users]
+                }
+              }
+            },
             userSuggestions: {
               keyArgs: ['q', 'limit'],
               merge (existing, incoming) {

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -41,7 +41,7 @@ function bech32encode (hexString) {
 export function SettingsHeader () {
   const router = useRouter()
   const pathParts = router.asPath.split('/').filter(segment => !!segment)
-  const activeKey = pathParts.length === 1 ? 'general' : 'subscriptions'
+  const activeKey = pathParts[1] ?? 'general'
   return (
     <>
       <h2 className='mb-2 text-start'>settings</h2>
@@ -57,6 +57,11 @@ export function SettingsHeader () {
         <Nav.Item>
           <Link href='/settings/subscriptions' passHref legacyBehavior>
             <Nav.Link eventKey='subscriptions'>subscriptions</Nav.Link>
+          </Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Link href='/settings/mutes' passHref legacyBehavior>
+            <Nav.Link eventKey='mutes'>muted users</Nav.Link>
           </Link>
         </Nav.Item>
       </Nav>

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -61,7 +61,7 @@ export function SettingsHeader () {
         </Nav.Item>
         <Nav.Item>
           <Link href='/settings/mutes' passHref legacyBehavior>
-            <Nav.Link eventKey='mutes'>muted users</Nav.Link>
+            <Nav.Link eventKey='mutes'>muted stackers</Nav.Link>
           </Link>
         </Nav.Item>
       </Nav>

--- a/pages/settings/mutes/index.js
+++ b/pages/settings/mutes/index.js
@@ -8,7 +8,7 @@ import { MuteUserContextProvider } from '@/components/mute'
 
 export const getServerSideProps = getGetServerSideProps({ query: MY_MUTED_USERS, authRequired: true })
 
-export default function MuMutedUsers ({ ssrData }) {
+export default function MyMutedUsers ({ ssrData }) {
   const muteUserContextValue = useMemo(() => ({ refetchQueries: ['MyMutedUsers'] }), [])
   return (
     <Layout>

--- a/pages/settings/mutes/index.js
+++ b/pages/settings/mutes/index.js
@@ -1,0 +1,31 @@
+import { useMemo } from 'react'
+import { getGetServerSideProps } from '@/api/ssrApollo'
+import Layout from '@/components/layout'
+import UserList from '@/components/user-list'
+import { MY_MUTED_USERS } from '@/fragments/users'
+import { SettingsHeader } from '../index'
+import { MuteUserContextProvider } from '@/components/mute'
+
+export const getServerSideProps = getGetServerSideProps({ query: MY_MUTED_USERS, authRequired: true })
+
+export default function MuMutedUsers ({ ssrData }) {
+  const muteUserContextValue = useMemo(() => ({ refetchQueries: ['MyMutedUsers'] }), [])
+  return (
+    <Layout>
+      <div className='pb-3 w-100 mt-2'>
+        <SettingsHeader />
+        <div className='mb-4 text-muted'>Well now, reckon these here are the folks you've gone and silenced.</div>
+        <MuteUserContextProvider value={muteUserContextValue}>
+          <UserList
+            ssrData={ssrData} query={MY_MUTED_USERS}
+            destructureData={data => data.myMutedUsers}
+            variables={{}}
+            rank
+            nymActionDropdown
+            statCompsProp={[]}
+          />
+        </MuteUserContextProvider>
+      </div>
+    </Layout>
+  )
+}


### PR DESCRIPTION
## Description
Closes #943 

Add a muted users management tab to the settings page - a tab where you can view all the stackers whom you've muted, and you can manage your mutes for each individually. The approach is as follows:

1. Add a "muted users" tab to the settings page that links to new page at `/settings/mutes`
2. Create a new user graphql query which returns all users that you've muted
3. Displays a list of these users, in pages of 21
4. Each user in the list has an action overflow menu, where you can manage your subscription(s) and mutes, just like on the user profile page
5. When you unmute a stacker in the list, the list reloads to reflect that change, including removing said stacker from the list

## Screenshots
New "muted users" tab on settings page nav bar:
<img width="857" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/d21e21f3-20dd-4d42-94c0-d9742d38d094">

The muted users listing:
<img width="864" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/62dda6ef-2c4c-402f-ab6f-238475c3ad23">


Pagination available:
<img width="844" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/37e44dcc-94b9-4882-85f5-0c4be8ade279">

No more data left to fetch
<img width="829" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/56ddff45-68c4-4a0a-bcd4-fbae60899209">

Mobile preview:
<img width="433" alt="image" src="https://github.com/stackernews/stacker.news/assets/128755788/22c034fb-ba38-478f-b4fd-218b24248897">


## Additional Context
This is largely a port/copy/paste from #1000 with some minor changes for mutes instead of subscriptions

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [X] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [X] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [X] For frontend changes: Tested on mobile?
