### PR TITLE
Merge serializeInvoiceable with serialize without bug

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1282,13 +1282,13 @@ export const updateItem = async (parent, { sub: subName, forward, options, ...it
   const fwdUsers = await getForwardUsers(models, forward)
 
   const uploadIds = uploadIdsFromText(item.text, { models })
-  const { totalFees: imgFees } = await imageFeesInfo(uploadIds, { models, me })
+  const { totalFees: imgFees } = await imageFeesInfo(uploadIds, { models, me });
 
-  item = await serialize(
+  ([item] = await serialize(
     models.$queryRawUnsafe(`${SELECT} FROM update_item($1::JSONB, $2::JSONB, $3::JSONB, $4::INTEGER[]) AS "Item"`,
       JSON.stringify(item), JSON.stringify(fwdUsers), JSON.stringify(options), uploadIds),
     { models, lnd, me, hash, hmac, fee: imgFees }
-  )
+  ))
 
   await createMentions(item, models)
 
@@ -1329,14 +1329,14 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
       fee = sub.baseCost * ANON_FEE_MULTIPLIER + (item.boost || 0)
     }
   }
-  fee += imgFees
+  fee += imgFees;
 
-  item = await serialize(
+  ([item] = await serialize(
     models.$queryRawUnsafe(
       `${SELECT} FROM create_item($1::JSONB, $2::JSONB, $3::JSONB, '${spamInterval}'::INTERVAL, $4::INTEGER[]) AS "Item"`,
       JSON.stringify(item), JSON.stringify(fwdUsers), JSON.stringify(options), uploadIds),
     { models, lnd, me, hash, hmac, fee }
-  )
+  ))
 
   await createMentions(item, models)
 

--- a/api/resolvers/rewards.js
+++ b/api/resolvers/rewards.js
@@ -1,6 +1,6 @@
 import { GraphQLError } from 'graphql'
 import { amountSchema, ssValidate } from '@/lib/validate'
-import { serializeInvoicable } from './serial'
+import serialize from './serial'
 import { ANON_USER_ID } from '@/lib/constants'
 import { getItem } from './item'
 import { topUsers } from './user'
