### PR TITLE
Allow HTTP and HTTPS over Tor for LNbits

### DIFF
--- a/lib/cln.js
+++ b/lib/cln.js
@@ -2,11 +2,12 @@ import fetch from 'cross-fetch'
 import https from 'https'
 import crypto from 'crypto'
 import { HttpProxyAgent, HttpsProxyAgent } from '@/lib/proxy'
+import { TOR_REGEXP } from '@/lib/url'
 
 export const createInvoice = async ({ socket, rune, cert, label, description, msats, expiry }) => {
   let protocol, agent
   const httpsAgentOptions = { ca: cert ? Buffer.from(cert, 'base64') : undefined }
-  const isOnion = /\.onion(:[0-9]+)?$/.test(socket)
+  const isOnion = TOR_REGEXP.test(socket)
   if (isOnion) {
     // we support HTTP and HTTPS over Tor
     protocol = cert ? 'https:' : 'http:'

--- a/lib/url.js
+++ b/lib/url.js
@@ -93,3 +93,5 @@ export const MEDIA_DOMAIN_REGEXP = new RegExp(`^https?://${process.env.NEXT_PUBL
 
 // this regex is not a bullet proof way of checking if a url points to an image. to be sure, fetch the url and check the mimetype
 export const IMG_URL_REGEXP = /^(https?:\/\/.*\.(?:png|jpg|jpeg|gif))$/
+
+export const TOR_REGEXP = /\.onion(:[0-9]+)?$/

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -10,7 +10,7 @@ import { msatsToSats, numWithUnits, abbrNum, ensureB64, B64_URL_REGEX } from './
 import * as usersFragments from '@/fragments/users'
 import * as subsFragments from '@/fragments/subs'
 import { isInvoicableMacaroon, isInvoiceMacaroon } from './macaroon'
-import { parseNwcUrl } from './url'
+import { TOR_REGEXP, parseNwcUrl } from './url'
 import { datePivot } from './time'
 import { decodeRune } from '@/lib/cln'
 import bip39Words from './bip39-words'
@@ -601,11 +601,27 @@ export const lnAddrSchema = ({ payerData, min, max, commentAllowed } = {}) =>
   }, {})))
 
 export const lnbitsSchema = object({
-  url: process.env.NODE_ENV === 'development'
+  url: process.env.NODE_ENV !== 'development'
     ? string()
       .or([string().matches(/^(http:\/\/)?localhost:\d+$/), string().url()], 'invalid url')
       .required('required').trim()
-    : string().url().required('required').trim().https(),
+    : string().url().required('required').trim()
+      .test(async (url, context) => {
+        if (TOR_REGEXP.test(url)) {
+          // allow HTTP and HTTPS over Tor
+          if (!/^https?:\/\//.test(url)) {
+            return context.createError({ message: 'http or https required' })
+          }
+          return true
+        }
+        try {
+          // force HTTPS over clearnet
+          await string().https().validate(url)
+        } catch (err) {
+          return context.createError({ message: err.message })
+        }
+        return true
+      }),
   adminKey: string().length(32)
 })
 


### PR DESCRIPTION
## Description

This allows using `http://` or `https://` if .onion is used for LNbits

Hopefully closes #1166 

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
