### PR TITLE
fix sndev to make .env.local optional in docker compose files

### DIFF
--- a/sndev
+++ b/sndev
@@ -13,7 +13,12 @@ docker__compose() {
     COMPOSE_PROFILES="images,search,payments,email,capture"
   fi
 
-  CURRENT_UID=$(id -u) CURRENT_GID=$(id -g) COMPOSE_PROFILES=$COMPOSE_PROFILES command docker compose --env-file .env.development --env-file .env.local "$@"
+  ENV_LOCAL=
+  if [ -f .env.local ]; then
+    ENV_LOCAL='--env-file .env.local'
+  fi
+
+  CURRENT_UID=$(id -u) CURRENT_GID=$(id -g) COMPOSE_PROFILES=$COMPOSE_PROFILES command docker compose --env-file .env.development $ENV_LOCAL "$@"
 }
 
 docker__exec() {


### PR DESCRIPTION
Fix for [this](https://github.com/stackernews/stacker.news/commit/dd6e921e2e00950f19da5bd6d76769c89268d1bb#r141179262)

only specify `.env.local` to docker compose if it exists.

cc @ekzyis 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced Docker setup to automatically check for and utilize a local environment file if available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->