### PR TITLE
Fix images from media domain not loaded if imgproxyOnly enabled

### DIFF
--- a/components/image.js
+++ b/components/image.js
@@ -1,6 +1,6 @@
 import styles from './text.module.css'
 import { Fragment, useState, useEffect, useMemo, useCallback, forwardRef, useRef, memo } from 'react'
-import { IMGPROXY_URL_REGEXP } from '@/lib/url'
+import { IMGPROXY_URL_REGEXP, MEDIA_DOMAIN_REGEXP } from '@/lib/url'
 import { useShowModal } from './modal'
 import { useMe } from './me'
 import { Dropdown } from 'react-bootstrap'
@@ -63,7 +63,7 @@ function ImageOriginal ({ src, topLevel, rel, tab, children, onClick, ...props }
   }
 }
 
-function ImageProxy ({ src, srcSet: { dimensions, ...srcSetObj } = {}, onClick, topLevel, onError, ...props }) {
+function TrustedImage ({ src, srcSet: { dimensions, ...srcSetObj } = {}, onClick, topLevel, onError, ...props }) {
   const srcSet = useMemo(() => {
     if (Object.keys(srcSetObj).length === 0) return undefined
     // srcSetObj shape: { [widthDescriptor]: <imgproxyUrl>, ... }
@@ -132,7 +132,7 @@ export default function ZoomableImage ({ src, srcSet, ...props }) {
   const showModal = useShowModal()
 
   // if `srcSet` is falsy, it means the image was not processed by worker yet
-  const [imgproxy, setImgproxy] = useState(!!srcSet || IMGPROXY_URL_REGEXP.test(src))
+  const [trustedDomain, setTrustedDomain] = useState(!!srcSet || IMGPROXY_URL_REGEXP.test(src) || MEDIA_DOMAIN_REGEXP.test(src))
 
   // backwards compatibility:
   // src may already be imgproxy url since we used to replace image urls with imgproxy urls
@@ -158,13 +158,13 @@ export default function ZoomableImage ({ src, srcSet, ...props }) {
       </Dropdown.Item>)
   }), [showModal, originalUrl, styles])
 
-  const handleError = useCallback(() => setImgproxy(false), [setImgproxy])
+  const handleError = useCallback(() => setTrustedDomain(false), [setTrustedDomain])
 
   if (!src) return null
 
-  if (imgproxy) {
+  if (trustedDomain) {
     return (
-      <ImageProxy
+      <TrustedImage
         src={src} srcSet={srcSet}
         onClick={handleClick} onError={handleError} {...props}
       />

--- a/lib/url.js
+++ b/lib/url.js
@@ -89,5 +89,7 @@ export const URL_REGEXP = /^((https?|ftp):\/\/)?(www.)?(((([a-z]|\d|-|\.|_|~|[\u
 export const WS_REGEXP = /^(wss?:\/\/)([0-9]{1,3}(?:\.[0-9]{1,3}){3}|(?=[^\/]{1,254}(?![^\/]))(?:(?=[a-zA-Z0-9-]{1,63}\.)(?:xn--+)?[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*\.)+[a-zA-Z]{2,63})(:([0-9]{1,5}))?(\/[^\s`@#$^&=.?"{}\\]+\/?)*([^\s`@#$^&=?"{}\/\\]+)?(\?[^\s`#$^"{}\\]+)*$/
 
 export const IMGPROXY_URL_REGEXP = new RegExp(`^${process.env.NEXT_PUBLIC_IMGPROXY_URL}.*$`)
+export const MEDIA_DOMAIN_REGEXP = new RegExp(`^https?://${process.env.NEXT_PUBLIC_MEDIA_DOMAIN}/.*$`)
+
 // this regex is not a bullet proof way of checking if a url points to an image. to be sure, fetch the url and check the mimetype
 export const IMG_URL_REGEXP = /^(https?:\/\/.*\.(?:png|jpg|jpeg|gif))$/


### PR DESCRIPTION
## Description

Fix #1152

Images from our media domain (m.stacker.news) were not trusted so these images didn't load for stackers which had `imgproxyOnly` enabled until the worker processed the image and srcSet with imgproxy URLs was available.

I renamed `<ImageProxy>` to `<TrustedImage>` since it describes better why we're doing what we're doing.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
