### PR TITLE
Fix no notification for @delete usage in post

### DIFF
--- a/components/toast.js
+++ b/components/toast.js
@@ -110,7 +110,7 @@ export const ToastProvider = ({ children }) => {
   // Only clear toasts with no cancel function on page navigation
   // since navigation should not interfere with being able to cancel an action.
   useEffect(() => {
-    const handleRouteChangeStart = () => setToasts(toasts => toasts.length > 0 ? toasts.filter(({ onCancel, onUndo }) => onCancel || onUndo) : toasts)
+    const handleRouteChangeStart = () => setToasts(toasts => toasts.length > 0 ? toasts.filter(({ onCancel, onUndo, persistOnNavigate }) => onCancel || onUndo || persistOnNavigate) : toasts)
     router.events.on('routeChangeStart', handleRouteChangeStart)
 
     return () => {

--- a/lib/form.js
+++ b/lib/form.js
@@ -40,6 +40,7 @@ export const toastDeleteScheduled = (toaster, upsertResponseData, dataKey, isEdi
     }[dataKey] ?? 'item'
 
     const message = `${itemType === 'comment' ? 'your comment' : isEdit ? `this ${itemType}` : `your new ${itemType}`} will be deleted at ${deleteScheduledAt.toLocaleString()}`
-    toaster.success(message)
+    // only persist this on navigation for posts, not comments
+    toaster.success(message, { persistOnNavigate: itemType !== 'comment' })
   }
 }


### PR DESCRIPTION
## Description
Closes #728 

This PR fixes the issue where using the at-delete directive in posts wasn't showing the success/confirmation toast like it's supposed to. This is accomplished by:

1. introducing `persistOnNavigate` option for toasts
2. pass `persistOnNavigate: true` when creating or editing a post, but not a comment

## Screenshots
N/A

## Additional Context
I suspect this was never an issue in local dev, but was an issue in prod, due to differences in how route changes are handled when running next.js in dev vs prod mode. Given that submitting a new post, or editing an existing post both result in a navigation to a new URL, my theory is that in dev mode, there is something that causes the `routeChangeStart` event _not_ to trigger, which is what's removing toasts on page navigation in production. Or, it may trigger, but the timing is different than in prod (relative to when the toast is added), causing this feature to work in dev but not in prod.

I placed breakpoints in prod and shoe-horned in a change representative of this PR and it seemed to do the trick, so that's how I verified it.
 
## Checklist
- [X] Are your changes backwards compatible?
- [X] Did you QA this? Could we deploy this straight to production?
- [ ] For frontend changes: Tested on mobile?
- [ ] Did you introduce any new environment variables? If so, call them out explicitly in the PR description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added persistence control for toasts on navigation, allowing specific notifications to remain visible during page transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->