### PR TITLE
Replace toasts with improved custom optimistic UX

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -895,7 +895,7 @@ export default {
              WHERE act IN ('TIP', 'FEE')
              AND "itemId" = ${Number(id)}::INTEGER
              AND "userId" = ${me.id}::INTEGER)::INTEGER)`,
-          { models }
+          { models, lnd, hash, hmac }
         )
       } else {
         await serialize(

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -106,7 +106,8 @@ export function BountyForm ({
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}
-      invoiceable={{ requireSession: true }}
+      requireSession
+      invoiceable
       onSubmit={
         handleSubmit ||
         onSubmit

--- a/components/dont-link-this.js
+++ b/components/dont-link-this.js
@@ -1,13 +1,12 @@
 import Dropdown from 'react-bootstrap/Dropdown'
 import { useShowModal } from './modal'
 import { useToast } from './toast'
-import ItemAct, { zapUndosThresholdReached } from './item-act'
+import ItemAct from './item-act'
 import AccordianItem from './accordian-item'
 import Flag from '@/svgs/flag-fill.svg'
 import { useMemo } from 'react'
 import getColor from '@/lib/rainbow'
 import { gql, useMutation } from '@apollo/client'
-import { useMe } from './me'
 
 export function DownZap ({ id, meDontLikeSats, ...props }) {
   const style = useMemo(() => (meDontLikeSats
@@ -24,8 +23,6 @@ export function DownZap ({ id, meDontLikeSats, ...props }) {
 function DownZapper ({ id, As, children }) {
   const toaster = useToast()
   const showModal = useShowModal()
-  const me = useMe()
-
   return (
     <As
       onClick={async () => {
@@ -34,9 +31,6 @@ function DownZapper ({ id, As, children }) {
             <ItemAct
               onClose={(amount) => {
                 onClose()
-                // undo prompt was toasted before closing modal if zap undos are enabled
-                // so an additional success toast would be confusing
-                if (!zapUndosThresholdReached(me, amount)) toaster.success('item downzapped')
               }} itemId={id} down
             >
               <AccordianItem

--- a/components/dont-link-this.js
+++ b/components/dont-link-this.js
@@ -29,9 +29,7 @@ function DownZapper ({ id, As, children }) {
         try {
           showModal(onClose =>
             <ItemAct
-              onClose={(amount) => {
-                onClose()
-              }} itemId={id} down
+              onClose={onClose} itemId={id} down
             >
               <AccordianItem
                 header='what is a downzap?' body={

--- a/components/fee-button.js
+++ b/components/fee-button.js
@@ -11,7 +11,6 @@ import AnonIcon from '@/svgs/spy-fill.svg'
 import { useShowModal } from './modal'
 import Link from 'next/link'
 import { SubmitButton } from './form'
-import { PaymentProvider } from './payment'
 
 const FeeButtonContext = createContext()
 
@@ -93,9 +92,7 @@ export function FeeButtonProvider ({ baseLineItems = {}, useRemoteLineItems = ()
 
   return (
     <FeeButtonContext.Provider value={value}>
-      <PaymentProvider>
-        {children}
-      </PaymentProvider>
+      {children}
     </FeeButtonContext.Provider>
   )
 }

--- a/components/fee-button.js
+++ b/components/fee-button.js
@@ -88,7 +88,7 @@ export function FeeButtonProvider ({ baseLineItems = {}, useRemoteLineItems = ()
       setDisabled,
       free
     }
-  }, [me, baseLineItems, lineItems, remoteLineItems, mergeLineItems, disabled, setDisabled])
+  }, [me?.privates?.sats, baseLineItems, lineItems, remoteLineItems, mergeLineItems, disabled, setDisabled])
 
   return (
     <FeeButtonContext.Provider value={value}>

--- a/components/form.js
+++ b/components/form.js
@@ -803,7 +803,7 @@ const StorageKeyPrefixContext = createContext()
 export function Form ({
   initial, schema, onSubmit, children, initialError, validateImmediately,
   storageKeyPrefix, validateOnChange = true, invoiceable, requireSession, innerRef,
-  optimisticUpdate, ...props
+  optimisticUpdate, onError, ...props
 }) {
   const toaster = useToast()
   const initialErrorToasted = useRef(false)
@@ -855,7 +855,11 @@ export function Form ({
         return
       }
       const msg = err.message || err.toString?.()
-      toaster.danger('submit error: ' + msg)
+      if (onError) {
+        onError({ amount, ...values, reason: msg })
+      } else {
+        toaster.danger('submit error: ' + msg)
+      }
       cancel?.()
     }
   }, [me, onSubmit, feeButton?.total, toaster, clearLocalStorage, storageKeyPrefix, payment])

--- a/components/form.js
+++ b/components/form.js
@@ -802,7 +802,7 @@ const StorageKeyPrefixContext = createContext()
 export function Form ({
   initial, schema, onSubmit, children, initialError, validateImmediately,
   storageKeyPrefix, validateOnChange = true, invoiceable, requireSession, innerRef,
-  beforePayment, ...props
+  optimisticUpdate, ...props
 }) {
   const toaster = useToast()
   const initialErrorToasted = useRef(false)
@@ -841,7 +841,7 @@ export function Form ({
         }
         let hash, hmac
         if (invoiceable) {
-          revert = beforePayment?.({ amount, ...values }, ...args);
+          revert = optimisticUpdate?.({ amount, ...values }, ...args);
           [{ hash, hmac }, cancel] = await payment.request(amount)
         }
         await onSubmit({ hash, hmac, amount, ...values }, ...args)

--- a/components/form.js
+++ b/components/form.js
@@ -33,6 +33,7 @@ import EyeClose from '@/svgs/eye-close-line.svg'
 import Info from './info'
 import { InvoiceCanceledError, usePayment } from './payment'
 import { useMe } from './me'
+import { ActCanceledError } from './item-act'
 
 export class SessionRequiredError extends Error {
   constructor () {
@@ -841,7 +842,7 @@ export function Form ({
         }
         let hash, hmac
         if (invoiceable) {
-          revert = optimisticUpdate?.({ amount, ...values }, ...args);
+          revert = await optimisticUpdate?.({ amount, ...values }, ...args);
           [{ hash, hmac }, cancel] = await payment.request(amount)
         }
         await onSubmit({ hash, hmac, amount, ...values }, ...args)
@@ -850,7 +851,7 @@ export function Form ({
       }
     } catch (err) {
       revert?.()
-      if (err instanceof InvoiceCanceledError) {
+      if (err instanceof InvoiceCanceledError || err instanceof ActCanceledError) {
         return
       }
       const msg = err.message || err.toString?.()

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -1,22 +1,33 @@
-import { useState, useCallback, useEffect } from 'react'
-import { useApolloClient, useMutation, useQuery } from '@apollo/client'
-import { Button } from 'react-bootstrap'
-import { gql } from 'graphql-tag'
+import { useState, useEffect } from 'react'
 import { numWithUnits } from '@/lib/format'
 import AccordianItem from './accordian-item'
-import Qr, { QrSkeleton } from './qr'
-import { INVOICE } from '@/fragments/wallet'
-import InvoiceStatus from './invoice-status'
-import { useMe } from './me'
-import { useShowModal } from './modal'
+import Qr from './qr'
 import Countdown from './countdown'
 import PayerData from './payer-data'
 import Bolt11Info from './bolt11-info'
-import { useWebLN } from './webln'
-import { FAST_POLL_INTERVAL } from '@/lib/constants'
+import { useQuery } from '@apollo/client'
+import { INVOICE } from '@/fragments/wallet'
+import { FAST_POLL_INTERVAL, SSR } from '@/lib/constants'
 
-export function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn }) {
+export default function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn, poll }) {
   const [expired, setExpired] = useState(new Date(invoice.expiredAt) <= new Date())
+
+  const { data, error } = useQuery(INVOICE, SSR
+    ? {}
+    : {
+        pollInterval: FAST_POLL_INTERVAL,
+        variables: { id: invoice.id },
+        nextFetchPolicy: 'cache-and-network',
+        skip: !poll
+      })
+
+  if (data) {
+    invoice = data.invoice
+  }
+
+  if (error) {
+    return <div>{error.toString()}</div>
+  }
 
   // if webLn was not passed, use true by default
   if (webLn === undefined) webLn = true
@@ -104,290 +115,4 @@ export function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn }
 
     </>
   )
-}
-
-const JITInvoice = ({ invoice: { id, hash, hmac, expiresAt }, onPayment, onCancel, onRetry }) => {
-  const { data, loading, error } = useQuery(INVOICE, {
-    pollInterval: FAST_POLL_INTERVAL,
-    variables: { id }
-  })
-  const [retryError, setRetryError] = useState(0)
-  if (error) {
-    if (error.message?.includes('invoice not found')) {
-      return
-    }
-    return <div>error</div>
-  }
-  if (!data || loading) {
-    return <QrSkeleton description status='loading' />
-  }
-
-  const retry = !!onRetry
-  let errorStatus = 'Something went wrong trying to perform the action after payment.'
-  if (retryError > 0) {
-    errorStatus = 'Something still went wrong.\nYou can retry or cancel the invoice to return your funds.'
-  }
-
-  return (
-    <>
-      <Invoice invoice={data.invoice} modal onPayment={onPayment} successVerb='received' webLn={false} />
-      {retry
-        ? (
-          <>
-            <div className='my-3'>
-              <InvoiceStatus variant='failed' status={errorStatus} />
-            </div>
-            <div className='d-flex flex-row mt-3 justify-content-center'>
-              <Button
-                className='mx-1' variant='info' onClick={async () => {
-                  try {
-                    await onRetry()
-                  } catch (err) {
-                    console.error('retry error:', err)
-                    setRetryError(retryError => retryError + 1)
-                  }
-                }}
-              >Retry
-              </Button>
-              <Button
-                className='mx-1'
-                variant='danger'
-                onClick={onCancel}
-              >Cancel
-              </Button>
-            </div>
-          </>
-          )
-        : null}
-    </>
-  )
-}
-
-const defaultOptions = {
-  requireSession: false,
-  forceInvoice: false
-}
-export const useInvoiceable = (onSubmit, options = defaultOptions) => {
-  const me = useMe()
-  const [createInvoice] = useMutation(gql`
-    mutation createInvoice($amount: Int!) {
-      createInvoice(amount: $amount, hodlInvoice: true, expireSecs: 180) {
-        id
-        bolt11
-        hash
-        hmac
-        expiresAt
-      }
-    }`)
-  const [cancelInvoice] = useMutation(gql`
-    mutation cancelInvoice($hash: String!, $hmac: String!) {
-      cancelInvoice(hash: $hash, hmac: $hmac) {
-        id
-      }
-    }
-  `)
-
-  const showModal = useShowModal()
-  const provider = useWebLN()
-  const client = useApolloClient()
-  const pollInvoice = (id) => client.query({ query: INVOICE, fetchPolicy: 'no-cache', variables: { id } })
-
-  const onSubmitWrapper = useCallback(async (
-    { cost, ...formValues },
-    { variables, optimisticResponse, update, flowId, ...submitArgs }) => {
-    // some actions require a session
-    if (!me && options.requireSession) {
-      throw new Error('you must be logged in')
-    }
-
-    // id for toast flows
-    if (!flowId) flowId = (+new Date()).toString(16)
-
-    // educated guesses where action might pass in the invoice amount
-    // (field 'cost' has highest precedence)
-    cost ??= formValues.amount
-
-    // attempt action for the first time
-    if (!cost || (me && !options.forceInvoice)) {
-      try {
-        const insufficientFunds = me?.privates.sats < cost
-        return await onSubmit(formValues,
-          { ...submitArgs, flowId, variables, optimisticsResponse: insufficientFunds ? null : optimisticResponse, update })
-      } catch (error) {
-        if (!payOrLoginError(error) || !cost) {
-          // can't handle error here - bail
-          throw error
-        }
-      }
-    }
-
-    // initial attempt of action failed. we will create an invoice, pay and retry now.
-    const { data, error } = await createInvoice({ variables: { amount: cost } })
-    if (error) {
-      throw error
-    }
-    const inv = data.createInvoice
-
-    // If this is a zap, we need to manually be optimistic to have a consistent
-    // UX across custodial and WebLN zaps since WebLN zaps don't call GraphQL
-    // mutations which implement optimistic responses natively.
-    // Therefore, we check if this is a zap and then wrap the WebLN payment logic
-    // with manual cache update calls.
-    const itemId = optimisticResponse?.act?.id
-    const isZap = !!itemId
-    let _update
-    if (isZap && update) {
-      _update = () => {
-        const fragment = {
-          id: `Item:${itemId}`,
-          fragment: gql`
-          fragment ItemMeSatsInvoice on Item {
-            sats
-            meSats
-          }
-        `
-        }
-        const item = client.cache.readFragment(fragment)
-        update(client.cache, { data: optimisticResponse })
-        // undo function
-        return () => client.cache.writeFragment({ ...fragment, data: item })
-      }
-    }
-
-    // wait until invoice is paid or modal is closed
-    const { modalOnClose, webLn, gqlCacheUpdateUndo } = await waitForPayment({
-      invoice: inv,
-      showModal,
-      provider,
-      pollInvoice,
-      gqlCacheUpdate: _update,
-      flowId
-    })
-
-    const retry = () => onSubmit(
-      { hash: inv.hash, hmac: inv.hmac, expiresAt: inv.expiresAt, ...formValues },
-      // unset update function since we already ran an cache update if we paid using WebLN
-      // also unset update function if null was explicitly passed in
-      { ...submitArgs, variables, update: webLn ? null : undefined })
-    // first retry
-    try {
-      const ret = await retry()
-      modalOnClose?.()
-      return ret
-    } catch (error) {
-      gqlCacheUpdateUndo?.()
-      console.error('retry error:', error)
-    }
-
-    // retry until success or cancel
-    return await new Promise((resolve, reject) => {
-      const cancelAndReject = async () => {
-        await cancelInvoice({ variables: { hash: inv.hash, hmac: inv.hmac } })
-        reject(new Error('invoice canceled'))
-      }
-      showModal(onClose => {
-        return (
-          <JITInvoice
-            invoice={inv}
-            onCancel={async () => {
-              await cancelAndReject()
-              onClose()
-            }}
-            onRetry={async () => {
-              resolve(await retry())
-              onClose()
-            }}
-          />
-        )
-      }, { keepOpen: true, onClose: cancelAndReject })
-    })
-  }, [onSubmit, provider, createInvoice, !!me])
-
-  return onSubmitWrapper
-}
-
-const INVOICE_CANCELED_ERROR = 'invoice canceled'
-const waitForPayment = async ({ invoice, showModal, provider, pollInvoice, gqlCacheUpdate, flowId }) => {
-  if (provider) {
-    try {
-      return await waitForWebLNPayment({ provider, invoice, pollInvoice, gqlCacheUpdate, flowId })
-    } catch (err) {
-      // check for errors which mean that QR code will also fail
-      if (err.message === INVOICE_CANCELED_ERROR) {
-        throw err
-      }
-    }
-  }
-
-  // QR code as fallback
-  return await new Promise((resolve, reject) => {
-    showModal(onClose => {
-      return (
-        <JITInvoice
-          invoice={invoice}
-          onPayment={() => resolve({ modalOnClose: onClose })}
-        />
-      )
-    }, { keepOpen: true, onClose: reject })
-  })
-}
-
-const waitForWebLNPayment = async ({ provider, invoice, pollInvoice, gqlCacheUpdate, flowId }) => {
-  let undoUpdate
-  try {
-    // try WebLN provider first
-    return await new Promise((resolve, reject) => {
-      // be optimistic and pretend zap was already successful for consistent zapping UX
-      undoUpdate = gqlCacheUpdate?.()
-      // can't use await here since we might be paying JIT invoices
-      // and sendPaymentAsync is not supported yet.
-      // see https://www.webln.guide/building-lightning-apps/webln-reference/webln.sendpaymentasync
-      provider.sendPayment({ ...invoice, flowId })
-        // WebLN payment will never resolve here for JIT invoices
-        // since they only get resolved after settlement which can't happen here
-        .then(() => resolve({ webLn: true, gqlCacheUpdateUndo: undoUpdate }))
-        .catch(err => {
-          clearInterval(interval)
-          reject(err)
-        })
-      const interval = setInterval(async () => {
-        try {
-          const { data, error } = await pollInvoice(invoice.id)
-          if (error) {
-            clearInterval(interval)
-            return reject(error)
-          }
-          const { invoice: inv } = data
-          if (inv.isHeld && inv.satsReceived) {
-            clearInterval(interval)
-            resolve({ webLn: true, gqlCacheUpdateUndo: undoUpdate })
-          }
-          if (inv.cancelled) {
-            clearInterval(interval)
-            reject(new Error(INVOICE_CANCELED_ERROR))
-          }
-        } catch (err) {
-          clearInterval(interval)
-          reject(err)
-        }
-      }, FAST_POLL_INTERVAL)
-    })
-  } catch (err) {
-    undoUpdate?.()
-    console.error('WebLN payment failed:', err)
-    throw err
-  }
-}
-
-export const useInvoiceModal = (onPayment, deps) => {
-  const onPaymentMemo = useCallback(onPayment, deps)
-  return useInvoiceable(onPaymentMemo, { replaceModal: true })
-}
-
-export const payOrLoginError = (error) => {
-  const matches = ['insufficient funds', 'you must be logged in or pay']
-  if (Array.isArray(error)) {
-    return error.some(({ message }) => matches.some(m => message.includes(m)))
-  }
-  return matches.some(m => error.toString().includes(m))
 }

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -8,8 +8,9 @@ import Bolt11Info from './bolt11-info'
 import { useQuery } from '@apollo/client'
 import { INVOICE } from '@/fragments/wallet'
 import { FAST_POLL_INTERVAL, SSR } from '@/lib/constants'
+import { WebLnNotEnabledError } from './payment'
 
-export default function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn, poll }) {
+export default function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn, webLnError, poll }) {
   const [expired, setExpired] = useState(new Date(invoice.expiredAt) <= new Date())
 
   const { data, error } = useQuery(INVOICE, SSR
@@ -59,6 +60,11 @@ export default function Invoice ({ invoice, modal, onPayment, info, successVerb,
 
   return (
     <>
+      {webLnError && !(webLnError instanceof WebLnNotEnabledError) &&
+        <div className='text-center text-danger mb-3'>
+          Payment from attached wallet failed:
+          <div>{webLnError.toString()}</div>
+        </div>}
       <Qr
         webLn={webLn} value={invoice.bolt11}
         description={numWithUnits(invoice.satsRequested, { abbreviate: false })}

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -276,7 +276,7 @@ export function useZap () {
         return
       }
       console.error(error)
-      toaster.danger('zap: ' + error?.message || error?.toString?.())
+      toaster.danger('zap failed: ' + error?.message || error?.toString?.())
       cancel?.()
     }
   }, [strike, payment])

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -70,7 +70,7 @@ export default function ItemAct ({ onClose, item, down, children }) {
   const optimisticUpdate = useCallback(({ amount }) => {
     onClose()
     strike()
-    return actOptimisticUpdate(cache, { ...item, sats: Number(amount), act: down ? 'DONT_LIKE_THIS' : 'TIP', me })
+    return actOptimisticUpdate(cache, { ...item, sats: Number(amount), act: down ? 'DONT_LIKE_THIS' : 'TIP' }, { me })
   }, [cache, strike, onClose])
 
   // we need to wrap with PaymentProvider here since modals don't have access to PaymentContext by default

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -233,7 +233,6 @@ const zapUpdate = (cache, args) => {
 
   return () => {
     if (satsDelta > 0) {
-      // updateCache(`Item:${id}`, { sats: `-${satsDelta}`, meSats: `=${item.meSats}` })
       updateItemSats(id, -satsDelta, item.meSats)
       path.split('.').forEach(aId => {
         if (Number(aId) === Number(id)) return

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -41,7 +41,7 @@ const addCustomTip = (amount) => {
   window.localStorage.setItem('custom-tips', JSON.stringify(customTips))
 }
 
-export default function ItemAct ({ onClose, setPending, itemId, down, children }) {
+export default function ItemAct ({ onClose, itemId, down, children }) {
   const inputRef = useRef(null)
   const me = useMe()
   const [oValue, setOValue] = useState()
@@ -59,27 +59,22 @@ export default function ItemAct ({ onClose, setPending, itemId, down, children }
       const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
       window.localStorage.setItem(storageKey, existingAmount + amount)
     }
-    try {
-      await act({
-        variables: {
-          id: itemId,
-          sats: Number(amount),
-          act: down ? 'DONT_LIKE_THIS' : 'TIP',
-          hash,
-          hmac
-        }
-      })
-    } finally {
-      setPending(false)
-    }
+    await act({
+      variables: {
+        id: itemId,
+        sats: Number(amount),
+        act: down ? 'DONT_LIKE_THIS' : 'TIP',
+        hash,
+        hmac
+      }
+    })
     addCustomTip(Number(amount))
-  }, [me, act, down, itemId, strike, onClose, setPending])
+  }, [me, act, down, itemId, strike, onClose])
 
   const beforePayment = useCallback(() => {
-    setPending(true)
     onClose()
     strike()
-  }, [setPending, strike, onClose])
+  }, [strike, onClose])
 
   // we need to wrap with PaymentProvider here since modals don't have access to PaymentContext by default
   return (

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -58,18 +58,17 @@ export default function ItemAct ({ onClose, item, down, children, abortSignal })
 
   const onSubmit = useCallback(async ({ amount, hash, hmac }) => {
     try {
-      const act = down ? 'DONT_LIKE_THIS' : 'TIP'
       await act({
         variables: {
           id: item.id,
           sats: Number(amount),
-          act,
+          act: down ? 'DONT_LIKE_THIS' : 'TIP',
           hash,
           hmac
         }
       })
       addCustomTip(Number(amount))
-      persistItemPendingSats({ ...item, act, sats: -amount })
+      persistItemPendingSats({ ...item, act: down ? 'DONT_LIKE_THIS' : 'TIP', sats: -amount })
     } finally {
       abortSignal.done()
     }

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -183,7 +183,7 @@ export const actOptimisticUpdate = (cache, { id, sats, path, act }, { me }) => {
   }
 }
 
-export function useAct ({ onUpdate } = {}) {
+export function useAct () {
   const [act] = useMutation(
     gql`
       mutation act($id: ID!, $sats: Int!, $act: String, $hash: String, $hmac: String) {

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -188,26 +188,28 @@ const updateItemSats = (cache, { id, path, act, sats }, { me }) => {
   }
 }
 
