### PR TITLE
Update node-fetch to v2.6.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "next-auth": "^4.23.2",
         "next-plausible": "^3.11.1",
         "next-seo": "^6.1.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "node-s3-url-encode": "^0.0.4",
         "nodemailer": "^6.9.6",
         "nostr": "^0.2.8",
@@ -14738,11 +14738,22 @@
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-gyp-build": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "next-auth": "^4.23.2",
     "next-plausible": "^3.11.1",
     "next-seo": "^6.1.0",
-    "node-fetch": "^2.6.1",
+    "node-fetch": "^2.6.7",
     "node-s3-url-encode": "^0.0.4",
     "nodemailer": "^6.9.6",
     "nostr": "^0.2.8",


### PR DESCRIPTION

## Description

[dependabot reported vuln with CVSS score of 8.8](https://github.com/stackernews/stacker.news/security/dependabot/9)

tested that CLN wallet still attaches fine so this is safe to ship


## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [ ] For frontend changes: Tested on mobile?

<!-- New env vars need to be called out
so they can be properly configured for prod. -->
- [ ] Did you introduce any new environment variables? If so, call them out explicitly in the PR description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the `node-fetch` library to version `2.6.7` to enhance security and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->