### PR TITLE
Add explicit word break for items

### DIFF
--- a/components/item.module.css
+++ b/components/item.module.css
@@ -90,6 +90,7 @@ a.link:visited {
     color: var(--theme-grey);
     vertical-align: text-top;
     margin-bottom: .125rem;
+    word-break: break-word;
 }
 
 .other svg {
@@ -156,6 +157,7 @@ a.link:visited {
 .main {
     display: flex;
     align-items: baseline;
+    word-break: break-word;
 }
 
 .children {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -320,6 +320,10 @@ $zindex-sticky: 900;
   color: var(--theme-grey) !important;
 }
 
+.text-reset {
+  word-break: break-word;
+}
+
 ol,
 ul,
 dl {

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -320,10 +320,6 @@ $zindex-sticky: 900;
   color: var(--theme-grey) !important;
 }
 
-.text-reset {
-  word-break: break-word;
-}
-
 ol,
 ul,
 dl {


### PR DESCRIPTION
## Description

<!--
A clear and concise description of what you changed and why.
Don't forget to mention which tickets this closes (if any).
Use following syntax to close them automatically on merge: closes #<number>
-->

Closes #1125 
adds an explicit word break to the main and other item components to handle the text of long titles. Firefox handles this break by default but it seems that chrome and safari do not

## Screenshots

chrome linebreak (note the `break-all` behavior in the url where the rest of the title has `break-word`) 
![image](https://github.com/stackernews/stacker.news/assets/108441023/db57425b-8690-4a1b-9b09-967c9c045c6b)

firefox linebreak (no change from prod)
![image](https://github.com/stackernews/stacker.news/assets/108441023/f35515b0-a098-41ed-a09d-9826b32a7fc9)


## Additional Context

This bit of css seems to only be necessary for chrome or safari based browsers as firefox seems to already have some default line-breaks built for slash characters. however, since I cannot explicitly state to make a linebreak on a "/" I opted to add `word-break: break-word;` instead. as a result the word breaks on firefox <-> chrome look slightly different
<!--
You can mention here anything that you think is relevant for this PR. Some examples:
* You encountered something that you didn't understand while working on this PR
* You were not sure about something you did but did not find a better way
* You initially had a different approach but went with a different approach for some reason
-->

## Checklist

**Are your changes backwards compatible? Please answer below:**

<!-- put your answer about backwards compatibility here -->

Yaaasss
<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

<!-- put your answer about QA here -->
Yaaasss 

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->
Tested in firefox and chrome, not on safari