-const persistItemSats = (prefix, { id, path, act, sats }) => {
-  const storageKey = `TIP-item:${prefix}:${act}:${id}`
+const persistItemAnonSats = ({ id, path, act, sats }) => {
+  const storageKey = `TIP-item:ANON:${act}:${id}`
+  const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
+  window.localStorage.setItem(storageKey, existingAmount + sats)
+  // we don't save TIP-comment for anons because we only need TIP-comment for
+  // persistence of pending item.commentSats but anon sats are never pending
+  // since anons have to pay immediately or optimistic update is reverted.
+  // XXX this changes when anons can have attached wallets
+}
+
+const persistItemPendingSats = ({ id, path, act, sats }) => {
+  const storageKey = `TIP-item:PENDING:${act}:${id}`
   const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
   window.localStorage.setItem(storageKey, existingAmount + sats)
   if (act === 'TIP') {
     path.split('.').forEach(aId => {
       if (Number(aId) === Number(id)) return
-      const storageKey = `TIP-comment:${prefix}:${act}:${aId}`
+      const storageKey = `TIP-comment:PENDING:${act}:${aId}`
       const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
       window.localStorage.setItem(storageKey, existingAmount + sats)
     })
   }
-}
-
-const persistItemAnonSats = ({ id, path, act, sats }) => {
-  persistItemSats('ANON', { id, path, act, sats })
-}
-
-const persistItemPendingSats = ({ id, path, act, sats }) => {
-  persistItemSats('PENDING', { id, path, act, sats })
 }
 
 export const actOptimisticUpdate = (cache, { id, sats, path, act }, { me }) => {

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -69,7 +69,7 @@ export default function ItemAct ({ onClose, item, down, children, abortSignal })
         }
       })
       addCustomTip(Number(amount))
-      persistItemPendingSats({ ...item, act: down ? 'DONT_LIKE_THIS' : 'TIP', sats: -amount })
+      if (me) persistItemPendingSats({ ...item, act: down ? 'DONT_LIKE_THIS' : 'TIP', sats: -amount })
     } finally {
       abortSignal?.done()
     }
