### PR TITLE
Sticky-top css now uses a custom zindex

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -130,6 +130,8 @@ $accordion-button-icon-dark:         $accordion-button-icon;
 $accordion-button-active-icon-dark:  $accordion-button-icon;
 
 
+$zindex-sticky: 900;
+
 :root, [data-bs-theme=light] {
   --theme-navLink: rgba(0, 0, 0, 0.55);
   --theme-navLinkFocus: rgba(0, 0, 0, 0.7);


### PR DESCRIPTION
## Description

<!--

A clear and concise description of what you changed and why.

Bullet points can be enough.

You can use the following PRs as inspiration:
  - https://github.com/stackernews/stacker.news/pull/227 (feature)
  - https://github.com/stackernews/stacker.news/pull/915 (feature)
  - https://github.com/stackernews/stacker.news/pull/871 (fix)
  - <your PR could be here>

Don't forget to mention which tickets this closes (if any).
Use following syntax to close them automatically on merge: closes #<NUMBER>

-->

Bootstrap's `sticky-top` class has a default zindex of `1020` https://bootstrapshuffle.com/classes/positioning/sticky-top but we needed it below `1000` so I used the `$zindex-sticky: 900;` variable to override this in our global scss file.

closes #1060 

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?
  - tested! works

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [x] For frontend changes: Tested on mobile?
  - sticky-top-lg only applies on large screens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Introduced a new styling variable for managing sticky element layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->