### PR TITLE
Hidden price sizing

### DIFF
--- a/components/hidden-wallet-summary.js
+++ b/components/hidden-wallet-summary.js
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef } from 'react'
 import { abbrNum, numWithUnits } from '@/lib/format'
 import { useMe } from './me'
 
@@ -6,17 +6,15 @@ export default function HiddenWalletSummary ({ abbreviate, fixedWidth }) {
   const me = useMe()
   const [hover, setHover] = useState(false)
 
-  // prevent layout shifts when hovering by fixing width to initial rendered width
   const ref = useRef()
-  const [width, setWidth] = useState(undefined)
-  useEffect(() => {
-    setWidth(ref.current?.offsetWidth)
-  }, [])
+  // prevent layout shifts when hovering by fixing width to initial rendered width of '******'
+  // We can simply multiply 6 by '0.6em' since monopsace has a fixed width for all characters
+  const width = '3.6em'
 
   return (
     <span
-      ref={ref} style={{ width: fixedWidth ? width : undefined }}
-      className='text-monospace' align='right' onPointerEnter={() => setHover(true)} onPointerLeave={() => setHover(false)}
+      ref={ref} style={{ display: 'block', minWidth: fixedWidth ? width : undefined, textAlign: 'right' }}
+      className='text-monospace' onPointerEnter={() => setHover(true)} onPointerLeave={() => setHover(false)}
     >
       {hover ? (abbreviate ? abbrNum(me.privates?.sats) : numWithUnits(me.privates?.sats, { abbreviate: false, format: true })) : '******'}
     </span>

--- a/components/hidden-wallet-summary.js
+++ b/components/hidden-wallet-summary.js
@@ -13,7 +13,7 @@ export default function HiddenWalletSummary ({ abbreviate, fixedWidth }) {
 
   return (
     <span
-      ref={ref} style={{ display: 'block', minWidth: fixedWidth ? width : undefined, textAlign: 'right' }}
+      ref={ref} style={{ display: 'block', width: fixedWidth ? width : undefined, textAlign: 'right' }}
       className='text-monospace' onPointerEnter={() => setHover(true)} onPointerLeave={() => setHover(false)}
     >
       {hover ? (abbreviate ? abbrNum(me.privates?.sats) : numWithUnits(me.privates?.sats, { abbreviate: false, format: true })) : '******'}


### PR DESCRIPTION
## Description

<!--

A clear and concise description of what you changed and why.

Bullet points can be enough.

You can use the following PRs as inspiration:
  - https://github.com/stackernews/stacker.news/pull/227 (feature)
  - https://github.com/stackernews/stacker.news/pull/915 (feature)
  - https://github.com/stackernews/stacker.news/pull/871 (fix)
  - <your PR could be here>

Don't forget to mention which tickets this closes (if any).
Use following syntax to close them automatically on merge: closes #<NUMBER>

-->

The fixed width for the hidden price stars was not properly determining the expected width of the number "underneath" (note if your cursor is near the edge of the numers it "flashes") this change ensures that the width is actually fixed and since this span uses monospace we can hard code the width based on the width of the 6 `******` characters at `0.6em` each. Ths the total width when hidden is `3.6em`  

This will break down at > 1000.0t sats as the value will be longer than the stars but if you have that much in stacker news god help you (also it will overflow to the right,not really moving anything)

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [x] For frontend changes: Tested on mobile?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed layout shifts in the wallet summary component by setting a constant width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->