@@ -300,7 +300,7 @@ export function useZap () {
       let hash, hmac;
       [{ hash, hmac }, cancel] = await payment.request(sats - meSats)
       await zap({ variables: { ...variables, hash, hmac } })
-      persistItemPendingSats({ ...item, act, sats: -(sats - meSats) })
+      if (me) persistItemPendingSats({ ...item, act, sats: -(sats - meSats) })
     } catch (error) {
       revert?.()
       if (error instanceof InvoiceCanceledError || error instanceof ActCanceledError) {

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -5,13 +5,13 @@ import { Form, Input, SubmitButton } from './form'
 import { useMe } from './me'
 import UpBolt from '@/svgs/bolt.svg'
 import { amountSchema } from '@/lib/validate'
-import { gql, useApolloClient, useMutation } from '@apollo/client'
-import { payOrLoginError, useInvoiceModal } from './invoice'
-import { TOAST_DEFAULT_DELAY_MS, useToast, withToastFlow } from './toast'
+import { gql, useMutation } from '@apollo/client'
+import { useToast } from './toast'
 import { useLightning } from './lightning'
 import { nextTip } from './upvote'
+import { InvoiceCanceledError, PaymentProvider, usePayment } from './payment'
 
-const defaultTips = [100, 1000, 10000, 100000]
+const defaultTips = [100, 1000, 10_000, 100_000]
 
 const Tips = ({ setOValue }) => {
   const tips = [...getCustomTips(), ...defaultTips].sort((a, b) => a - b)
@@ -41,27 +41,19 @@ const addCustomTip = (amount) => {
   window.localStorage.setItem('custom-tips', JSON.stringify(customTips))
 }
 
-export const zapUndosThresholdReached = (me, amount) => {
-  if (!me) return false
-  const enabled = me.privates.zapUndos !== null
-  return enabled ? amount >= me.privates.zapUndos : false
-}
-
 export default function ItemAct ({ onClose, itemId, down, children }) {
   const inputRef = useRef(null)
   const me = useMe()
   const [oValue, setOValue] = useState()
   const strike = useLightning()
-  const toaster = useToast()
-  const client = useApolloClient()
 
   useEffect(() => {
     inputRef.current?.focus()
   }, [onClose, itemId])
 
-  const [act, actUpdate] = useAct()
+  const act = useAct()
 
-  const onSubmit = useCallback(async ({ amount, hash, hmac }, { update, keepOpen }) => {
+  const onSubmit = useCallback(async ({ amount, hash, hmac }) => {
     if (!me) {
       const storageKey = `TIP-item:${itemId}`
       const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
@@ -74,119 +66,43 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
         act: down ? 'DONT_LIKE_THIS' : 'TIP',
         hash,
         hmac
-      },
-      update
+      }
     })
-    // only strike when zap undos not enabled
-    // due to optimistic UX on zap undos
-    if (!zapUndosThresholdReached(me, Number(amount))) await strike()
+    strike()
     addCustomTip(Number(amount))
-    if (!keepOpen) onClose(Number(amount))
   }, [me, act, down, itemId, strike])
 
-  const onSubmitWithUndos = withToastFlow(toaster)(
-    (values, args) => {
-      const { flowId } = args
-      let canceled
-      const sats = values.amount
-      const insufficientFunds = me?.privates?.sats < sats
-      const invoiceAttached = values.hash && values.hmac
-      if (insufficientFunds && !invoiceAttached) throw new Error('insufficient funds')
-      // payments from external wallets already have their own flow
-      // and we don't want to show undo toasts for them
-      const skipToastFlow = invoiceAttached
-      // update function for optimistic UX
-      const update = () => {
-        const fragment = {
-          id: `Item:${itemId}`,
-          fragment: gql`
-          fragment ItemMeSatsSubmit on Item {
-            path
-            sats
-            meSats
-            meDontLikeSats
-          }
-        `
-        }
-        const item = client.cache.readFragment(fragment)
-        const optimisticResponse = {
-          act: {
-            id: itemId, sats, path: item.path, act: down ? 'DONT_LIKE_THIS' : 'TIP'
-          }
-        }
-        actUpdate(client.cache, { data: optimisticResponse })
-        return () => client.cache.writeFragment({ ...fragment, data: item })
-      }
-      let undoUpdate
-      return {
-        skipToastFlow,
-        flowId,
-        tag: itemId,
-        type: 'zap',
-        pendingMessage: `${down ? 'down' : ''}zapped ${sats} sats`,
-        onPending: async () => {
-          if (skipToastFlow) {
-            return onSubmit(values, { flowId, ...args, update: null })
-          }
-          await strike()
-          onClose(sats)
-          return new Promise((resolve, reject) => {
-            undoUpdate = update()
-            setTimeout(() => {
-              if (canceled) return resolve()
-              onSubmit(values, { flowId, ...args, update: null, keepOpen: true })
-                .then(resolve)
-                .catch((err) => {
-                  undoUpdate()
-                  reject(err)
-                })
-            }, TOAST_DEFAULT_DELAY_MS)
-          })
-        },
-        onUndo: () => {
-          canceled = true
-          undoUpdate?.()
-        },
-        hideSuccess: true,
-        hideError: true,
-        timeout: TOAST_DEFAULT_DELAY_MS
-      }
-    }
-  )
-
+  // we need to wrap with PaymentProvider here since modals don't have access to PaymentContext by default
   return (
-    <Form
-      initial={{
-        amount: me?.privates?.tipDefault || defaultTips[0],
-        default: false
-      }}
-      schema={amountSchema}
-      invoiceable
-      onSubmit={(values, ...args) => {
-        if (zapUndosThresholdReached(me, values.amount)) {
-          return onSubmitWithUndos(values, ...args)
-        }
-        return onSubmit(values, ...args)
-      }}
-    >
-      <Input
-        label='amount'
-        name='amount'
-        type='number'
-        innerRef={inputRef}
-        overrideValue={oValue}
-        required
-        autoFocus
-        append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
-      />
-      <div>
-        <Tips setOValue={setOValue} />
-      </div>
-      {children}
-      <div className='d-flex mt-3'>
-        <SubmitButton variant={down ? 'danger' : 'success'} className='ms-auto mt-1 px-4' value='TIP'>{down && 'down'}zap</SubmitButton>
-      </div>
-    </Form>
+    <PaymentProvider>
+      <Form
+        initial={{
+          amount: me?.privates?.tipDefault || defaultTips[0],
+          default: false
+        }}
+        schema={amountSchema}
+        invoiceable
+        onSubmit={onSubmit}
+      >
+        <Input
+          label='amount'
+          name='amount'
+          type='number'
+          innerRef={inputRef}
+          overrideValue={oValue}
+          required
+          autoFocus
+          append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
+        />
+        <div>
+          <Tips setOValue={setOValue} />
+        </div>
+        {children}
+        <div className='d-flex mt-3'>
+          <SubmitButton variant={down ? 'danger' : 'success'} className='ms-auto mt-1 px-4' value='TIP'>{down && 'down'}zap</SubmitButton>
+        </div>
+      </Form>
+    </PaymentProvider>
   )
 }
 
@@ -256,7 +172,7 @@ export function useAct ({ onUpdate } = {}) {
         }
       }`, { update }
   )
-  return [act, update]
+  return act
 }
 
 export function useZap () {
@@ -309,116 +225,39 @@ export function useZap () {
 
   const [zap] = useMutation(
     gql`
-      mutation idempotentAct($id: ID!, $sats: Int!) {
-        act(id: $id, sats: $sats, idempotent: true) {
+      mutation idempotentAct($id: ID!, $sats: Int!, $hash: String, $hmac: String) {
+        act(id: $id, sats: $sats, hash: $hash, hmac: $hmac, idempotent: true) {
           id
           sats
           path
         }
-      }`
+      }`, { update }
   )
 
   const toaster = useToast()
   const strike = useLightning()
-  const [act] = useAct()
-  const client = useApolloClient()
-
-  const invoiceableAct = useInvoiceModal(
-    async ({ hash, hmac }, { variables, ...apolloArgs }) => {
-      await act({ variables: { ...variables, hash, hmac }, ...apolloArgs })
-      strike()
-    }, [act, strike])
-
-  const zapWithUndos = withToastFlow(toaster)(
-    ({ variables, optimisticResponse, update, flowId }) => {
-      const { id: itemId, amount } = variables
-      let canceled
-      // update function for optimistic UX
-      const _update = () => {
-        const fragment = {
-          id: `Item:${itemId}`,
-          fragment: gql`
-          fragment ItemMeSatsUndos on Item {
-            sats
-            meSats
-          }
-        `
-        }
-        const item = client.cache.readFragment(fragment)
-        update(client.cache, { data: optimisticResponse })
-        // undo function
-        return () => client.cache.writeFragment({ ...fragment, data: item })
-      }
-      let undoUpdate
-      return {
-        flowId,
-        tag: itemId,
-        type: 'zap',
-        pendingMessage: `zapped ${amount} sats`,
-        onPending: () =>
-          new Promise((resolve, reject) => {
-            undoUpdate = _update()
-            setTimeout(
-              () => {
-                if (canceled) return resolve()
-                zap({ variables, optimisticResponse, update: null }).then(resolve).catch((err) => {
-                  undoUpdate()
-                  reject(err)
-                })
-              },
-              TOAST_DEFAULT_DELAY_MS
-            )
-          }),
-        onUndo: () => {
-          // we can't simply clear the timeout on cancel since
-          // the onPending promise would never settle in that case
-          canceled = true
-          undoUpdate?.()
-        },
-        hideSuccess: true,
-        hideError: true,
-        timeout: TOAST_DEFAULT_DELAY_MS
-      }
-    }
-  )
+  const payment = usePayment()
 
   return useCallback(async ({ item, me }) => {
     const meSats = (item?.meSats || 0)
 
     // add current sats to next tip since idempotent zaps use desired total zap not difference
     const sats = meSats + nextTip(meSats, { ...me?.privates })
-    const amount = sats - meSats
 
-    const variables = { id: item.id, sats, act: 'TIP', amount }
-    const insufficientFunds = me?.privates.sats < amount
-    const optimisticResponse = { act: { path: item.path, ...variables } }
-    const flowId = (+new Date()).toString(16)
-    const zapArgs = { variables, optimisticResponse: insufficientFunds ? null : optimisticResponse, update, flowId }
+    let hash, hmac, cancel
     try {
-      if (insufficientFunds) throw new Error('insufficient funds')
+      [{ hash, hmac }, cancel] = await payment.request(sats - meSats)
+      const variables = { id: item.id, sats, act: 'TIP', hash, hmac }
+      const optimisticResponse = { act: { path: item.path, ...variables } }
+      await zap({ variables, optimisticResponse })
       strike()
-      if (zapUndosThresholdReached(me, amount)) {
-        await zapWithUndos(zapArgs)
-      } else {
-        await zap(zapArgs)
-      }
     } catch (error) {
-      if (payOrLoginError(error)) {
-        // call non-idempotent version
-        const amount = sats - meSats
-        optimisticResponse.act.amount = amount
-        try {
-          await invoiceableAct({ amount }, {
-            variables: { ...variables, sats: amount },
-            optimisticResponse,
-            update,
-            flowId
-          })
-        } catch (error) {}
+      if (error instanceof InvoiceCanceledError) {
         return
       }
       console.error(error)
       toaster.danger('zap: ' + error?.message || error?.toString?.())
+      cancel?.()
     }
-  })
+  }, [strike, payment])
 }

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -55,11 +55,6 @@ export default function ItemAct ({ onClose, item, down, children }) {
   const act = useAct()
 
   const onSubmit = useCallback(async ({ amount, hash, hmac }) => {
-    if (!me) {
-      const storageKey = `TIP-item:${item.id}`
-      const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
-      window.localStorage.setItem(storageKey, existingAmount + amount)
-    }
     await act({
       variables: {
         id: item.id,
@@ -114,7 +109,17 @@ export default function ItemAct ({ onClose, item, down, children }) {
 }
 
 export const actUpdate = (cache, { id, sats, path, act }, { me }) => {
+  const updateItemMeAnonSats = (id, sats) => {
+    if (!me) {
+      const storageKey = `TIP-item:${id}`
+      const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
+      window.localStorage.setItem(storageKey, existingAmount + sats)
+    }
+  }
+
   const updateItemSats = (id, sats) => {
+    if (!me) updateItemMeAnonSats(id, sats)
+
     cache.modify({
       id: `Item:${id}`,
       fields: {

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -8,7 +8,7 @@ import { amountSchema } from '@/lib/validate'
 import { gql, useApolloClient, useMutation } from '@apollo/client'
 import { useLightning } from './lightning'
 import { nextTip } from './upvote'
-import { InvoiceCanceledError, PaymentProvider, usePayment } from './payment'
+import { InvoiceCanceledError, usePayment } from './payment'
 import { ZAP_UNDO_DELAY } from '@/lib/constants'
 import { NotificationType, useNotifications } from './notifications'
 import { useToast } from './toast'
@@ -93,50 +93,47 @@ export default function ItemAct ({ onClose, item, down, children, abortSignal })
     return revert
   }, [cache, strike, onClose, abortSignal])
 
-  // we need to wrap with PaymentProvider here since modals don't have access to PaymentContext by default
   return (
-    <PaymentProvider>
-      <Form
-        initial={{
-          amount: me?.privates?.tipDefault || defaultTips[0],
-          default: false
-        }}
-        schema={amountSchema}
-        invoiceable
-        onSubmit={onSubmit}
-        optimisticUpdate={optimisticUpdate}
-        onError={me
-          ? ({ reason, amount }) => {
-              notify(NotificationType.ZapError, { reason, amount, itemId: item.id })
-            }
-          : undefined}
-        beforeSubmit={({ amount }) => {
-          const nid = notify(NotificationType.ZapPending, { amount, itemId: item.id }, false)
-          return { nid }
-        }}
-        afterSubmit={({ amount, nid }) => {
-          unnotify(nid)
-        }}
-      >
-        <Input
-          label='amount'
-          name='amount'
-          type='number'
-          innerRef={inputRef}
-          overrideValue={oValue}
-          required
-          autoFocus
-          append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
-        />
-        <div>
-          <Tips setOValue={setOValue} />
-        </div>
-        {children}
-        <div className='d-flex mt-3'>
-          <SubmitButton variant={down ? 'danger' : 'success'} className='ms-auto mt-1 px-4' value='TIP'>{down && 'down'}zap</SubmitButton>
-        </div>
-      </Form>
-    </PaymentProvider>
+    <Form
+      initial={{
+        amount: me?.privates?.tipDefault || defaultTips[0],
+        default: false
+      }}
+      schema={amountSchema}
+      invoiceable
+      onSubmit={onSubmit}
+      optimisticUpdate={optimisticUpdate}
+      onError={me
+        ? ({ reason, amount }) => {
+            notify(NotificationType.ZapError, { reason, amount, itemId: item.id })
+          }
+        : undefined}
+      beforeSubmit={({ amount }) => {
+        const nid = notify(NotificationType.ZapPending, { amount, itemId: item.id }, false)
+        return { nid }
+      }}
+      afterSubmit={({ amount, nid }) => {
+        unnotify(nid)
+      }}
+    >
+      <Input
+        label='amount'
+        name='amount'
+        type='number'
+        innerRef={inputRef}
+        overrideValue={oValue}
+        required
+        autoFocus
+        append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
+      />
+      <div>
+        <Tips setOValue={setOValue} />
+      </div>
+      {children}
+      <div className='d-flex mt-3'>
+        <SubmitButton variant={down ? 'danger' : 'success'} className='ms-auto mt-1 px-4' value='TIP'>{down && 'down'}zap</SubmitButton>
+      </div>
+    </Form>
   )
 }
 

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -70,7 +70,7 @@ export default function ItemAct ({ onClose, item, down, children, abortSignal })
       addCustomTip(Number(amount))
       persistItemPendingSats({ ...item, act: down ? 'DONT_LIKE_THIS' : 'TIP', sats: -amount })
     } finally {
-      abortSignal.done()
+      abortSignal?.done()
     }
   }, [me, act, down, item.id, strike, onClose, abortSignal])
 
@@ -78,7 +78,7 @@ export default function ItemAct ({ onClose, item, down, children, abortSignal })
     onClose()
     strike()
     const revert = actOptimisticUpdate(cache, { ...item, sats: Number(amount), act: down ? 'DONT_LIKE_THIS' : 'TIP' }, { me })
-    abortSignal.start()
+    abortSignal?.start()
     if (zapUndoTrigger(me, amount)) {
       try {
         await zapUndo(abortSignal)
@@ -87,7 +87,7 @@ export default function ItemAct ({ onClose, item, down, children, abortSignal })
         throw err
       }
     } else {
-      abortSignal.done()
+      abortSignal?.done()
     }
     return revert
   }, [cache, strike, onClose, abortSignal])
@@ -285,12 +285,12 @@ export function useZap () {
       const variables = { path: item.path, id: item.id, sats, act }
       revert = zapOptimisticUpdate(cache, variables, { me })
       strike()
-      abortSignal.start()
+      abortSignal?.start()
       nid = notify(NotificationType.ZapPending, { amount: sats - meSats, itemId: item.id }, false)
       if (zapUndoTrigger(me, sats)) {
         await zapUndo(abortSignal)
       } else {
-        abortSignal.done()
+        abortSignal?.done()
       }
       let hash, hmac;
       [{ hash, hmac }, cancel] = await payment.request(sats - meSats)
@@ -305,7 +305,7 @@ export function useZap () {
       notify(NotificationType.ZapError, { reason, amount: sats - meSats, itemId: item.id })
       cancel?.()
     } finally {
-      abortSignal.done()
+      abortSignal?.done()
       unnotify(nid)
     }
   }, [strike, payment])

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -146,7 +146,7 @@ const updateItemSats = (cache, { id, path, act, sats }, { me }) => {
     // in that case, it is important that we first revert the persisted sats
     // before calling cache.modify since cache.modify will trigger field reads
     // and thus persisted sats will be counted
-    if (!me) persistItemAnonSats({ id, sats })
+    if (!me) persistItemAnonSats({ id, path, act, sats })
     else persistItemPendingSats({ id, path, act, sats })
   }
 

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -34,7 +34,6 @@ export default function ItemInfo ({
   const [canEdit, setCanEdit] =
     useState(item.mine && (Date.now() < editThreshold))
   const [hasNewComments, setHasNewComments] = useState(false)
-  const [meTotalSats, setMeTotalSats] = useState(0)
   const root = useRoot()
   const sub = item?.sub || root?.sub
 
@@ -43,10 +42,6 @@ export default function ItemInfo ({
       setHasNewComments(newComments(item))
     }
   }, [item])
-
-  useEffect(() => {
-    if (item) setMeTotalSats((item.meSats || 0) + (item.meAnonSats || 0))
-  }, [item?.meSats, item?.meAnonSats])
 
   // territory founders can pin any post in their territory
   // and OPs can pin any root reply in their post
@@ -66,7 +61,7 @@ export default function ItemInfo ({
             unitPlural: 'stackers'
           })} ${item.mine
             ? `\\ ${numWithUnits(item.meSats, { abbreviate: false })} to post`
-            : `(${numWithUnits(meTotalSats, { abbreviate: false })}${item.meDontLikeSats
+            : `(${numWithUnits(item.meSats, { abbreviate: false })}${item.meDontLikeSats
               ? ` & ${numWithUnits(item.meDontLikeSats, { abbreviate: false, unitSingular: 'downsat', unitPlural: 'downsats' })}`
               : ''} from me)`} `}
           >
@@ -174,7 +169,7 @@ export default function ItemInfo ({
               <CrosspostDropdownItem item={item} />}
             {me && !item.position &&
             !item.mine && !item.deletedAt &&
-            (item.meDontLikeSats > meTotalSats
+            (item.meDontLikeSats > item.meSats
               ? <DropdownItemUpVote item={item} />
               : <DontLikeThisDropdownItem id={item.id} />)}
             {me && sub && !item.mine && !item.outlawed && Number(me.id) === Number(sub.userId) && sub.moderated &&

--- a/components/job-form.js
+++ b/components/job-form.js
@@ -104,7 +104,8 @@ export default function JobForm ({ item, sub }) {
         }}
         schema={jobSchema}
         storageKeyPrefix={storageKeyPrefix}
-        invoiceable={{ requireSession: true }}
+        requireSession
+        invoiceable
         onSubmit={onSubmit}
       >
         <div className='form-group'>

--- a/components/modal.js
+++ b/components/modal.js
@@ -3,6 +3,7 @@ import Modal from 'react-bootstrap/Modal'
 import BackArrow from '@/svgs/arrow-left-line.svg'
 import { useRouter } from 'next/router'
 import ActionDropdown from './action-dropdown'
+import { PaymentProvider } from './payment'
 
 export const ShowModalContext = createContext(() => null)
 
@@ -56,26 +57,28 @@ export default function useModal () {
     }
     const className = modalOptions?.fullScreen ? 'fullscreen' : ''
     return (
-      <Modal
-        onHide={modalOptions?.keepOpen ? null : onClose} show={!!modalContent}
-        className={className}
-        dialogClassName={className}
-        contentClassName={className}
-      >
-        <div className='d-flex flex-row'>
-          {modalOptions?.overflow &&
-            <div className={'modal-btn modal-overflow ' + className}>
-              <ActionDropdown>
-                {modalOptions.overflow}
-              </ActionDropdown>
-            </div>}
-          {modalStack.length > 0 ? <div className='modal-btn modal-back' onClick={onBack}><BackArrow width={18} height={18} className='fill-white' /></div> : null}
-          <div className={'modal-btn modal-close ' + className} onClick={onClose}>X</div>
-        </div>
-        <Modal.Body className={className}>
-          {modalContent}
-        </Modal.Body>
-      </Modal>
+      <PaymentProvider>
+        <Modal
+          onHide={modalOptions?.keepOpen ? null : onClose} show={!!modalContent}
+          className={className}
+          dialogClassName={className}
+          contentClassName={className}
+        >
+          <div className='d-flex flex-row'>
+            {modalOptions?.overflow &&
+              <div className={'modal-btn modal-overflow ' + className}>
+                <ActionDropdown>
+                  {modalOptions.overflow}
+                </ActionDropdown>
+              </div>}
+            {modalStack.length > 0 ? <div className='modal-btn modal-back' onClick={onBack}><BackArrow width={18} height={18} className='fill-white' /></div> : null}
+            <div className={'modal-btn modal-close ' + className} onClick={onClose}>X</div>
+          </div>
+          <Modal.Body className={className}>
+            {modalContent}
+          </Modal.Body>
+        </Modal>
+      </PaymentProvider>
     )
   }, [modalContent, onClose, modalOptions, onBack, modalStack])
 

--- a/components/modal.js
+++ b/components/modal.js
@@ -3,7 +3,6 @@ import Modal from 'react-bootstrap/Modal'
 import BackArrow from '@/svgs/arrow-left-line.svg'
 import { useRouter } from 'next/router'
 import ActionDropdown from './action-dropdown'
-import { PaymentProvider } from './payment'
 
 export const ShowModalContext = createContext(() => null)
 
@@ -57,28 +56,26 @@ export default function useModal () {
     }
     const className = modalOptions?.fullScreen ? 'fullscreen' : ''
     return (
-      <PaymentProvider>
-        <Modal
-          onHide={modalOptions?.keepOpen ? null : onClose} show={!!modalContent}
-          className={className}
-          dialogClassName={className}
-          contentClassName={className}
-        >
-          <div className='d-flex flex-row'>
-            {modalOptions?.overflow &&
-              <div className={'modal-btn modal-overflow ' + className}>
-                <ActionDropdown>
-                  {modalOptions.overflow}
-                </ActionDropdown>
-              </div>}
-            {modalStack.length > 0 ? <div className='modal-btn modal-back' onClick={onBack}><BackArrow width={18} height={18} className='fill-white' /></div> : null}
-            <div className={'modal-btn modal-close ' + className} onClick={onClose}>X</div>
-          </div>
-          <Modal.Body className={className}>
-            {modalContent}
-          </Modal.Body>
-        </Modal>
-      </PaymentProvider>
+      <Modal
+        onHide={modalOptions?.keepOpen ? null : onClose} show={!!modalContent}
+        className={className}
+        dialogClassName={className}
+        contentClassName={className}
+      >
+        <div className='d-flex flex-row'>
+          {modalOptions?.overflow &&
+            <div className={'modal-btn modal-overflow ' + className}>
+              <ActionDropdown>
+                {modalOptions.overflow}
+              </ActionDropdown>
+            </div>}
+          {modalStack.length > 0 ? <div className='modal-btn modal-back' onClick={onBack}><BackArrow width={18} height={18} className='fill-white' /></div> : null}
+          <div className={'modal-btn modal-close ' + className} onClick={onClose}>X</div>
+        </div>
+        <Modal.Body className={className}>
+          {modalContent}
+        </Modal.Body>
+      </Modal>
     )
   }, [modalContent, onClose, modalOptions, onBack, modalStack])
 

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -596,7 +596,13 @@ const NotificationContext = createContext()
 const storageKey = 'notifications'
 function loadNotifications () {
   const stored = window.localStorage.getItem(storageKey)
-  return stored ? JSON.parse(stored) : []
+  if (!stored) return []
+  const filtered = JSON.parse(stored).filter(({ sortTime }) => {
+    // only keep notifications younger than 24 hours
+    return new Date(sortTime) >= datePivot(new Date(), { hours: -24 })
+  })
+  window.localStorage.setItem(storageKey, JSON.stringify(filtered))
+  return filtered
 }
 function saveNotification (n) {
   const stored = window.localStorage.getItem(storageKey)

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -611,7 +611,7 @@ export function NotificationProvider ({ children }) {
 
   const notify = useCallback((type, props, hasNewNotes = true) => {
     const id = crypto.randomUUID()
-    const n = { __typename: type, id, ...props }
+    const n = { __typename: type, id, createdAt: +new Date(), ...props }
     setNotifications(notifications => [n, ...notifications])
     saveNotification(n)
     if (hasNewNotes) {
@@ -649,6 +649,7 @@ export function ZapError ({ n }) {
       <div className='w-100 me-1'>
         <div className='fw-bold text-danger'>
           failed to zap {n.amount} sats: {n.reason}
+          <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.createdAt))}</small>
         </div>
         {n.item.title
           ? <Item item={n.item} />
@@ -674,6 +675,7 @@ export function ZapPending ({ n }) {
       <div className='w-100 me-1'>
         <div className='fw-bold text-info'>
           zap of {n.amount} sats pending
+          <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.createdAt))}</small>
         </div>
         {n.item.title
           ? <Item item={n.item} />

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -30,6 +30,7 @@ import { nextBillingWithGrace } from '@/lib/territory'
 import { commentSubTreeRootId } from '@/lib/item'
 import LinkToContext from './link-to-context'
 import { Badge } from 'react-bootstrap'
+import { ITEM_FULL } from '@/fragments/items'
 
 export const NotificationType = {
   ZapError: 'ZAP_ERROR',
@@ -606,7 +607,14 @@ export function NotificationProvider ({ children }) {
   const client = useApolloClient()
 
   useEffect(() => {
-    setNotifications(loadNotifications())
+    const loaded = loadNotifications()
+    // populate cache with items
+    loaded.forEach(({ item }) => {
+      if (item?.id) {
+        client.query({ query: ITEM_FULL, variables: { id: item.id }, fetchPolicy: 'cache-first' })
+      }
+    })
+    setNotifications(loaded)
   }, [])
 
   const notify = useCallback((type, props, hasNewNotes = true) => {

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -677,10 +677,10 @@ export function useNotifications () {
 function ClientNotification ({ n, title, variant }) {
   return (
     <div className='ms-2'>
-      <div className={`fw-bold text-${variant}`}>
+      <small className={`fw-bold text-${variant}`}>
         {title}
         <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.sortTime))}</small>
-      </div>
+      </small>
       {!n.item
         ? null
         : n.item.title

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -700,12 +700,11 @@ function ZapError ({ n }) {
 }
 
 function ZapPending ({ n }) {
-  const title = `zap of ${n.amount} sats pending`
   const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
   if (expired) {
     return <ZapError n={{ ...n, reason: 'invoice expired' }} />
   }
-  return <ClientNotification n={n} title={title} variant='info' />
+  return null
 }
 
 function ReplyError ({ n }) {
@@ -714,12 +713,11 @@ function ReplyError ({ n }) {
 }
 
 function ReplyPending ({ n }) {
-  const title = 'reply pending'
   const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
   if (expired) {
     return <ReplyError n={{ ...n, reason: 'invoice expired' }} />
   }
-  return <ClientNotification n={n} title={title} variant='info' />
+  return null
 }
 
 function BountyError ({ n }) {
@@ -728,12 +726,11 @@ function BountyError ({ n }) {
 }
 
 function BountyPending ({ n }) {
-  const title = 'bounty payment pending'
   const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
   if (expired) {
     return <BountyError n={{ ...n, reason: 'invoice expired' }} />
   }
-  return <ClientNotification n={n} title={title} variant='info' />
+  return null
 }
 
 function PollVoteError ({ n }) {
@@ -742,10 +739,9 @@ function PollVoteError ({ n }) {
 }
 
 function PollVotePending ({ n }) {
-  const title = 'poll vote pending'
   const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
   if (expired) {
     return <PollVoteError n={{ ...n, reason: 'invoice expired' }} />
   }
-  return <ClientNotification n={n} title={title} variant='info' />
+  return null
 }

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -38,7 +38,9 @@ export const NotificationType = {
   ReplyError: 'REPLY_ERROR',
   ReplyPending: 'REPLY_PENDING',
   BountyError: 'BOUNTY_ERROR',
-  BountyPending: 'BOUNTY_PENDING'
+  BountyPending: 'BOUNTY_PENDING',
+  PollVoteError: 'POLL_VOTE_ERROR',
+  PollVotePending: 'POLL_VOTE_PENDING'
 }
 
 function Notification ({ n, fresh }) {
@@ -68,7 +70,9 @@ function Notification ({ n, fresh }) {
         (type === NotificationType.ReplyError && <ReplyError n={n} />) ||
         (type === NotificationType.ReplyPending && <ReplyPending n={n} />) ||
         (type === NotificationType.BountyError && <BountyError n={n} />) ||
-        (type === NotificationType.BountyPending && <BountyPending n={n} />)
+        (type === NotificationType.BountyPending && <BountyPending n={n} />) ||
+        (type === NotificationType.PollVotePending && <PollVotePending n={n} />) ||
+        (type === NotificationType.PollVoteError && <PollVoteError n={n} />)
       }
     </NotificationLayout>
   )
@@ -122,6 +126,8 @@ const defaultOnClick = n => {
   if (type === NotificationType.ReplyPending) return {}
   if (type === NotificationType.BountyError) return {}
   if (type === NotificationType.BountyPending) return {}
+  if (type === NotificationType.PollVoteError) return {}
+  if (type === NotificationType.PollVotePending) return {}
 
   // Votification, Mention, JobChanged, Reply all have item
   if (!n.item.title) {
@@ -726,6 +732,20 @@ function BountyPending ({ n }) {
   const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
   if (expired) {
     return <BountyError n={{ ...n, reason: 'invoice expired' }} />
+  }
+  return <ClientNotification n={n} title={title} variant='info' />
+}
+
+function PollVoteError ({ n }) {
+  const title = `failed to submit poll vote: ${n.reason}`
+  return <ClientNotification n={n} title={title} variant='danger' />
+}
+
+function PollVotePending ({ n }) {
+  const title = 'poll vote pending'
+  const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
+  if (expired) {
+    return <PollVoteError n={{ ...n, reason: 'invoice expired' }} />
   }
   return <ClientNotification n={n} title={title} variant='info' />
 }

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -36,7 +36,9 @@ export const NotificationType = {
   ZapError: 'ZAP_ERROR',
   ZapPending: 'ZAP_PENDING',
   ReplyError: 'REPLY_ERROR',
-  ReplyPending: 'REPLY_PENDING'
+  ReplyPending: 'REPLY_PENDING',
+  BountyError: 'BOUNTY_ERROR',
+  BountyPending: 'BOUNTY_PENDING'
 }
 
 function Notification ({ n, fresh }) {
@@ -64,7 +66,9 @@ function Notification ({ n, fresh }) {
         (type === NotificationType.ZapError && <ZapError n={n} />) ||
         (type === NotificationType.ZapPending && <ZapPending n={n} />) ||
         (type === NotificationType.ReplyError && <ReplyError n={n} />) ||
-        (type === NotificationType.ReplyPending && <ReplyPending n={n} />)
+        (type === NotificationType.ReplyPending && <ReplyPending n={n} />) ||
+        (type === NotificationType.BountyError && <BountyError n={n} />) ||
+        (type === NotificationType.BountyPending && <BountyPending n={n} />)
       }
     </NotificationLayout>
   )
@@ -116,6 +120,8 @@ const defaultOnClick = n => {
   if (type === NotificationType.ZapPending) return {}
   if (type === NotificationType.ReplyError) return {}
   if (type === NotificationType.ReplyPending) return {}
+  if (type === NotificationType.BountyError) return {}
+  if (type === NotificationType.BountyPending) return {}
 
   // Votification, Mention, JobChanged, Reply all have item
   if (!n.item.title) {
@@ -706,6 +712,20 @@ function ReplyPending ({ n }) {
   const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
   if (expired) {
     return <ReplyError n={{ ...n, reason: 'invoice expired' }} />
+  }
+  return <ClientNotification n={n} title={title} variant='info' />
+}
+
+function BountyError ({ n }) {
+  const title = `failed to pay bounty: ${n.reason}`
+  return <ClientNotification n={n} title={title} variant='danger' />
+}
+
+function BountyPending ({ n }) {
+  const title = 'bounty payment pending'
+  const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
+  if (expired) {
+    return <BountyError n={{ ...n, reason: 'invoice expired' }} />
   }
   return <ClientNotification n={n} title={title} variant='info' />
 }

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -564,9 +564,12 @@ export default function Notifications ({ ssrData }) {
 
   if (!dat) return <CommentsFlatSkeleton />
 
+  const sorted = [...clientSideNotifications, ...notifications]
+    .sort((a, b) => new Date(b.sortTime).getTime() - new Date(a.sortTime).getTime())
+
   return (
     <>
-      {[...clientSideNotifications, ...notifications].map(n =>
+      {sorted.map(n =>
         <Notification
           n={n} key={nid(n)}
           fresh={new Date(n.sortTime) > new Date(router?.query?.checkedAt ?? lastChecked)}
@@ -629,7 +632,7 @@ export function NotificationProvider ({ children }) {
 
   const notify = useCallback((type, props, hasNewNotes = true) => {
     const id = crypto.randomUUID()
-    const n = { __typename: type, id, createdAt: +new Date(), ...props }
+    const n = { __typename: type, id, sortTime: +new Date(), ...props }
     setNotifications(notifications => [n, ...notifications])
     saveNotification(n)
     if (hasNewNotes) {
@@ -665,7 +668,7 @@ function ClientNotification ({ n, title, variant }) {
     <div className='ms-2'>
       <div className={`fw-bold text-${variant}`}>
         {title}
-        <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.createdAt))}</small>
+        <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.sortTime))}</small>
       </div>
       {n.item.title
         ? <Item item={n.item} />
@@ -686,7 +689,7 @@ function ZapError ({ n }) {
 }
 
 function ZapPending ({ n }) {
-  const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
+  const expired = n.sortTime < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
   if (expired) {
     return <ZapError n={{ ...n, reason: 'invoice expired' }} />
   }
@@ -699,7 +702,7 @@ function ReplyError ({ n }) {
 }
 
 function ReplyPending ({ n }) {
-  const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
+  const expired = n.sortTime < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
   if (expired) {
     return <ReplyError n={{ ...n, reason: 'invoice expired' }} />
   }
@@ -712,7 +715,7 @@ function BountyError ({ n }) {
 }
 
 function BountyPending ({ n }) {
-  const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
+  const expired = n.sortTime < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
   if (expired) {
     return <BountyError n={{ ...n, reason: 'invoice expired' }} />
   }
@@ -725,7 +728,7 @@ function PollVoteError ({ n }) {
 }
 
 function PollVotePending ({ n }) {
-  const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
+  const expired = n.sortTime < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
   if (expired) {
     return <PollVoteError n={{ ...n, reason: 'invoice expired' }} />
   }

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -34,7 +34,9 @@ import { ITEM_FULL } from '@/fragments/items'
 
 export const NotificationType = {
   ZapError: 'ZAP_ERROR',
-  ZapPending: 'ZAP_PENDING'
+  ZapPending: 'ZAP_PENDING',
+  ReplyError: 'REPLY_ERROR',
+  ReplyPending: 'REPLY_PENDING'
 }
 
 function Notification ({ n, fresh }) {
@@ -60,7 +62,9 @@ function Notification ({ n, fresh }) {
         (type === 'TerritoryPost' && <TerritoryPost n={n} />) ||
         (type === 'TerritoryTransfer' && <TerritoryTransfer n={n} />) ||
         (type === NotificationType.ZapError && <ZapError n={n} />) ||
-        (type === NotificationType.ZapPending && <ZapPending n={n} />)
+        (type === NotificationType.ZapPending && <ZapPending n={n} />) ||
+        (type === NotificationType.ReplyError && <ReplyError n={n} />) ||
+        (type === NotificationType.ReplyPending && <ReplyPending n={n} />)
       }
     </NotificationLayout>
   )
@@ -110,6 +114,8 @@ const defaultOnClick = n => {
   if (type === 'TerritoryTransfer') return { href: `/~${n.sub.name}` }
   if (type === NotificationType.ZapError) return {}
   if (type === NotificationType.ZapPending) return {}
+  if (type === NotificationType.ReplyError) return {}
+  if (type === NotificationType.ReplyPending) return {}
 
   // Votification, Mention, JobChanged, Reply all have item
   if (!n.item.title) {
@@ -683,6 +689,58 @@ function ZapPending ({ n }) {
       <div className='w-100 me-1'>
         <div className='fw-bold text-info'>
           zap of {n.amount} sats pending
+          <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.createdAt))}</small>
+        </div>
+        {n.item.title
+          ? <Item item={n.item} />
+          : (
+            <div className='pb-2'>
+              <RootProvider root={n.item.root}>
+                <Comment item={n.item} noReply includeParent noComments clickToContext />
+              </RootProvider>
+            </div>
+            )}
+      </div>
+      <div className={styles.close} onClick={() => unnotify(n.id)}>
+        X
+      </div>
+    </div>
+  )
+}
+
+function ReplyError ({ n }) {
+  const { unnotify } = useNotifications()
+  return (
+    <div className='d-flex ms-2'>
+      <div className='w-100 me-1'>
+        <div className='fw-bold text-danger'>
+          failed to submit reply: {n.reason}
+          <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.createdAt))}</small>
+        </div>
+        {n.item.title
+          ? <Item item={n.item} />
+          : (
+            <div className='pb-2'>
+              <RootProvider root={n.item.root}>
+                <Comment item={n.item} noReply includeParent noComments clickToContext />
+              </RootProvider>
+            </div>
+            )}
+      </div>
+      <div className={styles.close} onClick={() => unnotify(n.id)}>
+        X
+      </div>
+    </div>
+  )
+}
+
+function ReplyPending ({ n }) {
+  const { unnotify } = useNotifications()
+  return (
+    <div className='d-flex ms-2'>
+      <div className='w-100 me-1'>
+        <div className='fw-bold text-info'>
+          reply pending
           <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.createdAt))}</small>
         </div>
         {n.item.title

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -650,7 +650,7 @@ export function useNotifications () {
   return useContext(NotificationContext)
 }
 
-export function ZapError ({ n }) {
+function ZapError ({ n }) {
   const { unnotify } = useNotifications()
   return (
     <div className='d-flex ms-2'>
@@ -676,7 +676,7 @@ export function ZapError ({ n }) {
   )
 }
 
-export function ZapPending ({ n }) {
+function ZapPending ({ n }) {
   const { unnotify } = useNotifications()
   return (
     <div className='d-flex ms-2'>

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -6,7 +6,7 @@ import ItemJob from './item-job'
 import { HAS_NOTIFICATIONS, NOTIFICATIONS } from '@/fragments/notifications'
 import MoreFooter from './more-footer'
 import Invite from './invite'
-import { dayMonthYear, timeSince } from '@/lib/time'
+import { datePivot, dayMonthYear, timeSince } from '@/lib/time'
 import Link from 'next/link'
 import Check from '@/svgs/check-double-line.svg'
 import HandCoin from '@/svgs/hand-coin-fill.svg'
@@ -689,6 +689,10 @@ function ZapError ({ n }) {
 
 function ZapPending ({ n }) {
   const title = `zap of ${n.amount} sats pending`
+  const expired = n.createdAt < datePivot(new Date(), { seconds: -180_000 })
+  if (expired) {
+    return <ZapError n={{ ...n, reason: 'invoice expired' }} />
+  }
   return <ClientNotification n={n} title={title} variant='info' />
 }
 
@@ -699,5 +703,9 @@ function ReplyError ({ n }) {
 
 function ReplyPending ({ n }) {
   const title = 'reply pending'
+  const expired = n.createdAt < datePivot(new Date(), { seconds: -180_000 })
+  if (expired) {
+    return <ReplyError n={{ ...n, reason: 'invoice expired' }} />
+  }
   return <ClientNotification n={n} title={title} variant='info' />
 }

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -120,14 +120,6 @@ const defaultOnClick = n => {
   if (type === 'Referral') return { href: '/referrals/month' }
   if (type === 'Streak') return {}
   if (type === 'TerritoryTransfer') return { href: `/~${n.sub.name}` }
-  if (type === NotificationType.ZapError) return {}
-  if (type === NotificationType.ZapPending) return {}
-  if (type === NotificationType.ReplyError) return {}
-  if (type === NotificationType.ReplyPending) return {}
-  if (type === NotificationType.BountyError) return {}
-  if (type === NotificationType.BountyPending) return {}
-  if (type === NotificationType.PollVoteError) return {}
-  if (type === NotificationType.PollVotePending) return {}
 
   // Votification, Mention, JobChanged, Reply all have item
   if (!n.item.title) {
@@ -669,27 +661,21 @@ export function useNotifications () {
 }
 
 function ClientNotification ({ n, title, variant }) {
-  const { unnotify } = useNotifications()
   return (
-    <div className='d-flex ms-2'>
-      <div className='w-100 me-1'>
-        <div className={`fw-bold text-${variant}`}>
-          {title}
-          <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.createdAt))}</small>
-        </div>
-        {n.item.title
-          ? <Item item={n.item} />
-          : (
-            <div className='pb-2'>
-              <RootProvider root={n.item.root}>
-                <Comment item={n.item} noReply includeParent noComments clickToContext />
-              </RootProvider>
-            </div>
-            )}
+    <div className='ms-2'>
+      <div className={`fw-bold text-${variant}`}>
+        {title}
+        <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.createdAt))}</small>
       </div>
-      <div className={styles.close} onClick={() => unnotify(n.id)}>
-        X
-      </div>
+      {n.item.title
+        ? <Item item={n.item} />
+        : (
+          <div className='pb-2'>
+            <RootProvider root={n.item.root}>
+              <Comment item={n.item} noReply includeParent noComments clickToContext />
+            </RootProvider>
+          </div>
+          )}
     </div>
   )
 }

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -10,7 +10,7 @@ import { datePivot, dayMonthYear, timeSince } from '@/lib/time'
 import Link from 'next/link'
 import Check from '@/svgs/check-double-line.svg'
 import HandCoin from '@/svgs/hand-coin-fill.svg'
-import { LOST_BLURBS, FOUND_BLURBS, UNKNOWN_LINK_REL } from '@/lib/constants'
+import { LOST_BLURBS, FOUND_BLURBS, UNKNOWN_LINK_REL, JIT_INVOICE_TIMEOUT_MS } from '@/lib/constants'
 import CowboyHatIcon from '@/svgs/cowboy.svg'
 import BaldIcon from '@/svgs/bald.svg'
 import { RootProvider } from './root'
@@ -689,7 +689,7 @@ function ZapError ({ n }) {
 
 function ZapPending ({ n }) {
   const title = `zap of ${n.amount} sats pending`
-  const expired = n.createdAt < datePivot(new Date(), { seconds: -180_000 })
+  const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
   if (expired) {
     return <ZapError n={{ ...n, reason: 'invoice expired' }} />
   }
@@ -703,7 +703,7 @@ function ReplyError ({ n }) {
 
 function ReplyPending ({ n }) {
   const title = 'reply pending'
-  const expired = n.createdAt < datePivot(new Date(), { seconds: -180_000 })
+  const expired = n.createdAt < datePivot(new Date(), { seconds: -JIT_INVOICE_TIMEOUT_MS })
   if (expired) {
     return <ReplyError n={{ ...n, reason: 'invoice expired' }} />
   }

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -656,13 +656,13 @@ export function useNotifications () {
   return useContext(NotificationContext)
 }
 
-function ZapError ({ n }) {
+function ClientNotification ({ n, title, variant }) {
   const { unnotify } = useNotifications()
   return (
     <div className='d-flex ms-2'>
       <div className='w-100 me-1'>
-        <div className='fw-bold text-danger'>
-          failed to zap {n.amount} sats: {n.reason}
+        <div className={`fw-bold text-${variant}`}>
+          {title}
           <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.createdAt))}</small>
         </div>
         {n.item.title
@@ -680,82 +680,24 @@ function ZapError ({ n }) {
       </div>
     </div>
   )
+}
+
+function ZapError ({ n }) {
+  const title = `failed to zap ${n.amount} sats: ${n.reason}`
+  return <ClientNotification n={n} title={title} variant='danger' />
 }
 
 function ZapPending ({ n }) {
-  const { unnotify } = useNotifications()
-  return (
-    <div className='d-flex ms-2'>
-      <div className='w-100 me-1'>
-        <div className='fw-bold text-info'>
-          zap of {n.amount} sats pending
-          <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.createdAt))}</small>
-        </div>
-        {n.item.title
-          ? <Item item={n.item} />
-          : (
-            <div className='pb-2'>
-              <RootProvider root={n.item.root}>
-                <Comment item={n.item} noReply includeParent noComments clickToContext />
-              </RootProvider>
-            </div>
-            )}
-      </div>
-      <div className={styles.close} onClick={() => unnotify(n.id)}>
-        X
-      </div>
-    </div>
-  )
+  const title = `zap of ${n.amount} sats pending`
+  return <ClientNotification n={n} title={title} variant='info' />
 }
 
 function ReplyError ({ n }) {
-  const { unnotify } = useNotifications()
-  return (
-    <div className='d-flex ms-2'>
-      <div className='w-100 me-1'>
-        <div className='fw-bold text-danger'>
-          failed to submit reply: {n.reason}
-          <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.createdAt))}</small>
-        </div>
-        {n.item.title
-          ? <Item item={n.item} />
-          : (
-            <div className='pb-2'>
-              <RootProvider root={n.item.root}>
-                <Comment item={n.item} noReply includeParent noComments clickToContext />
-              </RootProvider>
-            </div>
-            )}
-      </div>
-      <div className={styles.close} onClick={() => unnotify(n.id)}>
-        X
-      </div>
-    </div>
-  )
+  const title = `failed to submit reply: ${n.reason}`
+  return <ClientNotification n={n} title={title} variant='danger' />
 }
 
 function ReplyPending ({ n }) {
-  const { unnotify } = useNotifications()
-  return (
-    <div className='d-flex ms-2'>
-      <div className='w-100 me-1'>
-        <div className='fw-bold text-info'>
-          reply pending
-          <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.createdAt))}</small>
-        </div>
-        {n.item.title
-          ? <Item item={n.item} />
-          : (
-            <div className='pb-2'>
-              <RootProvider root={n.item.root}>
-                <Comment item={n.item} noReply includeParent noComments clickToContext />
-              </RootProvider>
-            </div>
-            )}
-      </div>
-      <div className={styles.close} onClick={() => unnotify(n.id)}>
-        X
-      </div>
-    </div>
-  )
+  const title = 'reply pending'
+  return <ClientNotification n={n} title={title} variant='info' />
 }

--- a/components/notifications.module.css
+++ b/components/notifications.module.css
@@ -34,3 +34,14 @@
     vertical-align: middle;
     margin-left: 0.5rem;
 }
+
+.close {
+    font-family: "lightning";
+    cursor: pointer;
+    font-size: 150%;
+    color: #fff;
+}
+
+.close:hover {
+    opacity: 0.7;
+}

--- a/components/notifications.module.css
+++ b/components/notifications.module.css
@@ -34,14 +34,3 @@
     vertical-align: middle;
     margin-left: 0.5rem;
 }
-
-.close {
-    font-family: "lightning";
-    cursor: pointer;
-    font-size: 150%;
-    color: #fff;
-}
-
-.close:hover {
-    opacity: 0.7;
-}

--- a/components/pay-bounty.js
+++ b/components/pay-bounty.js
@@ -61,7 +61,7 @@ export default function PayBounty ({ children, item }) {
       const sats = root.bounty
       const variables = { id: item.id, sats, path: item.path, act: 'TIP' }
       revert = bountyPaidOptimisticUpdate(cache, variables, { me, onComplete })
-      nid = notify(NotificationType.BountyPending, { sats, item: { ...item, root } }, false);
+      nid = notify(NotificationType.BountyPending, { sats, itemId: item.id }, false);
       [{ hash, hmac }, cancel] = await payment.request(sats)
       await act({ variables: { ...variables, hash, hmac } })
     } catch (err) {
@@ -70,7 +70,7 @@ export default function PayBounty ({ children, item }) {
         return
       }
       const reason = err?.message || err?.toString?.()
-      notify(NotificationType.BountyError, { reason, sats: root.bounty, item: { ...item, root } })
+      notify(NotificationType.BountyError, { reason, sats: root.bounty, itemId: item.id })
       cancel?.()
     } finally {
       unnotify(nid)

--- a/components/payment.js
+++ b/components/payment.js
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo } from 'react'
+import { useCallback } from 'react'
 import { useMe } from './me'
 import { gql, useApolloClient, useMutation } from '@apollo/client'
 import { useWebLN } from './webln'
@@ -7,8 +7,6 @@ import { INVOICE } from '@/fragments/wallet'
 import Invoice from '@/components/invoice'
 import { useFeeButton } from './fee-button'
 import { useShowModal } from './modal'
-
-const PaymentContext = createContext()
 
 export class InvoiceCanceledError extends Error {
   constructor (hash) {
@@ -161,7 +159,7 @@ const useQrPayment = () => {
   return waitForQrPayment
 }
 
-export const PaymentProvider = ({ children }) => {
+export const usePayment = () => {
   const me = useMe()
   const feeButton = useFeeButton()
   const invoice = useInvoice()
@@ -207,14 +205,5 @@ export const PaymentProvider = ({ children }) => {
     }
   }, [invoice])
 
-  const value = useMemo(() => ({ request, cancel }), [request, cancel])
-  return (
-    <PaymentContext.Provider value={value}>
-      {children}
-    </PaymentContext.Provider>
-  )
-}
-
-export const usePayment = () => {
-  return useContext(PaymentContext)
+  return { request, cancel }
 }

--- a/components/payment.js
+++ b/components/payment.js
@@ -2,7 +2,7 @@ import { createContext, useCallback, useContext, useMemo } from 'react'
 import { useMe } from './me'
 import { gql, useApolloClient, useMutation } from '@apollo/client'
 import { useWebLN } from './webln'
-import { FAST_POLL_INTERVAL } from '@/lib/constants'
+import { FAST_POLL_INTERVAL, JIT_INVOICE_TIMEOUT_MS } from '@/lib/constants'
 import { INVOICE } from '@/fragments/wallet'
 import Invoice from '@/components/invoice'
 import { useFeeButton } from './fee-button'
@@ -35,8 +35,8 @@ const useInvoice = () => {
   const client = useApolloClient()
 
   const [createInvoice] = useMutation(gql`
-    mutation createInvoice($amount: Int!) {
-      createInvoice(amount: $amount, hodlInvoice: true, expireSecs: 180) {
+    mutation createInvoice($amount: Int!, $expireSecs: Int!) {
+      createInvoice(amount: $amount, hodlInvoice: true, expireSecs: $expireSecs) {
         id
         bolt11
         hash
@@ -54,7 +54,7 @@ const useInvoice = () => {
   `)
 
   const create = useCallback(async amount => {
-    const { data, error } = await createInvoice({ variables: { amount } })
+    const { data, error } = await createInvoice({ variables: { amount, expireSecs: JIT_INVOICE_TIMEOUT_MS / 1000 } })
     if (error) {
       throw error
     }

--- a/components/payment.js
+++ b/components/payment.js
@@ -24,6 +24,13 @@ export class WebLnNotEnabledError extends Error {
   }
 }
 
+export class InvoiceExpiredError extends Error {
+  constructor () {
+    super('invoice expired')
+    this.name = 'InvoiceExpiredError'
+  }
+}
+
 const useInvoice = () => {
   const client = useApolloClient()
 
@@ -166,8 +173,8 @@ export const PaymentProvider = ({ children }) => {
     try {
       return await waitForWebLnPayment(invoice)
     } catch (err) {
-      if (err instanceof InvoiceCanceledError) {
-        // bail since qr code payment will also fail if invoice was canceled
+      if (err instanceof InvoiceCanceledError || err instanceof InvoiceExpiredError) {
+        // bail since qr code payment will also fail
         throw err
       }
       webLnError = err

--- a/components/payment.js
+++ b/components/payment.js
@@ -12,7 +12,7 @@ const PaymentContext = createContext()
 
 export class InvoiceCanceledError extends Error {
   constructor (hash) {
-    super(`invoice canceled: ${hash}`, hash)
+    super(`invoice canceled: ${hash}`)
     this.name = 'InvoiceCanceledError'
   }
 }

--- a/components/payment.js
+++ b/components/payment.js
@@ -129,7 +129,7 @@ const useQrPayment = () => {
   const invoice = useInvoice()
   const showModal = useShowModal()
 
-  const waitForQrPayment = useCallback(async (inv) => {
+  const waitForQrPayment = useCallback(async (inv, webLnError) => {
     return await new Promise((resolve, reject) => {
       let paid
       const cancelAndReject = async (onClose) => {
@@ -143,6 +143,7 @@ const useQrPayment = () => {
           modal
           successVerb='received'
           webLn={false}
+          webLnError={webLnError}
           onPayment={() => { paid = true; onClose(); resolve() }}
           poll
         />,
@@ -161,6 +162,7 @@ export const PaymentProvider = ({ children }) => {
   const waitForQrPayment = useQrPayment()
 
   const waitForPayment = useCallback(async (invoice) => {
+    let webLnError
     try {
       return await waitForWebLnPayment(invoice)
     } catch (err) {
@@ -168,9 +170,9 @@ export const PaymentProvider = ({ children }) => {
         // bail since qr code payment will also fail if invoice was canceled
         throw err
       }
-      // ignore any other error and fallback to QR code
+      webLnError = err
     }
-    return await waitForQrPayment(invoice)
+    return await waitForQrPayment(invoice, webLnError)
   }, [waitForWebLnPayment, waitForQrPayment])
 
   const request = useCallback(async (amount) => {

--- a/components/payment.js
+++ b/components/payment.js
@@ -1,0 +1,211 @@
+import { createContext, useCallback, useContext, useMemo } from 'react'
+import { useMe } from './me'
+import { gql, useApolloClient, useMutation } from '@apollo/client'
+import { useWebLN } from './webln'
+import { FAST_POLL_INTERVAL } from '@/lib/constants'
+import { INVOICE } from '@/fragments/wallet'
+import Invoice from '@/components/invoice'
+import { useFeeButton } from './fee-button'
+import { useShowModal } from './modal'
+
+const PaymentContext = createContext()
+
+export class InvoiceCanceledError extends Error {
+  constructor (hash) {
+    super(`invoice canceled: ${hash}`, hash)
+    this.name = 'InvoiceCanceledError'
+  }
+}
+
+export class WebLnNotEnabledError extends Error {
+  constructor () {
+    super('no enabled WebLN provider found')
+    this.name = 'WebLnNotEnabledError'
+  }
+}
+
+const useInvoice = () => {
+  const client = useApolloClient()
+
+  const [createInvoice] = useMutation(gql`
+    mutation createInvoice($amount: Int!) {
+      createInvoice(amount: $amount, hodlInvoice: true, expireSecs: 180) {
+        id
+        bolt11
+        hash
+        hmac
+        expiresAt
+        satsRequested
+      }
+    }`)
+  const [cancelInvoice] = useMutation(gql`
+    mutation cancelInvoice($hash: String!, $hmac: String!) {
+      cancelInvoice(hash: $hash, hmac: $hmac) {
+        id
+      }
+    }
+  `)
+
+  const create = useCallback(async amount => {
+    const { data, error } = await createInvoice({ variables: { amount } })
+    if (error) {
+      throw error
+    }
+    const invoice = data.createInvoice
+    return invoice
+  }, [createInvoice])
+
+  const isPaid = useCallback(async id => {
+    const { data, error } = await client.query({ query: INVOICE, fetchPolicy: 'no-cache', variables: { id } })
+    if (error) {
+      throw error
+    }
+    const { hash, isHeld, satsReceived, cancelled } = data.invoice
+    // if we're polling for invoices, we're using JIT invoices so isHeld must be set
+    if (isHeld && satsReceived) {
+      return true
+    }
+    if (cancelled) {
+      throw new InvoiceCanceledError(hash)
+    }
+    return false
+  }, [client])
+
+  const waitUntilPaid = useCallback(async id => {
+    return await new Promise((resolve, reject) => {
+      const interval = setInterval(async () => {
+        try {
+          const paid = await isPaid(id)
+          if (paid) {
+            resolve()
+            clearInterval(interval)
+          }
+        } catch (err) {
+          reject(err)
+          clearInterval(interval)
+        }
+      }, FAST_POLL_INTERVAL)
+    })
+  }, [isPaid])
+
+  const cancel = useCallback(async ({ hash, hmac }) => {
+    return await cancelInvoice({ variables: { hash, hmac } })
+  }, [cancelInvoice])
+
+  return { create, isPaid, waitUntilPaid, cancel }
+}
+
+const useWebLnPayment = () => {
+  const invoice = useInvoice()
+  const provider = useWebLN()
+
+  const waitForWebLnPayment = useCallback(async ({ id, bolt11 }) => {
+    if (!provider) {
+      throw new WebLnNotEnabledError()
+    }
+    try {
+      return await new Promise((resolve, reject) => {
+        // can't use await here since we might pay JIT invoices and sendPaymentAsync is not supported yet.
+        // see https://www.webln.guide/building-lightning-apps/webln-reference/webln.sendpaymentasync
+        provider.sendPayment(bolt11)
+          // JIT invoice payments will never resolve here
+          // since they only get resolved after settlement which can't happen here
+          .then(resolve)
+          .catch(reject)
+        invoice.waitUntilPaid(id)
+          .then(resolve)
+          .catch(reject)
+      })
+    } catch (err) {
+      console.error('WebLN payment failed:', err)
+      throw err
+    }
+  }, [provider, invoice])
+
+  return waitForWebLnPayment
+}
+
+const useQrPayment = () => {
+  const invoice = useInvoice()
+  const showModal = useShowModal()
+
+  const waitForQrPayment = useCallback(async (inv) => {
+    return await new Promise((resolve, reject) => {
+      let paid
+      const cancelAndReject = async (onClose) => {
+        if (paid) return
+        await invoice.cancel(inv)
+        reject(new InvoiceCanceledError(inv.hash))
+      }
+      showModal(onClose =>
+        <Invoice
+          invoice={inv}
+          modal
+          successVerb='received'
+          webLn={false}
+          onPayment={() => { paid = true; onClose(); resolve() }}
+          poll
+        />,
+      { keepOpen: true, onClose: cancelAndReject })
+    })
+  }, [invoice])
+
+  return waitForQrPayment
+}
+
+export const PaymentProvider = ({ children }) => {
+  const me = useMe()
+  const feeButton = useFeeButton()
+  const invoice = useInvoice()
+  const waitForWebLnPayment = useWebLnPayment()
+  const waitForQrPayment = useQrPayment()
+
+  const waitForPayment = useCallback(async (invoice) => {
+    try {
+      return await waitForWebLnPayment(invoice)
+    } catch (err) {
+      if (err instanceof InvoiceCanceledError) {
+        // bail since qr code payment will also fail if invoice was canceled
+        throw err
+      }
+      // ignore any other error and fallback to QR code
+    }
+    return await waitForQrPayment(invoice)
+  }, [waitForWebLnPayment, waitForQrPayment])
+
+  const request = useCallback(async (amount) => {
+    amount ??= feeButton?.total
+    const free = feeButton?.free
+
+    // if user has enough funds in their custodial wallet or action is free, never prompt for payment
+    // XXX this will probably not work as intended for deposits < balance
+    //   which means you can't always fund your custodial wallet with attached wallets ...
+    //   but should this even be the case?
+    const insufficientFunds = !me || me.privates.sats < amount
+    if (free || !insufficientFunds) return [{ hash: null, hmac: null }, null]
+
+    const inv = await invoice.create(amount)
+
+    await waitForPayment(inv)
+
+    const cancel = () => invoice.cancel(inv).catch(console.error)
+    return [inv, cancel]
+  }, [me, feeButton?.total, invoice, waitForPayment])
+
+  const cancel = useCallback(({ hash, hmac }) => {
+    if (hash && hmac) {
+      invoice.cancel({ hash, hmac }).catch(console.error)
+    }
+  }, [invoice])
+
+  const value = useMemo(() => ({ request, cancel }), [request, cancel])
+  return (
+    <PaymentContext.Provider value={value}>
+      {children}
+    </PaymentContext.Provider>
+  )
+}
+
+export const usePayment = () => {
+  return useContext(PaymentContext)
+}

--- a/components/poll.js
+++ b/components/poll.js
@@ -10,7 +10,6 @@ import ActionTooltip from './action-tooltip'
 import { POLL_COST } from '@/lib/constants'
 import { InvoiceCanceledError, usePayment } from './payment'
 import { NotificationType, useNotifications } from './notifications'
-import { useRoot } from './root'
 
 const pollVoteOptimisticUpdate = (cache, { id: itemId, pollOptionId }) => {
   const updateVote = (vote) => {
@@ -51,7 +50,6 @@ export default function Poll ({ item }) {
         pollVote(id: $id, hash: $hash, hmac: $hmac)
       }`
   )
-  const root = useRoot()
   const { notify, unnotify } = useNotifications()
 
   const PollButton = ({ v }) => {
@@ -67,7 +65,7 @@ export default function Poll ({ item }) {
               try {
                 let hash, hmac
                 revert = pollVoteOptimisticUpdate(cache, { id: item.id, pollOptionId: v.id })
-                nid = notify(NotificationType.PollVotePending, { item: { ...item, root } }, false);
+                nid = notify(NotificationType.PollVotePending, { itemId: item.id }, false);
                 [{ hash, hmac }, cancel] = await payment.request(item.pollCost || POLL_COST)
                 await pollVote({ variables: { id: v.id, hash, hmac } })
               } catch (err) {
@@ -76,7 +74,7 @@ export default function Poll ({ item }) {
                   return
                 }
                 const reason = err.message || err.toString?.()
-                notify(NotificationType.PollVoteError, { reason, item: { ...item, root } })
+                notify(NotificationType.PollVoteError, { reason, itemId: item.id })
                 cancel?.()
               } finally {
                 unnotify(nid)

--- a/components/qr.js
+++ b/components/qr.js
@@ -1,7 +1,7 @@
 import QRCode from 'qrcode.react'
 import { CopyInput, InputSkeleton } from './form'
 import InvoiceStatus from './invoice-status'
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 import { useWebLN } from './webln'
 import SimpleCountdown from './countdown'
 import Bolt11Info from './bolt11-info'
@@ -9,15 +9,12 @@ import Bolt11Info from './bolt11-info'
 export default function Qr ({ asIs, value, webLn, statusVariant, description, status }) {
   const qrValue = asIs ? value : 'lightning:' + value.toUpperCase()
   const provider = useWebLN()
-  // XXX antipattern ... we shouldn't be getting multiple renders
-  const sendPayment = useRef(false)
 
   useEffect(() => {
     async function effect () {
-      if (webLn && provider && !sendPayment.current) {
-        sendPayment.current = true
+      if (webLn && provider) {
         try {
-          await provider.sendPayment({ bolt11: value })
+          await provider.sendPayment(value)
         } catch (e) {
           console.log(e?.message)
         }

--- a/components/reply.js
+++ b/components/reply.js
@@ -16,7 +16,7 @@ import { Button } from 'react-bootstrap'
 import { useRoot } from './root'
 import { commentSubTreeRootId } from '@/lib/item'
 import { InvoiceCanceledError, usePayment } from './payment'
-import { UNKNOWN_LINK_REL } from '@/lib/constants'
+import { ANON_USER_ID, UNKNOWN_LINK_REL } from '@/lib/constants'
 
 const cacheAddComment = (cache, parentId, data) => {
   cache.modify({
@@ -90,7 +90,7 @@ const upsertCommentUpdate = (cache, item, { text, me }) => {
     createdAt: new Date(),
     deletedAt: null,
     text,
-    user: { ...me, meMute: false },
+    user: me ? { ...me, meMute: false } : { id: ANON_USER_ID, name: 'anon', optional: { streak: 0 }, meMute: false },
     comments: [],
     position: null,
     sats: 0,

--- a/components/reply.js
+++ b/components/reply.js
@@ -79,9 +79,9 @@ const cacheRevertAncestorUpdate = (cache, ancestors) => {
 }
 
 const PENDING_COMMENT_ID = 'PENDING'
-const upsertCommentUpdate = (cache, item, { text, me }) => {
+const upsertCommentOptimisticUpdate = (cache, { id: itemId, path, text }, { me }) => {
   const id = PENDING_COMMENT_ID
-  const parentId = item.id
+  const parentId = itemId
 
   const fragment = {
     __typename: 'Item',
@@ -114,7 +114,7 @@ const upsertCommentUpdate = (cache, item, { text, me }) => {
   }
   cacheAddComment(cache, parentId, fragment)
 
-  const ancestors = item.path.split('.')
+  const ancestors = path.split('.')
   cacheUpdateAncestors(cache, ancestors)
 
   const root = ancestors[0]
@@ -216,10 +216,10 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
     onCancelQuote?.()
   }, [setReply, parentId, onCancelQuote])
 
-  const beforePayment = useCallback(({ text }, { resetForm }) => {
+  const optimisticUpdate = useCallback(({ text }, { resetForm }) => {
     setReply(replyOpen || false)
     resetForm({ text: '' })
-    return upsertCommentUpdate(cache, item, { text, me })
+    return upsertCommentOptimisticUpdate(cache, { ...item, text }, { me })
   }, [setReply, cache, item, me])
 
   return (
@@ -276,7 +276,7 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
               schema={commentSchema}
               invoiceable
               onSubmit={onSubmit}
-              beforePayment={beforePayment}
+              optimisticUpdate={optimisticUpdate}
               storageKeyPrefix={`reply-${parentId}`}
             >
               <MarkdownInput

--- a/components/reply.js
+++ b/components/reply.js
@@ -15,6 +15,7 @@ import { useShowModal } from './modal'
 import { Button } from 'react-bootstrap'
 import { useRoot } from './root'
 import { commentSubTreeRootId } from '@/lib/item'
+import { InvoiceCanceledError, usePayment } from './payment'
 
 export function ReplyOnAnotherPage ({ item }) {
   const rootId = commentSubTreeRootId(item)
@@ -40,6 +41,7 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
   const showModal = useShowModal()
   const root = useRoot()
   const sub = item?.sub || root?.sub
+  const payment = usePayment()
 
   useEffect(() => {
     if (replyOpen || quote || !!window.localStorage.getItem('reply-' + parentId + '-' + 'text')) {
@@ -97,10 +99,19 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
   )
 
   const onSubmit = useCallback(async ({ amount, hash, hmac, ...values }, { resetForm }) => {
-    const { data } = await upsertComment({ variables: { parentId, hash, hmac, ...values } })
-    toastDeleteScheduled(toaster, data, 'upsertComment', false, values.text)
-    resetForm({ text: '' })
-    setReply(replyOpen || false)
+    try {
+      const { data } = await upsertComment({ variables: { parentId, hash, hmac, ...values } })
+      toastDeleteScheduled(toaster, data, 'upsertComment', false, values.text)
+      resetForm({ text: '' })
+      setReply(replyOpen || false)
+    } catch (err) {
+      if (err instanceof InvoiceCanceledError) {
+        return
+      }
+      const msg = err.message || err.toString?.()
+      toaster.danger('reply error: ' + msg)
+      payment.cancel?.({ hash, hmac })
+    }
   }, [upsertComment, setReply, parentId])
 
   useEffect(() => {

--- a/components/reply.js
+++ b/components/reply.js
@@ -15,7 +15,6 @@ import { useShowModal } from './modal'
 import { Button } from 'react-bootstrap'
 import { useRoot } from './root'
 import { commentSubTreeRootId } from '@/lib/item'
-import { InvoiceCanceledError, usePayment } from './payment'
 import { ANON_USER_ID, UNKNOWN_LINK_REL } from '@/lib/constants'
 
 const cacheAddComment = (cache, parentId, data) => {
@@ -151,7 +150,6 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
   const showModal = useShowModal()
   const root = useRoot()
   const sub = item?.sub || root?.sub
-  const payment = usePayment()
   const cache = useApolloClient().cache
 
   useEffect(() => {
@@ -191,19 +189,10 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
   )
 
   const onSubmit = useCallback(async ({ amount, hash, hmac, ...values }, { resetForm }) => {
-    try {
-      const { data } = await upsertComment({ variables: { parentId, hash, hmac, ...values } })
-      toastDeleteScheduled(toaster, data, 'upsertComment', false, values.text)
-      resetForm({ text: '' })
-      setReply(replyOpen || false)
-    } catch (err) {
-      if (err instanceof InvoiceCanceledError) {
-        return
-      }
-      const msg = err.message || err.toString?.()
-      toaster.danger('reply error: ' + msg)
-      payment.cancel?.({ hash, hmac })
-    }
+    const { data } = await upsertComment({ variables: { parentId, hash, hmac, ...values } })
+    toastDeleteScheduled(toaster, data, 'upsertComment', false, values.text)
+    resetForm({ text: '' })
+    setReply(replyOpen || false)
   }, [upsertComment, setReply, parentId])
 
   useEffect(() => {

--- a/components/reply.js
+++ b/components/reply.js
@@ -269,10 +269,10 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
               onSubmit={onSubmit}
               optimisticUpdate={optimisticUpdate}
               onError={({ reason }) => {
-                notify(NotificationType.ReplyError, { reason, item: { ...item, root } })
+                notify(NotificationType.ReplyError, { reason, itemId: item.id })
               }}
               beforeSubmit={() => {
-                const nid = notify(NotificationType.ReplyPending, { item: { ...item, root } }, false)
+                const nid = notify(NotificationType.ReplyPending, { itemId: item.id }, false)
                 return { nid }
               }}
               afterSubmit={({ nid }) => {

--- a/components/toast.js
+++ b/components/toast.js
@@ -75,6 +75,16 @@ export const ToastProvider = ({ children }) => {
         ...options
       }
       return dispatchToast(toast)
+    },
+    undo: (options) => {
+      const toast = {
+        body: (onClose) => <ToastUndo handleClick={options.onClick} onClose={onClose} />,
+        variant: 'undo',
+        autohide: true,
+        delay: TOAST_DEFAULT_DELAY_MS,
+        ...options
+      }
+      return dispatchToast(toast)
     }
   }), [dispatchToast, removeToast])
 
@@ -137,18 +147,22 @@ export const ToastProvider = ({ children }) => {
               key={toast.id} bg={toast.variant} show autohide={toast.autohide}
               delay={toast.delay} className={`${styles.toast} ${styles[toast.variant]} ${textStyle}`} onClose={() => removeToast(toast)}
             >
-              <ToastBody>
-                <div className='d-flex align-items-center'>
-                  <div className='flex-grow-1'>{toast.body}</div>
-                  <Button
-                    variant={null}
-                    className='p-0 ps-2'
-                    aria-label='close'
-                    onClick={onClose}
-                  ><div className={`${styles.toastClose} ${textStyle}`}>X</div>
-                  </Button>
-                </div>
-              </ToastBody>
+              {typeof toast.body === 'function'
+                ? toast.body(onClose)
+                : (
+                  <ToastBody>
+                    <div className='d-flex align-items-center'>
+                      <div className='flex-grow-1'>{toast.body}</div>
+                      <Button
+                        variant={null}
+                        className='p-0 ps-2'
+                        aria-label='close'
+                        onClick={onClose}
+                      ><div className={`${styles.toastClose} ${textStyle}`}>X</div>
+                      </Button>
+                    </div>
+                  </ToastBody>
+                  )}
               {toast.progressBar && <div className={`${styles.progressBar} ${styles[toast.variant]}`} style={{ animationDuration, animationDelay }} />}
             </Toast>
           )
@@ -160,3 +174,19 @@ export const ToastProvider = ({ children }) => {
 }
 
 export const useToast = () => useContext(ToastContext)
+
+const ToastUndo = ({ handleClick, onClose }) => {
+  // TODO: make more pretty
+  return (
+    <ToastBody
+      onClick={() => {
+        handleClick()
+        onClose()
+      }}
+    >
+      <div className='d-flex fw-bold align-items-center flex-right'>
+        undo
+      </div>
+    </ToastBody>
+  )
+}

--- a/components/toast.js
+++ b/components/toast.js
@@ -75,16 +75,6 @@ export const ToastProvider = ({ children }) => {
         ...options
       }
       return dispatchToast(toast)
-    },
-    undo: (options) => {
-      const toast = {
-        body: (onClose) => <ToastUndo handleClick={options.onClick} onClose={onClose} />,
-        variant: 'undo',
-        autohide: true,
-        delay: TOAST_DEFAULT_DELAY_MS,
-        ...options
-      }
-      return dispatchToast(toast)
     }
   }), [dispatchToast, removeToast])
 
@@ -147,22 +137,18 @@ export const ToastProvider = ({ children }) => {
               key={toast.id} bg={toast.variant} show autohide={toast.autohide}
               delay={toast.delay} className={`${styles.toast} ${styles[toast.variant]} ${textStyle}`} onClose={() => removeToast(toast)}
             >
-              {typeof toast.body === 'function'
-                ? toast.body(onClose)
-                : (
-                  <ToastBody>
-                    <div className='d-flex align-items-center'>
-                      <div className='flex-grow-1'>{toast.body}</div>
-                      <Button
-                        variant={null}
-                        className='p-0 ps-2'
-                        aria-label='close'
-                        onClick={onClose}
-                      ><div className={`${styles.toastClose} ${textStyle}`}>X</div>
-                      </Button>
-                    </div>
-                  </ToastBody>
-                  )}
+              <ToastBody>
+                <div className='d-flex align-items-center'>
+                  <div className='flex-grow-1'>{toast.body}</div>
+                  <Button
+                    variant={null}
+                    className='p-0 ps-2'
+                    aria-label='close'
+                    onClick={onClose}
+                  ><div className={`${styles.toastClose} ${textStyle}`}>X</div>
+                  </Button>
+                </div>
+              </ToastBody>
               {toast.progressBar && <div className={`${styles.progressBar} ${styles[toast.variant]}`} style={{ animationDuration, animationDelay }} />}
             </Toast>
           )
@@ -174,19 +160,3 @@ export const ToastProvider = ({ children }) => {
 }
 
 export const useToast = () => useContext(ToastContext)
-
-const ToastUndo = ({ handleClick, onClose }) => {
-  // TODO: make more pretty
-  return (
-    <ToastBody
-      onClick={() => {
-        handleClick()
-        onClose()
-      }}
-    >
-      <div className='d-flex fw-bold align-items-center flex-right'>
-        undo
-      </div>
-    </ToastBody>
-  )
-}

--- a/components/toast.module.css
+++ b/components/toast.module.css
@@ -21,20 +21,6 @@
   border-color: var(--bs-warning-border-subtle);
 }
 
-.toastUndo {
-  font-style: normal;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-}
-
-.toastCancel {
-  font-style: italic;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-}
-
 .toastClose {
   color: #fff;
   font-family: "lightning";

--- a/components/toast.module.css
+++ b/components/toast.module.css
@@ -33,12 +33,6 @@
   align-items: center;
 }
 
-.undo {
-  background-color:  var(--bs-warning);
-  border-width: 0px;
-  color: black;
-}
-
 .progressBar {
   width: 0;
   height: 5px;

--- a/components/toast.module.css
+++ b/components/toast.module.css
@@ -1,5 +1,6 @@
 .toastContainer {
   transform: translate3d(0, 0, 0);
+  margin-bottom: 53px; /* padding for bottom nav bar on mobile */
 }
 
 .toast {
@@ -32,6 +33,12 @@
   align-items: center;
 }
 
+.undo {
+  background-color:  var(--bs-warning);
+  border-width: 0px;
+  color: black;
+}
+
 .progressBar {
   width: 0;
   height: 5px;
@@ -54,8 +61,6 @@
   background-color: var(--bs-warning);
 }
 
-
-
 @keyframes progressBar {
   0% {
     width: 0;
@@ -71,7 +76,7 @@
 }
 
 @media screen and (min-width: 400px) {
-  .toast {
-    width: var(--bs-toast-max-width);
+  .toastContainer {
+    margin-bottom: 0px;
   }
 }

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -149,7 +149,7 @@ export default function UpVote ({ item, className }) {
     [item?.mine, item?.meForward, item?.deletedAt])
 
   const [meSats, overlayText, color, nextColor] = useMemo(() => {
-    const meSats = (item?.meSats || item?.meAnonSats || 0)
+    const meSats = item?.meSats || 0
 
     // what should our next tip be?
     const sats = nextTip(meSats, { ...me?.privates })
@@ -157,7 +157,7 @@ export default function UpVote ({ item, className }) {
     return [
       meSats, me ? numWithUnits(sats, { abbreviate: false }) : 'zap it',
       getColor(meSats), getColor(meSats + sats)]
-  }, [item?.meSats, item?.meAnonSats, me?.privates?.tipDefault, me?.privates?.turboDefault])
+  }, [item?.meSats, me?.privates?.tipDefault, me?.privates?.turboDefault])
 
   const handleModalClosed = () => {
     setHover(false)

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -2,7 +2,7 @@ import UpBolt from '@/svgs/bolt.svg'
 import styles from './upvote.module.css'
 import { gql, useMutation } from '@apollo/client'
 import ActionTooltip from './action-tooltip'
-import ItemAct, { useAct, useZap } from './item-act'
+import ItemAct, { useZap } from './item-act'
 import { useMe } from './me'
 import getColor from '@/lib/rainbow'
 import { useCallback, useMemo, useRef, useState } from 'react'
@@ -125,7 +125,6 @@ export default function UpVote ({ item, className }) {
     }
   }, [me, tipShow, setWalkthrough])
 
-  const act = useAct()
   const zap = useZap()
 
   const disabled = useMemo(() => item?.mine || item?.meForward || item?.deletedAt,
@@ -176,7 +175,7 @@ export default function UpVote ({ item, className }) {
 
       await zap({ item, me })
     } else {
-      showModal(onClose => <ItemAct onClose={onClose} itemId={item.id} act={act} />, { onClose: handleModalClosed })
+      showModal(onClose => <ItemAct onClose={onClose} itemId={item.id} />, { onClose: handleModalClosed })
     }
   }
 

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -12,6 +12,7 @@ import Popover from 'react-bootstrap/Popover'
 import { useShowModal } from './modal'
 import { numWithUnits } from '@/lib/format'
 import { Dropdown } from 'react-bootstrap'
+import { useRoot } from './root'
 
 const UpvotePopover = ({ target, show, handleClose }) => {
   const me = useMe()
@@ -110,6 +111,7 @@ export default function UpVote ({ item, className }) {
         setWalkthrough(upvotePopover: $upvotePopover, tipPopover: $tipPopover)
       }`
   )
+  const root = useRoot()
   const [abortController, setAbortController] = useState(null)
   const pending = !!abortController?.started
 
@@ -179,7 +181,9 @@ export default function UpVote ({ item, className }) {
     const controller = new ZapUndoController(setAbortController)
 
     showModal(onClose =>
-      <ItemAct onClose={onClose} item={item} abortSignal={controller.signal} />, { onClose: handleModalClosed })
+      // error notifications require item.root to be set for comment zaps
+      // and modals don't have access to useRoot so we need to pass root here manually
+      <ItemAct onClose={onClose} item={{ ...item, root }} abortSignal={controller.signal} />, { onClose: handleModalClosed })
   }
 
   const handleShortPress = async () => {
@@ -206,7 +210,7 @@ export default function UpVote ({ item, className }) {
 
       await zap({ item, me }, { abortSignal: controller.signal })
     } else {
-      showModal(onClose => <ItemAct onClose={onClose} item={item} />, { onClose: handleModalClosed })
+      showModal(onClose => <ItemAct onClose={onClose} item={{ ...item, root }} />, { onClose: handleModalClosed })
     }
   }
 

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -125,7 +125,7 @@ export default function UpVote ({ item, className }) {
     }
   }, [me, tipShow, setWalkthrough])
 
-  const [act] = useAct()
+  const act = useAct()
   const zap = useZap()
 
   const disabled = useMemo(() => item?.mine || item?.meForward || item?.deletedAt,
@@ -159,7 +159,7 @@ export default function UpVote ({ item, className }) {
       <ItemAct onClose={onClose} itemId={item.id} />, { onClose: handleModalClosed })
   }
 
-  const handleShortPress = () => {
+  const handleShortPress = async () => {
     if (me) {
       if (!item) return
 
@@ -173,7 +173,6 @@ export default function UpVote ({ item, className }) {
       } else {
         setTipShow(true)
       }
-
       zap({ item, me })
     } else {
       showModal(onClose => <ItemAct onClose={onClose} itemId={item.id} act={act} />, { onClose: handleModalClosed })

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -155,7 +155,7 @@ export default function UpVote ({ item, className }) {
 
     setTipShow(false)
     showModal(onClose =>
-      <ItemAct onClose={onClose} itemId={item.id} />, { onClose: handleModalClosed })
+      <ItemAct onClose={onClose} item={item} />, { onClose: handleModalClosed })
   }
 
   const handleShortPress = async () => {
@@ -175,7 +175,7 @@ export default function UpVote ({ item, className }) {
 
       await zap({ item, me })
     } else {
-      showModal(onClose => <ItemAct onClose={onClose} itemId={item.id} />, { onClose: handleModalClosed })
+      showModal(onClose => <ItemAct onClose={onClose} item={item} />, { onClose: handleModalClosed })
     }
   }
 

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -96,7 +96,6 @@ export default function UpVote ({ item, className }) {
         setWalkthrough(upvotePopover: $upvotePopover, tipPopover: $tipPopover)
       }`
   )
-  const [pending, setPending] = useState(null)
 
   const setVoteShow = useCallback((yes) => {
     if (!me) return
@@ -157,7 +156,7 @@ export default function UpVote ({ item, className }) {
 
     setTipShow(false)
     showModal(onClose =>
-      <ItemAct onClose={onClose} itemId={item.id} setPending={setPending} />, { onClose: handleModalClosed })
+      <ItemAct onClose={onClose} itemId={item.id} />, { onClose: handleModalClosed })
   }
 
   const handleShortPress = async () => {
@@ -174,12 +173,8 @@ export default function UpVote ({ item, className }) {
       } else {
         setTipShow(true)
       }
-      try {
-        setPending(true)
-        await zap({ item, me })
-      } finally {
-        setPending(false)
-      }
+
+      await zap({ item, me })
     } else {
       showModal(onClose => <ItemAct onClose={onClose} itemId={item.id} act={act} />, { onClose: handleModalClosed })
     }
@@ -207,8 +202,7 @@ export default function UpVote ({ item, className }) {
                       `${styles.upvote}
                       ${className || ''}
                       ${disabled ? styles.noSelfTips : ''}
-                      ${meSats ? styles.voted : ''}
-                      ${pending ? styles.pending : ''}`
+                      ${meSats ? styles.voted : ''}`
                     }
               style={meSats || hover
                 ? {

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -96,6 +96,7 @@ export default function UpVote ({ item, className }) {
         setWalkthrough(upvotePopover: $upvotePopover, tipPopover: $tipPopover)
       }`
   )
+  const [pending, setPending] = useState(null)
 
   const setVoteShow = useCallback((yes) => {
     if (!me) return
@@ -173,7 +174,12 @@ export default function UpVote ({ item, className }) {
       } else {
         setTipShow(true)
       }
-      zap({ item, me })
+      try {
+        setPending(true)
+        await zap({ item, me })
+      } finally {
+        setPending(false)
+      }
     } else {
       showModal(onClose => <ItemAct onClose={onClose} itemId={item.id} act={act} />, { onClose: handleModalClosed })
     }
@@ -201,7 +207,8 @@ export default function UpVote ({ item, className }) {
                       `${styles.upvote}
                       ${className || ''}
                       ${disabled ? styles.noSelfTips : ''}
-                      ${meSats ? styles.voted : ''}`
+                      ${meSats ? styles.voted : ''}
+                      ${pending ? styles.pending : ''}`
                     }
               style={meSats || hover
                 ? {

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -157,7 +157,7 @@ export default function UpVote ({ item, className }) {
 
     setTipShow(false)
     showModal(onClose =>
-      <ItemAct onClose={onClose} itemId={item.id} />, { onClose: handleModalClosed })
+      <ItemAct onClose={onClose} itemId={item.id} setPending={setPending} />, { onClose: handleModalClosed })
   }
 
   const handleShortPress = async () => {

--- a/components/upvote.module.css
+++ b/components/upvote.module.css
@@ -35,3 +35,17 @@
     left: 4px;
     width: 17px;
 }
+
+.pending {
+    animation-name: pulse;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+    animation-duration: 0.25s;
+    animation-direction: alternate;
+}
+
+@keyframes pulse {
+	0% {
+		fill: #a5a5a5;
+	}
+}

--- a/components/upvote.module.css
+++ b/components/upvote.module.css
@@ -35,17 +35,3 @@
     left: 4px;
     width: 17px;
 }
-
-.pending {
-    animation-name: pulse;
-    animation-iteration-count: infinite;
-    animation-timing-function: linear;
-    animation-duration: 0.25s;
-    animation-direction: alternate;
-}
-
-@keyframes pulse {
-	0% {
-		fill: #a5a5a5;
-	}
-}

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -1,8 +1,6 @@
-import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { LNbitsProvider, useLNbits } from './lnbits'
 import { NWCProvider, useNWC } from './nwc'
-import { useToast, withToastFlow } from '@/components/toast'
-import { gql, useMutation } from '@apollo/client'
 import { LNCProvider, useLNC } from './lnc'
 
 const WebLNContext = createContext({})
@@ -86,31 +84,6 @@ function RawWebLNProvider ({ children }) {
   // TODO: implement fallbacks via provider priority
   const provider = enabledProviders[0]
 
-  const toaster = useToast()
-  const [cancelInvoice] = useMutation(gql`
-    mutation cancelInvoice($hash: String!, $hmac: String!) {
-      cancelInvoice(hash: $hash, hmac: $hmac) {
-        id
-      }
-    }
-  `)
-
-  const sendPaymentWithToast = withToastFlow(toaster)(
-    ({ bolt11, hash, hmac, expiresAt, flowId }) => {
-      const expiresIn = (+new Date(expiresAt)) - (+new Date())
-      return {
-        flowId: flowId || hash,
-        type: 'payment',
-        onPending: async () => {
-          await provider.sendPayment(bolt11)
-        },
-        // hash and hmac are only passed for JIT invoices
-        onCancel: () => hash && hmac ? cancelInvoice({ variables: { hash, hmac } }) : undefined,
-        timeout: expiresIn
-      }
-    }
-  )
-
   const setProvider = useCallback((defaultProvider) => {
     // move provider to the start to set it as default
     setEnabledProviders(providers => {
@@ -129,8 +102,17 @@ function RawWebLNProvider ({ children }) {
     await lnc.clearConfig()
   }, [])
 
+  const value = useMemo(() => ({
+    provider: isEnabled(provider)
+      ? { sendPayment: provider.sendPayment }
+      : null,
+    enabledProviders,
+    setProvider,
+    clearConfig
+  }), [provider, enabledProviders, setProvider])
+
   return (
-    <WebLNContext.Provider value={{ provider: isEnabled(provider) ? { sendPayment: sendPaymentWithToast } : null, enabledProviders, setProvider, clearConfig }}>
+    <WebLNContext.Provider value={value}>
       {children}
     </WebLNContext.Provider>
   )

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -8,6 +8,7 @@ import { Status, migrateLocalStorage } from '.'
 import { bolt11Tags } from '@/lib/bolt11'
 import { Wallet } from '@/lib/constants'
 import { useMe } from '../me'
+import { InvoiceExpiredError } from '../payment'
 
 const NWCContext = createContext()
 
@@ -210,7 +211,7 @@ export function NWCProvider ({ children }) {
           const timer = setTimeout(() => {
             const msg = 'timeout waiting for payment'
             logger.error(msg)
-            reject(new Error(msg))
+            reject(new InvoiceExpiredError())
             sub?.close()
           }, timeout)
 

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -208,7 +208,7 @@ export function NWCProvider ({ children }) {
           // timeout is same as invoice expiry
           const timeout = 180_000
           const timer = setTimeout(() => {
-            const msg = 'timeout waiting for info event'
+            const msg = 'timeout waiting for payment'
             logger.error(msg)
             reject(new Error(msg))
             sub?.close()

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -6,7 +6,7 @@ import { parseNwcUrl } from '@/lib/url'
 import { useWalletLogger } from '../logger'
 import { Status, migrateLocalStorage } from '.'
 import { bolt11Tags } from '@/lib/bolt11'
-import { Wallet } from '@/lib/constants'
+import { JIT_INVOICE_TIMEOUT_MS, Wallet } from '@/lib/constants'
 import { useMe } from '../me'
 import { InvoiceExpiredError } from '../payment'
 
@@ -207,7 +207,7 @@ export function NWCProvider ({ children }) {
         (async function () {
           // timeout since NWC is async (user needs to confirm payment in wallet)
           // timeout is same as invoice expiry
-          const timeout = 180_000
+          const timeout = JIT_INVOICE_TIMEOUT_MS
           const timer = setTimeout(() => {
             const msg = 'timeout waiting for payment'
             logger.error(msg)

--- a/fragments/comments.js
+++ b/fragments/comments.js
@@ -17,7 +17,6 @@ export const COMMENT_FIELDS = gql`
       meMute
     }
     sats
-    meAnonSats @client
     upvotes
     freedFreebie
     boost

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -28,7 +28,6 @@ export const ITEM_FIELDS = gql`
     otsHash
     position
     sats
-    meAnonSats @client
     boost
     bounty
     bountyPaidTo

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -228,7 +228,39 @@ function getClient (uri) {
               read (meAnonSats, { readField }) {
                 if (typeof window === 'undefined') return null
                 const itemId = readField('id')
-                return meAnonSats ?? Number(window.localStorage.getItem(`TIP-item:${itemId}`) || '0')
+                return meAnonSats ?? Number(window.localStorage.getItem(`TIP-item:ANON:${itemId}`) || '0')
+              }
+            },
+            sats: {
+              read (sats, { readField }) {
+                if (SSR) return sats
+                const itemId = readField('id')
+                const mePendingSats = Number(window.localStorage.getItem(`TIP-item:PENDING:TIP:${itemId}`) || '0')
+                return sats + mePendingSats
+              }
+            },
+            meSats: {
+              read (meSats, { readField }) {
+                if (SSR) return meSats
+                const itemId = readField('id')
+                const mePendingSats = Number(window.localStorage.getItem(`TIP-item:PENDING:TIP:${itemId}`) || '0')
+                return meSats + mePendingSats
+              }
+            },
+            meDontLikeSats: {
+              read (meDontLikeSats, { readField }) {
+                if (SSR) return meDontLikeSats
+                const itemId = readField('id')
+                const mePendingSats = Number(window.localStorage.getItem(`TIP-item:PENDING:DONT_LIKE_THIS:${itemId}`) || '0')
+                return meDontLikeSats + mePendingSats
+              }
+            },
+            commentSats: {
+              read (commentSats, { readField }) {
+                if (SSR) return commentSats
+                const itemId = readField('id')
+                const mePendingCommentSats = Number(window.localStorage.getItem(`TIP-comment:PENDING:${itemId}`) || '0')
+                return commentSats + mePendingCommentSats
               }
             }
           }

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -224,13 +224,6 @@ function getClient (uri) {
         },
         Item: {
           fields: {
-            meAnonSats: {
-              read (meAnonSats, { readField }) {
-                if (typeof window === 'undefined') return null
-                const itemId = readField('id')
-                return meAnonSats ?? Number(window.localStorage.getItem(`TIP-item:ANON:${itemId}`) || '0')
-              }
-            },
             sats: {
               read (sats, { readField }) {
                 if (SSR) return sats
@@ -244,7 +237,8 @@ function getClient (uri) {
                 if (SSR) return meSats
                 const itemId = readField('id')
                 const mePendingSats = Number(window.localStorage.getItem(`TIP-item:PENDING:TIP:${itemId}`) || '0')
-                return meSats + mePendingSats
+                const meAnonSats = Number(window.localStorage.getItem(`TIP-item:ANON:TIP:${itemId}`) || '0')
+                return meSats + mePendingSats + meAnonSats
               }
             },
             meDontLikeSats: {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -65,6 +65,7 @@ export const RESERVED_MAX_USER_ID = 615
 export const GLOBAL_SEED = 616
 export const FREEBIE_BASE_COST_THRESHOLD = 10
 export const USER_IDS_BALANCE_NO_LIMIT = [...SN_USER_IDS, AD_USER_ID]
+export const ZAP_UNDO_DELAY = 5000
 
 // WIP ultimately subject to this list: https://ofac.treasury.gov/sanctions-programs-and-country-information
 // From lawyers: north korea, cuba, iran, ukraine, syria

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -127,6 +127,7 @@ export const ITEM_ALLOW_EDITS = [
 ]
 
 export const INVOICE_RETENTION_DAYS = 7
+export const JIT_INVOICE_TIMEOUT_MS = 180_000
 
 export const FAST_POLL_INTERVAL = Number(process.env.NEXT_PUBLIC_FAST_POLL_INTERVAL)
 export const NORMAL_POLL_INTERVAL = Number(process.env.NEXT_PUBLIC_NORMAL_POLL_INTERVAL)

--- a/lib/new-comments.js
+++ b/lib/new-comments.js
@@ -9,9 +9,16 @@ export function commentsViewed (item) {
 }
 
 export function commentsViewedAfterComment (rootId, createdAt) {
+  const prevCommentsViewedAt = window.localStorage.getItem(`${COMMENTS_VIEW_PREFIX}:${rootId}`)
   window.localStorage.setItem(`${COMMENTS_VIEW_PREFIX}:${rootId}`, new Date(createdAt).getTime())
   const existingRootComments = window.localStorage.getItem(`${COMMENTS_NUM_PREFIX}:${rootId}`) || 0
   window.localStorage.setItem(`${COMMENTS_NUM_PREFIX}:${rootId}`, existingRootComments + 1)
+
+  return () => {
+    // revert function
+    window.localStorage.setItem(`${COMMENTS_VIEW_PREFIX}:${rootId}`, prevCommentsViewedAt)
+    window.localStorage.setItem(`${COMMENTS_NUM_PREFIX}:${rootId}`, existingRootComments)
+  }
 }
 
 export function commentsViewedAt (item) {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -22,6 +22,7 @@ import { WebLNProvider } from '@/components/webln'
 import dynamic from 'next/dynamic'
 import { HasNewNotesProvider } from '@/components/use-has-new-notes'
 import { PaymentProvider } from '@/components/payment'
+import { NotificationProvider } from '@/components/notifications'
 
 const PWAPrompt = dynamic(() => import('react-ios-pwa-prompt'), { ssr: false })
 
@@ -105,30 +106,32 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
           <ApolloProvider client={client}>
             <MeProvider me={me}>
               <HasNewNotesProvider>
-                <LoggerProvider>
-                  <ServiceWorkerProvider>
-                    <PriceProvider price={price}>
-                      <LightningProvider>
-                        <ToastProvider>
-                          <WebLNProvider>
-                            <ShowModalProvider>
-                              <PaymentProvider>
-                                <BlockHeightProvider blockHeight={blockHeight}>
-                                  <ChainFeeProvider chainFee={chainFee}>
-                                    <ErrorBoundary>
-                                      <Component ssrData={ssrData} {...otherProps} />
-                                      {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
-                                    </ErrorBoundary>
-                                  </ChainFeeProvider>
-                                </BlockHeightProvider>
-                              </PaymentProvider>
-                            </ShowModalProvider>
-                          </WebLNProvider>
-                        </ToastProvider>
-                      </LightningProvider>
-                    </PriceProvider>
-                  </ServiceWorkerProvider>
-                </LoggerProvider>
+                <NotificationProvider>
+                  <LoggerProvider>
+                    <ServiceWorkerProvider>
+                      <PriceProvider price={price}>
+                        <LightningProvider>
+                          <ToastProvider>
+                            <WebLNProvider>
+                              <ShowModalProvider>
+                                <PaymentProvider>
+                                  <BlockHeightProvider blockHeight={blockHeight}>
+                                    <ChainFeeProvider chainFee={chainFee}>
+                                      <ErrorBoundary>
+                                        <Component ssrData={ssrData} {...otherProps} />
+                                        {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
+                                      </ErrorBoundary>
+                                    </ChainFeeProvider>
+                                  </BlockHeightProvider>
+                                </PaymentProvider>
+                              </ShowModalProvider>
+                            </WebLNProvider>
+                          </ToastProvider>
+                        </LightningProvider>
+                      </PriceProvider>
+                    </ServiceWorkerProvider>
+                  </LoggerProvider>
+                </NotificationProvider>
               </HasNewNotesProvider>
             </MeProvider>
           </ApolloProvider>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -21,6 +21,7 @@ import { ChainFeeProvider } from '@/components/chain-fee.js'
 import { WebLNProvider } from '@/components/webln'
 import dynamic from 'next/dynamic'
 import { HasNewNotesProvider } from '@/components/use-has-new-notes'
+import { PaymentProvider } from '@/components/payment'
 
 const PWAPrompt = dynamic(() => import('react-ios-pwa-prompt'), { ssr: false })
 
@@ -111,14 +112,16 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
                         <ToastProvider>
                           <WebLNProvider>
                             <ShowModalProvider>
-                              <BlockHeightProvider blockHeight={blockHeight}>
-                                <ChainFeeProvider chainFee={chainFee}>
-                                  <ErrorBoundary>
-                                    <Component ssrData={ssrData} {...otherProps} />
-                                    {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
-                                  </ErrorBoundary>
-                                </ChainFeeProvider>
-                              </BlockHeightProvider>
+                              <PaymentProvider>
+                                <BlockHeightProvider blockHeight={blockHeight}>
+                                  <ChainFeeProvider chainFee={chainFee}>
+                                    <ErrorBoundary>
+                                      <Component ssrData={ssrData} {...otherProps} />
+                                      {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
+                                    </ErrorBoundary>
+                                  </ChainFeeProvider>
+                                </BlockHeightProvider>
+                              </PaymentProvider>
                             </ShowModalProvider>
                           </WebLNProvider>
                         </ToastProvider>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -21,7 +21,6 @@ import { ChainFeeProvider } from '@/components/chain-fee.js'
 import { WebLNProvider } from '@/components/webln'
 import dynamic from 'next/dynamic'
 import { HasNewNotesProvider } from '@/components/use-has-new-notes'
-import { PaymentProvider } from '@/components/payment'
 import { NotificationProvider } from '@/components/notifications'
 
 const PWAPrompt = dynamic(() => import('react-ios-pwa-prompt'), { ssr: false })
@@ -114,16 +113,14 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
                           <ToastProvider>
                             <WebLNProvider>
                               <ShowModalProvider>
-                                <PaymentProvider>
-                                  <BlockHeightProvider blockHeight={blockHeight}>
-                                    <ChainFeeProvider chainFee={chainFee}>
-                                      <ErrorBoundary>
-                                        <Component ssrData={ssrData} {...otherProps} />
-                                        {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
-                                      </ErrorBoundary>
-                                    </ChainFeeProvider>
-                                  </BlockHeightProvider>
-                                </PaymentProvider>
+                                <BlockHeightProvider blockHeight={blockHeight}>
+                                  <ChainFeeProvider chainFee={chainFee}>
+                                    <ErrorBoundary>
+                                      <Component ssrData={ssrData} {...otherProps} />
+                                      {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
+                                    </ErrorBoundary>
+                                  </ChainFeeProvider>
+                                </BlockHeightProvider>
                               </ShowModalProvider>
                             </WebLNProvider>
                           </ToastProvider>

--- a/pages/invoices/[id].js
+++ b/pages/invoices/[id].js
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/client'
-import { Invoice } from '@/components/invoice'
+import Invoice from '@/components/invoice'
 import { QrSkeleton } from '@/components/qr'
 import { CenterLayout } from '@/components/layout'
 import { useRouter } from 'next/router'
@@ -10,6 +10,7 @@ import { getGetServerSideProps } from '@/api/ssrApollo'
 // force SSR to include CSP nonces
 export const getServerSideProps = getGetServerSideProps({ query: null })
 
+// TODO: we can probably replace this component with <Invoice poll>
 export default function FullInvoice () {
   const router = useRouter()
   const { data, error } = useQuery(INVOICE, SSR

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -26,7 +26,7 @@ import { NostrAuth } from '@/components/nostr-auth'
 import { useToast } from '@/components/toast'
 import { useServiceWorkerLogger } from '@/components/logger'
 import { useMe } from '@/components/me'
-import { INVOICE_RETENTION_DAYS } from '@/lib/constants'
+import { INVOICE_RETENTION_DAYS, ZAP_UNDO_DELAY } from '@/lib/constants'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 import DeleteIcon from '@/svgs/delete-bin-line.svg'
 import { useField } from 'formik'
@@ -993,10 +993,8 @@ const ZapUndosField = () => {
                 zap undos
                 <Info>
                   <ul className='fw-bold'>
-                    <li>An undo button is shown after every zap that exceeds or is equal to the threshold</li>
-                    <li>The button is shown for 5 seconds</li>
-                    <li>The button is only shown for zaps from the custodial wallet</li>
-                    <li>Use a budget or manual approval with attached wallets</li>
+                    <li>After every zap that exceeds or is equal to the threshold, the bolt will pulse for {ZAP_UNDO_DELAY / 1000} seconds</li>
+                    <li>Click the bolt while it's pulsing to undo the zap</li>
                   </ul>
                 </Info>
               </div>


### PR DESCRIPTION
## Description

Close #849 Related to #848

As mentioned in #1071, this replaces `useInvoiceable` with `usePayment` which has a simpler API.

This PR also contains changes to improve the external payment UX by replacing generic toasts with custom UX code per action.

TODO:
- [x] #1071
- [x] optimistic zap UX
- [x] optimistic custom zap UX (custom zap = zapping via long press)
- [x] optimistic reply UX
- [x] ~optimistic post UX~ _canceled because this is most likely better implemented using server-side code so let's first get user feedback on client-side optimistic update code before delving deeper into UX patterns that include server-side code_
  - [x] ~bounty form~
  - [x] ~discussion form~
  - [x] ~link form~
  - [x] ~poll form~
  - [x] ~job form~
- [x] optimistic poll votes UX
- [x] optimistic bounty payments UX
- [x] ~territory admin optimistic UX~
  - [x] ~create~
  - [x] ~update~
  - [x] ~unarchive~
- [x] (zap) undos
- [x] remove unnecessary payment context (see [this comment](https://github.com/stackernews/stacker.news/pull/1161#discussion_r1593327834))
- [x] fix `meAnonSats` not immediately updated

**Error handling**

- [x] inform users about errors in notifications to let them retry
- [x] ~remove fallback to QR code on attached wallet payment failure since it interrupts UX (rely on out-of-band error handling like notifications instead) (?)~ _let's see in production first_
- [x] fix `Cannot read properties of null (reading 'meSats')` when reloading page on /notifications and trying to zap error notification because cache is not populated
- [x] fix client notifications don't use cache but static item data. this means optimistic updates don't work for client notifications.

## Screenshots

Since toasts for success _and_ error were removed for better UX, we now use ~dismissible~ error notifications that are only stored locally. So if you zap something and it fails, it looks like this:

![localhost_3000_(iPhone SE)](https://github.com/stackernews/stacker.news/assets/27162016/6421d02f-5b66-447a-aa83-32f6951eb648)

## Additional Context

See https://github.com/stackernews/stacker.news/pull/1071#issuecomment-2094562629 for additional context regarding move from `useInvoiceable` to `usePayment`. Most notably, `JITInvoice` is no longer with us. I removed it because it made the code more complicated and the retry/cancel UX was bad and lead regularly to confusion ("sats received" vs "error"). The HODL invoice is now immediately canceled if the action fails. With the new custom optimistic UX, retries via literally retrying (pressing `reply`, zapping again etc.) are imo simple enough.

## Checklist

**Are your changes backwards compatible? Please answer below:**

<!-- put your answer about backwards compatibility here -->

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

<!-- put your answer about QA here -->

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
