### PR TITLE
Exclude bios from spam detection

### DIFF
--- a/prisma/migrations/20240416181215_item_spam_exclude_bios/migration.sql
+++ b/prisma/migrations/20240416181215_item_spam_exclude_bios/migration.sql
@@ -1,0 +1,45 @@
+-- exclude bios from spam detection
+CREATE OR REPLACE FUNCTION item_spam(parent_id INTEGER, user_id INTEGER, within INTERVAL)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    repeats INTEGER;
+    self_replies INTEGER;
+BEGIN
+    -- no fee escalation
+    IF within = interval '0' THEN
+        RETURN 0;
+    END IF;
+
+    SELECT count(*) INTO repeats
+    FROM "Item"
+    WHERE (
+        (parent_id IS NULL AND "parentId" IS NULL)
+        OR
+        ("parentId" = parent_id AND user_id <> (SELECT i."userId" FROM "Item" i WHERE i.id = "Item"."rootId"))
+    )
+    AND "userId" = user_id
+    AND "bio" = 'f'
+    AND created_at > now_utc() - within;
+
+    IF parent_id IS NULL THEN
+        RETURN repeats;
+    END IF;
+
+    WITH RECURSIVE base AS (
+        SELECT "Item".id, "Item"."parentId", "Item"."userId"
+        FROM "Item"
+        WHERE id = parent_id
+        AND "userId" = user_id
+        AND created_at > now_utc() - within
+        AND user_id <> (SELECT i."userId" FROM "Item" i WHERE i.id = "Item"."rootId")
+      UNION ALL
+        SELECT "Item".id, "Item"."parentId", "Item"."userId"
+        FROM base p
+        JOIN "Item" ON "Item".id = p."parentId" AND "Item"."userId" = p."userId" AND "Item".created_at > now_utc() - within)
+    SELECT count(*) INTO self_replies FROM base;
+
+    RETURN repeats + self_replies;
+END;
+$$;


### PR DESCRIPTION
## Description

We've had several new stackers report that fees were high. They were 10x the normal price because bios counted towards the spam interval. This PR excludes bio from that interval.

## Video

https://github.com/stackernews/stacker.news/assets/27162016/0a0c4443-840b-4b91-9832-e446ca927844

## Additional Context

This is the function diff:

```diff
diff --git a/prisma/migrations/20240416181215_item_spam_exclude_bios/migration.sql b/prisma/migrations/20240416181215_item_spam_exclude_bios/migration.sql
index fb0fce11..5ad205c7 100644
--- a/prisma/migrations/20240416181215_item_spam_exclude_bios/migration.sql
+++ b/prisma/migrations/20240416181215_item_spam_exclude_bios/migration.sql
@@ -20,6 +20,7 @@ BEGIN
         ("parentId" = parent_id AND user_id <> (SELECT i."userId" FROM "Item" i WHERE i.id = "Item"."rootId"))
     )
     AND "userId" = user_id
+    AND "bio" = 'f'
     AND created_at > now_utc() - within;

     IF parent_id IS NULL THEN
```

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [ ] For frontend changes: Tested on mobile?

<!-- New env vars need to be called out
so they can be properly configured for prod. -->
- [ ] Did you introduce any new environment variables? If so, call them out explicitly in the PR description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced spam detection to exclude bios, improving content relevance and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->