### PR TITLE
Fix provider default setting

### DIFF
--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -63,7 +63,7 @@ function RawWebLNProvider ({ children }) {
         return null
       })
     })
-  }, [...availableProviders])
+  }, [])
 
   // keep list in sync with underlying providers
   useEffect(() => {
@@ -130,7 +130,7 @@ function RawWebLNProvider ({ children }) {
   }, [])
 
   return (
-    <WebLNContext.Provider value={{ provider: isEnabled(provider) ? { sendPayment: sendPaymentWithToast } : null, enabledProviders, setProvider, clearConfig }}>
+    <WebLNContext.Provider value={{ provider: isEnabled(provider) ? { name: provider.name, sendPayment: sendPaymentWithToast } : null, enabledProviders, setProvider, clearConfig }}>
       {children}
     </WebLNContext.Provider>
   )


### PR DESCRIPTION
## Description

The default setting to pick which provider to use if multiple are enabled didn't work. It restored the persisted order before it was saved. It was supposed to only restore the persisted order on first render.

The providers also weren't able to tell if they were the default since `WebLNContext` didn't expose the name property. Now it does.

## Additional Context

This will create a conflict with #1181 but I'll resolve it. Feel free to merge #1181 or this first.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
