### PR TITLE
Use njump.me for nostr links

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -54,7 +54,7 @@ const SocialsPopover = (
   <Popover>
     <Popover.Body style={{ fontWeight: 500, fontSize: '.9rem' }}>
       <a
-        href='https://snort.social/p/npub1jfujw6llhq7wuvu5detycdsq5v5yqf56sgrdq8wlgrryx2a2p09svwm0gx' className='nav-link p-0 d-inline-flex'
+        href='https://njump.me/npub1jfujw6llhq7wuvu5detycdsq5v5yqf56sgrdq8wlgrryx2a2p09svwm0gx' className='nav-link p-0 d-inline-flex'
         target='_blank' rel='noreferrer'
       >
         nostr

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -160,7 +160,7 @@ export default function ItemInfo ({
             opentimestamp
           </Link>}
         {item?.noteId && (
-          <Dropdown.Item onClick={() => window.open(`https://nostr.com/${item.noteId}`, '_blank', 'noopener,noreferrer,nofollow')}>
+          <Dropdown.Item onClick={() => window.open(`https://njump.me/${item.noteId}`, '_blank', 'noopener,noreferrer,nofollow')}>
             nostr note
           </Dropdown.Item>
         )}

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -235,14 +235,14 @@ function NostrZap ({ n }) {
       <div className='fw-bold text-nostr ms-2 py-1'>
         <NostrIcon width={24} height={24} className='fill-nostr me-1' />{numWithUnits(n.earnedSats)} zap from
         {// eslint-disable-next-line
-        <Link className='mx-1 text-reset text-underline' target='_blank' href={`https://snort.social/p/${npub}`} rel={UNKNOWN_LINK_REL}>
+        <Link className='mx-1 text-reset text-underline' target='_blank' href={`https://njump.me/${npub}`} rel={UNKNOWN_LINK_REL}>
           {npub.slice(0, 10)}...
         </Link>
         }
         on {note
           ? (
             // eslint-disable-next-line
-            <Link className='mx-1 text-reset text-underline' target='_blank' href={`https://snort.social/e/${note}`} rel={UNKNOWN_LINK_REL}>
+            <Link className='mx-1 text-reset text-underline' target='_blank' href={`https://njump.me/${note}`} rel={UNKNOWN_LINK_REL}>
               {note.slice(0, 12)}...
             </Link>)
           : 'nostr'}

--- a/components/user-header.js
+++ b/components/user-header.js
@@ -213,7 +213,7 @@ function SocialLink ({ name, id }) {
     const npub = hexToBech32(id)
     return (
       // eslint-disable-next-line
-      <Link className={className} target='_blank' href={`https://nostr.com/${npub}`} rel={UNKNOWN_LINK_REL}>
+      <Link className={className} target='_blank' href={`https://njump.me/${npub}`} rel={UNKNOWN_LINK_REL}>
         <NostrIcon width={20} height={20} className='me-1' />
         {npub.slice(0, 10)}...{npub.slice(-10)}
       </Link>


### PR DESCRIPTION
## Description

* [njump](https://github.com/fiatjaf/njump) is what is powering the preview in nostr.com so it seems more fitting to directly go to https://njump.me
* Also removed some existing usage of https://snort.social

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

QA'd by making sure links in this format are working:

- npub links: https://njump.me/npub1jfujw6llhq7wuvu5detycdsq5v5yqf56sgrdq8wlgrryx2a2p09svwm0gx
- note links: https://njump.me/note16tjnh2el3ze78e36tcupwukf9en295k5ft8zq0jr042kdug7urgqeukp9t (redirect to nevent)

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated URLs across various components to reflect the new domain change from `https://snort.social` and `https://nostr.com` to `https://njump.me`. This change affects links in the footer, notifications, item information, and user header sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->