### PR TITLE
Internal links are not target=_blank by default

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -178,6 +178,7 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
             // If [text](url) was parsed as <a> and text is not empty and not a link itself,
             // we don't render it as an image since it was probably a conscious choice to include text.
             const text = children[0]
+            const internalURL = process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : 'https://stacker.news'
             if (!!text && !/^https?:\/\//.test(text)) {
               if (props['data-footnote-ref'] || typeof props['data-footnote-backref'] !== 'undefined') {
                 return (
@@ -191,14 +192,14 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
               }
               return (
                 // eslint-disable-next-line
-                <a id={props.id} target='_blank' rel={rel ?? UNKNOWN_LINK_REL} href={href}>{text}</a>
+                <a id={props.id} target={href.startsWith(internalURL) || href.startsWith('/') ? '_self' : '_blank'} rel={rel ?? UNKNOWN_LINK_REL} href={href}>{text}</a>
               )
             }
 
             try {
               const linkText = parseInternalLinks(href)
               if (linkText) {
-                return <a target='_blank' href={href} rel='noreferrer'>{linkText}</a>
+                return <a target={href.startsWith(internalURL) || href.startsWith('/') ? '_self' : '_blank'} rel='noreferrer' href={href}>{linkText}</a>
               }
             } catch {
               // ignore errors like invalid URLs

--- a/lib/url.js
+++ b/lib/url.js
@@ -1,3 +1,5 @@
+import { SSR } from './constants'
+
 export function ensureProtocol (value) {
   if (!value) return value
   value = value.trim()
@@ -28,11 +30,12 @@ export function removeTracking (value) {
  */
 export function parseInternalLinks (href) {
   const url = new URL(href)
+  const internalURL = SSR ? 'https://stacker.news' : window.location.origin
   const { pathname, searchParams } = url
   // ignore empty parts which exist due to pathname starting with '/'
   const emptyPart = part => !!part
   const parts = pathname.split('/').filter(emptyPart)
-  if (parts[0] === 'items' && /^[0-9]+$/.test(parts[1])) {
+  if (parts[0] === 'items' && /^[0-9]+$/.test(parts[1]) && url.origin === internalURL) {
     const itemId = parts[1]
     // check for valid item page due to referral links like /items/123456/r/ekzyis
     const itemPages = ['edit', 'ots', 'related']


### PR DESCRIPTION
## Description

ensures that internal links do not open in new tabs by default 

Closes #1036

<!--

A clear and concise description of what you changed and why.

Bullet points can be enough.

You can use the following PRs as inspiration:
  - https://github.com/stackernews/stacker.news/pull/227 (feature)
  - https://github.com/stackernews/stacker.news/pull/915 (feature)
  - https://github.com/stackernews/stacker.news/pull/871 (fix)
  - <your PR could be here>

Don't forget to mention which tickets this closes (if any).
Use following syntax to close them automatically on merge: closes #<NUMBER>

-->

## Additional Context

Adds some logic to ensure that links are considered internal links only when they start with `https://stacker.news` in prod or when links start with `/` indicating it is a next internal route.  This prevents the site getting confused on links like `https://example.com/items/134500`.  I suppose this will not work on the sn onion site

<!--

You can mention here anything that you think is relevant for this PR. Some examples:

* You encountered something that you didn't understand while working on this PR
* You were not sure about something you did but did not find a better way
* You initially had a different approach but went with a different approach for some reason

-->

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [x] For frontend changes: Tested on mobile?
