### PR TITLE
Fix cert required

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -159,6 +159,7 @@ const hexOrBase64Validator = string().test({
   name: 'hex-or-base64',
   message: 'invalid encoding',
   test: (val) => {
+    if (typeof val === 'undefined') return true
     try {
       ensureB64(val)
       return true


### PR DESCRIPTION
## Description

The missing `required` attribute does not make the certificate for LND autowithdrawals optional. It still verifies if the value is properly encoded. This PR fixes that.

## Screenshots

Before:

![localhost_3000_settings_wallets_lnd(iPhone SE)](https://github.com/stackernews/stacker.news/assets/27162016/2c85c820-9014-4bfa-8b64-f29026c5a36c)

After:

![localhost_3000_settings_wallets_lnd(iPhone SE) (1)](https://github.com/stackernews/stacker.news/assets/27162016/6293da59-e62c-4ec4-8213-517be161d9d9)

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [ ] For frontend changes: Tested on mobile?

<!-- New env vars need to be called out
so they can be properly configured for prod. -->
- [ ] Did you introduce any new environment variables? If so, call them out explicitly in the PR description.
