### PR TITLE
Fix TypeError if autowithdrawal creation failed

### DIFF
--- a/worker/autowithdraw.js
+++ b/worker/autowithdraw.js
@@ -87,7 +87,7 @@ export async function autoWithdraw ({ data: { id }, models, lnd }) {
           : wallet.type === 'CLN' ? 'walletCLN' : 'walletLightningAddress',
         level: 'ERROR',
         message: 'autowithdrawal failed: ' + details
-      })
+      }, { me: user, models })
     }
   }
 


### PR DESCRIPTION
## Description

Related to #1069. I mentioned [here](https://github.com/stackernews/stacker.news/issues/1069#issuecomment-2056556283) that only routing errors don't show up but actually due to this bug, no error showed up in the logs.

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [ ] For frontend changes: Tested on mobile?

<!-- New env vars need to be called out
so they can be properly configured for prod. -->
- [ ] Did you introduce any new environment variables? If so, call them out explicitly in the PR description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error logging in the automatic withdrawal feature to include more detailed user information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->