@@ -168,9 +168,9 @@ export default {
     donateToRewards: async (parent, { sats, hash, hmac }, { me, models, lnd }) => {
       await ssValidate(amountSchema, { amount: sats })
 
-      await serializeInvoicable(
+      await serialize(
         models.$queryRaw`SELECT donate(${sats}::INTEGER, ${me?.id || ANON_USER_ID}::INTEGER)`,
-        { models, lnd, hash, hmac, me, enforceFee: sats }
+        { models, lnd, me, hash, hmac, fee: sats }
       )
 
       return sats

--- a/api/resolvers/serial.js
+++ b/api/resolvers/serial.js
@@ -6,13 +6,30 @@ import { createHmac } from './wallet'
 import { msatsToSats, numWithUnits } from '@/lib/format'
 import { BALANCE_LIMIT_MSATS } from '@/lib/constants'
 
-export default async function serialize (models, ...calls) {
-  return await retry(async bail => {
+export default async function serialize (trx, { models, lnd, me, hash, hmac, fee }) {
+  // wrap first argument in array if not array already
+  const isArray = Array.isArray(trx)
+  if (!isArray) trx = [trx]
+
+  // conditional queries can be added inline using && syntax
+  // we filter any falsy value out here
+  trx = trx.filter(q => !!q)
+
+  let invoice
+  if (hash) {
+    invoice = await checkInvoice(models, hash, hmac, fee)
+    trx = [
+      models.$executeRaw`SELECT confirm_invoice(${hash}, ${invoice.msatsReceived})`,
+      ...trx
+    ]
+  }
+
+  let results = await retry(async bail => {
     try {
-      const [, ...result] = await models.$transaction(
-        [models.$executeRaw`SELECT ASSERT_SERIALIZED()`, ...calls],
+      const [, ...results] = await models.$transaction(
+        [models.$executeRaw`SELECT ASSERT_SERIALIZED()`, ...trx],
         { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
-      return calls.length > 1 ? result : result[0]
+      return results
     } catch (error) {
       console.log(error)
       // two cases where we get insufficient funds:
@@ -64,35 +81,17 @@ export default async function serialize (models, ...calls) {
     maxTimeout: 100,
     retries: 10
   })
-}
-
-export async function serializeInvoicable (query, { models, lnd, hash, hmac, me, enforceFee }) {
-  if (!me && !hash) {
-    throw new Error('you must be logged in or pay')
-  }
-
-  let trx = Array.isArray(query) ? query : [query]
-
-  let invoice
-  if (hash) {
-    invoice = await checkInvoice(models, hash, hmac, enforceFee)
-    trx = [
-      models.$executeRaw`SELECT confirm_invoice(${hash}, ${invoice.msatsReceived})`,
-      ...trx
-    ]
-  }
-
-  let results = await serialize(models, ...trx)
 
   if (hash) {
-    if (invoice?.isHeld) { await settleHodlInvoice({ secret: invoice.preimage, lnd }) }
+    if (invoice?.isHeld) {
+      await settleHodlInvoice({ secret: invoice.preimage, lnd })
+    }
     // remove first element since that is the confirmed invoice
-    [, ...results] = results
+    results = results.slice(1)
   }
 
-  // if there is only one result, return it directly, else the array
-  results = results.flat(2)
-  return results.length > 1 ? results : results[0]
+  // if first argument was not an array, unwrap the result
+  return isArray ? results : results[0]
 }
 
 export async function checkInvoice (models, hash, hmac, fee) {

--- a/api/resolvers/serial.js
+++ b/api/resolvers/serial.js
@@ -1,4 +1,5 @@
 import { GraphQLError } from 'graphql'
+import { timingSafeEqual } from 'crypto'
 import retry from 'async-retry'
 import Prisma from '@prisma/client'
 import { settleHodlInvoice } from 'ln-service'
@@ -102,7 +103,7 @@ async function verifyPayment (models, hash, hmac, fee) {
     throw new GraphQLError('hmac required', { extensions: { code: 'BAD_INPUT' } })
   }
   const hmac2 = createHmac(hash)
-  if (hmac !== hmac2) {
+  if (!timingSafeEqual(Buffer.from(hmac), Buffer.from(hmac2))) {
     throw new GraphQLError('bad hmac', { extensions: { code: 'FORBIDDEN' } })
   }
 

--- a/api/resolvers/serial.js
+++ b/api/resolvers/serial.js
@@ -17,7 +17,7 @@ export default async function serialize (trx, { models, lnd, me, hash, hmac, fee
 
   let invoice
   if (hash) {
-    invoice = await checkInvoice(models, hash, hmac, fee)
+    invoice = await verifyPayment(models, hash, hmac, fee)
     trx = [
       models.$executeRaw`SELECT confirm_invoice(${hash}, ${invoice.msatsReceived})`,
       ...trx
@@ -94,7 +94,7 @@ export default async function serialize (trx, { models, lnd, me, hash, hmac, fee
   return isArray ? results : results[0]
 }
 
-export async function checkInvoice (models, hash, hmac, fee) {
+async function verifyPayment (models, hash, hmac, fee) {
   if (!hash) {
     throw new GraphQLError('hash required', { extensions: { code: 'BAD_INPUT' } })
   }

--- a/pages/api/lnurlp/[username]/pay.js
+++ b/pages/api/lnurlp/[username]/pay.js
@@ -80,11 +80,13 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
       expires_at: expiresAt
     })
 
-    await serialize(models,
+    await serialize(
       models.$queryRaw`SELECT * FROM create_invoice(${invoice.id}, NULL, ${invoice.request},
         ${expiresAt}::timestamp, ${Number(amount)}, ${user.id}::INTEGER, ${noteStr || description},
         ${comment || null}, ${parsedPayerData || null}::JSONB, ${INV_PENDING_LIMIT}::INTEGER,
-        ${USER_IDS_BALANCE_NO_LIMIT.includes(Number(user.id)) ? 0 : BALANCE_LIMIT_MSATS})`)
+        ${USER_IDS_BALANCE_NO_LIMIT.includes(Number(user.id)) ? 0 : BALANCE_LIMIT_MSATS})`,
+      { models }
+    )
 
     return res.status(200).json({
       pr: invoice.request,

--- a/pages/invites/[id].js
+++ b/pages/invites/[id].js
@@ -36,8 +36,10 @@ export async function getServerSideProps ({ req, res, query: { id, error = null 
     try {
       // attempt to send gift
       // catch any errors and just ignore them for now
-      await serialize(models,
-        models.$queryRawUnsafe('SELECT invite_drain($1::INTEGER, $2::TEXT)', session.user.id, id))
+      await serialize(
+        models.$queryRawUnsafe('SELECT invite_drain($1::INTEGER, $2::TEXT)', session.user.id, id),
+        { models }
+      )
       const invite = await models.invite.findUnique({ where: { id } })
       notifyInvite(invite.userId)
     } catch (e) {

--- a/worker/auction.js
+++ b/worker/auction.js
@@ -17,7 +17,6 @@ export async function auction ({ models }) {
 
   // for each item, run serialized auction function
   items.forEach(async item => {
-    await serialize(models,
-      models.$executeRaw`SELECT run_auction(${item.id}::INTEGER)`)
+    await serialize(models.$executeRaw`SELECT run_auction(${item.id}::INTEGER)`, { models })
   })
 }

--- a/worker/earn.js
+++ b/worker/earn.js
@@ -79,9 +79,11 @@ export async function earn ({ name }) {
       console.log('stacker', earner.userId, 'earned', earnings, 'proportion', earner.proportion, 'rank', earner.rank, 'type', earner.type)
 
       if (earnings > 0) {
-        await serialize(models,
+        await serialize(
           models.$executeRaw`SELECT earn(${earner.userId}::INTEGER, ${earnings},
-          ${now}::timestamp without time zone, ${earner.type}::"EarnType", ${earner.id}::INTEGER, ${earner.rank}::INTEGER)`)
+          ${now}::timestamp without time zone, ${earner.type}::"EarnType", ${earner.id}::INTEGER, ${earner.rank}::INTEGER)`,
+          { models }
+        )
 
         const userN = notifications[earner.userId] || {}
 

--- a/worker/territory.js
+++ b/worker/territory.js
@@ -34,7 +34,7 @@ export async function territoryBilling ({ data: { subName }, boss, models }) {
 
   try {
     const queries = paySubQueries(sub, models)
-    await serialize(models, ...queries)
+    await serialize(queries, { models })
   } catch (e) {
     console.error(e)
     await territoryStatusUpdate()
@@ -42,7 +42,7 @@ export async function territoryBilling ({ data: { subName }, boss, models }) {
 }
 
 export async function territoryRevenue ({ models }) {
-  await serialize(models,
+  await serialize(
     models.$executeRaw`
       WITH revenue AS (
         SELECT coalesce(sum(msats), 0) as revenue, "subName", "userId"
@@ -69,6 +69,7 @@ export async function territoryRevenue ({ models }) {
       )
       UPDATE users SET msats = users.msats + "SubActResult".msats
       FROM "SubActResult"
-      WHERE users.id = "SubActResult"."userId"`
+      WHERE users.id = "SubActResult"."userId"`,
+    { models }
   )
 }

--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -121,10 +121,10 @@ async function checkInvoice ({ data: { hash }, boss, models, lnd }) {
     // ALSO: is_confirmed and is_held are mutually exclusive
     // that is, a hold invoice will first be is_held but not is_confirmed
     // and once it's settled it will be is_confirmed but not is_held
-    const [[{ confirm_invoice: code }]] = await serialize(models,
+    const [[{ confirm_invoice: code }]] = await serialize([
       models.$queryRaw`SELECT confirm_invoice(${inv.id}, ${Number(inv.received_mtokens)})`,
       models.invoice.update({ where: { hash }, data: { confirmedIndex: inv.confirmed_index } })
-    )
+    ], { models })
 
     // don't send notifications for JIT invoices
     if (dbInv.preimage) return
@@ -143,7 +143,7 @@ async function checkInvoice ({ data: { hash }, boss, models, lnd }) {
     // and without setting the user balance
     // those will be set when the invoice is settled by user action
     const expiresAt = new Date(Math.min(dbInv.expiresAt, datePivot(new Date(), { seconds: 60 })))
-    return await serialize(models,
+    return await serialize([
       models.$queryRaw`
       INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter)
       VALUES ('finalizeHodlInvoice', jsonb_build_object('hash', ${hash}), 21, true, ${expiresAt})`,
@@ -154,11 +154,12 @@ async function checkInvoice ({ data: { hash }, boss, models, lnd }) {
           expiresAt,
           isHeld: true
         }
-      }))
+      })
+    ], { models })
   }
 
   if (inv.is_canceled) {
-    return await serialize(models,
+    return await serialize(
       models.invoice.update({
         where: {
           hash: inv.id
@@ -166,7 +167,8 @@ async function checkInvoice ({ data: { hash }, boss, models, lnd }) {
         data: {
           cancelled: true
         }
-      }))
+      }), { models }
+    )
   }
 }
 
@@ -228,8 +230,10 @@ async function checkWithdrawal ({ data: { hash }, boss, models, lnd }) {
   if (wdrwl?.is_confirmed) {
     const fee = Number(wdrwl.payment.fee_mtokens)
     const paid = Number(wdrwl.payment.mtokens) - fee
-    const [{ confirm_withdrawl: code }] = await serialize(models, models.$queryRaw`
-      SELECT confirm_withdrawl(${dbWdrwl.id}::INTEGER, ${paid}, ${fee})`)
+    const [{ confirm_withdrawl: code }] = await serialize(
+      models.$queryRaw`SELECT confirm_withdrawl(${dbWdrwl.id}::INTEGER, ${paid}, ${fee})`,
+      { models }
+    )
     if (code === 0) {
       notifyWithdrawal(dbWdrwl.userId, wdrwl)
     }
@@ -245,9 +249,10 @@ async function checkWithdrawal ({ data: { hash }, boss, models, lnd }) {
       status = 'ROUTE_NOT_FOUND'
     }
 
-    await serialize(models,
+    await serialize(
       models.$executeRaw`
-        SELECT reverse_withdrawl(${dbWdrwl.id}::INTEGER, ${status}::"WithdrawlStatus")`
+        SELECT reverse_withdrawl(${dbWdrwl.id}::INTEGER, ${status}::"WithdrawlStatus")`,
+      { models }
     )
   }
 }


### PR DESCRIPTION
## Description

#1040 contained a bug that broke item creation and updating and was thus reverted.

Turns out that was at least one reason why `results.flat(2)` was needed (see https://github.com/stackernews/stacker.news/pull/1040#discussion_r1555123391).

This PR contains the same changes + ffbbcad0f3e75ef86f2f517cc58cce1d31b72df5 which fixes item creation and updating without flattening results which was also something I wanted to get rid of.

## Additional Context

I now searched for `serialize` and tested everything that depends on the return value of it + zaps.

Therefore, following functions were tested:

- `createItem`
- `updateItem`
- `act` via zaps and custom zaps
- `donateToRewards`
- `paySub`
- `createSub`
- `updateSub`
- `createInvoice`
- `cancelInvoice`
- `createWithdrawal`

Also tested invoice and withdrawal confirmations.

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [ ] For frontend changes: Tested on mobile?

<!-- New env vars need to be called out
so they can be properly configured for prod. -->
- [ ] Did you introduce any new environment variables? If so, call them out explicitly in the PR description.
