### PR TITLE
Use crypto.randomBytes for unique CLN invoice label

### DIFF
--- a/lib/cln.js
+++ b/lib/cln.js
@@ -1,10 +1,10 @@
 import fetch from 'node-fetch'
 import https from 'https'
+import crypto from 'crypto'
 
 export const createInvoice = async ({ socket, rune, cert, label, description, msats, expiry }) => {
   const agent = cert ? new https.Agent({ ca: Buffer.from(cert, 'base64') }) : undefined
   const url = 'https://' + socket + '/v1/invoice'
-  const randomId = Math.floor(Math.random() * 1000)
   const res = await fetch(url, {
     method: 'POST',
     headers: {
@@ -16,8 +16,9 @@ export const createInvoice = async ({ socket, rune, cert, label, description, ms
     },
     agent,
     body: JSON.stringify({
-      // why does CLN require a unique label?
-      label: description ? `${description} ${randomId}` : randomId,
+      // CLN requires a unique label for every invoice
+      // see https://docs.corelightning.org/reference/lightning-invoice
+      label: crypto.randomBytes(16).toString('hex'),
       description,
       amount_msat: msats,
       expiry


### PR DESCRIPTION
## Description

For some reason, CLN requires that one manually sets unique labels for each invoice. I don't think they ever can be used again. See API docs for [`lightning-invoice`](https://docs.corelightning.org/reference/lightning-invoice) and [`lightning-createinvoice`](https://docs.corelightning.org/reference/lightning-createinvoice).

Using `Math.floor(Math.random() * 1000)` was just a placeholder since I thought I was missing something but I accepted that this is really how one has to use this API.

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [ ] For frontend changes: Tested on mobile?

<!-- New env vars need to be called out
so they can be properly configured for prod. -->
- [ ] Did you introduce any new environment variables? If so, call them out explicitly in the PR description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
	- Improved the security and uniqueness of invoice labels by using a more robust method for generation aligned with current standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->