### PR TITLE
Show preimage of confirmed withdrawals

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -45,8 +45,7 @@ export async function getInvoice (parent, { id }, { me, models, lnd }) {
 
   try {
     if (inv.confirmedAt) {
-      const lnInv = await getInvoiceFromLnd({ id: inv.hash, lnd })
-      inv.confirmedPreimage = lnInv.secret
+      inv.confirmedPreimage = (await getInvoiceFromLnd({ id: inv.hash, lnd })).secret
     }
   } catch (err) {
     console.error('error fetching invoice from LND', err)
@@ -79,8 +78,7 @@ export async function getWithdrawl (parent, { id }, { me, models, lnd }) {
 
   try {
     if (wdrwl.status === 'CONFIRMED') {
-      const payment = await getPayment({ id: wdrwl.hash, lnd })
-      wdrwl.preimage = payment.payment.secret
+      wdrwl.preimage = (await getPayment({ id: wdrwl.hash, lnd })).payment.secret
     }
   } catch (err) {
     console.error('error fetching payment from LND', err)

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -86,6 +86,7 @@ export default gql`
     satsFeePaid: Int
     status: String
     autoWithdraw: Boolean!
+    preimage: String
   }
 
   type Fact {

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -31,6 +31,7 @@ export const WITHDRAWL = gql`
       satsFeePaid
       status
       autoWithdraw
+      preimage
     }
   }`
 

--- a/pages/withdrawals/[id].js
+++ b/pages/withdrawals/[id].js
@@ -112,7 +112,7 @@ function LoadWithdrawl () {
       </div>
       <InvoiceStatus variant={variant} status={status} />
       <div className='w-100 mt-3'>
-        <Bolt11Info bolt11={data.withdrawl.bolt11}>
+        <Bolt11Info bolt11={data.withdrawl.bolt11} preimage={data.withdrawl.preimage}>
           <PrivacyOption wd={data.withdrawl} />
         </Bolt11Info>
       </div>


### PR DESCRIPTION
## Description

This adds a preimage field to withdrawals.

closes #1105

## Video

https://github.com/stackernews/stacker.news/assets/27162016/e13f9807-d07f-443b-a1a9-4c0cbbcaf2ce

## Additional Context

## Checklist

- [x] Are your changes backwards compatible?

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
- [x] Did you QA this? Could we deploy this straight to production?

- [ ] For frontend changes: Tested on mobile?

- [ ] Did you introduce any new environment variables? If so, call them out explicitly in the PR description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced the withdrawal page to display payment preimage for confirmed transactions, improving transaction tracking and verification for users.
- **Bug Fixes**
	- Updated the withdrawal function to correctly fetch payment details, ensuring accurate and reliable transaction information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->