### PR TITLE
Use password field to NWC connection

### DIFF
--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -47,6 +47,8 @@ export default function NWC () {
           initialValue={nwcUrl}
           label='connection'
           name='nwcUrl'
+          type='password'
+          autoComplete='new-password'
           required
           autoFocus
         />


### PR DESCRIPTION
## Description

The NWC connection string contains sensitive data and thus should be handled like a password. 
Setting the input type to password and preventing auto complete prevents the user from accidentally exposing the connection string and it prevents the browser from saving the field value.



## Additional Context

I don't have a running stacker.news instance and made this change using the GitHub editor.  🙈
But I hope it's a bit better than a plain issue :) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security for the NWC URL input field in settings by adding password-type entry and disabling autocomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->