### PR TITLE
Replace useInvoiceable with usePayment

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -891,7 +891,7 @@ export default {
              WHERE act IN ('TIP', 'FEE')
              AND "itemId" = ${Number(id)}::INTEGER
              AND "userId" = ${me.id}::INTEGER)::INTEGER)`,
-          { models }
+          { models, lnd, hash, hmac }
         )
       } else {
         await serialize(

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -104,7 +104,8 @@ export function BountyForm ({
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}
-      invoiceable={{ requireSession: true }}
+      requireSession
+      invoiceable
       onSubmit={
         handleSubmit ||
         onSubmit

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -1,22 +1,33 @@
-import { useState, useCallback, useEffect } from 'react'
-import { useApolloClient, useMutation, useQuery } from '@apollo/client'
-import { Button } from 'react-bootstrap'
-import { gql } from 'graphql-tag'
+import { useState, useEffect } from 'react'
 import { numWithUnits } from '@/lib/format'
 import AccordianItem from './accordian-item'
-import Qr, { QrSkeleton } from './qr'
-import { INVOICE } from '@/fragments/wallet'
-import InvoiceStatus from './invoice-status'
-import { useMe } from './me'
-import { useShowModal } from './modal'
+import Qr from './qr'
 import Countdown from './countdown'
 import PayerData from './payer-data'
 import Bolt11Info from './bolt11-info'
-import { useWebLN } from './webln'
-import { FAST_POLL_INTERVAL } from '@/lib/constants'
+import { useQuery } from '@apollo/client'
+import { INVOICE } from '@/fragments/wallet'
+import { FAST_POLL_INTERVAL, SSR } from '@/lib/constants'
 
-export function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn }) {
+export default function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn, poll }) {
   const [expired, setExpired] = useState(new Date(invoice.expiredAt) <= new Date())
+
+  const { data, error } = useQuery(INVOICE, SSR
+    ? {}
+    : {
+        pollInterval: FAST_POLL_INTERVAL,
+        variables: { id: invoice.id },
+        nextFetchPolicy: 'cache-and-network',
+        skip: !poll
+      })
+
+  if (data) {
+    invoice = data.invoice
+  }
+
+  if (error) {
+    return <div>{error.toString()}</div>
+  }
 
   // if webLn was not passed, use true by default
   if (webLn === undefined) webLn = true
@@ -104,290 +115,4 @@ export function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn }
 
     </>
   )
-}
-
-const JITInvoice = ({ invoice: { id, hash, hmac, expiresAt }, onPayment, onCancel, onRetry }) => {
-  const { data, loading, error } = useQuery(INVOICE, {
-    pollInterval: FAST_POLL_INTERVAL,
-    variables: { id }
-  })
-  const [retryError, setRetryError] = useState(0)
-  if (error) {
-    if (error.message?.includes('invoice not found')) {
-      return
-    }
-    return <div>error</div>
-  }
-  if (!data || loading) {
-    return <QrSkeleton description status='loading' />
-  }
-
-  const retry = !!onRetry
-  let errorStatus = 'Something went wrong trying to perform the action after payment.'
-  if (retryError > 0) {
-    errorStatus = 'Something still went wrong.\nYou can retry or cancel the invoice to return your funds.'
-  }
-
-  return (
-    <>
-      <Invoice invoice={data.invoice} modal onPayment={onPayment} successVerb='received' webLn={false} />
-      {retry
-        ? (
-          <>
-            <div className='my-3'>
-              <InvoiceStatus variant='failed' status={errorStatus} />
-            </div>
-            <div className='d-flex flex-row mt-3 justify-content-center'>
-              <Button
-                className='mx-1' variant='info' onClick={async () => {
-                  try {
-                    await onRetry()
-                  } catch (err) {
-                    console.error('retry error:', err)
-                    setRetryError(retryError => retryError + 1)
-                  }
-                }}
-              >Retry
-              </Button>
-              <Button
-                className='mx-1'
-                variant='danger'
-                onClick={onCancel}
-              >Cancel
-              </Button>
-            </div>
-          </>
-          )
-        : null}
-    </>
-  )
-}
-
-const defaultOptions = {
-  requireSession: false,
-  forceInvoice: false
-}
-export const useInvoiceable = (onSubmit, options = defaultOptions) => {
-  const me = useMe()
-  const [createInvoice] = useMutation(gql`
-    mutation createInvoice($amount: Int!) {
-      createInvoice(amount: $amount, hodlInvoice: true, expireSecs: 180) {
-        id
-        bolt11
-        hash
-        hmac
-        expiresAt
-      }
-    }`)
-  const [cancelInvoice] = useMutation(gql`
-    mutation cancelInvoice($hash: String!, $hmac: String!) {
-      cancelInvoice(hash: $hash, hmac: $hmac) {
-        id
-      }
-    }
-  `)
-
-  const showModal = useShowModal()
-  const provider = useWebLN()
-  const client = useApolloClient()
-  const pollInvoice = (id) => client.query({ query: INVOICE, fetchPolicy: 'no-cache', variables: { id } })
-
-  const onSubmitWrapper = useCallback(async (
-    { cost, ...formValues },
-    { variables, optimisticResponse, update, flowId, ...submitArgs }) => {
-    // some actions require a session
-    if (!me && options.requireSession) {
-      throw new Error('you must be logged in')
-    }
-
-    // id for toast flows
-    if (!flowId) flowId = (+new Date()).toString(16)
-
-    // educated guesses where action might pass in the invoice amount
-    // (field 'cost' has highest precedence)
-    cost ??= formValues.amount
-
-    // attempt action for the first time
-    if (!cost || (me && !options.forceInvoice)) {
-      try {
-        const insufficientFunds = me?.privates.sats < cost
-        return await onSubmit(formValues,
-          { ...submitArgs, flowId, variables, optimisticsResponse: insufficientFunds ? null : optimisticResponse, update })
-      } catch (error) {
-        if (!payOrLoginError(error) || !cost) {
-          // can't handle error here - bail
-          throw error
-        }
-      }
-    }
-
-    // initial attempt of action failed. we will create an invoice, pay and retry now.
-    const { data, error } = await createInvoice({ variables: { amount: cost } })
-    if (error) {
-      throw error
-    }
-    const inv = data.createInvoice
-
-    // If this is a zap, we need to manually be optimistic to have a consistent
-    // UX across custodial and WebLN zaps since WebLN zaps don't call GraphQL
-    // mutations which implement optimistic responses natively.
-    // Therefore, we check if this is a zap and then wrap the WebLN payment logic
-    // with manual cache update calls.
-    const itemId = optimisticResponse?.act?.id
-    const isZap = !!itemId
-    let _update
-    if (isZap && update) {
-      _update = () => {
-        const fragment = {
-          id: `Item:${itemId}`,
-          fragment: gql`
-          fragment ItemMeSatsInvoice on Item {
-            sats
-            meSats
-          }
-        `
-        }
-        const item = client.cache.readFragment(fragment)
-        update(client.cache, { data: optimisticResponse })
-        // undo function
-        return () => client.cache.writeFragment({ ...fragment, data: item })
-      }
-    }
-
-    // wait until invoice is paid or modal is closed
-    const { modalOnClose, webLn, gqlCacheUpdateUndo } = await waitForPayment({
-      invoice: inv,
-      showModal,
-      provider,
-      pollInvoice,
-      gqlCacheUpdate: _update,
-      flowId
-    })
-
-    const retry = () => onSubmit(
-      { hash: inv.hash, hmac: inv.hmac, expiresAt: inv.expiresAt, ...formValues },
-      // unset update function since we already ran an cache update if we paid using WebLN
-      // also unset update function if null was explicitly passed in
-      { ...submitArgs, variables, update: webLn ? null : undefined })
-    // first retry
-    try {
-      const ret = await retry()
-      modalOnClose?.()
-      return ret
-    } catch (error) {
-      gqlCacheUpdateUndo?.()
-      console.error('retry error:', error)
-    }
-
-    // retry until success or cancel
-    return await new Promise((resolve, reject) => {
-      const cancelAndReject = async () => {
-        await cancelInvoice({ variables: { hash: inv.hash, hmac: inv.hmac } })
-        reject(new Error('invoice canceled'))
-      }
-      showModal(onClose => {
-        return (
-          <JITInvoice
-            invoice={inv}
-            onCancel={async () => {
-              await cancelAndReject()
-              onClose()
-            }}
-            onRetry={async () => {
-              resolve(await retry())
-              onClose()
-            }}
-          />
-        )
-      }, { keepOpen: true, onClose: cancelAndReject })
-    })
-  }, [onSubmit, provider, createInvoice, !!me])
-
-  return onSubmitWrapper
-}
-
-const INVOICE_CANCELED_ERROR = 'invoice canceled'
-const waitForPayment = async ({ invoice, showModal, provider, pollInvoice, gqlCacheUpdate, flowId }) => {
-  if (provider) {
-    try {
-      return await waitForWebLNPayment({ provider, invoice, pollInvoice, gqlCacheUpdate, flowId })
-    } catch (err) {
-      // check for errors which mean that QR code will also fail
-      if (err.message === INVOICE_CANCELED_ERROR) {
-        throw err
-      }
-    }
-  }
-
-  // QR code as fallback
-  return await new Promise((resolve, reject) => {
-    showModal(onClose => {
-      return (
-        <JITInvoice
-          invoice={invoice}
-          onPayment={() => resolve({ modalOnClose: onClose })}
-        />
-      )
-    }, { keepOpen: true, onClose: reject })
-  })
-}
-
-const waitForWebLNPayment = async ({ provider, invoice, pollInvoice, gqlCacheUpdate, flowId }) => {
-  let undoUpdate
-  try {
-    // try WebLN provider first
-    return await new Promise((resolve, reject) => {
-      // be optimistic and pretend zap was already successful for consistent zapping UX
-      undoUpdate = gqlCacheUpdate?.()
-      // can't use await here since we might be paying JIT invoices
-      // and sendPaymentAsync is not supported yet.
-      // see https://www.webln.guide/building-lightning-apps/webln-reference/webln.sendpaymentasync
-      provider.sendPayment({ ...invoice, flowId })
-        // WebLN payment will never resolve here for JIT invoices
-        // since they only get resolved after settlement which can't happen here
-        .then(() => resolve({ webLn: true, gqlCacheUpdateUndo: undoUpdate }))
-        .catch(err => {
-          clearInterval(interval)
-          reject(err)
-        })
-      const interval = setInterval(async () => {
-        try {
-          const { data, error } = await pollInvoice(invoice.id)
-          if (error) {
-            clearInterval(interval)
-            return reject(error)
-          }
-          const { invoice: inv } = data
-          if (inv.isHeld && inv.satsReceived) {
-            clearInterval(interval)
-            resolve({ webLn: true, gqlCacheUpdateUndo: undoUpdate })
-          }
-          if (inv.cancelled) {
-            clearInterval(interval)
-            reject(new Error(INVOICE_CANCELED_ERROR))
-          }
-        } catch (err) {
-          clearInterval(interval)
-          reject(err)
-        }
-      }, FAST_POLL_INTERVAL)
-    })
-  } catch (err) {
-    undoUpdate?.()
-    console.error('WebLN payment failed:', err)
-    throw err
-  }
-}
-
-export const useInvoiceModal = (onPayment, deps) => {
-  const onPaymentMemo = useCallback(onPayment, deps)
-  return useInvoiceable(onPaymentMemo, { replaceModal: true })
-}
-
-export const payOrLoginError = (error) => {
-  const matches = ['insufficient funds', 'you must be logged in or pay']
-  if (Array.isArray(error)) {
-    return error.some(({ message }) => matches.some(m => message.includes(m)))
-  }
-  return matches.some(m => error.toString().includes(m))
 }

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -5,13 +5,13 @@ import { Form, Input, SubmitButton } from './form'
 import { useMe } from './me'
 import UpBolt from '@/svgs/bolt.svg'
 import { amountSchema } from '@/lib/validate'
-import { gql, useApolloClient, useMutation } from '@apollo/client'
-import { payOrLoginError, useInvoiceModal } from './invoice'
-import { TOAST_DEFAULT_DELAY_MS, useToast, withToastFlow } from './toast'
+import { gql, useMutation } from '@apollo/client'
+import { useToast } from './toast'
 import { useLightning } from './lightning'
 import { nextTip } from './upvote'
+import { InvoiceCanceledError, PaymentProvider, usePayment } from './payment'
 
-const defaultTips = [100, 1000, 10000, 100000]
+const defaultTips = [100, 1000, 10_000, 100_000]
 
 const Tips = ({ setOValue }) => {
   const tips = [...getCustomTips(), ...defaultTips].sort((a, b) => a - b)
@@ -41,27 +41,19 @@ const addCustomTip = (amount) => {
   window.localStorage.setItem('custom-tips', JSON.stringify(customTips))
 }
 
-export const zapUndosThresholdReached = (me, amount) => {
-  if (!me) return false
-  const enabled = me.privates.zapUndos !== null
-  return enabled ? amount >= me.privates.zapUndos : false
-}
-
 export default function ItemAct ({ onClose, itemId, down, children }) {
   const inputRef = useRef(null)
   const me = useMe()
   const [oValue, setOValue] = useState()
   const strike = useLightning()
-  const toaster = useToast()
-  const client = useApolloClient()
 
   useEffect(() => {
     inputRef.current?.focus()
   }, [onClose, itemId])
 
-  const [act, actUpdate] = useAct()
+  const act = useAct()
 
-  const onSubmit = useCallback(async ({ amount, hash, hmac }, { update, keepOpen }) => {
+  const onSubmit = useCallback(async ({ amount, hash, hmac }) => {
     if (!me) {
       const storageKey = `TIP-item:${itemId}`
       const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
@@ -74,119 +66,43 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
         act: down ? 'DONT_LIKE_THIS' : 'TIP',
         hash,
         hmac
-      },
-      update
+      }
     })
-    // only strike when zap undos not enabled
-    // due to optimistic UX on zap undos
-    if (!zapUndosThresholdReached(me, Number(amount))) await strike()
+    strike()
     addCustomTip(Number(amount))
-    if (!keepOpen) onClose(Number(amount))
   }, [me, act, down, itemId, strike])
 
-  const onSubmitWithUndos = withToastFlow(toaster)(
-    (values, args) => {
-      const { flowId } = args
-      let canceled
-      const sats = values.amount
-      const insufficientFunds = me?.privates?.sats < sats
-      const invoiceAttached = values.hash && values.hmac
-      if (insufficientFunds && !invoiceAttached) throw new Error('insufficient funds')
-      // payments from external wallets already have their own flow
-      // and we don't want to show undo toasts for them
-      const skipToastFlow = invoiceAttached
-      // update function for optimistic UX
-      const update = () => {
-        const fragment = {
-          id: `Item:${itemId}`,
-          fragment: gql`
-          fragment ItemMeSatsSubmit on Item {
-            path
-            sats
-            meSats
-            meDontLikeSats
-          }
-        `
-        }
-        const item = client.cache.readFragment(fragment)
-        const optimisticResponse = {
-          act: {
-            id: itemId, sats, path: item.path, act: down ? 'DONT_LIKE_THIS' : 'TIP'
-          }
-        }
-        actUpdate(client.cache, { data: optimisticResponse })
-        return () => client.cache.writeFragment({ ...fragment, data: item })
-      }
-      let undoUpdate
-      return {
-        skipToastFlow,
-        flowId,
-        tag: itemId,
-        type: 'zap',
-        pendingMessage: `${down ? 'down' : ''}zapped ${sats} sats`,
-        onPending: async () => {
-          if (skipToastFlow) {
-            return onSubmit(values, { flowId, ...args, update: null })
-          }
-          await strike()
-          onClose(sats)
-          return new Promise((resolve, reject) => {
-            undoUpdate = update()
-            setTimeout(() => {
-              if (canceled) return resolve()
-              onSubmit(values, { flowId, ...args, update: null, keepOpen: true })
-                .then(resolve)
-                .catch((err) => {
-                  undoUpdate()
-                  reject(err)
-                })
-            }, TOAST_DEFAULT_DELAY_MS)
-          })
-        },
-        onUndo: () => {
-          canceled = true
-          undoUpdate?.()
-        },
-        hideSuccess: true,
-        hideError: true,
-        timeout: TOAST_DEFAULT_DELAY_MS
-      }
-    }
-  )
-
+  // we need to wrap with PaymentProvider here since modals don't have access to PaymentContext by default
   return (
-    <Form
-      initial={{
-        amount: me?.privates?.tipDefault || defaultTips[0],
-        default: false
-      }}
-      schema={amountSchema}
-      invoiceable
-      onSubmit={(values, ...args) => {
-        if (zapUndosThresholdReached(me, values.amount)) {
-          return onSubmitWithUndos(values, ...args)
-        }
-        return onSubmit(values, ...args)
-      }}
-    >
-      <Input
-        label='amount'
-        name='amount'
-        type='number'
-        innerRef={inputRef}
-        overrideValue={oValue}
-        required
-        autoFocus
-        append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
-      />
-      <div>
-        <Tips setOValue={setOValue} />
-      </div>
-      {children}
-      <div className='d-flex mt-3'>
-        <SubmitButton variant={down ? 'danger' : 'success'} className='ms-auto mt-1 px-4' value='TIP'>{down && 'down'}zap</SubmitButton>
-      </div>
-    </Form>
+    <PaymentProvider>
+      <Form
+        initial={{
+          amount: me?.privates?.tipDefault || defaultTips[0],
+          default: false
+        }}
+        schema={amountSchema}
+        invoiceable
+        onSubmit={onSubmit}
+      >
+        <Input
+          label='amount'
+          name='amount'
+          type='number'
+          innerRef={inputRef}
+          overrideValue={oValue}
+          required
+          autoFocus
+          append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
+        />
+        <div>
+          <Tips setOValue={setOValue} />
+        </div>
+        {children}
+        <div className='d-flex mt-3'>
+          <SubmitButton variant={down ? 'danger' : 'success'} className='ms-auto mt-1 px-4' value='TIP'>{down && 'down'}zap</SubmitButton>
+        </div>
+      </Form>
+    </PaymentProvider>
   )
 }
 
@@ -256,7 +172,7 @@ export function useAct ({ onUpdate } = {}) {
         }
       }`, { update }
   )
