### PR TITLE
Flip the PasswordHider icons for consistent UX

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -1061,10 +1061,10 @@ function PasswordHider ({ onClick, showPass }) {
       onClick={onClick}
     >
       {!showPass
-        ? <EyeClose
+        ? <Eye
             fill='var(--bs-body-color)' height={20} width={20}
           />
-        : <Eye
+        : <EyeClose
             fill='var(--bs-body-color)' height={20} width={20}
           />}
     </InputGroup.Text>


### PR DESCRIPTION
## Description

<!--
A clear and concise description of what you changed and why.
Don't forget to mention which tickets this closes (if any).
Use following syntax to close them automatically on merge: closes #<number>
-->
from @ekzyis's comment
 > I just noticed that the UI/UX is reversed for comments. When the comment is uncollapsed, we show the closed eye to collapse it. When it's collapsed, we show the open eye to uncollapse it.
> 
> So I think we should make it consistent here. A classic case of [this](https://dev.to/ben/should-a-button-communicate-the-current-state-the-intended-behavior-or-both-50na).

## Screenshots

<!--
If your changes are user facing, please add screenshots of the new UI.
You can also create a video to showcase your changes (useful to show UX).
-->

![image](https://github.com/stackernews/stacker.news/assets/108441023/65059855-3072-4040-a88c-89de0600888e)

![image](https://github.com/stackernews/stacker.news/assets/108441023/e1ea12c8-5e69-4588-9897-fa4c7739ba7e)


## Checklist

- [x] Are your changes backwards compatible?

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
- [x] Did you QA this? Could we deploy this straight to production?

- [x] For frontend changes: Tested on mobile?