### PR TITLE
[1124] - Use Mempool For Fee Rate

### DIFF
--- a/api/resolvers/chainFee.js
+++ b/api/resolvers/chainFee.js
@@ -1,17 +1,16 @@
-import lndService from 'ln-service'
-import lnd from '@/api/lnd'
-
 const cache = new Map()
 const expiresIn = 1000 * 30 // 30 seconds in milliseconds
 
 async function fetchChainFeeRate () {
-  let chainFee = 0
-  try {
-    const fee = await lndService.getChainFeeRate({ lnd })
-    chainFee = fee.tokens_per_vbyte
-  } catch (err) {
-    console.error('fetchChainFee', err)
-  }
+  const url = 'https://mempool.space/api/v1/fees/recommended'
+  const chainFee = await fetch(url)
+    .then((res) => res.json())
+    .then((body) => body.hourFee)
+    .catch((err) => {
+      console.error('fetchChainFee', err)
+      return 0
+    })
+
   cache.set('fee', { fee: chainFee, createdAt: Date.now() })
   return chainFee
 }

--- a/components/price.js
+++ b/components/price.js
@@ -43,39 +43,37 @@ export function PriceProvider ({ price, children }) {
   )
 }
 
+const STORAGE_KEY = 'asSats'
+
+const carousel = [
+  'fiat',
+  'yep',
+  '1btc',
+  'blockHeight',
+  'chainFee',
+  'halving'
+]
+
 export default function Price ({ className }) {
   const [asSats, setAsSats] = useState(undefined)
+  const [pos, setPos] = useState(0)
+
   useEffect(() => {
-    const satSelection = window.localStorage.getItem('asSats')
+    const satSelection = window.localStorage.getItem(STORAGE_KEY)
     setAsSats(satSelection ?? 'fiat')
+    setPos(carousel.findIndex((item) => item === satSelection))
   }, [])
 
   const { price, fiatSymbol } = usePrice()
   const { height: blockHeight, halving } = useBlockHeight()
   const { fee: chainFee } = useChainFee()
 
-  // Options: yep, 1btc, blockHeight, undefined
-  // yep -> 1btc -> blockHeight -> chainFee -> undefined -> yep
   const handleClick = () => {
-    if (asSats === 'yep') {
-      window.localStorage.setItem('asSats', '1btc')
-      setAsSats('1btc')
-    } else if (asSats === '1btc') {
-      window.localStorage.setItem('asSats', 'blockHeight')
-      setAsSats('blockHeight')
-    } else if (asSats === 'blockHeight') {
-      window.localStorage.setItem('asSats', 'chainFee')
-      setAsSats('chainFee')
-    } else if (asSats === 'chainFee') {
-      window.localStorage.setItem('asSats', 'halving')
-      setAsSats('halving')
-    } else if (asSats === 'halving') {
-      window.localStorage.removeItem('asSats')
-      setAsSats('fiat')
-    } else {
-      window.localStorage.setItem('asSats', 'yep')
-      setAsSats('yep')
-    }
+    const nextPos = (pos + 1) % carousel.length
+
+    window.localStorage.setItem(STORAGE_KEY, carousel[nextPos])
+    setAsSats(carousel[nextPos])
+    setPos(nextPos)
   }
 
   const compClassName = (className || '') + ' text-reset pointer'

--- a/components/price.js
+++ b/components/price.js
@@ -48,11 +48,11 @@ const DEFAULT_SELECTION = 'fiat'
 
 const carousel = [
   'fiat',
-  // 'yep',
+  'yep',
   '1btc',
-  // 'blockHeight',
+  'blockHeight',
   'chainFee',
-  // 'halving'
+  'halving'
 ]
 
 export default function Price ({ className }) {

--- a/components/price.js
+++ b/components/price.js
@@ -44,14 +44,15 @@ export function PriceProvider ({ price, children }) {
 }
 
 const STORAGE_KEY = 'asSats'
+const DEFAULT_SELECTION = 'fiat'
 
 const carousel = [
   'fiat',
-  'yep',
+  // 'yep',
   '1btc',
-  'blockHeight',
+  // 'blockHeight',
   'chainFee',
-  'halving'
+  // 'halving'
 ]
 
 export default function Price ({ className }) {
@@ -59,9 +60,9 @@ export default function Price ({ className }) {
   const [pos, setPos] = useState(0)
 
   useEffect(() => {
-    const satSelection = window.localStorage.getItem(STORAGE_KEY)
-    setAsSats(satSelection ?? 'fiat')
-    setPos(carousel.findIndex((item) => item === satSelection))
+    const selection = window.localStorage.getItem(STORAGE_KEY) ?? DEFAULT_SELECTION
+    setAsSats(selection)
+    setPos(carousel.findIndex((item) => item === selection))
   }, [])
 
   const { price, fiatSymbol } = usePrice()


### PR DESCRIPTION
Fixes #1124 

## Description
This PR addresses an issue with the transaction fee rate shown in the header as it wasn't updating regularly.
- Uses Mempool for latest transaction fee (uses `hourFee` but can be changed to higher or lower priority if requested)
- Tidies up onClick handler to reduce repetitive code

**Note:** the existing implementation deletes the local storage entry on every complete cycle of clicking the price component. However, with these changes nothing is deleted as it doesn't appear necessary. Please let me know if I've overlooked something.

Tested locally on desktop using a minimal compose profiles setup. Might benefit from some extra eyes on this as it's my first PR.