-  return [act, update]
+  return act
 }
 
 export function useZap () {
@@ -309,116 +225,39 @@ export function useZap () {
 
   const [zap] = useMutation(
     gql`
-      mutation idempotentAct($id: ID!, $sats: Int!) {
-        act(id: $id, sats: $sats, idempotent: true) {
+      mutation idempotentAct($id: ID!, $sats: Int!, $hash: String, $hmac: String) {
+        act(id: $id, sats: $sats, hash: $hash, hmac: $hmac, idempotent: true) {
           id
           sats
           path
         }
-      }`
+      }`, { update }
   )
 
   const toaster = useToast()
   const strike = useLightning()
-  const [act] = useAct()
-  const client = useApolloClient()
-
-  const invoiceableAct = useInvoiceModal(
-    async ({ hash, hmac }, { variables, ...apolloArgs }) => {
-      await act({ variables: { ...variables, hash, hmac }, ...apolloArgs })
-      strike()
-    }, [act, strike])
-
-  const zapWithUndos = withToastFlow(toaster)(
-    ({ variables, optimisticResponse, update, flowId }) => {
-      const { id: itemId, amount } = variables
-      let canceled
-      // update function for optimistic UX
-      const _update = () => {
-        const fragment = {
-          id: `Item:${itemId}`,
-          fragment: gql`
-          fragment ItemMeSatsUndos on Item {
-            sats
-            meSats
-          }
-        `
-        }
-        const item = client.cache.readFragment(fragment)
-        update(client.cache, { data: optimisticResponse })
-        // undo function
-        return () => client.cache.writeFragment({ ...fragment, data: item })
-      }
-      let undoUpdate
-      return {
-        flowId,
-        tag: itemId,
-        type: 'zap',
-        pendingMessage: `zapped ${amount} sats`,
-        onPending: () =>
-          new Promise((resolve, reject) => {
-            undoUpdate = _update()
-            setTimeout(
-              () => {
-                if (canceled) return resolve()
-                zap({ variables, optimisticResponse, update: null }).then(resolve).catch((err) => {
-                  undoUpdate()
-                  reject(err)
-                })
-              },
-              TOAST_DEFAULT_DELAY_MS
-            )
-          }),
-        onUndo: () => {
-          // we can't simply clear the timeout on cancel since
-          // the onPending promise would never settle in that case
-          canceled = true
-          undoUpdate?.()
-        },
-        hideSuccess: true,
-        hideError: true,
-        timeout: TOAST_DEFAULT_DELAY_MS
-      }
-    }
-  )
+  const payment = usePayment()
 
   return useCallback(async ({ item, me }) => {
     const meSats = (item?.meSats || 0)
 
     // add current sats to next tip since idempotent zaps use desired total zap not difference
     const sats = meSats + nextTip(meSats, { ...me?.privates })
-    const amount = sats - meSats
 
-    const variables = { id: item.id, sats, act: 'TIP', amount }
-    const insufficientFunds = me?.privates.sats < amount
-    const optimisticResponse = { act: { path: item.path, ...variables } }
-    const flowId = (+new Date()).toString(16)
-    const zapArgs = { variables, optimisticResponse: insufficientFunds ? null : optimisticResponse, update, flowId }
+    let hash, hmac, cancel
     try {
-      if (insufficientFunds) throw new Error('insufficient funds')
+      [{ hash, hmac }, cancel] = await payment.request(sats - meSats)
+      const variables = { id: item.id, sats, act: 'TIP', hash, hmac }
+      const optimisticResponse = { act: { path: item.path, ...variables } }
+      await zap({ variables, optimisticResponse })
       strike()
-      if (zapUndosThresholdReached(me, amount)) {
-        await zapWithUndos(zapArgs)
-      } else {
-        await zap(zapArgs)
-      }
     } catch (error) {
-      if (payOrLoginError(error)) {
-        // call non-idempotent version
-        const amount = sats - meSats
-        optimisticResponse.act.amount = amount
-        try {
-          await invoiceableAct({ amount }, {
-            variables: { ...variables, sats: amount },
-            optimisticResponse,
-            update,
-            flowId
-          })
-        } catch (error) {}
+      if (error instanceof InvoiceCanceledError) {
         return
       }
       console.error(error)
       toaster.danger('zap: ' + error?.message || error?.toString?.())
+      cancel?.()
     }
-  })
+  }, [strike, payment])
 }

--- a/components/job-form.js
+++ b/components/job-form.js
@@ -103,7 +103,8 @@ export default function JobForm ({ item, sub }) {
         }}
         schema={jobSchema}
         storageKeyPrefix={storageKeyPrefix}
-        invoiceable={{ requireSession: true }}
+        requireSession
+        invoiceable
         onSubmit={onSubmit}
       >
         <div className='form-group'>

--- a/components/modal.js
+++ b/components/modal.js
@@ -3,6 +3,7 @@ import Modal from 'react-bootstrap/Modal'
 import BackArrow from '@/svgs/arrow-left-line.svg'
 import { useRouter } from 'next/router'
 import ActionDropdown from './action-dropdown'
+import { PaymentProvider } from './payment'
 
 export const ShowModalContext = createContext(() => null)
 
@@ -56,26 +57,28 @@ export default function useModal () {
     }
     const className = modalOptions?.fullScreen ? 'fullscreen' : ''
     return (
-      <Modal
-        onHide={modalOptions?.keepOpen ? null : onClose} show={!!modalContent}
-        className={className}
-        dialogClassName={className}
-        contentClassName={className}
-      >
-        <div className='d-flex flex-row'>
-          {modalOptions?.overflow &&
-            <div className={'modal-btn modal-overflow ' + className}>
-              <ActionDropdown>
-                {modalOptions.overflow}
-              </ActionDropdown>
-            </div>}
-          {modalStack.length > 0 ? <div className='modal-btn modal-back' onClick={onBack}><BackArrow width={18} height={18} className='fill-white' /></div> : null}
-          <div className={'modal-btn modal-close ' + className} onClick={onClose}>X</div>
-        </div>
-        <Modal.Body className={className}>
-          {modalContent}
-        </Modal.Body>
-      </Modal>
+      <PaymentProvider>
+        <Modal
+          onHide={modalOptions?.keepOpen ? null : onClose} show={!!modalContent}
+          className={className}
+          dialogClassName={className}
+          contentClassName={className}
+        >
+          <div className='d-flex flex-row'>
+            {modalOptions?.overflow &&
+              <div className={'modal-btn modal-overflow ' + className}>
+                <ActionDropdown>
+                  {modalOptions.overflow}
+                </ActionDropdown>
+              </div>}
+            {modalStack.length > 0 ? <div className='modal-btn modal-back' onClick={onBack}><BackArrow width={18} height={18} className='fill-white' /></div> : null}
+            <div className={'modal-btn modal-close ' + className} onClick={onClose}>X</div>
+          </div>
+          <Modal.Body className={className}>
+            {modalContent}
+          </Modal.Body>
+        </Modal>
+      </PaymentProvider>
     )
   }, [modalContent, onClose, modalOptions, onBack, modalStack])
 

--- a/components/payment.js
+++ b/components/payment.js
@@ -1,0 +1,211 @@
+import { createContext, useCallback, useContext, useMemo } from 'react'
+import { useMe } from './me'
+import { gql, useApolloClient, useMutation } from '@apollo/client'
+import { useWebLN } from './webln'
+import { FAST_POLL_INTERVAL } from '@/lib/constants'
+import { INVOICE } from '@/fragments/wallet'
+import Invoice from '@/components/invoice'
+import { useFeeButton } from './fee-button'
+import { useShowModal } from './modal'
+
+const PaymentContext = createContext()
+
+export class InvoiceCanceledError extends Error {
+  constructor (hash) {
+    super(`invoice canceled: ${hash}`, hash)
+    this.name = 'InvoiceCanceledError'
+  }
+}
+
+export class WebLnNotEnabledError extends Error {
+  constructor () {
+    super('no enabled WebLN provider found')
+    this.name = 'WebLnNotEnabledError'
+  }
+}
+
+const useInvoice = () => {
+  const client = useApolloClient()
+
+  const [createInvoice] = useMutation(gql`
+    mutation createInvoice($amount: Int!) {
+      createInvoice(amount: $amount, hodlInvoice: true, expireSecs: 180) {
+        id
+        bolt11
+        hash
+        hmac
+        expiresAt
+        satsRequested
+      }
+    }`)
+  const [cancelInvoice] = useMutation(gql`
+    mutation cancelInvoice($hash: String!, $hmac: String!) {
+      cancelInvoice(hash: $hash, hmac: $hmac) {
+        id
+      }
+    }
+  `)
+
+  const create = useCallback(async amount => {
+    const { data, error } = await createInvoice({ variables: { amount } })
+    if (error) {
+      throw error
+    }
+    const invoice = data.createInvoice
+    return invoice
+  }, [createInvoice])
+
+  const isPaid = useCallback(async id => {
+    const { data, error } = await client.query({ query: INVOICE, fetchPolicy: 'no-cache', variables: { id } })
+    if (error) {
+      throw error
+    }
+    const { hash, isHeld, satsReceived, cancelled } = data.invoice
+    // if we're polling for invoices, we're using JIT invoices so isHeld must be set
+    if (isHeld && satsReceived) {
+      return true
+    }
+    if (cancelled) {
+      throw new InvoiceCanceledError(hash)
+    }
+    return false
+  }, [client])
+
+  const waitUntilPaid = useCallback(async id => {
+    return await new Promise((resolve, reject) => {
+      const interval = setInterval(async () => {
+        try {
+          const paid = await isPaid(id)
+          if (paid) {
+            resolve()
+            clearInterval(interval)
+          }
+        } catch (err) {
+          reject(err)
+          clearInterval(interval)
+        }
+      }, FAST_POLL_INTERVAL)
+    })
+  }, [isPaid])
+
+  const cancel = useCallback(async ({ hash, hmac }) => {
+    return await cancelInvoice({ variables: { hash, hmac } })
+  }, [cancelInvoice])
+
+  return { create, isPaid, waitUntilPaid, cancel }
+}
+
+const useWebLnPayment = () => {
+  const invoice = useInvoice()
+  const provider = useWebLN()
+
+  const waitForWebLnPayment = useCallback(async ({ id, bolt11 }) => {
+    if (!provider) {
+      throw new WebLnNotEnabledError()
+    }
+    try {
+      return await new Promise((resolve, reject) => {
+        // can't use await here since we might pay JIT invoices and sendPaymentAsync is not supported yet.
+        // see https://www.webln.guide/building-lightning-apps/webln-reference/webln.sendpaymentasync
+        provider.sendPayment(bolt11)
+          // JIT invoice payments will never resolve here
+          // since they only get resolved after settlement which can't happen here
+          .then(resolve)
+          .catch(reject)
+        invoice.waitUntilPaid(id)
+          .then(resolve)
+          .catch(reject)
+      })
+    } catch (err) {
+      console.error('WebLN payment failed:', err)
+      throw err
+    }
+  }, [provider, invoice])
+
+  return waitForWebLnPayment
+}
+
+const useQrPayment = () => {
+  const invoice = useInvoice()
+  const showModal = useShowModal()
+
+  const waitForQrPayment = useCallback(async (inv) => {
+    return await new Promise((resolve, reject) => {
+      let paid
+      const cancelAndReject = async (onClose) => {
+        if (paid) return
+        await invoice.cancel(inv)
+        reject(new InvoiceCanceledError(inv.hash))
+      }
+      showModal(onClose =>
+        <Invoice
+          invoice={inv}
+          modal
+          successVerb='received'
+          webLn={false}
+          onPayment={() => { paid = true; onClose(); resolve() }}
+          poll
+        />,
+      { keepOpen: true, onClose: cancelAndReject })
+    })
+  }, [invoice])
+
+  return waitForQrPayment
+}
+
+export const PaymentProvider = ({ children }) => {
+  const me = useMe()
+  const feeButton = useFeeButton()
+  const invoice = useInvoice()
+  const waitForWebLnPayment = useWebLnPayment()
+  const waitForQrPayment = useQrPayment()
+
+  const waitForPayment = useCallback(async (invoice) => {
+    try {
+      return await waitForWebLnPayment(invoice)
+    } catch (err) {
+      if (err instanceof InvoiceCanceledError) {
+        // bail since qr code payment will also fail if invoice was canceled
+        throw err
+      }
+      // ignore any other error and fallback to QR code
+    }
+    return await waitForQrPayment(invoice)
+  }, [waitForWebLnPayment, waitForQrPayment])
+
+  const request = useCallback(async (amount) => {
+    amount ??= feeButton?.total
+    const free = feeButton?.free
+
+    // if user has enough funds in their custodial wallet or action is free, never prompt for payment
+    // XXX this will probably not work as intended for deposits < balance
+    //   which means you can't always fund your custodial wallet with attached wallets ...
+    //   but should this even be the case?
+    const insufficientFunds = !me || me.privates.sats < amount
+    if (free || !insufficientFunds) return [{ hash: null, hmac: null }, null]
+
+    const inv = await invoice.create(amount)
+
+    await waitForPayment(inv)
+
+    const cancel = () => invoice.cancel(inv).catch(console.error)
+    return [inv, cancel]
+  }, [me, feeButton?.total, invoice, waitForPayment])
+
+  const cancel = useCallback(({ hash, hmac }) => {
+    if (hash && hmac) {
+      invoice.cancel({ hash, hmac }).catch(console.error)
+    }
+  }, [invoice])
+
+  const value = useMemo(() => ({ request, cancel }), [request, cancel])
+  return (
+    <PaymentContext.Provider value={value}>
+      {children}
+    </PaymentContext.Provider>
+  )
+}
+
+export const usePayment = () => {
+  return useContext(PaymentContext)
+}

--- a/components/qr.js
+++ b/components/qr.js
@@ -1,7 +1,7 @@
 import QRCode from 'qrcode.react'
 import { CopyInput, InputSkeleton } from './form'
 import InvoiceStatus from './invoice-status'
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { useWebLN } from './webln'
 import SimpleCountdown from './countdown'
 import Bolt11Info from './bolt11-info'
@@ -9,15 +9,12 @@ import Bolt11Info from './bolt11-info'
 export default function Qr ({ asIs, value, webLn, statusVariant, description, status }) {
   const qrValue = asIs ? value : 'lightning:' + value.toUpperCase()
   const provider = useWebLN()
-  // XXX antipattern ... we shouldn't be getting multiple renders
-  const sendPayment = useRef(false)
 
   useEffect(() => {
     async function effect () {
-      if (webLn && provider && !sendPayment.current) {
-        sendPayment.current = true
+      if (webLn && provider) {
         try {
-          await provider.sendPayment({ bolt11: value })
+          await provider.sendPayment(value)
         } catch (e) {
           console.log(e?.message)
         }

--- a/components/reply.js
+++ b/components/reply.js
@@ -15,6 +15,7 @@ import { useShowModal } from './modal'
 import { Button } from 'react-bootstrap'
 import { useRoot } from './root'
 import { commentSubTreeRootId } from '@/lib/item'
+import { InvoiceCanceledError, usePayment } from './payment'
 
 export function ReplyOnAnotherPage ({ item }) {
   const rootId = commentSubTreeRootId(item)
@@ -40,6 +41,7 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
   const showModal = useShowModal()
   const root = useRoot()
   const sub = item?.sub || root?.sub
+  const payment = usePayment()
 
   useEffect(() => {
     if (replyOpen || quote || !!window.localStorage.getItem('reply-' + parentId + '-' + 'text')) {
@@ -97,10 +99,19 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
   )
 
   const onSubmit = useCallback(async ({ amount, hash, hmac, ...values }, { resetForm }) => {
-    const { data } = await upsertComment({ variables: { parentId, hash, hmac, ...values } })
-    toastDeleteScheduled(toaster, data, 'upsertComment', false, values.text)
-    resetForm({ text: '' })
-    setReply(replyOpen || false)
+    try {
+      const { data } = await upsertComment({ variables: { parentId, hash, hmac, ...values } })
+      toastDeleteScheduled(toaster, data, 'upsertComment', false, values.text)
+      resetForm({ text: '' })
+      setReply(replyOpen || false)
+    } catch (err) {
+      if (err instanceof InvoiceCanceledError) {
+        return
+      }
+      const msg = err.message || err.toString?.()
+      toaster.danger('reply error: ' + msg)
+      payment.cancel?.({ hash, hmac })
+    }
   }, [upsertComment, setReply, parentId])
 
   useEffect(() => {

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -125,7 +125,7 @@ export default function UpVote ({ item, className }) {
     }
   }, [me, tipShow, setWalkthrough])
 
-  const [act] = useAct()
+  const act = useAct()
   const zap = useZap()
 
   const disabled = useMemo(() => item?.mine || item?.meForward || item?.deletedAt,
@@ -159,7 +159,7 @@ export default function UpVote ({ item, className }) {
       <ItemAct onClose={onClose} itemId={item.id} />, { onClose: handleModalClosed })
   }
 
-  const handleShortPress = () => {
+  const handleShortPress = async () => {
     if (me) {
       if (!item) return
 
@@ -173,7 +173,6 @@ export default function UpVote ({ item, className }) {
       } else {
         setTipShow(true)
       }
-
       zap({ item, me })
     } else {
       showModal(onClose => <ItemAct onClose={onClose} itemId={item.id} act={act} />, { onClose: handleModalClosed })

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -21,6 +21,7 @@ import { ChainFeeProvider } from '@/components/chain-fee.js'
 import { WebLNProvider } from '@/components/webln'
 import dynamic from 'next/dynamic'
 import { HasNewNotesProvider } from '@/components/use-has-new-notes'
+import { PaymentProvider } from '@/components/payment'
 
 const PWAPrompt = dynamic(() => import('react-ios-pwa-prompt'), { ssr: false })
 
@@ -111,14 +112,16 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
                         <ToastProvider>
                           <WebLNProvider>
                             <ShowModalProvider>
-                              <BlockHeightProvider blockHeight={blockHeight}>
-                                <ChainFeeProvider chainFee={chainFee}>
-                                  <ErrorBoundary>
-                                    <Component ssrData={ssrData} {...otherProps} />
-                                    {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
-                                  </ErrorBoundary>
-                                </ChainFeeProvider>
-                              </BlockHeightProvider>
+                              <PaymentProvider>
+                                <BlockHeightProvider blockHeight={blockHeight}>
+                                  <ChainFeeProvider chainFee={chainFee}>
+                                    <ErrorBoundary>
+                                      <Component ssrData={ssrData} {...otherProps} />
+                                      {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
+                                    </ErrorBoundary>
+                                  </ChainFeeProvider>
+                                </BlockHeightProvider>
+                              </PaymentProvider>
                             </ShowModalProvider>
                           </WebLNProvider>
                         </ToastProvider>

--- a/pages/invoices/[id].js
+++ b/pages/invoices/[id].js
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/client'
-import { Invoice } from '@/components/invoice'
+import Invoice from '@/components/invoice'
 import { QrSkeleton } from '@/components/qr'
 import { CenterLayout } from '@/components/layout'
 import { useRouter } from 'next/router'
@@ -10,6 +10,7 @@ import { getGetServerSideProps } from '@/api/ssrApollo'
 // force SSR to include CSP nonces
 export const getServerSideProps = getGetServerSideProps({ query: null })
 
+// TODO: we can probably replace this component with <Invoice poll>
 export default function FullInvoice () {
   const router = useRouter()
   const { data, error } = useQuery(INVOICE, SSR


### PR DESCRIPTION
## Description

### Problem

This PR is the first step of refactoring the layers of code for external payments.

Essentially, we have three layers: 

1. Optimistic UX via manual Apollo cache updates
2. Zap undo: delay zapping and show option to "undo" (which is technically a cancel)
3. Payment code (custodial vs attached)

These layers are currently a mess since code for them is all over the place + zap undo, external payments and toast flows for both are implemented by wrapping functions. We don't have _distinct_ layers that don't leak into each other.

### Solution

This PR focuses on the payment layer. It replaces the function wrapper `useInvoiceable` with `usePayment` which hooks into the new context `PaymentContext`.[^1] This implements what I described in https://github.com/stackernews/stacker.news/pull/1041#issuecomment-2043959494:

> I really like the Context API since it seems to capsulate stuff well which is currently the biggest problem with the zap undo + webln + invoiceable + optimistic UX mess: everything is mixed together which requires to keep a lot of things in mind at once. So I thought about using the Context API more anyway.
>
> **Therefore, afaict, this discussion hints that `useInvoiceable` should indeed also be used as a context (renamed as `useInvoice` for example) or that at least our current invoice flow should make more use of contexts. This would also make sense from a natural language view: invoices are always created with some context. The context is the thing we're paying for.**

[^1]: This is somewhat related to "composition over inheritance" since wrapping functions can be seen as inheritance imo.

All `usePayment` does is to provide a function which returns a hash and hmac for anything that requires an external payment (QR or WebLN). The context is aware of the fee and freebies via the `FeeButtonContext` as well as the user balance so it knows when a payment is required and when not. This way, we can simply always call `usePayment` in `Form::onSubmit` if `invoiceableV2` is set without suffering latency overhead as described in #858.

`invoiceableV2` is a feature flag to gradually move from the old code used by `invoiceable` to the new code. I didn't want to change the old code but completely rewrite it while being able to easily look at it while doing so. When the old code is no longer needed, we can rename `invoiceableV2` to `invoiceable`. `invoiceableV2` is currently only used for comments.

I didn't want to create one big PR for all layers since I prefer to focus on one layer at a time. Make them do one thing but do it well.

This is also why this PR does not merge into `master` but `wallet-ux`. When refactor of all layers is merged into `wallet-ux` + real UX improvements on top, we can merge `wallet-ux` into `master`.

So consider this PR more as a way for early feedback before we actually deploy this. Merging it does not mean the code will not change later on when it's in `wallet-ux` but ideally, it wouldn't if I created good abstractions.

## Screenshots

<!--

If your changes are user facing, please add screenshots of the new UI.

You can also create a video to showcase your changes (useful to show UX).

-->

## Additional Context

<!--

You can mention here anything that you think is relevant for this PR. Some examples:

* You encountered something that you didn't understand while working on this PR
* You were not sure about something you did but did not find a better way
* You initially had a different approach but went with a different approach for some reason

-->

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [ ] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [ ] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [ ] For frontend changes: Tested on mobile?

<!-- New env vars need to be called out
so they can be properly configured for prod. -->
- [ ] Did you introduce any new environment variables? If so, call them out explicitly in the PR description.
