### PR TITLE
Remove .env.local from env_file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,4 @@
-x-env_file: &env_file
-  - .env.development
-  - path: .env.local
-    required: false
+x-env_file: &env_file .env.development
 x-healthcheck: &healthcheck
   interval: 10s
   timeout: 10s


### PR DESCRIPTION
## Description

Arrays for `env_file` are only supported in Docker Compose >=v2.24 which is too new (from January 2024). Most distros distribute older packages.

Since `--env-` file as defined in the sndev script acts as an override for env_file anyway, we can safely remove it here.

## Additional Context

See https://github.com/stackernews/stacker.news/pull/1082#issuecomment-2081230695 and https://github.com/stackernews/stacker.news/commit/dd6e921e2e00950f19da5bd6d76769c89268d1bb#r141433414

## Checklist

- [x] Are your changes backwards compatible?

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
- [x] Did you QA this? Could we deploy this straight to production?

- [ ] For frontend changes: Tested on mobile?

- [ ] Did you introduce any new environment variables? If so, call them out explicitly in the PR description.
