### PR TITLE
Fix duplicate autowithdrawal logs

### DIFF
--- a/prisma/migrations/20240429_224542_reverse_withdrawal_return_value/migration.sql
+++ b/prisma/migrations/20240429_224542_reverse_withdrawal_return_value/migration.sql
@@ -1,0 +1,23 @@
+CREATE OR REPLACE FUNCTION reverse_withdrawl(wid INTEGER, wstatus "WithdrawlStatus")
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    msats_fee_paying BIGINT;
+    msats_paying BIGINT;
+    user_id INTEGER;
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    IF EXISTS (SELECT 1 FROM "Withdrawl" WHERE id = wid AND status IS NULL) THEN
+        SELECT "msatsPaying", "msatsFeePaying", "userId" INTO msats_paying, msats_fee_paying, user_id
+        FROM "Withdrawl" WHERE id = wid AND status IS NULL;
+
+        UPDATE "Withdrawl" SET status = wstatus, updated_at = now_utc() WHERE id = wid AND status IS NULL;
+
+        UPDATE users SET msats = msats + msats_paying + msats_fee_paying WHERE id = user_id;
+        RETURN 0;
+    END IF;
+    RETURN 1;
+END;
+$$;

--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -238,11 +238,11 @@ async function checkWithdrawal ({ data: { hash }, boss, models, lnd }) {
     )
     if (code === 0) {
       notifyWithdrawal(dbWdrwl.userId, wdrwl)
-    }
-    if (dbWdrwl.wallet) {
-      // this was an autowithdrawal
-      const message = `autowithdrawal of ${numWithUnits(msatsToSats(paid), { abbreviate: false })} with ${numWithUnits(msatsToSats(fee), { abbreviate: false })} as fee`
-      await addWalletLog({ wallet: dbWdrwl.wallet.type, level: 'SUCCESS', message }, { models, me: { id: dbWdrwl.userId } })
+      if (dbWdrwl.wallet) {
+        // this was an autowithdrawal
+        const message = `autowithdrawal of ${numWithUnits(msatsToSats(paid), { abbreviate: false })} with ${numWithUnits(msatsToSats(fee), { abbreviate: false })} as fee`
+        await addWalletLog({ wallet: dbWdrwl.wallet.type, level: 'SUCCESS', message }, { models, me: { id: dbWdrwl.userId } })
+      }
     }
   } else if (wdrwl?.is_failed || notFound) {
     let status = 'UNKNOWN_FAILURE'; let message = 'unknown failure'

--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -260,15 +260,15 @@ async function checkWithdrawal ({ data: { hash }, boss, models, lnd }) {
       message = 'no route found'
     }
 
-    await serialize(
-      models.$executeRaw`
+    const [{ reverse_withdrawl: code }] = await serialize(
+      models.$queryRaw`
         SELECT reverse_withdrawl(${dbWdrwl.id}::INTEGER, ${status}::"WithdrawlStatus")`,
       { models }
     )
 
-    if (dbWdrwl.wallet) {
+    if (code === 0 && dbWdrwl.wallet) {
       // add error into log for autowithdrawal
-      addWalletLog({
+      await addWalletLog({
         wallet: dbWdrwl.wallet.type,
         level: 'ERROR',
         message: 'autowithdrawal failed: ' + message


### PR DESCRIPTION
## Description

A slice of my logs:

> 23 Apr	[lnd]	OK	autowithdrawal of 60 sats with 0 sats as fee
23 Apr	[lnd]	OK	autowithdrawal of 60 sats with 0 sats as fee
23 Apr	[lnd]	OK	autowithdrawal of 60 sats with 0 sats as fee
23 Apr	[lnd]	OK	autowithdrawal of 60 sats with 0 sats as fee
24 Apr	[lnd]	OK	autowithdrawal of 59 sats with 0 sats as fee
24 Apr	[lnd]	OK	autowithdrawal of 59 sats with 0 sats as fee
24 Apr	[lnd]	OK	autowithdrawal of 59 sats with 0 sats as fee
24 Apr	[lnd]	OK	autowithdrawal of 59 sats with 0 sats as fee
25 Apr	[lnd]	OK	autowithdrawal of 161 sats with 0 sats as fee
25 Apr	[lnd]	OK	autowithdrawal of 161 sats with 0 sats as fee
25 Apr	[lnd]	OK	autowithdrawal of 161 sats with 0 sats as fee
25 Apr	[lnd]	OK	autowithdrawal of 161 sats with 0 sats as fee
25 Apr	[lnd]	OK	autowithdrawal of 68 sats with 0 sats as fee
25 Apr	[lnd]	OK	autowithdrawal of 68 sats with 0 sats as fee
25 Apr	[lnd]	OK	autowithdrawal of 68 sats with 0 sats as fee
25 Apr	[lnd]	OK	autowithdrawal of 98 sats with 0 sats as fee
25 Apr	[lnd]	OK	autowithdrawal of 98 sats with 0 sats as fee
25 Apr	[lnd]	OK	autowithdrawal of 98 sats with 0 sats as fee
25 Apr	[lnd]	OK	autowithdrawal of 98 sats with 0 sats as fee
27 Apr	[lnd]	OK	autowithdrawal of 170 sats with 0 sats as fee
27 Apr	[lnd]	OK	autowithdrawal of 170 sats with 0 sats as fee
27 Apr	[lnd]	OK	autowithdrawal of 170 sats with 0 sats as fee
27 Apr	[lnd]	OK	autowithdrawal of 170 sats with 0 sats as fee
27 Apr	[lnd]	OK	autowithdrawal of 170 sats with 0 sats as fee
27 Apr	[lnd]	OK	autowithdrawal of 55 sats with 0 sats as fee
27 Apr	[lnd]	OK	autowithdrawal of 55 sats with 0 sats as fee
27 Apr	[lnd]	OK	autowithdrawal of 55 sats with 0 sats as fee
27 Apr	[lnd]	OK	autowithdrawal of 50 sats with 0 sats as fee
27 Apr	[lnd]	OK	autowithdrawal of 50 sats with 0 sats as fee
27 Apr	[lnd]	OK	autowithdrawal of 50 sats with 0 sats as fee
27 Apr	[lnd]	OK	autowithdrawal of 50 sats with 0 sats as fee

This PR should fix duplicates for successful and failed autowithdrawals.

## Additional context

Can't reproduce bug locally because it only occurs in prod with multiple workers running.

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes, tested successful autowithdrawal and failed autowithdrawal. Logs were still created fine.

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a function to reverse withdrawal transactions, enabling funds to be returned to users and updating transaction status accordingly.

- **Refactor**
	- Enhanced error handling and execution flow in the withdrawal process to improve reliability and clarity in operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->