### PR TITLE
Fix TypeError: Failed to construct 'URL': Invalid URL

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -178,7 +178,12 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
             // If [text](url) was parsed as <a> and text is not empty and not a link itself,
             // we don't render it as an image since it was probably a conscious choice to include text.
             const text = children[0]
-            const url = !href.startsWith('/') && new URL(href)
+            let url
+            try {
+              url = !href.startsWith('/') && new URL(href)
+            } catch {
+              // ignore invalid URLs
+            }
             const internalURL = process.env.NEXT_PUBLIC_URL
             if (!!text && !/^https?:\/\//.test(text)) {
               if (props['data-footnote-ref'] || typeof props['data-footnote-backref'] !== 'undefined') {
@@ -191,7 +196,7 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
                   </Link>
                 )
               }
-              if (href.startsWith('/') || url.origin === internalURL) {
+              if (href.startsWith('/') || url?.origin === internalURL) {
                 return (
                   <Link
                     id={props.id}


### PR DESCRIPTION
## Description

This site currently gives me a 500 error: https://stacker.news/items/508794

This is the error in the console: `TypeError: Failed to construct 'URL': Invalid URL`

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [ ] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [ ] For frontend changes: Tested on mobile?

<!-- New env vars need to be called out
so they can be properly configured for prod. -->
- [ ] Did you introduce any new environment variables? If so, call them out explicitly in the PR description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved URL error handling in the Text component to gracefully ignore invalid URLs and enhanced URL origin checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->