### PR TITLE
Fix unintended sharing of wallets and logs

### DIFF
--- a/components/logger.js
+++ b/components/logger.js
@@ -126,14 +126,14 @@ export function useServiceWorkerLogger () {
 const WalletLoggerContext = createContext()
 const WalletLogsContext = createContext()
 
-const initIndexedDB = async (storeName) => {
+const initIndexedDB = async (dbName, storeName) => {
   return new Promise((resolve, reject) => {
     if (!window.indexedDB) {
       return reject(new Error('IndexedDB not supported'))
     }
 
     // https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB
-    const request = window.indexedDB.open('app:storage', 1)
+    const request = window.indexedDB.open(dbName, 1)
 
     let db
     request.onupgradeneeded = () => {
@@ -159,7 +159,12 @@ const initIndexedDB = async (storeName) => {
 }
 
 const WalletLoggerProvider = ({ children }) => {
+  const me = useMe()
   const [logs, setLogs] = useState([])
+  let dbName = 'app:storage'
+  if (me) {
+    dbName = `${dbName}:${me.id}`
+  }
   const idbStoreName = 'wallet_logs'
   const idb = useRef()
   const logQueue = useRef([])
@@ -211,7 +216,7 @@ const WalletLoggerProvider = ({ children }) => {
   }, [])
 
   useEffect(() => {
-    initIndexedDB(idbStoreName)
+    initIndexedDB(dbName, idbStoreName)
       .then(db => {
         idb.current = db
 

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -262,15 +262,10 @@ export function LogoutDropdownItem () {
   return (
     <Dropdown.Item
       onClick={async () => {
-        try {
-          // order is important because we need to be logged in to delete push subscription on server
-          const pushSubscription = await swRegistration?.pushManager.getSubscription()
-          if (pushSubscription) {
-            await togglePushSubscription()
-          }
-        } catch (err) {
-          // don't prevent signout because of an unsubscription error
-          console.error(err)
+        // order is important because we need to be logged in to delete push subscription on server
+        const pushSubscription = await swRegistration?.pushManager.getSubscription()
+        if (pushSubscription) {
+          await togglePushSubscription().catch(console.error)
         }
         // detach wallets
         await webLN.clearConfig().catch(console.error)

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -23,6 +23,7 @@ import classNames from 'classnames'
 import SnIcon from '@/svgs/sn.svg'
 import { useHasNewNotes } from '../use-has-new-notes'
 import { useWalletLogger } from '../logger'
+import { useWebLNConfigurator } from '../webln'
 
 export function Brand ({ className }) {
   return (
@@ -162,8 +163,6 @@ export function NavWalletSummary ({ className }) {
 
 export function MeDropdown ({ me, dropNavKey }) {
   if (!me) return null
-  const { registration: swRegistration, togglePushSubscription } = useServiceWorker()
-  const { deleteLogs } = useWalletLogger()
   return (
     <div className='position-relative'>
       <Dropdown className={styles.dropdown} align='end'>
@@ -202,22 +201,7 @@ export function MeDropdown ({ me, dropNavKey }) {
             </Link>
           </div>
           <Dropdown.Divider />
-          <Dropdown.Item
-            onClick={async () => {
-              // order is important because we need to be logged in to delete push subscription on server
-              const pushSubscription = await swRegistration?.pushManager.getSubscription()
-              if (pushSubscription) {
-                // don't prevent signout because of an unsubscription error
-                await togglePushSubscription().catch(console.error)
-              }
-              // delete client wallet logs to prevent leak of private data if a shared device was used
-              await deleteLogs(Wallet.NWC).catch(console.error)
-              await deleteLogs(Wallet.LNbits).catch(console.error)
-              await deleteLogs(Wallet.LNC).catch(console.error)
-              await signOut({ callbackUrl: '/' })
-            }}
-          >logout
-          </Dropdown.Item>
+          <LogoutDropdownItem />
         </Dropdown.Menu>
       </Dropdown>
       {!me.bioId &&
@@ -268,6 +252,36 @@ export default function LoginButton ({ className }) {
     >
       login
     </Button>
+  )
+}
+
+export function LogoutDropdownItem () {
+  const { registration: swRegistration, togglePushSubscription } = useServiceWorker()
+  const webLN = useWebLNConfigurator()
+  const { deleteLogs } = useWalletLogger()
+  return (
+    <Dropdown.Item
+      onClick={async () => {
+        try {
+          // order is important because we need to be logged in to delete push subscription on server
+          const pushSubscription = await swRegistration?.pushManager.getSubscription()
+          if (pushSubscription) {
+            await togglePushSubscription()
+          }
+        } catch (err) {
+          // don't prevent signout because of an unsubscription error
+          console.error(err)
+        }
+        // detach wallets
+        await webLN.clearConfig().catch(console.error)
+        // delete client wallet logs to prevent leak of private data if a shared device was used
+        await deleteLogs(Wallet.NWC).catch(console.error)
+        await deleteLogs(Wallet.LNbits).catch(console.error)
+        await deleteLogs(Wallet.LNC).catch(console.error)
+        await signOut({ callbackUrl: '/' })
+      }}
+    >logout
+    </Dropdown.Item>
   )
 }
 

--- a/components/nav/mobile/offcanvas.js
+++ b/components/nav/mobile/offcanvas.js
@@ -2,9 +2,7 @@ import { useState } from 'react'
 import { Dropdown, Image, Nav, Navbar, Offcanvas } from 'react-bootstrap'
 import { MEDIA_URL } from '@/lib/constants'
 import Link from 'next/link'
-import { useServiceWorker } from '@/components/serviceworker'
-import { signOut } from 'next-auth/react'
-import { LoginButtons, NavWalletSummary } from '../common'
+import { LoginButtons, LogoutDropdownItem, NavWalletSummary } from '../common'
 import AnonIcon from '@/svgs/spy-fill.svg'
 import styles from './footer.module.css'
 import classNames from 'classnames'
@@ -14,7 +12,6 @@ export default function OffCanvas ({ me, dropNavKey }) {
 
   const handleClose = () => setShow(false)
   const handleShow = () => setShow(true)
-  const { registration: swRegistration, togglePushSubscription } = useServiceWorker()
 
   const MeImage = ({ onClick }) => me
     ? (
@@ -78,22 +75,7 @@ export default function OffCanvas ({ me, dropNavKey }) {
                     </Link>
                   </div>
                   <Dropdown.Divider />
-                  <Dropdown.Item
-                    onClick={async () => {
-                      try {
-                        // order is important because we need to be logged in to delete push subscription on server
-                        const pushSubscription = await swRegistration?.pushManager.getSubscription()
-                        if (pushSubscription) {
-                          await togglePushSubscription()
-                        }
-                      } catch (err) {
-                        // don't prevent signout because of an unsubscription error
-                        console.error(err)
-                      }
-                      await signOut({ callbackUrl: '/' })
-                    }}
-                  >logout
-                  </Dropdown.Item>
+                  <LogoutDropdownItem />
                 </>
                 )
               : <LoginButtons />}

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -33,6 +33,15 @@ export const Status = {
   Error: 'Error'
 }
 
+export function migrateLocalStorage (oldStorageKey, newStorageKey) {
+  const item = window.localStorage.getItem(oldStorageKey)
+  if (item) {
+    window.localStorage.setItem(newStorageKey, item)
+    window.localStorage.removeItem(oldStorageKey)
+  }
+  return item
+}
+
 function RawWebLNProvider ({ children }) {
   const lnbits = useLNbits()
   const nwc = useNWC()

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -114,8 +114,14 @@ function RawWebLNProvider ({ children }) {
     })
   }, [setEnabledProviders])
 
+  const clearConfig = useCallback(async () => {
+    lnbits.clearConfig()
+    nwc.clearConfig()
+    await lnc.clearConfig()
+  }, [])
+
   return (
-    <WebLNContext.Provider value={{ provider: isEnabled(provider) ? { sendPayment: sendPaymentWithToast } : null, enabledProviders, setProvider }}>
+    <WebLNContext.Provider value={{ provider: isEnabled(provider) ? { sendPayment: sendPaymentWithToast } : null, enabledProviders, setProvider, clearConfig }}>
       {children}
     </WebLNContext.Provider>
   )

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -117,10 +117,12 @@ export function LNbitsProvider ({ children }) {
   const loadConfig = useCallback(async () => {
     let configStr = window.localStorage.getItem(storageKey)
     setStatus(Status.Initialized)
-    if (me && !configStr) {
-      // backwards compatibility: try old storageKey
-      const oldStorageKey = storageKey.split(':').slice(0, -1).join(':')
-      configStr = window.localStorage.getItem(oldStorageKey)
+    if (!configStr) {
+      if (me) {
+        // backwards compatibility: try old storageKey
+        const oldStorageKey = storageKey.split(':').slice(0, -1).join(':')
+        configStr = window.localStorage.getItem(oldStorageKey)
+      }
       if (!configStr) {
         logger.info('no existing config found')
         return

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react'
 import { useWalletLogger } from '../logger'
-import { Status } from '.'
+import { Status, migrateLocalStorage } from '.'
 import { bolt11Tags } from '@/lib/bolt11'
 import { Wallet } from '@/lib/constants'
 import { useMe } from '../me'
@@ -121,7 +121,7 @@ export function LNbitsProvider ({ children }) {
       if (me) {
         // backwards compatibility: try old storageKey
         const oldStorageKey = storageKey.split(':').slice(0, -1).join(':')
-        configStr = window.localStorage.getItem(oldStorageKey)
+        configStr = migrateLocalStorage(oldStorageKey, storageKey)
       }
       if (!configStr) {
         logger.info('no existing config found')

--- a/components/webln/lnbits.js
+++ b/components/webln/lnbits.js
@@ -3,6 +3,7 @@ import { useWalletLogger } from '../logger'
 import { Status } from '.'
 import { bolt11Tags } from '@/lib/bolt11'
 import { Wallet } from '@/lib/constants'
+import { useMe } from '../me'
 
 // Reference: https://github.com/getAlby/bitcoin-connect/blob/v3.2.0-alpha/src/connectors/LnbitsConnector.ts
 
@@ -65,13 +66,17 @@ const getPayment = async (baseUrl, adminKey, paymentHash) => {
 }
 
 export function LNbitsProvider ({ children }) {
+  const me = useMe()
   const [url, setUrl] = useState('')
   const [adminKey, setAdminKey] = useState('')
   const [status, setStatus] = useState()
   const { logger } = useWalletLogger(Wallet.LNbits)
 
   const name = 'LNbits'
-  const storageKey = 'webln:provider:lnbits'
+  let storageKey = 'webln:provider:lnbits'
+  if (me) {
+    storageKey = `${storageKey}:${me.id}`
+  }
 
   const getInfo = useCallback(async () => {
     const response = await getWallet(url, adminKey)
@@ -110,11 +115,16 @@ export function LNbitsProvider ({ children }) {
   }, [logger, url, adminKey])
 
   const loadConfig = useCallback(async () => {
-    const configStr = window.localStorage.getItem(storageKey)
+    let configStr = window.localStorage.getItem(storageKey)
     setStatus(Status.Initialized)
-    if (!configStr) {
-      logger.info('no existing config found')
-      return
+    if (me && !configStr) {
+      // backwards compatibility: try old storageKey
+      const oldStorageKey = storageKey.split(':').slice(0, -1).join(':')
+      configStr = window.localStorage.getItem(oldStorageKey)
+      if (!configStr) {
+        logger.info('no existing config found')
+        return
+      }
     }
 
     const config = JSON.parse(configStr)
@@ -141,7 +151,7 @@ export function LNbitsProvider ({ children }) {
       logger.info('wallet disabled')
       throw err
     }
-  }, [logger])
+  }, [me, logger])
 
   const saveConfig = useCallback(async (config) => {
     // immediately store config so it's not lost even if config is invalid

--- a/components/webln/lnc.js
+++ b/components/webln/lnc.js
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useState } from 'react'
 import { useWalletLogger } from '../logger'
 import LNC from '@lightninglabs/lnc-web'
-import { Status } from '.'
+import { Status, migrateLocalStorage } from '.'
 import { bolt11Tags } from '@/lib/bolt11'
 import useModal from '../modal'
 import { Form, PasswordInput, SubmitButton } from '../form'
@@ -15,6 +15,8 @@ const mutex = new Mutex()
 
 async function getLNC ({ me }) {
   if (window.lnc) return window.lnc
+  // backwards compatibility: migrate to new storage key
+  if (me) migrateLocalStorage('lnc-web:default', `lnc-web:${me.id}`)
   window.lnc = new LNC({ namespace: me?.id })
   return window.lnc
 }

--- a/components/webln/lnc.js
+++ b/components/webln/lnc.js
@@ -8,13 +8,14 @@ import { Form, PasswordInput, SubmitButton } from '../form'
 import CancelButton from '../cancel-button'
 import { Mutex } from 'async-mutex'
 import { Wallet } from '@/lib/constants'
+import { useMe } from '../me'
 
 const LNCContext = createContext()
 const mutex = new Mutex()
 
-async function getLNC () {
+async function getLNC ({ me }) {
   if (window.lnc) return window.lnc
-  window.lnc = new LNC({ })
+  window.lnc = new LNC({ namespace: me?.id })
   return window.lnc
 }
 
@@ -33,6 +34,7 @@ function validateNarrowPerms (lnc) {
 }
 
 export function LNCProvider ({ children }) {
+  const me = useMe()
   const { logger } = useWalletLogger(Wallet.LNC)
   const [config, setConfig] = useState({})
   const [lnc, setLNC] = useState()
@@ -165,7 +167,7 @@ export function LNCProvider ({ children }) {
   useEffect(() => {
     (async () => {
       try {
-        const lnc = await getLNC()
+        const lnc = await getLNC({ me })
         setLNC(lnc)
         setStatus(Status.Initialized)
         if (lnc.credentials.isPaired) {
@@ -185,7 +187,7 @@ export function LNCProvider ({ children }) {
         setStatus(Status.Error)
       }
     })()
-  }, [setStatus, setConfig, logger])
+  }, [me, setStatus, setConfig, logger])
 
   return (
     <LNCContext.Provider value={{ name: 'lnc', status, unlock, getInfo, sendPayment, config, saveConfig, clearConfig }}>

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -104,10 +104,12 @@ export function NWCProvider ({ children }) {
   const loadConfig = useCallback(async () => {
     let configStr = window.localStorage.getItem(storageKey)
     setStatus(Status.Initialized)
-    if (me && !configStr) {
-      // backwards compatibility: try old storageKey
-      const oldStorageKey = storageKey.split(':').slice(0, -1).join(':')
-      configStr = window.localStorage.getItem(oldStorageKey)
+    if (!configStr) {
+      if (me) {
+        // backwards compatibility: try old storageKey
+        const oldStorageKey = storageKey.split(':').slice(0, -1).join(':')
+        configStr = window.localStorage.getItem(oldStorageKey)
+      }
       if (!configStr) {
         logger.info('no existing config found')
         return

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -4,7 +4,7 @@ import { createContext, useCallback, useContext, useEffect, useState } from 'rea
 import { Relay, finalizeEvent, nip04 } from 'nostr-tools'
 import { parseNwcUrl } from '@/lib/url'
 import { useWalletLogger } from '../logger'
-import { Status } from '.'
+import { Status, migrateLocalStorage } from '.'
 import { bolt11Tags } from '@/lib/bolt11'
 import { Wallet } from '@/lib/constants'
 import { useMe } from '../me'
@@ -108,7 +108,7 @@ export function NWCProvider ({ children }) {
       if (me) {
         // backwards compatibility: try old storageKey
         const oldStorageKey = storageKey.split(':').slice(0, -1).join(':')
-        configStr = window.localStorage.getItem(oldStorageKey)
+        configStr = migrateLocalStorage(oldStorageKey, storageKey)
       }
       if (!configStr) {
         logger.info('no existing config found')


### PR DESCRIPTION
## Description

Close #927

TODO:
- [x] suffix localStorage key for NWC, LNbits
- [x] suffix localStorage key for LNC
- [x] suffix IndexedDB database for wallet logs
- [x] detach attached wallets on logout
- [x] delete wallet logs on logout (done in #1101) 

## Additional Context

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes, stackers will still be able to access their current attached wallets without attaching them again. If a wallet wasn't found with the new key, we will fallback to the old key and migrate it to the new key.

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes, but I couldn't test LNC since I don't know how to connect it. See https://github.com/stackernews/stacker.news/pull/1104#discussion_r1582239915.

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
