### PR TITLE
Fix the tests for parseInternalLinks

### DIFF
--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -7,6 +7,8 @@ const cases = [
   ['https://stacker.news/items/123/related', '#123/related'],
   // invalid links should not be parsed so user can spot error
   ['https://stacker.news/items/123foobar', undefined],
+  // Invalid origin should not be parsed so no malicious links
+  ['https://example.com/items/123', undefined],
   // parse referral links
   ['https://stacker.news/items/123/r/ekzyis', '#123'],
   // use comment id if available
@@ -21,6 +23,7 @@ describe('internal links', () => {
   test.each(cases)(
     'parses %p as %p',
     (href, expected) => {
+      process.env.NEXT_PUBLIC_URL = 'https://stacker.news'
       const actual = parseInternalLinks(href)
       expect(actual).toBe(expected)
     }


### PR DESCRIPTION
## Description

- adds env variables to run the tests in `/lib/url.spec.js`

- adds a new test to prove non-valid origins fail

<!--

A clear and concise description of what you changed and why.

Bullet points can be enough.

You can use the following PRs as inspiration:
  - https://github.com/stackernews/stacker.news/pull/227 (feature)
  - https://github.com/stackernews/stacker.news/pull/915 (feature)
  - https://github.com/stackernews/stacker.news/pull/871 (fix)
  - <your PR could be here>

Don't forget to mention which tickets this closes (if any).
Use following syntax to close them automatically on merge: closes #<NUMBER>

-->

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?
