### PR TITLE
Add PasswordInput component

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -1054,7 +1054,7 @@ function Client (Component) {
   }
 }
 
-export function PasswordHider ({ onClick }) {
+function PasswordHider ({ onClick }) {
   const [showPass, setShowPass] = useState(false)
 
   const handleClick = () => {
@@ -1075,6 +1075,23 @@ export function PasswordHider ({ onClick }) {
             fill='var(--bs-body-color)' height={20} width={20}
           />}
     </InputGroup.Text>
+  )
+}
+
+export function PassworInput ({ initialValue, label, name, newPass, autoFocus, required = true }) {
+  const [showPass, setShowPass] = useState(false)
+
+  return (
+    <ClientInput
+      initialValue={initialValue}
+      label={label}
+      name={name}
+      type={showPass ? 'text' : 'password'}
+      autoComplete={newPass ? 'new-password' : 'current-password'}
+      autoFocus={autoFocus}
+      required={required}
+      append={<PasswordHider onClick={() => setShowPass(!showPass)} />}
+    />
   )
 }
 

--- a/components/form.js
+++ b/components/form.js
@@ -1054,11 +1054,8 @@ function Client (Component) {
   }
 }
 
-function PasswordHider ({ onClick }) {
-  const [showPass, setShowPass] = useState(false)
-
+function PasswordHider ({ onClick, showPass }) {
   const handleClick = () => {
-    setShowPass(!showPass)
     onClick()
   }
 
@@ -1090,7 +1087,7 @@ export function PasswordInput ({ initialValue, label, name, newPass, autoFocus, 
       autoComplete={newPass ? 'new-password' : 'current-password'}
       autoFocus={autoFocus}
       required={required}
-      append={<PasswordHider onClick={() => setShowPass(!showPass)} />}
+      append={<PasswordHider showPass={showPass} onClick={() => setShowPass(!showPass)} />}
     />
   )
 }

--- a/components/form.js
+++ b/components/form.js
@@ -29,6 +29,8 @@ import { AWS_S3_URL_REGEXP } from '@/lib/constants'
 import { whenRange } from '@/lib/time'
 import { useFeeButton } from './fee-button'
 import Thumb from '@/svgs/thumb-up-fill.svg'
+import Eye from '@/svgs/eye-fill.svg'
+import EyeClose from '@/svgs/eye-close-line.svg'
 import Info from './info'
 
 export function SubmitButton ({
@@ -1050,6 +1052,30 @@ function Client (Component) {
 
     return <Component {...props} />
   }
+}
+
+export function PasswordHider ({ onClick }) {
+  const [showPass, setShowPass] = useState(false)
+
+  const handleClick = () => {
+    setShowPass(!showPass)
+    onClick()
+  }
+
+  return (
+    <InputGroup.Text
+      style={{ cursor: 'pointer' }}
+      onClick={handleClick}
+    >
+      {!showPass
+        ? <EyeClose
+            fill='var(--bs-body-color)' height={20} width={20}
+          />
+        : <Eye
+            fill='var(--bs-body-color)' height={20} width={20}
+          />}
+    </InputGroup.Text>
+  )
 }
 
 export const ClientInput = Client(Input)

--- a/components/form.js
+++ b/components/form.js
@@ -1055,14 +1055,10 @@ function Client (Component) {
 }
 
 function PasswordHider ({ onClick, showPass }) {
-  const handleClick = () => {
-    onClick()
-  }
-
   return (
     <InputGroup.Text
       style={{ cursor: 'pointer' }}
-      onClick={handleClick}
+      onClick={onClick}
     >
       {!showPass
         ? <EyeClose
@@ -1075,18 +1071,14 @@ function PasswordHider ({ onClick, showPass }) {
   )
 }
 
-export function PasswordInput ({ initialValue, label, name, newPass, autoFocus, required }) {
+export function PasswordInput ({ newPass, ...props }) {
   const [showPass, setShowPass] = useState(false)
 
   return (
     <ClientInput
-      initialValue={initialValue}
-      label={label}
-      name={name}
+      {...props}
       type={showPass ? 'text' : 'password'}
       autoComplete={newPass ? 'new-password' : 'current-password'}
-      autoFocus={autoFocus}
-      required={required}
       append={<PasswordHider showPass={showPass} onClick={() => setShowPass(!showPass)} />}
     />
   )

--- a/components/form.js
+++ b/components/form.js
@@ -1078,7 +1078,7 @@ function PasswordHider ({ onClick }) {
   )
 }
 
-export function PassworInput ({ initialValue, label, name, newPass, autoFocus, required = true }) {
+export function PasswordInput ({ initialValue, label, name, newPass, autoFocus, required }) {
   const [showPass, setShowPass] = useState(false)
 
   return (

--- a/pages/settings/wallets/lnbits.js
+++ b/pages/settings/wallets/lnbits.js
@@ -1,5 +1,5 @@
 import { getGetServerSideProps } from '@/api/ssrApollo'
-import { Form, ClientInput, ClientCheckbox } from '@/components/form'
+import { Form, ClientInput, ClientCheckbox, PassworInput } from '@/components/form'
 import { CenterLayout } from '@/components/layout'
 import { WalletButtonBar, WalletCard } from '@/components/wallet-card'
 import { lnbitsSchema } from '@/lib/validate'
@@ -51,12 +51,11 @@ export default function LNbits () {
           required
           autoFocus
         />
-        <ClientInput
+        <PassworInput
           initialValue={adminKey}
-          type='password'
-          autoComplete='false'
           label='admin key'
           name='adminKey'
+          newPass
         />
         <ClientCheckbox
           disabled={!enabled || isDefault || enabledProviders.length === 1}

--- a/pages/settings/wallets/lnbits.js
+++ b/pages/settings/wallets/lnbits.js
@@ -56,6 +56,7 @@ export default function LNbits () {
           label='admin key'
           name='adminKey'
           newPass
+          required
         />
         <ClientCheckbox
           disabled={!enabled || isDefault || enabledProviders.length === 1}

--- a/pages/settings/wallets/lnbits.js
+++ b/pages/settings/wallets/lnbits.js
@@ -1,5 +1,5 @@
 import { getGetServerSideProps } from '@/api/ssrApollo'
-import { Form, ClientInput, ClientCheckbox, PassworInput } from '@/components/form'
+import { Form, ClientInput, ClientCheckbox, PasswordInput } from '@/components/form'
 import { CenterLayout } from '@/components/layout'
 import { WalletButtonBar, WalletCard } from '@/components/wallet-card'
 import { lnbitsSchema } from '@/lib/validate'
@@ -51,7 +51,7 @@ export default function LNbits () {
           required
           autoFocus
         />
-        <PassworInput
+        <PasswordInput
           initialValue={adminKey}
           label='admin key'
           name='adminKey'

--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -1,5 +1,5 @@
 import { getGetServerSideProps } from '@/api/ssrApollo'
-import { Form, ClientCheckbox, PassworInput } from '@/components/form'
+import { Form, ClientCheckbox, PasswordInput } from '@/components/form'
 import { CenterLayout } from '@/components/layout'
 import { WalletButtonBar, WalletCard } from '@/components/wallet-card'
 import { nwcSchema } from '@/lib/validate'
@@ -43,11 +43,12 @@ export default function NWC () {
           }
         }}
       >
-        <PassworInput
+        <PasswordInput
           initialValue={nwcUrl}
           label='connection'
           name='nwcUrl'
           newPass
+          required
           autoFocus
         />
         <ClientCheckbox

--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -1,5 +1,5 @@
 import { getGetServerSideProps } from '@/api/ssrApollo'
-import { Form, ClientInput, ClientCheckbox } from '@/components/form'
+import { Form, ClientInput, ClientCheckbox, PasswordHider } from '@/components/form'
 import { CenterLayout } from '@/components/layout'
 import { WalletButtonBar, WalletCard } from '@/components/wallet-card'
 import { nwcSchema } from '@/lib/validate'
@@ -9,6 +9,7 @@ import { useNWC } from '@/components/webln/nwc'
 import { WalletSecurityBanner } from '@/components/banners'
 import { useWebLNConfigurator } from '@/components/webln'
 import WalletLogs from '@/components/wallet-logs'
+import { useState } from 'react'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
@@ -19,6 +20,7 @@ export default function NWC () {
   const isDefault = provider?.name === name
   const toaster = useToast()
   const router = useRouter()
+  const [showPass, setShowPass] = useState(false)
 
   return (
     <CenterLayout>
@@ -47,10 +49,11 @@ export default function NWC () {
           initialValue={nwcUrl}
           label='connection'
           name='nwcUrl'
-          type='password'
+          type={showPass ? 'text' : 'password'}
           autoComplete='new-password'
           required
           autoFocus
+          append={<PasswordHider onClick={() => setShowPass(!showPass)} />}
         />
         <ClientCheckbox
           disabled={!enabled || isDefault || enabledProviders.length === 1}

--- a/pages/settings/wallets/nwc.js
+++ b/pages/settings/wallets/nwc.js
@@ -1,5 +1,5 @@
 import { getGetServerSideProps } from '@/api/ssrApollo'
-import { Form, ClientInput, ClientCheckbox, PasswordHider } from '@/components/form'
+import { Form, ClientCheckbox, PassworInput } from '@/components/form'
 import { CenterLayout } from '@/components/layout'
 import { WalletButtonBar, WalletCard } from '@/components/wallet-card'
 import { nwcSchema } from '@/lib/validate'
@@ -9,7 +9,6 @@ import { useNWC } from '@/components/webln/nwc'
 import { WalletSecurityBanner } from '@/components/banners'
 import { useWebLNConfigurator } from '@/components/webln'
 import WalletLogs from '@/components/wallet-logs'
-import { useState } from 'react'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
@@ -20,7 +19,6 @@ export default function NWC () {
   const isDefault = provider?.name === name
   const toaster = useToast()
   const router = useRouter()
-  const [showPass, setShowPass] = useState(false)
 
   return (
     <CenterLayout>
@@ -45,15 +43,12 @@ export default function NWC () {
           }
         }}
       >
-        <ClientInput
+        <PassworInput
           initialValue={nwcUrl}
           label='connection'
           name='nwcUrl'
-          type={showPass ? 'text' : 'password'}
-          autoComplete='new-password'
-          required
+          newPass
           autoFocus
-          append={<PasswordHider onClick={() => setShowPass(!showPass)} />}
         />
         <ClientCheckbox
           disabled={!enabled || isDefault || enabledProviders.length === 1}


### PR DESCRIPTION
## Description

Adds a PasswordHider component input group that can be appended on the end of password inputs

Closes #1077 

## Screenshots

<!--

If your changes are user facing, please add screenshots of the new UI.

You can also create a video to showcase your changes (useful to show UX).

-->

![Screenshot_2024-04-18_10-18-54](https://github.com/stackernews/stacker.news/assets/108441023/623da916-3b36-496a-8c19-cc1f5f2197f5)

![Screenshot_2024-04-18_10-18-35](https://github.com/stackernews/stacker.news/assets/108441023/7177c477-f332-4066-987c-2feb8d5cfd00)

## Checklist

<!-- Examples for backwards incompatible changes:
- dropping database columns
- changing GraphQL type definitions to make a field mandatory -->
- [x] Are your changes backwards compatible?

<!-- If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback. -->
- [x] Did you QA this? Could we deploy this straight to production?
  - Only added on the NWC input are there other Password inputs in sn?

<!-- You should be able to use the mobile browser emulator in your browser to test this. -->
- [x] For frontend changes: Tested on mobile?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Enhanced user experience by adding password visibility toggle feature in settings, allowing users to switch between hiding and showing password inputs.
	- Introduced a new `PasswordInput` component for handling password inputs in the LNBits settings page.
	- Improved security and user interaction by replacing `ClientInput` with `PasswordInput` in the NWC settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->