### PR TITLE
Replace toasts - be more optimistic - prepaid and postpaid

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1386,15 +1386,15 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
     })
 
     let invoice
-    const actionData = { cost: err.cost, credits: err.balance }
     await models.$transaction(
       async (tx) => {
         // insert pending item
         ([item] = await tx.$queryRawUnsafe(
           `${SELECT} FROM create_item($1::JSONB, $2::JSONB, $3::JSONB, '${spamInterval}'::INTERVAL, $4::INTEGER[]) AS "Item"`,
-          JSON.stringify({ ...item, status: 'PENDING' }), JSON.stringify(fwdUsers), JSON.stringify(options), uploadIds));
+          JSON.stringify({ ...item, status: 'PENDING' }), JSON.stringify(fwdUsers), JSON.stringify(options), uploadIds))
 
         // set required invoice data to update item on payment
+        const actionData = { cost: err.cost, credits: err.balance };
         ([invoice] = await tx.$queryRaw`SELECT * FROM create_invoice(${lndInv.id}, NULL, ${lndInv.request},
           ${expiresAt}::timestamp, ${mtokens}, ${item.userId}::INTEGER, ${description}, NULL, NULL,
           ${invLimit}::INTEGER, ${balanceLimit}, 'ITEM'::"ActionType", ${item.id}::INTEGER, ${JSON.stringify(actionData)}::JSONB)`)

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1396,6 +1396,7 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
           ${invLimit}::INTEGER, ${balanceLimit}, 'ITEM'::"ActionType", ${item.id}::INTEGER, ${JSON.stringify(actionData)}::JSONB)`)
         }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
 
+      // hmac is not required to submit action again but to allow user to cancel payment
       invoice.hmac = createHmac(invoice.hash)
 
       item.invoice = invoice

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -9,7 +9,7 @@ import {
   ITEM_SPAM_INTERVAL, ITEM_FILTER_THRESHOLD,
   COMMENT_DEPTH_LIMIT, COMMENT_TYPE_QUERY,
   ANON_USER_ID, ANON_ITEM_SPAM_INTERVAL, POLL_COST,
-  ITEM_ALLOW_EDITS, GLOBAL_SEED, ANON_FEE_MULTIPLIER, NOFOLLOW_LIMIT, UNKNOWN_LINK_REL, JIT_INVOICE_TIMEOUT_MS, ANON_INV_PENDING_LIMIT, ANON_BALANCE_LIMIT_MSATS, INV_PENDING_LIMIT, USER_IDS_BALANCE_NO_LIMIT, BALANCE_LIMIT_MSATS
+  ITEM_ALLOW_EDITS, GLOBAL_SEED, ANON_FEE_MULTIPLIER, NOFOLLOW_LIMIT, UNKNOWN_LINK_REL, ANON_INV_PENDING_LIMIT, ANON_BALANCE_LIMIT_MSATS, INV_PENDING_LIMIT, USER_IDS_BALANCE_NO_LIMIT, BALANCE_LIMIT_MSATS, DEFAULT_INVOICE_TIMEOUT_MS
 } from '@/lib/constants'
 import { msatsToSats } from '@/lib/format'
 import { parse } from 'tldts'
@@ -1375,7 +1375,8 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
     const invLimit = me ? INV_PENDING_LIMIT : ANON_INV_PENDING_LIMIT
     const balanceLimit = USER_IDS_BALANCE_NO_LIMIT.includes(Number(me?.id)) ? 0 : me ? BALANCE_LIMIT_MSATS : ANON_BALANCE_LIMIT_MSATS
     const description = 'Creating item on stacker.news'
-    const expiresAt = datePivot(new Date(), { seconds: me ? JIT_INVOICE_TIMEOUT_MS : 180 })
+    // TODO: allow users to configure expiration
+    const expiresAt = datePivot(new Date(), { milliseconds: DEFAULT_INVOICE_TIMEOUT_MS })
     const mtokens = err.cost - err.balance
 
     const lndInv = await createInvoice({

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -899,7 +899,7 @@ export default {
              WHERE act IN ('TIP', 'FEE')
              AND "itemId" = ${Number(id)}::INTEGER
              AND "userId" = ${me.id}::INTEGER)::INTEGER)`,
-          { models }
+          { models, lnd, hash, hmac }
         )
       } else {
         await serialize(

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1428,7 +1428,7 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
         // since SubscribeToInvoices does not trigger if an invoice expired, we need a job that handles expired invoices
         await tx.$queryRaw`
           INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter)
-          VALUES ('finalizeAction', jsonb_build_object('type', 'ITEM', 'id', ${item.id}::INTEGER), 21, true, ${expiresAt})`
+          VALUES ('finalizeAction', jsonb_build_object('hash', ${invoice.hash}::TEXT), 21, true, ${expiresAt})`
       }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })
 
     // hmac is not required to submit action again but to allow user to cancel payment

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1386,6 +1386,7 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
     })
 
     let invoice
+    // need to use interactive tx here to set invoice.actionId = item.id
     await models.$transaction(
       async (tx) => {
         // insert pending item
@@ -1395,7 +1396,8 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
 
         // set required invoice data to update item on payment
         const actionData = { cost: err.cost, credits: err.balance };
-        ([invoice] = await tx.$queryRaw`SELECT * FROM create_invoice(${lndInv.id}, NULL, ${lndInv.request},
+        ([invoice] = await tx.$queryRaw`
+          SELECT * FROM create_invoice(${lndInv.id}, NULL, ${lndInv.request},
           ${expiresAt}::timestamp, ${mtokens}, ${item.userId}::INTEGER, ${description}, NULL, NULL,
           ${invLimit}::INTEGER, ${balanceLimit}, 'ITEM'::"ActionType", ${item.id}::INTEGER, ${JSON.stringify(actionData)}::JSONB)`)
       }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable })

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -68,7 +68,7 @@ async function comments (me, models, id, sort) {
   return comments
 }
 
-export async function getItem (parent, { id }, { me, models }) {
+export async function getItem (parent, { id, status = true }, { me, models }) {
   const [item] = await itemQueryWithMeta({
     me,
     models,
@@ -76,7 +76,7 @@ export async function getItem (parent, { id }, { me, models }) {
       ${SELECT}
       FROM "Item"
       WHERE id = $1
-      AND ${statusClause(me)}`
+      ${status ? `AND ${statusClause(me)}` : ''}`
   }, Number(id))
   return item
 }

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1437,15 +1437,22 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
     item.invoice = invoice
   }
 
-  await enqueueDeletionJob(item, models)
+  item.comments = []
 
-  // TODO: don't notify users on pending items
+  // we need to insert these even for pending items to show toasts
+  // we will delete the jobs if payment failed
+  await enqueueDeletionJob(item, models)
   await createReminderAndJob({ me, item, models })
+
+  const isPending = !!item.invoice
+  if (isPending) {
+    return item
+  }
+
   await createMentions(item, models)
   notifyUserSubscribers({ models, item })
   notifyTerritorySubscribers({ models, item })
 
-  item.comments = []
   return item
 }
 

--- a/api/resolvers/notifications.js
+++ b/api/resolvers/notifications.js
@@ -1,6 +1,6 @@
 import { GraphQLError } from 'graphql'
 import { decodeCursor, LIMIT, nextNoteCursorEncoded } from '@/lib/cursor'
-import { getItem, filterClause, whereClause, muteClause } from './item'
+import { getItem, filterClause, whereClause, muteClause, statusClause } from './item'
 import { getInvoice, getWithdrawl } from './wallet'
 import { pushSubscriptionSchema, ssValidate } from '@/lib/validate'
 import { replyToSubscription } from '@/lib/webPush'
@@ -151,7 +151,8 @@ export default {
           ${whereClause(
             '"Item".created_at < $2',
             await filterClause(me, models),
-            muteClause(me))}
+            muteClause(me),
+            statusClause(me))}
           ORDER BY id ASC, CASE
             WHEN type = 'Mention' THEN 1
             WHEN type = 'Reply' THEN 2

--- a/api/resolvers/notifications.js
+++ b/api/resolvers/notifications.js
@@ -216,6 +216,7 @@ export default {
             WHERE "Invoice"."userId" = $1
             AND "confirmedAt" IS NOT NULL
             AND "isHeld" IS NULL
+            AND "actionType" IS NULL
             AND created_at < $2
             ORDER BY "sortTime" DESC
             LIMIT ${LIMIT})`

--- a/api/resolvers/notifications.js
+++ b/api/resolvers/notifications.js
@@ -315,6 +315,16 @@ export default {
         LIMIT ${LIMIT})`
       )
 
+      queries.push(
+        `(SELECT "Item".id::text, "Item"."created_at" AS "sortTime", NULL as "earnedSats", 'FailedItem' AS type
+        FROM "Item"
+        WHERE "Item"."userId" = $1
+        AND "Item"."created_at" < $2
+        AND "Item"."status" = 'FAILED'
+        ORDER BY "sortTime" DESC
+        LIMIT ${LIMIT})`
+      )
+
       const notifications = await models.$queryRawUnsafe(
         `SELECT id, "sortTime", "earnedSats", type,
             "sortTime" AS "minSortTime"
@@ -397,6 +407,9 @@ export default {
       const { itemId } = await models.reminder.findUnique({ where: { id: Number(n.id) } })
       return await getItem(n, { id: itemId }, { models, me })
     }
+  },
+  FailedItem: {
+    item: async (n, args, { models, me }) => getItem(n, { id: n.id, status: false }, { models, me })
   },
   TerritoryTransfer: {
     sub: async (n, args, { models, me }) => {

--- a/api/resolvers/serial.js
+++ b/api/resolvers/serial.js
@@ -15,7 +15,7 @@ export class InsufficientFundsError extends GraphQLError {
   }
 }
 
-export default async function serialize (trx, { models, lnd, me, hash, hmac, fee }) {
+export default async function serialize (trx, { models, lnd, hash, hmac, fee }) {
   // wrap first argument in array if not array already
   const isArray = Array.isArray(trx)
   if (!isArray) trx = [trx]

--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -4,7 +4,7 @@ import { GraphQLError } from 'graphql'
 import { decodeCursor, LIMIT, nextCursorEncoded } from '@/lib/cursor'
 import { msatsToSats } from '@/lib/format'
 import { bioSchema, emailSchema, settingsSchema, ssValidate, userSchema } from '@/lib/validate'
-import { getItem, updateItem, filterClause, createItem, whereClause, muteClause } from './item'
+import { getItem, updateItem, filterClause, createItem, whereClause, muteClause, statusClause } from './item'
 import { ANON_USER_ID, DELETE_USER_ID, RESERVED_MAX_USER_ID, SN_NO_REWARDS_IDS } from '@/lib/constants'
 import { viewGroup } from './growth'
 import { timeUnitForRange, whenRange } from '@/lib/time'
@@ -285,6 +285,7 @@ export default {
             'r.created_at >= "ThreadSubscription".created_at',
             await filterClause(me, models),
             muteClause(me),
+            statusClause(me),
             ...(user.noteAllDescendants ? [] : ['r.level = 1'])
           )})`, me.id, lastChecked)
       if (newThreadSubReply.exists) {
@@ -305,7 +306,8 @@ export default {
               OR ("Item"."parentId" IS NOT NULL AND "UserSubscription"."commentsSubscribedAt" IS NOT NULL AND "Item".created_at >= "UserSubscription"."commentsSubscribedAt")
             )`,
             await filterClause(me, models),
-            muteClause(me))})`, me.id, lastChecked)
+            muteClause(me),
+            statusClause(me))})`, me.id, lastChecked)
       if (newUserSubs.exists) {
         foundNotes()
         return true
@@ -323,7 +325,8 @@ export default {
             '"Mention".created_at > $2',
             '"Item"."userId" <> $1',
             await filterClause(me, models),
-            muteClause(me)
+            muteClause(me),
+            statusClause(me)
           )})`, me.id, lastChecked)
         if (newMentions.exists) {
           foundNotes()

--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -490,6 +490,20 @@ export default {
         return true
       }
 
+      const newFailedItems = await models.item.findFirst({
+        where: {
+          userId: me.id,
+          status: 'FAILED',
+          updatedAt: {
+            gt: lastChecked
+          }
+        }
+      })
+      if (newFailedItems) {
+        foundNotes()
+        return true
+      }
+
       // update checkedNotesAt to prevent rechecking same time period
       models.user.update({
         where: { id: me.id },

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -391,7 +391,7 @@ export default {
             cancelled: true
           }
         }),
-        ...actionErrorQueries({ data: inv, models })
+        ...(await actionErrorQueries({ data: inv, models }))
       ], { models }
       )
       return { ...inv, cancelled: true }

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -7,7 +7,7 @@ import { SELECT } from './item'
 import { lnAddrOptions } from '@/lib/lnurl'
 import { msatsToSats, msatsToSatsDecimal, ensureB64 } from '@/lib/format'
 import { CLNAutowithdrawSchema, LNDAutowithdrawSchema, amountSchema, lnAddrAutowithdrawSchema, lnAddrSchema, ssValidate, withdrawlSchema } from '@/lib/validate'
-import { ANON_BALANCE_LIMIT_MSATS, ANON_INV_PENDING_LIMIT, ANON_USER_ID, BALANCE_LIMIT_MSATS, INVOICE_RETENTION_DAYS, INV_PENDING_LIMIT, USER_IDS_BALANCE_NO_LIMIT, Wallet } from '@/lib/constants'
+import { ANON_BALANCE_LIMIT_MSATS, ANON_INV_PENDING_LIMIT, ANON_USER_ID, BALANCE_LIMIT_MSATS, DEFAULT_INVOICE_TIMEOUT_MS, INVOICE_RETENTION_DAYS, INV_PENDING_LIMIT, USER_IDS_BALANCE_NO_LIMIT, Wallet } from '@/lib/constants'
 import { datePivot } from '@/lib/time'
 import assertGofacYourself from './ofac'
 import assertApiKeyNotPermitted from './apiKey'
@@ -327,7 +327,7 @@ export default {
     }
   },
   Mutation: {
-    createInvoice: async (parent, { amount, hodlInvoice = false, expireSecs = 3600 }, { me, models, lnd, headers }) => {
+    createInvoice: async (parent, { amount, hodlInvoice = false, expireSecs = (DEFAULT_INVOICE_TIMEOUT_MS / 1000) }, { me, models, lnd, headers }) => {
       await ssValidate(amountSchema, { amount })
       await assertGofacYourself({ models, headers })
 

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -13,7 +13,7 @@ import assertGofacYourself from './ofac'
 import assertApiKeyNotPermitted from './apiKey'
 import { createInvoice as createInvoiceCLN } from '@/lib/cln'
 import { bolt11Tags } from '@/lib/bolt11'
-import { handleActionError } from 'worker/wallet'
+import { actionErrorQueries } from 'worker/action'
 
 export async function getInvoice (parent, { id }, { me, models, lnd }) {
   const inv = await models.invoice.findUnique({
@@ -391,7 +391,7 @@ export default {
             cancelled: true
           }
         }),
-        ...handleActionError({ data: inv, models })
+        ...actionErrorQueries({ data: inv, models })
       ], { models }
       )
       return { ...inv, cancelled: true }

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -125,6 +125,7 @@ export default gql`
     forwards: [ItemForward]
     imgproxyUrls: JSONObject
     rel: String
+    invoice: Invoice
   }
 
   input ItemForwardInput {

--- a/api/typeDefs/notifications.js
+++ b/api/typeDefs/notifications.js
@@ -127,10 +127,16 @@ export default gql`
     sortTime: Date!
   }
 
+  type FailedItem {
+    id: ID!
+    item: Item!
+    sortTime: Date!
+  }
+
   union Notification = Reply | Votification | Mention
     | Invitification | Earn | JobChanged | InvoicePaid | WithdrawlPaid | Referral
     | Streak | FollowActivity | ForwardedVotification | Revenue | SubStatus
-    | TerritoryPost | TerritoryTransfer | Reminder
+    | TerritoryPost | TerritoryTransfer | Reminder | FailedItem
 
   type Notifications {
     lastChecked: Date

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -108,7 +108,7 @@ export function BountyForm ({
       }}
       schema={schema}
       requireSession
-      invoiceable
+      prepaid
       onSubmit={
         handleSubmit ||
         onSubmit

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -30,6 +30,13 @@ export function BountyForm ({
   const toaster = useToast()
   const crossposter = useCrossposter()
   const schema = bountySchema({ client, me, existingBoost: item?.boost })
+
+  const queryTitle = router.query.title
+  const queryText = router.query.text ? decodeURI(router.query.text) : undefined
+  const querySub = router.query.sub
+  const queryBoost = router.query.boost
+  const queryBounty = router.query.bounty
+
   const [upsertBounty] = useMutation(
     gql`
       mutation upsertBounty(
@@ -109,12 +116,12 @@ export function BountyForm ({
   return (
     <Form
       initial={{
-        title: item?.title || '',
-        text: item?.text || '',
+        title: item?.title || queryTitle || '',
+        text: item?.text || queryText || '',
         crosspost: item ? !!item.noteId : me?.privates?.nostrCrossposting,
-        bounty: item?.bounty || 1000,
-        ...AdvPostInitial({ forward: normalizeForwards(item?.forwards), boost: item?.boost }),
-        ...SubSelectInitial({ sub: item?.subName || sub?.name })
+        bounty: item?.bounty || queryBounty || 1000,
+        ...AdvPostInitial({ forward: normalizeForwards(item?.forwards), boost: item?.boost || queryBoost }),
+        ...SubSelectInitial({ sub: item?.subName || sub?.name || querySub })
       }}
       schema={schema}
       requireSession

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -57,6 +57,14 @@ export function BountyForm ({
           id
           deleteScheduledAt
           reminderScheduledAt
+          invoice {
+            id
+            bolt11
+            hash
+            hmac
+            expiresAt
+            satsRequested
+          }
         }
       }
     `
@@ -91,6 +99,8 @@ export function BountyForm ({
         await router.push(prefix + '/recent')
       }
       toastUpsertSuccessMessages(toaster, data, 'upsertBounty', !!item, values.text)
+
+      return data.upsertBounty
     }, [upsertBounty, router]
   )
 
@@ -109,6 +119,7 @@ export function BountyForm ({
       schema={schema}
       requireSession
       prepaid
+      postpaid
       onSubmit={
         handleSubmit ||
         onSubmit

--- a/components/bounty-form.js
+++ b/components/bounty-form.js
@@ -107,7 +107,8 @@ export function BountyForm ({
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}
-      invoiceable={{ requireSession: true }}
+      requireSession
+      invoiceable
       onSubmit={
         handleSubmit ||
         onSubmit

--- a/components/client-notifications.js
+++ b/components/client-notifications.js
@@ -1,0 +1,184 @@
+import { useApolloClient } from '@apollo/client'
+import { useMe } from './me'
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { datePivot, timeSince } from '@/lib/time'
+import { ANON_USER_ID, JIT_INVOICE_TIMEOUT_MS } from '@/lib/constants'
+import { HAS_NOTIFICATIONS } from '@/fragments/notifications'
+import Item from './item'
+import { RootProvider } from './root'
+import Comment from './comment'
+
+const toType = t => ({ ERROR: `${t}_ERROR`, PENDING: `${t}_PENDING` })
+
+export const Types = {
+  Zap: toType('ZAP'),
+  Reply: toType('REPLY'),
+  Bounty: toType('BOUNTY'),
+  PollVote: toType('POLL_VOTE')
+}
+
+const ClientNotificationContext = createContext()
+
+export function ClientNotificationProvider ({ children }) {
+  const [notifications, setNotifications] = useState([])
+  const client = useApolloClient()
+  const me = useMe()
+  // anons don't have access to /notifications
+  // but we'll store client notifications anyway for simplicity's sake
+  const storageKey = `client-notifications:${me?.id || ANON_USER_ID}`
+
+  useEffect(() => {
+    const loaded = loadNotifications(storageKey, client)
+    setNotifications(loaded)
+  }, [storageKey])
+
+  const notify = useCallback((type, props) => {
+    const id = crypto.randomUUID()
+    const sortTime = new Date()
+    const expiresAt = +datePivot(sortTime, { milliseconds: JIT_INVOICE_TIMEOUT_MS })
+    const isError = type.endsWith('ERROR')
+    const n = { __typename: type, id, sortTime: +sortTime, pending: !isError, expiresAt, ...props }
+
+    setNotifications(notifications => [n, ...notifications])
+    saveNotification(storageKey, n)
+
+    if (isError) {
+      client?.writeQuery({
+        query: HAS_NOTIFICATIONS,
+        data: {
+          hasNewNotes: true
+        }
+      })
+    }
+
+    return id
+  }, [storageKey, client])
+
+  const unnotify = useCallback((id) => {
+    setNotifications(notifications => notifications.filter(n => n.id !== id))
+    removeNotification(storageKey, id)
+  }, [storageKey])
+
+  const value = useMemo(() => ({ notifications, notify, unnotify }), [notifications, notify, unnotify])
+  return (
+    <ClientNotificationContext.Provider value={value}>
+      {children}
+    </ClientNotificationContext.Provider>
+  )
+}
+
+export function ClientNotifyProvider ({ children, additionalProps }) {
+  const ctx = useClientNotifications()
+
+  const notify = useCallback((type, props) => {
+    return ctx.notify(type, { ...props, ...additionalProps })
+  }, [ctx.notify])
+
+  const value = useMemo(() => ({ ...ctx, notify }), [ctx, notify])
+  return (
+    <ClientNotificationContext.Provider value={value}>
+      {children}
+    </ClientNotificationContext.Provider>
+  )
+}
+
+export function useClientNotifications () {
+  return useContext(ClientNotificationContext)
+}
+
+function ClientNotification ({ n, message }) {
+  if (n.pending) {
+    const expired = n.expiresAt < +new Date()
+    if (!expired) return null
+    n.reason = 'invoice expired'
+  }
+
+  return (
+    <div className='ms-2'>
+      <small className='fw-bold text-danger'>
+        {n.reason ? `${message}: ${n.reason}` : message}
+        <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.sortTime))}</small>
+      </small>
+      {!n.item
+        ? null
+        : n.item.title
+          ? <Item item={n.item} />
+          : (
+            <div className='pb-2'>
+              <RootProvider root={n.item.root}>
+                <Comment item={n.item} noReply includeParent noComments clickToContext />
+              </RootProvider>
+            </div>
+            )}
+    </div>
+  )
+}
+
+export function ClientZap ({ n }) {
+  const message = `failed to zap ${n.sats || n.amount} sats`
+  return <ClientNotification n={n} message={message} />
+}
+
+export function ClientReply ({ n }) {
+  const message = 'failed to submit reply'
+  return <ClientNotification n={n} message={message} />
+}
+
+export function ClientBounty ({ n }) {
+  const message = 'failed to pay bounty'
+  return <ClientNotification n={n} message={message} />
+}
+
+export function ClientPollVote ({ n }) {
+  const message = 'failed to submit poll vote'
+  return <ClientNotification n={n} message={message} />
+}
+
+function loadNotifications (storageKey, client) {
+  const stored = window.localStorage.getItem(storageKey)
+  if (!stored) return []
+
+  const filtered = JSON.parse(stored).filter(({ sortTime }) => {
+    // only keep notifications younger than 24 hours
+    return new Date(sortTime) >= datePivot(new Date(), { hours: -24 })
+  })
+
+  let hasNewNotes = false
+  const mapped = filtered.map((n) => {
+    if (!n.pending) return n
+    // anything that is still pending when we load the page was interrupted
+    // so we immediately mark it as failed instead of waiting until it expired
+    const type = n.__typename.replace('PENDING', 'ERROR')
+    const reason = 'payment was interrupted'
+    hasNewNotes = true
+    return { ...n, __typename: type, pending: false, reason }
+  })
+
+  if (hasNewNotes) {
+    client?.writeQuery({
+      query: HAS_NOTIFICATIONS,
+      data: {
+        hasNewNotes: true
+      }
+    })
+  }
+
+  window.localStorage.setItem(storageKey, JSON.stringify(mapped))
+  return filtered
+}
+
+function saveNotification (storageKey, n) {
+  const stored = window.localStorage.getItem(storageKey)
+  if (stored) {
+    window.localStorage.setItem(storageKey, JSON.stringify([...JSON.parse(stored), n]))
+  } else {
+    window.localStorage.setItem(storageKey, JSON.stringify([n]))
+  }
+}
+
+function removeNotification (storageKey, id) {
+  const stored = window.localStorage.getItem(storageKey)
+  if (stored) {
+    window.localStorage.setItem(storageKey, JSON.stringify(JSON.parse(stored).filter(n => n.id !== id)))
+  }
+}

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -38,6 +38,14 @@ export function DiscussionForm ({
           id
           deleteScheduledAt
           reminderScheduledAt
+          invoice {
+            id
+            bolt11
+            hash
+            hmac
+            expiresAt
+            satsRequested
+          }
         }
       }`
   )
@@ -71,6 +79,8 @@ export function DiscussionForm ({
         await router.push(prefix + '/recent')
       }
       toastUpsertSuccessMessages(toaster, data, 'upsertDiscussion', !!item, values.text)
+
+      return data.upsertDiscussion
     }, [upsertDiscussion, router, item, sub, crossposter]
   )
 
@@ -97,6 +107,7 @@ export function DiscussionForm ({
       }}
       schema={schema}
       prepaid
+      postpaid
       onSubmit={handleSubmit || onSubmit}
       storageKeyPrefix={storageKeyPrefix}
     >

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -96,7 +96,7 @@ export function DiscussionForm ({
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}
-      invoiceable
+      prepaid
       onSubmit={handleSubmit || onSubmit}
       storageKeyPrefix={storageKeyPrefix}
     >

--- a/components/discussion-form.js
+++ b/components/discussion-form.js
@@ -25,11 +25,13 @@ export function DiscussionForm ({
   const client = useApolloClient()
   const me = useMe()
   const schema = discussionSchema({ client, me, existingBoost: item?.boost })
-  // if Web Share Target API was used
-  const shareTitle = router.query.title
-  const shareText = router.query.text ? decodeURI(router.query.text) : undefined
   const crossposter = useCrossposter()
   const toaster = useToast()
+
+  const queryTitle = router.query.title
+  const queryText = router.query.text ? decodeURI(router.query.text) : undefined
+  const querySub = router.query.sub
+  const queryBoost = router.query.boost
 
   const [upsertDiscussion] = useMutation(
     gql`
@@ -99,11 +101,11 @@ export function DiscussionForm ({
   return (
     <Form
       initial={{
-        title: item?.title || shareTitle || '',
-        text: item?.text || shareText || '',
+        title: item?.title || queryTitle || '',
+        text: item?.text || queryText || '',
         crosspost: item ? !!item.noteId : me?.privates?.nostrCrossposting,
-        ...AdvPostInitial({ forward: normalizeForwards(item?.forwards), boost: item?.boost }),
-        ...SubSelectInitial({ sub: item?.subName || sub?.name })
+        ...AdvPostInitial({ forward: normalizeForwards(item?.forwards), boost: item?.boost || queryBoost }),
+        ...SubSelectInitial({ sub: item?.subName || sub?.name || querySub })
       }}
       schema={schema}
       prepaid

--- a/components/dont-link-this.js
+++ b/components/dont-link-this.js
@@ -1,13 +1,12 @@
 import Dropdown from 'react-bootstrap/Dropdown'
 import { useShowModal } from './modal'
 import { useToast } from './toast'
-import ItemAct, { zapUndosThresholdReached } from './item-act'
+import ItemAct from './item-act'
 import AccordianItem from './accordian-item'
 import Flag from '@/svgs/flag-fill.svg'
 import { useMemo } from 'react'
 import getColor from '@/lib/rainbow'
 import { gql, useMutation } from '@apollo/client'
-import { useMe } from './me'
 
 export function DownZap ({ id, meDontLikeSats, ...props }) {
   const style = useMemo(() => (meDontLikeSats
@@ -24,7 +23,6 @@ export function DownZap ({ id, meDontLikeSats, ...props }) {
 function DownZapper ({ id, As, children }) {
   const toaster = useToast()
   const showModal = useShowModal()
-  const me = useMe()
 
   return (
     <As
@@ -32,12 +30,7 @@ function DownZapper ({ id, As, children }) {
         try {
           showModal(onClose =>
             <ItemAct
-              onClose={(amount) => {
-                onClose()
-                // undo prompt was toasted before closing modal if zap undos are enabled
-                // so an additional success toast would be confusing
-                if (!zapUndosThresholdReached(me, amount)) toaster.success('item downzapped')
-              }} itemId={id} down
+              onClose={onClose} itemId={id} down
             >
               <AccordianItem
                 header='what is a downzap?' body={

--- a/components/fee-button.js
+++ b/components/fee-button.js
@@ -11,7 +11,6 @@ import AnonIcon from '@/svgs/spy-fill.svg'
 import { useShowModal } from './modal'
 import Link from 'next/link'
 import { SubmitButton } from './form'
-import { PaymentProvider } from './payment'
 
 const FeeButtonContext = createContext()
 
@@ -93,9 +92,7 @@ export function FeeButtonProvider ({ baseLineItems = {}, useRemoteLineItems = ()
 
   return (
     <FeeButtonContext.Provider value={value}>
-      <PaymentProvider>
-        {children}
-      </PaymentProvider>
+      {children}
     </FeeButtonContext.Provider>
   )
 }

--- a/components/fee-button.js
+++ b/components/fee-button.js
@@ -88,7 +88,7 @@ export function FeeButtonProvider ({ baseLineItems = {}, useRemoteLineItems = ()
       setDisabled,
       free
     }
-  }, [me, baseLineItems, lineItems, remoteLineItems, mergeLineItems, disabled, setDisabled])
+  }, [me?.privates?.sats, baseLineItems, lineItems, remoteLineItems, mergeLineItems, disabled, setDisabled])
 
   return (
     <FeeButtonContext.Provider value={value}>

--- a/components/form.js
+++ b/components/form.js
@@ -35,6 +35,7 @@ import { InvoiceCanceledError, usePayment } from './payment'
 import { useMe } from './me'
 import { optimisticUpdate } from '@/lib/apollo'
 import { useClientNotifications } from './client-notifications'
+import { ActCanceledError } from './item-act'
 
 export class SessionRequiredError extends Error {
   constructor () {
@@ -804,7 +805,7 @@ const StorageKeyPrefixContext = createContext()
 export function Form ({
   initial, schema, onSubmit, children, initialError, validateImmediately,
   storageKeyPrefix, validateOnChange = true, prepaid, postpaid, requireSession, innerRef,
-  optimisticUpdate: optimisticUpdateArgs, clientNotification, ...props
+  optimisticUpdate: optimisticUpdateArgs, clientNotification, signal, ...props
 }) {
   const toaster = useToast()
   const initialErrorToasted = useRef(false)
@@ -848,6 +849,8 @@ export function Form ({
           revert = optimisticUpdate(optimisticUpdateArgs(variables))
         }
 
+        await signal?.pause({ me, amount })
+
         if (me && clientNotification) {
           nid = notify(clientNotification.PENDING, variables)
         }
@@ -871,7 +874,7 @@ export function Form ({
     } catch (err) {
       revert?.()
 
-      if (err instanceof InvoiceCanceledError) {
+      if (err instanceof InvoiceCanceledError || err instanceof ActCanceledError) {
         return
       }
 
@@ -889,7 +892,7 @@ export function Form ({
       // stored in localStorage to handle this case.
       if (nid) unnotify(nid)
     }
-  }, [me, onSubmit, feeButton?.total, toaster, clearLocalStorage, storageKeyPrefix, payment])
+  }, [me, onSubmit, feeButton?.total, toaster, clearLocalStorage, storageKeyPrefix, payment, signal])
 
   return (
     <Formik

--- a/components/form.js
+++ b/components/form.js
@@ -34,6 +34,7 @@ import Info from './info'
 import { InvoiceCanceledError, usePayment } from './payment'
 import { useMe } from './me'
 import { optimisticUpdate } from '@/lib/apollo'
+import { useClientNotifications } from './client-notifications'
 
 export class SessionRequiredError extends Error {
   constructor () {
@@ -803,13 +804,14 @@ const StorageKeyPrefixContext = createContext()
 export function Form ({
   initial, schema, onSubmit, children, initialError, validateImmediately,
   storageKeyPrefix, validateOnChange = true, prepaid, postpaid, requireSession, innerRef,
-  optimisticUpdate: optimisticUpdateArgs, ...props
+  optimisticUpdate: optimisticUpdateArgs, clientNotification, ...props
 }) {
   const toaster = useToast()
   const initialErrorToasted = useRef(false)
   const feeButton = useFeeButton()
   const payment = usePayment()
   const me = useMe()
+  const { notify, unnotify } = useClientNotifications()
 
   useEffect(() => {
     if (initialError && !initialErrorToasted.current) {
@@ -835,16 +837,22 @@ export function Form ({
 
   const onSubmitInner = useCallback(async ({ amount, ...values }, ...args) => {
     const variables = { amount, ...values }
-    let revert, cancel
+    let revert, cancel, nid
     try {
       if (onSubmit) {
         if (requireSession && !me) {
           throw new SessionRequiredError()
         }
-        let hash, hmac
+
         if (optimisticUpdateArgs) {
           revert = optimisticUpdate(optimisticUpdateArgs(variables))
         }
+
+        if (me && clientNotification) {
+          nid = notify(clientNotification.PENDING, variables)
+        }
+
+        let hash, hmac
         // stackers only use prepaid if postpaid is not set
         // anons always use prepaid even if postpaid is set
         if (prepaid && (!me || !postpaid)) {
@@ -856,17 +864,30 @@ export function Form ({
           // TODO: persist payment to continously attempt payment in background and handle errors
           await payment.send(data.invoice)
         }
+
         if (!storageKeyPrefix) return
         clearLocalStorage(values)
       }
     } catch (err) {
       revert?.()
+
       if (err instanceof InvoiceCanceledError) {
         return
       }
-      const msg = err.message || err.toString?.()
-      toaster.danger('submit error: ' + msg)
+
+      const reason = err.message || err.toString?.()
+      if (me && clientNotification) {
+        notify(clientNotification.ERROR, { ...variables, reason })
+      } else {
+        toaster.danger('submit error: ' + reason)
+      }
+
       cancel?.()
+    } finally {
+      // if we reach this line, the submit either failed or was successful so we can remove the pending notification.
+      // if we don't reach this line, the page was probably reloaded and we can use the pending notification
+      // stored in localStorage to handle this case.
+      if (nid) unnotify(nid)
     }
   }, [me, onSubmit, feeButton?.total, toaster, clearLocalStorage, storageKeyPrefix, payment])
 

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -1,22 +1,33 @@
-import { useState, useCallback, useEffect } from 'react'
-import { useApolloClient, useMutation, useQuery } from '@apollo/client'
-import { Button } from 'react-bootstrap'
-import { gql } from 'graphql-tag'
+import { useState, useEffect } from 'react'
 import { numWithUnits } from '@/lib/format'
 import AccordianItem from './accordian-item'
-import Qr, { QrSkeleton } from './qr'
-import { INVOICE } from '@/fragments/wallet'
-import InvoiceStatus from './invoice-status'
-import { useMe } from './me'
-import { useShowModal } from './modal'
+import Qr from './qr'
 import Countdown from './countdown'
 import PayerData from './payer-data'
 import Bolt11Info from './bolt11-info'
-import { useWebLN } from './webln'
-import { FAST_POLL_INTERVAL } from '@/lib/constants'
+import { useQuery } from '@apollo/client'
+import { INVOICE } from '@/fragments/wallet'
+import { FAST_POLL_INTERVAL, SSR } from '@/lib/constants'
 
-export function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn }) {
+export default function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn, poll }) {
   const [expired, setExpired] = useState(new Date(invoice.expiredAt) <= new Date())
+
+  const { data, error } = useQuery(INVOICE, SSR
+    ? {}
+    : {
+        pollInterval: FAST_POLL_INTERVAL,
+        variables: { id: invoice.id },
+        nextFetchPolicy: 'cache-and-network',
+        skip: !poll
+      })
+
+  if (data) {
+    invoice = data.invoice
+  }
+
+  if (error) {
+    return <div>{error.toString()}</div>
+  }
 
   // if webLn was not passed, use true by default
   if (webLn === undefined) webLn = true
@@ -104,290 +115,4 @@ export function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn }
 
     </>
   )
-}
-
-const JITInvoice = ({ invoice: { id, hash, hmac, expiresAt }, onPayment, onCancel, onRetry }) => {
-  const { data, loading, error } = useQuery(INVOICE, {
-    pollInterval: FAST_POLL_INTERVAL,
-    variables: { id }
-  })
-  const [retryError, setRetryError] = useState(0)
-  if (error) {
-    if (error.message?.includes('invoice not found')) {
-      return
-    }
-    return <div>error</div>
-  }
-  if (!data || loading) {
-    return <QrSkeleton description status='loading' />
-  }
-
-  const retry = !!onRetry
-  let errorStatus = 'Something went wrong trying to perform the action after payment.'
-  if (retryError > 0) {
-    errorStatus = 'Something still went wrong.\nYou can retry or cancel the invoice to return your funds.'
-  }
-
-  return (
-    <>
-      <Invoice invoice={data.invoice} modal onPayment={onPayment} successVerb='received' webLn={false} />
-      {retry
-        ? (
-          <>
-            <div className='my-3'>
-              <InvoiceStatus variant='failed' status={errorStatus} />
-            </div>
-            <div className='d-flex flex-row mt-3 justify-content-center'>
-              <Button
-                className='mx-1' variant='info' onClick={async () => {
-                  try {
-                    await onRetry()
-                  } catch (err) {
-                    console.error('retry error:', err)
-                    setRetryError(retryError => retryError + 1)
-                  }
-                }}
-              >Retry
-              </Button>
-              <Button
-                className='mx-1'
-                variant='danger'
-                onClick={onCancel}
-              >Cancel
-              </Button>
-            </div>
-          </>
-          )
-        : null}
-    </>
-  )
-}
-
-const defaultOptions = {
-  requireSession: false,
-  forceInvoice: false
-}
-export const useInvoiceable = (onSubmit, options = defaultOptions) => {
-  const me = useMe()
-  const [createInvoice] = useMutation(gql`
-    mutation createInvoice($amount: Int!) {
-      createInvoice(amount: $amount, hodlInvoice: true, expireSecs: 180) {
-        id
-        bolt11
-        hash
-        hmac
-        expiresAt
-      }
-    }`)
-  const [cancelInvoice] = useMutation(gql`
-    mutation cancelInvoice($hash: String!, $hmac: String!) {
-      cancelInvoice(hash: $hash, hmac: $hmac) {
-        id
-      }
-    }
-  `)
-
-  const showModal = useShowModal()
-  const provider = useWebLN()
-  const client = useApolloClient()
-  const pollInvoice = (id) => client.query({ query: INVOICE, fetchPolicy: 'no-cache', variables: { id } })
-
-  const onSubmitWrapper = useCallback(async (
-    { cost, ...formValues },
-    { variables, optimisticResponse, update, flowId, ...submitArgs }) => {
-    // some actions require a session
-    if (!me && options.requireSession) {
-      throw new Error('you must be logged in')
-    }
-
-    // id for toast flows
-    if (!flowId) flowId = (+new Date()).toString(16)
-
-    // educated guesses where action might pass in the invoice amount
-    // (field 'cost' has highest precedence)
-    cost ??= formValues.amount
-
-    // attempt action for the first time
-    if (!cost || (me && !options.forceInvoice)) {
-      try {
-        const insufficientFunds = me?.privates.sats < cost
-        return await onSubmit(formValues,
-          { ...submitArgs, flowId, variables, optimisticsResponse: insufficientFunds ? null : optimisticResponse, update })
-      } catch (error) {
-        if (!payOrLoginError(error) || !cost) {
-          // can't handle error here - bail
-          throw error
-        }
-      }
-    }
-
-    // initial attempt of action failed. we will create an invoice, pay and retry now.
-    const { data, error } = await createInvoice({ variables: { amount: cost } })
-    if (error) {
-      throw error
-    }
-    const inv = data.createInvoice
-
-    // If this is a zap, we need to manually be optimistic to have a consistent
-    // UX across custodial and WebLN zaps since WebLN zaps don't call GraphQL
-    // mutations which implement optimistic responses natively.
-    // Therefore, we check if this is a zap and then wrap the WebLN payment logic
-    // with manual cache update calls.
-    const itemId = optimisticResponse?.act?.id
-    const isZap = !!itemId
-    let _update
-    if (isZap && update) {
-      _update = () => {
-        const fragment = {
-          id: `Item:${itemId}`,
-          fragment: gql`
-          fragment ItemMeSatsInvoice on Item {
-            sats
-            meSats
-          }
-        `
-        }
-        const item = client.cache.readFragment(fragment)
-        update(client.cache, { data: optimisticResponse })
-        // undo function
-        return () => client.cache.writeFragment({ ...fragment, data: item })
-      }
-    }
-
-    // wait until invoice is paid or modal is closed
-    const { modalOnClose, webLn, gqlCacheUpdateUndo } = await waitForPayment({
-      invoice: inv,
-      showModal,
-      provider,
-      pollInvoice,
-      gqlCacheUpdate: _update,
-      flowId
-    })
-
-    const retry = () => onSubmit(
-      { hash: inv.hash, hmac: inv.hmac, expiresAt: inv.expiresAt, ...formValues },
-      // unset update function since we already ran an cache update if we paid using WebLN
-      // also unset update function if null was explicitly passed in
-      { ...submitArgs, variables, update: webLn ? null : undefined })
-    // first retry
-    try {
-      const ret = await retry()
-      modalOnClose?.()
-      return ret
-    } catch (error) {
-      gqlCacheUpdateUndo?.()
-      console.error('retry error:', error)
-    }
-
-    // retry until success or cancel
-    return await new Promise((resolve, reject) => {
-      const cancelAndReject = async () => {
-        await cancelInvoice({ variables: { hash: inv.hash, hmac: inv.hmac } })
-        reject(new Error('invoice canceled'))
-      }
-      showModal(onClose => {
-        return (
-          <JITInvoice
-            invoice={inv}
-            onCancel={async () => {
-              await cancelAndReject()
-              onClose()
-            }}
-            onRetry={async () => {
-              resolve(await retry())
-              onClose()
-            }}
-          />
-        )
-      }, { keepOpen: true, onClose: cancelAndReject })
-    })
-  }, [onSubmit, provider, createInvoice, !!me])
-
-  return onSubmitWrapper
-}
-
-const INVOICE_CANCELED_ERROR = 'invoice canceled'
-const waitForPayment = async ({ invoice, showModal, provider, pollInvoice, gqlCacheUpdate, flowId }) => {
-  if (provider) {
-    try {
-      return await waitForWebLNPayment({ provider, invoice, pollInvoice, gqlCacheUpdate, flowId })
-    } catch (err) {
-      // check for errors which mean that QR code will also fail
-      if (err.message === INVOICE_CANCELED_ERROR) {
-        throw err
-      }
-    }
-  }
-
-  // QR code as fallback
-  return await new Promise((resolve, reject) => {
-    showModal(onClose => {
-      return (
-        <JITInvoice
-          invoice={invoice}
-          onPayment={() => resolve({ modalOnClose: onClose })}
-        />
-      )
-    }, { keepOpen: true, onClose: reject })
-  })
-}
-
-const waitForWebLNPayment = async ({ provider, invoice, pollInvoice, gqlCacheUpdate, flowId }) => {
-  let undoUpdate
-  try {
-    // try WebLN provider first
-    return await new Promise((resolve, reject) => {
-      // be optimistic and pretend zap was already successful for consistent zapping UX
-      undoUpdate = gqlCacheUpdate?.()
-      // can't use await here since we might be paying JIT invoices
-      // and sendPaymentAsync is not supported yet.
-      // see https://www.webln.guide/building-lightning-apps/webln-reference/webln.sendpaymentasync
-      provider.sendPayment({ ...invoice, flowId })
-        // WebLN payment will never resolve here for JIT invoices
-        // since they only get resolved after settlement which can't happen here
-        .then(() => resolve({ webLn: true, gqlCacheUpdateUndo: undoUpdate }))
-        .catch(err => {
-          clearInterval(interval)
-          reject(err)
-        })
-      const interval = setInterval(async () => {
-        try {
-          const { data, error } = await pollInvoice(invoice.id)
-          if (error) {
-            clearInterval(interval)
-            return reject(error)
-          }
-          const { invoice: inv } = data
-          if (inv.isHeld && inv.satsReceived) {
-            clearInterval(interval)
-            resolve({ webLn: true, gqlCacheUpdateUndo: undoUpdate })
-          }
-          if (inv.cancelled) {
-            clearInterval(interval)
-            reject(new Error(INVOICE_CANCELED_ERROR))
-          }
-        } catch (err) {
-          clearInterval(interval)
-          reject(err)
-        }
-      }, FAST_POLL_INTERVAL)
-    })
-  } catch (err) {
-    undoUpdate?.()
-    console.error('WebLN payment failed:', err)
-    throw err
-  }
-}
-
-export const useInvoiceModal = (onPayment, deps) => {
-  const onPaymentMemo = useCallback(onPayment, deps)
-  return useInvoiceable(onPaymentMemo, { replaceModal: true })
-}
-
-export const payOrLoginError = (error) => {
-  const matches = ['insufficient funds', 'you must be logged in or pay']
-  if (Array.isArray(error)) {
-    return error.some(({ message }) => matches.some(m => message.includes(m)))
-  }
-  return matches.some(m => error.toString().includes(m))
 }

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -8,8 +8,9 @@ import Bolt11Info from './bolt11-info'
 import { useQuery } from '@apollo/client'
 import { INVOICE } from '@/fragments/wallet'
 import { FAST_POLL_INTERVAL, SSR } from '@/lib/constants'
+import { WebLnNotEnabledError } from './payment'
 
-export default function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn, poll }) {
+export default function Invoice ({ invoice, modal, onPayment, info, successVerb, webLn, webLnError, poll }) {
   const [expired, setExpired] = useState(new Date(invoice.expiredAt) <= new Date())
 
   const { data, error } = useQuery(INVOICE, SSR
@@ -59,6 +60,11 @@ export default function Invoice ({ invoice, modal, onPayment, info, successVerb,
 
   return (
     <>
+      {webLnError && !(webLnError instanceof WebLnNotEnabledError) &&
+        <div className='text-center text-danger mb-3'>
+          Payment from attached wallet failed:
+          <div>{webLnError.toString()}</div>
+        </div>}
       <Qr
         webLn={webLn} value={invoice.bolt11}
         description={numWithUnits(invoice.satsRequested, { abbreviate: false })}

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -41,6 +41,12 @@ const addCustomTip = (amount) => {
   window.localStorage.setItem('custom-tips', JSON.stringify(customTips))
 }
 
+const setItemMeAnonSats = ({ id, amount }) => {
+  const storageKey = `TIP-item:${id}`
+  const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
+  window.localStorage.setItem(storageKey, existingAmount + amount)
+}
+
 export default function ItemAct ({ onClose, itemId, down, children }) {
   const inputRef = useRef(null)
   const me = useMe()
@@ -54,11 +60,6 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
   const act = useAct()
 
   const onSubmit = useCallback(async ({ amount, hash, hmac }) => {
-    if (!me) {
-      const storageKey = `TIP-item:${itemId}`
-      const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
-      window.localStorage.setItem(storageKey, existingAmount + amount)
-    }
     await act({
       variables: {
         id: itemId,
@@ -68,6 +69,7 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
         hmac
       }
     })
+    setItemMeAnonSats({ id: itemId, amount })
     strike()
     addCustomTip(Number(amount))
   }, [me, act, down, itemId, strike])

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -145,7 +145,7 @@ export default function ItemAct ({ onClose, item, down, children }) {
         default: false
       }}
       schema={amountSchema}
-      invoiceable
+      prepaid
       optimisticUpdate={optimisticUpdate}
       onSubmit={onSubmit}
     >

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -9,7 +9,7 @@ import { gql, useMutation } from '@apollo/client'
 import { useToast } from './toast'
 import { useLightning } from './lightning'
 import { nextTip } from './upvote'
-import { InvoiceCanceledError, PaymentProvider, usePayment } from './payment'
+import { InvoiceCanceledError, usePayment } from './payment'
 
 const defaultTips = [100, 1000, 10_000, 100_000]
 
@@ -72,37 +72,34 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
     addCustomTip(Number(amount))
   }, [me, act, down, itemId, strike])
 
-  // we need to wrap with PaymentProvider here since modals don't have access to PaymentContext by default
   return (
-    <PaymentProvider>
-      <Form
-        initial={{
-          amount: me?.privates?.tipDefault || defaultTips[0],
-          default: false
-        }}
-        schema={amountSchema}
-        invoiceable
-        onSubmit={onSubmit}
-      >
-        <Input
-          label='amount'
-          name='amount'
-          type='number'
-          innerRef={inputRef}
-          overrideValue={oValue}
-          required
-          autoFocus
-          append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
-        />
-        <div>
-          <Tips setOValue={setOValue} />
-        </div>
-        {children}
-        <div className='d-flex mt-3'>
-          <SubmitButton variant={down ? 'danger' : 'success'} className='ms-auto mt-1 px-4' value='TIP'>{down && 'down'}zap</SubmitButton>
-        </div>
-      </Form>
-    </PaymentProvider>
+    <Form
+      initial={{
+        amount: me?.privates?.tipDefault || defaultTips[0],
+        default: false
+      }}
+      schema={amountSchema}
+      invoiceable
+      onSubmit={onSubmit}
+    >
+      <Input
+        label='amount'
+        name='amount'
+        type='number'
+        innerRef={inputRef}
+        overrideValue={oValue}
+        required
+        autoFocus
+        append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
+      />
+      <div>
+        <Tips setOValue={setOValue} />
+      </div>
+      {children}
+      <div className='d-flex mt-3'>
+        <SubmitButton variant={down ? 'danger' : 'success'} className='ms-auto mt-1 px-4' value='TIP'>{down && 'down'}zap</SubmitButton>
+      </div>
+    </Form>
   )
 }
 

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -5,13 +5,13 @@ import { Form, Input, SubmitButton } from './form'
 import { useMe } from './me'
 import UpBolt from '@/svgs/bolt.svg'
 import { amountSchema } from '@/lib/validate'
-import { gql, useApolloClient, useMutation } from '@apollo/client'
-import { payOrLoginError, useInvoiceModal } from './invoice'
-import { TOAST_DEFAULT_DELAY_MS, useToast, withToastFlow } from './toast'
+import { gql, useMutation } from '@apollo/client'
+import { useToast } from './toast'
 import { useLightning } from './lightning'
 import { nextTip } from './upvote'
+import { InvoiceCanceledError, PaymentProvider, usePayment } from './payment'
 
-const defaultTips = [100, 1000, 10000, 100000]
+const defaultTips = [100, 1000, 10_000, 100_000]
 
 const Tips = ({ setOValue }) => {
   const tips = [...getCustomTips(), ...defaultTips].sort((a, b) => a - b)
@@ -41,27 +41,19 @@ const addCustomTip = (amount) => {
   window.localStorage.setItem('custom-tips', JSON.stringify(customTips))
 }
 
-export const zapUndosThresholdReached = (me, amount) => {
-  if (!me) return false
-  const enabled = me.privates.zapUndos !== null
-  return enabled ? amount >= me.privates.zapUndos : false
-}
-
 export default function ItemAct ({ onClose, itemId, down, children }) {
   const inputRef = useRef(null)
   const me = useMe()
   const [oValue, setOValue] = useState()
   const strike = useLightning()
-  const toaster = useToast()
-  const client = useApolloClient()
 
   useEffect(() => {
     inputRef.current?.focus()
   }, [onClose, itemId])
 
-  const [act, actUpdate] = useAct()
+  const act = useAct()
 
-  const onSubmit = useCallback(async ({ amount, hash, hmac }, { update, keepOpen }) => {
+  const onSubmit = useCallback(async ({ amount, hash, hmac }) => {
     if (!me) {
       const storageKey = `TIP-item:${itemId}`
       const existingAmount = Number(window.localStorage.getItem(storageKey) || '0')
@@ -74,119 +66,43 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
         act: down ? 'DONT_LIKE_THIS' : 'TIP',
         hash,
         hmac
-      },
-      update
+      }
     })
-    // only strike when zap undos not enabled
-    // due to optimistic UX on zap undos
-    if (!zapUndosThresholdReached(me, Number(amount))) await strike()
+    strike()
     addCustomTip(Number(amount))
-    if (!keepOpen) onClose(Number(amount))
   }, [me, act, down, itemId, strike])
 
-  const onSubmitWithUndos = withToastFlow(toaster)(
-    (values, args) => {
-      const { flowId } = args
-      let canceled
-      const sats = values.amount
-      const insufficientFunds = me?.privates?.sats < sats
-      const invoiceAttached = values.hash && values.hmac
-      if (insufficientFunds && !invoiceAttached) throw new Error('insufficient funds')
-      // payments from external wallets already have their own flow
-      // and we don't want to show undo toasts for them
-      const skipToastFlow = invoiceAttached
-      // update function for optimistic UX
-      const update = () => {
-        const fragment = {
-          id: `Item:${itemId}`,
-          fragment: gql`
-          fragment ItemMeSatsSubmit on Item {
-            path
-            sats
-            meSats
-            meDontLikeSats
-          }
-        `
-        }
-        const item = client.cache.readFragment(fragment)
-        const optimisticResponse = {
-          act: {
-            id: itemId, sats, path: item.path, act: down ? 'DONT_LIKE_THIS' : 'TIP'
-          }
-        }
-        actUpdate(client.cache, { data: optimisticResponse })
-        return () => client.cache.writeFragment({ ...fragment, data: item })
-      }
-      let undoUpdate
-      return {
-        skipToastFlow,
-        flowId,
-        tag: itemId,
-        type: 'zap',
-        pendingMessage: `${down ? 'down' : ''}zapped ${sats} sats`,
-        onPending: async () => {
-          if (skipToastFlow) {
-            return onSubmit(values, { flowId, ...args, update: null })
-          }
-          await strike()
-          onClose(sats)
-          return new Promise((resolve, reject) => {
-            undoUpdate = update()
-            setTimeout(() => {
-              if (canceled) return resolve()
-              onSubmit(values, { flowId, ...args, update: null, keepOpen: true })
-                .then(resolve)
-                .catch((err) => {
-                  undoUpdate()
-                  reject(err)
-                })
-            }, TOAST_DEFAULT_DELAY_MS)
-          })
-        },
-        onUndo: () => {
-          canceled = true
-          undoUpdate?.()
-        },
-        hideSuccess: true,
-        hideError: true,
-        timeout: TOAST_DEFAULT_DELAY_MS
-      }
-    }
-  )
-
+  // we need to wrap with PaymentProvider here since modals don't have access to PaymentContext by default
   return (
-    <Form
-      initial={{
-        amount: me?.privates?.tipDefault || defaultTips[0],
-        default: false
-      }}
-      schema={amountSchema}
-      invoiceable
-      onSubmit={(values, ...args) => {
-        if (zapUndosThresholdReached(me, values.amount)) {
-          return onSubmitWithUndos(values, ...args)
-        }
-        return onSubmit(values, ...args)
-      }}
-    >
-      <Input
-        label='amount'
-        name='amount'
-        type='number'
-        innerRef={inputRef}
-        overrideValue={oValue}
-        required
-        autoFocus
-        append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
-      />
-      <div>
-        <Tips setOValue={setOValue} />
-      </div>
-      {children}
-      <div className='d-flex mt-3'>
-        <SubmitButton variant={down ? 'danger' : 'success'} className='ms-auto mt-1 px-4' value='TIP'>{down && 'down'}zap</SubmitButton>
-      </div>
-    </Form>
+    <PaymentProvider>
+      <Form
+        initial={{
+          amount: me?.privates?.tipDefault || defaultTips[0],
+          default: false
+        }}
+        schema={amountSchema}
+        invoiceable
+        onSubmit={onSubmit}
+      >
+        <Input
+          label='amount'
+          name='amount'
+          type='number'
+          innerRef={inputRef}
+          overrideValue={oValue}
+          required
+          autoFocus
+          append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
+        />
+        <div>
+          <Tips setOValue={setOValue} />
+        </div>
+        {children}
+        <div className='d-flex mt-3'>
+          <SubmitButton variant={down ? 'danger' : 'success'} className='ms-auto mt-1 px-4' value='TIP'>{down && 'down'}zap</SubmitButton>
+        </div>
+      </Form>
+    </PaymentProvider>
   )
 }
 
@@ -256,7 +172,7 @@ export function useAct ({ onUpdate } = {}) {
         }
       }`, { update }
   )
-  return [act, update]
+  return act
 }
 
 export function useZap () {
@@ -309,116 +225,39 @@ export function useZap () {
 
   const [zap] = useMutation(
     gql`
-      mutation idempotentAct($id: ID!, $sats: Int!) {
-        act(id: $id, sats: $sats, idempotent: true) {
+      mutation idempotentAct($id: ID!, $sats: Int!, $hash: String, $hmac: String) {
+        act(id: $id, sats: $sats, hash: $hash, hmac: $hmac, idempotent: true) {
           id
           sats
           path
         }
-      }`
+      }`, { update }
   )
 
   const toaster = useToast()
   const strike = useLightning()
-  const [act] = useAct()
-  const client = useApolloClient()
-
-  const invoiceableAct = useInvoiceModal(
-    async ({ hash, hmac }, { variables, ...apolloArgs }) => {
-      await act({ variables: { ...variables, hash, hmac }, ...apolloArgs })
-      strike()
-    }, [act, strike])
-
-  const zapWithUndos = withToastFlow(toaster)(
-    ({ variables, optimisticResponse, update, flowId }) => {
-      const { id: itemId, amount } = variables
-      let canceled
-      // update function for optimistic UX
-      const _update = () => {
-        const fragment = {
-          id: `Item:${itemId}`,
-          fragment: gql`
-          fragment ItemMeSatsUndos on Item {
-            sats
-            meSats
-          }
-        `
-        }
-        const item = client.cache.readFragment(fragment)
-        update(client.cache, { data: optimisticResponse })
-        // undo function
-        return () => client.cache.writeFragment({ ...fragment, data: item })
-      }
-      let undoUpdate
-      return {
-        flowId,
-        tag: itemId,
-        type: 'zap',
-        pendingMessage: `zapped ${amount} sats`,
-        onPending: () =>
-          new Promise((resolve, reject) => {
-            undoUpdate = _update()
-            setTimeout(
-              () => {
-                if (canceled) return resolve()
-                zap({ variables, optimisticResponse, update: null }).then(resolve).catch((err) => {
-                  undoUpdate()
-                  reject(err)
-                })
-              },
-              TOAST_DEFAULT_DELAY_MS
-            )
-          }),
-        onUndo: () => {
-          // we can't simply clear the timeout on cancel since
-          // the onPending promise would never settle in that case
-          canceled = true
-          undoUpdate?.()
-        },
-        hideSuccess: true,
-        hideError: true,
-        timeout: TOAST_DEFAULT_DELAY_MS
-      }
-    }
-  )
+  const payment = usePayment()
 
   return useCallback(async ({ item, me }) => {
     const meSats = (item?.meSats || 0)
 
     // add current sats to next tip since idempotent zaps use desired total zap not difference
     const sats = meSats + nextTip(meSats, { ...me?.privates })
-    const amount = sats - meSats
 
-    const variables = { id: item.id, sats, act: 'TIP', amount }
-    const insufficientFunds = me?.privates.sats < amount
-    const optimisticResponse = { act: { path: item.path, ...variables } }
-    const flowId = (+new Date()).toString(16)
-    const zapArgs = { variables, optimisticResponse: insufficientFunds ? null : optimisticResponse, update, flowId }
+    let hash, hmac, cancel
     try {
-      if (insufficientFunds) throw new Error('insufficient funds')
+      [{ hash, hmac }, cancel] = await payment.request(sats - meSats)
+      const variables = { id: item.id, sats, act: 'TIP', hash, hmac }
+      const optimisticResponse = { act: { path: item.path, ...variables } }
+      await zap({ variables, optimisticResponse })
       strike()
-      if (zapUndosThresholdReached(me, amount)) {
-        await zapWithUndos(zapArgs)
-      } else {
-        await zap(zapArgs)
-      }
     } catch (error) {
-      if (payOrLoginError(error)) {
-        // call non-idempotent version
-        const amount = sats - meSats
-        optimisticResponse.act.amount = amount
-        try {
-          await invoiceableAct({ amount }, {
-            variables: { ...variables, sats: amount },
-            optimisticResponse,
-            update,
-            flowId
-          })
-        } catch (error) {}
+      if (error instanceof InvoiceCanceledError) {
         return
       }
       console.error(error)
       toaster.danger('zap: ' + error?.message || error?.toString?.())
+      cancel?.()
     }
-  })
+  }, [strike, payment])
 }

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -268,8 +268,8 @@ export function useZap () {
       if (error instanceof InvoiceCanceledError) {
         return
       }
-      console.error(error)
-      toaster.danger('zap: ' + error?.message || error?.toString?.())
+      const reason = error?.message || error?.toString?.()
+      toaster.danger('zap failed: ' + reason)
       cancel?.()
     }
   }, [strike, payment])

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -73,6 +73,7 @@ export default function ItemAct ({ onClose, itemId, down, children }) {
     setItemMeAnonSats({ id: itemId, amount })
     strike()
     addCustomTip(Number(amount))
+    onClose()
   }, [me, act, down, itemId, strike])
 
   return (

--- a/components/job-form.js
+++ b/components/job-form.js
@@ -52,6 +52,14 @@ export default function JobForm ({ item, sub }) {
         id
         deleteScheduledAt
         reminderScheduledAt
+        invoice {
+          id
+          bolt11
+          hash
+          hmac
+          expiresAt
+          satsRequested
+        }
       }
     }`
   )
@@ -85,6 +93,8 @@ export default function JobForm ({ item, sub }) {
         await router.push(`/~${sub.name}/recent`)
       }
       toastUpsertSuccessMessages(toaster, data, 'upsertJob', !!item, values.text)
+
+      return data.upsertJob
     }, [upsertJob, router, logoId]
   )
 
@@ -107,6 +117,7 @@ export default function JobForm ({ item, sub }) {
         storageKeyPrefix={storageKeyPrefix}
         requireSession
         prepaid
+        postpaid
         onSubmit={onSubmit}
       >
         <div className='form-group'>

--- a/components/job-form.js
+++ b/components/job-form.js
@@ -105,7 +105,8 @@ export default function JobForm ({ item, sub }) {
         }}
         schema={jobSchema}
         storageKeyPrefix={storageKeyPrefix}
-        invoiceable={{ requireSession: true }}
+        requireSession
+        invoiceable
         onSubmit={onSubmit}
       >
         <div className='form-group'>

--- a/components/job-form.js
+++ b/components/job-form.js
@@ -106,7 +106,7 @@ export default function JobForm ({ item, sub }) {
         schema={jobSchema}
         storageKeyPrefix={storageKeyPrefix}
         requireSession
-        invoiceable
+        prepaid
         onSubmit={onSubmit}
       >
         <div className='form-group'>

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -77,6 +77,14 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
           id
           deleteScheduledAt
           reminderScheduledAt
+          invoice {
+            id
+            bolt11
+            hash
+            hmac
+            expiresAt
+            satsRequested
+          }
         }
       }`
   )
@@ -110,6 +118,8 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
         await router.push(prefix + '/recent')
       }
       toastUpsertSuccessMessages(toaster, data, 'upsertLink', !!item, values.text)
+
+      return data.upsertLink
     }, [upsertLink, router]
   )
 
@@ -144,6 +154,7 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
       }}
       schema={schema}
       prepaid
+      postpaid
       onSubmit={onSubmit}
       storageKeyPrefix={storageKeyPrefix}
     >

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -143,7 +143,7 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}
-      invoiceable
+      prepaid
       onSubmit={onSubmit}
       storageKeyPrefix={storageKeyPrefix}
     >

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -23,9 +23,12 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
   const me = useMe()
   const toaster = useToast()
   const schema = linkSchema({ client, me, existingBoost: item?.boost })
-  // if Web Share Target API was used
-  const shareUrl = router.query.url
-  const shareTitle = router.query.title
+
+  const queryUrl = router.query.url
+  const queryTitle = router.query.title
+  const queryText = router.query.text ? decodeURI(router.query.text) : undefined
+  const querySub = router.query.sub
+  const queryBoost = router.query.boost
 
   const crossposter = useCrossposter()
 
@@ -145,12 +148,12 @@ export function LinkForm ({ item, sub, editThreshold, children }) {
   return (
     <Form
       initial={{
-        title: item?.title || shareTitle || '',
-        url: item?.url || shareUrl || '',
-        text: item?.text || '',
+        title: item?.title || queryTitle || '',
+        url: item?.url || queryUrl || '',
+        text: item?.text || queryText || '',
         crosspost: item ? !!item.noteId : me?.privates?.nostrCrossposting,
-        ...AdvPostInitial({ forward: normalizeForwards(item?.forwards), boost: item?.boost }),
-        ...SubSelectInitial({ sub: item?.subName || sub?.name })
+        ...AdvPostInitial({ forward: normalizeForwards(item?.forwards), boost: item?.boost || queryBoost }),
+        ...SubSelectInitial({ sub: item?.subName || sub?.name || querySub })
       }}
       schema={schema}
       prepaid

--- a/components/modal.js
+++ b/components/modal.js
@@ -3,6 +3,7 @@ import Modal from 'react-bootstrap/Modal'
 import BackArrow from '@/svgs/arrow-left-line.svg'
 import { useRouter } from 'next/router'
 import ActionDropdown from './action-dropdown'
+import { PaymentProvider } from './payment'
 
 export const ShowModalContext = createContext(() => null)
 
@@ -56,26 +57,28 @@ export default function useModal () {
     }
     const className = modalOptions?.fullScreen ? 'fullscreen' : ''
     return (
-      <Modal
-        onHide={modalOptions?.keepOpen ? null : onClose} show={!!modalContent}
-        className={className}
-        dialogClassName={className}
-        contentClassName={className}
-      >
-        <div className='d-flex flex-row'>
-          {modalOptions?.overflow &&
-            <div className={'modal-btn modal-overflow ' + className}>
-              <ActionDropdown>
-                {modalOptions.overflow}
-              </ActionDropdown>
-            </div>}
-          {modalStack.length > 0 ? <div className='modal-btn modal-back' onClick={onBack}><BackArrow width={18} height={18} className='fill-white' /></div> : null}
-          <div className={'modal-btn modal-close ' + className} onClick={onClose}>X</div>
-        </div>
-        <Modal.Body className={className}>
-          {modalContent}
-        </Modal.Body>
-      </Modal>
+      <PaymentProvider>
+        <Modal
+          onHide={modalOptions?.keepOpen ? null : onClose} show={!!modalContent}
+          className={className}
+          dialogClassName={className}
+          contentClassName={className}
+        >
+          <div className='d-flex flex-row'>
+            {modalOptions?.overflow &&
+              <div className={'modal-btn modal-overflow ' + className}>
+                <ActionDropdown>
+                  {modalOptions.overflow}
+                </ActionDropdown>
+              </div>}
+            {modalStack.length > 0 ? <div className='modal-btn modal-back' onClick={onBack}><BackArrow width={18} height={18} className='fill-white' /></div> : null}
+            <div className={'modal-btn modal-close ' + className} onClick={onClose}>X</div>
+          </div>
+          <Modal.Body className={className}>
+            {modalContent}
+          </Modal.Body>
+        </Modal>
+      </PaymentProvider>
     )
   }, [modalContent, onClose, modalOptions, onBack, modalStack])
 

--- a/components/modal.js
+++ b/components/modal.js
@@ -3,7 +3,6 @@ import Modal from 'react-bootstrap/Modal'
 import BackArrow from '@/svgs/arrow-left-line.svg'
 import { useRouter } from 'next/router'
 import ActionDropdown from './action-dropdown'
-import { PaymentProvider } from './payment'
 
 export const ShowModalContext = createContext(() => null)
 
@@ -57,28 +56,26 @@ export default function useModal () {
     }
     const className = modalOptions?.fullScreen ? 'fullscreen' : ''
     return (
-      <PaymentProvider>
-        <Modal
-          onHide={modalOptions?.keepOpen ? null : onClose} show={!!modalContent}
-          className={className}
-          dialogClassName={className}
-          contentClassName={className}
-        >
-          <div className='d-flex flex-row'>
-            {modalOptions?.overflow &&
-              <div className={'modal-btn modal-overflow ' + className}>
-                <ActionDropdown>
-                  {modalOptions.overflow}
-                </ActionDropdown>
-              </div>}
-            {modalStack.length > 0 ? <div className='modal-btn modal-back' onClick={onBack}><BackArrow width={18} height={18} className='fill-white' /></div> : null}
-            <div className={'modal-btn modal-close ' + className} onClick={onClose}>X</div>
-          </div>
-          <Modal.Body className={className}>
-            {modalContent}
-          </Modal.Body>
-        </Modal>
-      </PaymentProvider>
+      <Modal
+        onHide={modalOptions?.keepOpen ? null : onClose} show={!!modalContent}
+        className={className}
+        dialogClassName={className}
+        contentClassName={className}
+      >
+        <div className='d-flex flex-row'>
+          {modalOptions?.overflow &&
+            <div className={'modal-btn modal-overflow ' + className}>
+              <ActionDropdown>
+                {modalOptions.overflow}
+              </ActionDropdown>
+            </div>}
+          {modalStack.length > 0 ? <div className='modal-btn modal-back' onClick={onBack}><BackArrow width={18} height={18} className='fill-white' /></div> : null}
+          <div className={'modal-btn modal-close ' + className} onClick={onClose}>X</div>
+        </div>
+        <Modal.Body className={className}>
+          {modalContent}
+        </Modal.Body>
+      </Modal>
     )
   }, [modalContent, onClose, modalOptions, onBack, modalStack])
 

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -41,8 +41,11 @@ function Notification ({ n, fresh }) {
   const item = data?.item
   const itemN = { item, ...n }
 
+  // we need to prevent links to failed items to be clickable since they lead to 404 pages
+  const overrideLinks = type === 'FailedItem'
+
   return (
-    <NotificationLayout nid={nid(n)} {...defaultOnClick(itemN)} fresh={fresh}>
+    <NotificationLayout nid={nid(n)} {...defaultOnClick(itemN)} fresh={fresh} overrideLinks={overrideLinks}>
       {
         (type === 'Earn' && <EarnNotification n={n} />) ||
         (type === 'Revenue' && <RevenueNotification n={n} />) ||
@@ -71,7 +74,7 @@ function Notification ({ n, fresh }) {
   )
 }
 
-function NotificationLayout ({ children, nid, href, as, fresh }) {
+function NotificationLayout ({ children, nid, href, as, fresh, overrideLinks }) {
   const router = useRouter()
   if (!href) return <div className={fresh ? styles.fresh : ''}>{children}</div>
   return (
@@ -89,6 +92,7 @@ function NotificationLayout ({ children, nid, href, as, fresh }) {
         router.push(href, as)
       }}
       href={href}
+      style={overrideLinks ? { zIndex: 1 } : undefined}
     >
       {children}
     </LinkToContext>

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -144,8 +144,16 @@ const onClickFailedItem = ({ n }) => {
 
   if (isPost) {
     const type = determineItemType(n.item)
-    const query = { type, title, text, url, bounty, boost, sub }
-    // TODO: prune query params by type
+    const query = { type, title, text, sub }
+    if (boost > 0) {
+      query.boost = boost
+    }
+    if (type === 'link') {
+      query.url = url
+    }
+    if (type === 'bounty' && bounty > 0) {
+      query.bounty = bounty
+    }
     return {
       href: {
         pathname: '/post',

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -167,7 +167,8 @@ const onClickFailedItem = ({ n }) => {
   }
 
   const rootId = commentSubTreeRootId(n.item)
-  const query = { id: rootId, text }
+  window.localStorage.setItem('reply-' + parentId + '-' + 'text', text)
+  const query = { id: rootId }
   if (Number(rootId) !== Number(parentId)) {
     query.commentId = parentId
   }

--- a/components/pay-bounty.js
+++ b/components/pay-bounty.js
@@ -63,8 +63,9 @@ export default function PayBounty ({ children, item }) {
       if (error instanceof InvoiceCanceledError) {
         return
       }
+      const reason = error?.message || error?.toString?.()
+      toaster.danger('pay bounty failed: ' + reason)
       cancel?.()
-      toaster.danger('pay bounty failed: ' + error?.message || error?.toString?.())
     }
   }
 

--- a/components/pay-bounty.js
+++ b/components/pay-bounty.js
@@ -28,6 +28,7 @@ export default function PayBounty ({ children, item }) {
     })
   }, [])
 
+  // FIXME: call onUpdate during optimistic update of act
   const act = useAct({ onUpdate })
 
   const handlePayBounty = async onComplete => {

--- a/components/payment.js
+++ b/components/payment.js
@@ -94,7 +94,9 @@ const useInvoice = () => {
   }, [isPaid])
 
   const cancel = useCallback(async ({ hash, hmac }) => {
-    return await cancelInvoice({ variables: { hash, hmac } })
+    const inv = await cancelInvoice({ variables: { hash, hmac } })
+    console.log('invoice canceled:', hash)
+    return inv
   }, [cancelInvoice])
 
   return { create, isPaid, waitUntilPaid, cancel }

--- a/components/payment.js
+++ b/components/payment.js
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useMemo } from 'react'
+import { useCallback } from 'react'
 import { useMe } from './me'
 import { gql, useApolloClient, useMutation } from '@apollo/client'
 import { useWebLN } from './webln'
@@ -7,8 +7,6 @@ import { INVOICE } from '@/fragments/wallet'
 import Invoice from '@/components/invoice'
 import { useFeeButton } from './fee-button'
 import { useShowModal } from './modal'
-
-const PaymentContext = createContext()
 
 export class InvoiceCanceledError extends Error {
   constructor (hash) {
@@ -161,7 +159,7 @@ const useQrPayment = () => {
   return waitForQrPayment
 }
 
-export const PaymentProvider = ({ children }) => {
+export const usePayment = () => {
   const me = useMe()
   const feeButton = useFeeButton()
   const invoice = useInvoice()
@@ -207,14 +205,5 @@ export const PaymentProvider = ({ children }) => {
     }
   }, [invoice])
 
-  const value = useMemo(() => ({ request, cancel }), [request, cancel])
-  return (
-    <PaymentContext.Provider value={value}>
-      {children}
-    </PaymentContext.Provider>
-  )
-}
-
-export const usePayment = () => {
-  return useContext(PaymentContext)
+  return { request, cancel }
 }

--- a/components/payment.js
+++ b/components/payment.js
@@ -183,12 +183,13 @@ export const usePayment = () => {
   const request = useCallback(async (amount) => {
     amount ??= feeButton?.total
     const free = feeButton?.free
+    const balance = me ? me.privates.sats : 0
 
     // if user has enough funds in their custodial wallet or action is free, never prompt for payment
     // XXX this will probably not work as intended for deposits < balance
     //   which means you can't always fund your custodial wallet with attached wallets ...
     //   but should this even be the case?
-    const insufficientFunds = !me || me.privates.sats < amount
+    const insufficientFunds = balance < amount
     if (free || !insufficientFunds) return [{ hash: null, hmac: null }, null]
 
     const inv = await invoice.create(amount)

--- a/components/payment.js
+++ b/components/payment.js
@@ -2,7 +2,7 @@ import { createContext, useCallback, useContext, useMemo } from 'react'
 import { useMe } from './me'
 import { gql, useApolloClient, useMutation } from '@apollo/client'
 import { useWebLN } from './webln'
-import { FAST_POLL_INTERVAL } from '@/lib/constants'
+import { FAST_POLL_INTERVAL, JIT_INVOICE_TIMEOUT_MS } from '@/lib/constants'
 import { INVOICE } from '@/fragments/wallet'
 import Invoice from '@/components/invoice'
 import { useFeeButton } from './fee-button'
@@ -35,8 +35,8 @@ const useInvoice = () => {
   const client = useApolloClient()
 
   const [createInvoice] = useMutation(gql`
-    mutation createInvoice($amount: Int!) {
-      createInvoice(amount: $amount, hodlInvoice: true, expireSecs: 180) {
+    mutation createInvoice($amount: Int!, $expireSecs: Int!) {
+      createInvoice(amount: $amount, hodlInvoice: true, expireSecs: $expireSecs) {
         id
         bolt11
         hash
@@ -54,7 +54,7 @@ const useInvoice = () => {
   `)
 
   const create = useCallback(async amount => {
-    const { data, error } = await createInvoice({ variables: { amount } })
+    const { data, error } = await createInvoice({ variables: { amount, expireSecs: JIT_INVOICE_TIMEOUT_MS / 1000 } })
     if (error) {
       throw error
     }

--- a/components/payment.js
+++ b/components/payment.js
@@ -206,5 +206,5 @@ export const usePayment = () => {
     }
   }, [invoice])
 
-  return { request, cancel }
+  return { request, cancel, send: waitForPayment }
 }

--- a/components/payment.js
+++ b/components/payment.js
@@ -24,6 +24,13 @@ export class WebLnNotEnabledError extends Error {
   }
 }
 
+export class InvoiceExpiredError extends Error {
+  constructor () {
+    super('invoice expired')
+    this.name = 'InvoiceExpiredError'
+  }
+}
+
 const useInvoice = () => {
   const client = useApolloClient()
 
@@ -166,8 +173,8 @@ export const PaymentProvider = ({ children }) => {
     try {
       return await waitForWebLnPayment(invoice)
     } catch (err) {
-      if (err instanceof InvoiceCanceledError) {
-        // bail since qr code payment will also fail if invoice was canceled
+      if (err instanceof InvoiceCanceledError || err instanceof InvoiceExpiredError) {
+        // bail since qr code payment will also fail
         throw err
       }
       webLnError = err

--- a/components/payment.js
+++ b/components/payment.js
@@ -12,7 +12,7 @@ const PaymentContext = createContext()
 
 export class InvoiceCanceledError extends Error {
   constructor (hash) {
-    super(`invoice canceled: ${hash}`, hash)
+    super(`invoice canceled: ${hash}`)
     this.name = 'InvoiceCanceledError'
   }
 }

--- a/components/payment.js
+++ b/components/payment.js
@@ -129,7 +129,7 @@ const useQrPayment = () => {
   const invoice = useInvoice()
   const showModal = useShowModal()
 
-  const waitForQrPayment = useCallback(async (inv) => {
+  const waitForQrPayment = useCallback(async (inv, webLnError) => {
     return await new Promise((resolve, reject) => {
       let paid
       const cancelAndReject = async (onClose) => {
@@ -143,6 +143,7 @@ const useQrPayment = () => {
           modal
           successVerb='received'
           webLn={false}
+          webLnError={webLnError}
           onPayment={() => { paid = true; onClose(); resolve() }}
           poll
         />,
@@ -161,6 +162,7 @@ export const PaymentProvider = ({ children }) => {
   const waitForQrPayment = useQrPayment()
 
   const waitForPayment = useCallback(async (invoice) => {
+    let webLnError
     try {
       return await waitForWebLnPayment(invoice)
     } catch (err) {
@@ -168,9 +170,9 @@ export const PaymentProvider = ({ children }) => {
         // bail since qr code payment will also fail if invoice was canceled
         throw err
       }
-      // ignore any other error and fallback to QR code
+      webLnError = err
     }
-    return await waitForQrPayment(invoice)
+    return await waitForQrPayment(invoice, webLnError)
   }, [waitForWebLnPayment, waitForQrPayment])
 
   const request = useCallback(async (amount) => {

--- a/components/payment.js
+++ b/components/payment.js
@@ -1,0 +1,211 @@
+import { createContext, useCallback, useContext, useMemo } from 'react'
+import { useMe } from './me'
+import { gql, useApolloClient, useMutation } from '@apollo/client'
+import { useWebLN } from './webln'
+import { FAST_POLL_INTERVAL } from '@/lib/constants'
+import { INVOICE } from '@/fragments/wallet'
+import Invoice from '@/components/invoice'
+import { useFeeButton } from './fee-button'
+import { useShowModal } from './modal'
+
+const PaymentContext = createContext()
+
+export class InvoiceCanceledError extends Error {
+  constructor (hash) {
+    super(`invoice canceled: ${hash}`, hash)
+    this.name = 'InvoiceCanceledError'
+  }
+}
+
+export class WebLnNotEnabledError extends Error {
+  constructor () {
+    super('no enabled WebLN provider found')
+    this.name = 'WebLnNotEnabledError'
+  }
+}
+
+const useInvoice = () => {
+  const client = useApolloClient()
+
+  const [createInvoice] = useMutation(gql`
+    mutation createInvoice($amount: Int!) {
+      createInvoice(amount: $amount, hodlInvoice: true, expireSecs: 180) {
+        id
+        bolt11
+        hash
+        hmac
+        expiresAt
+        satsRequested
+      }
+    }`)
+  const [cancelInvoice] = useMutation(gql`
+    mutation cancelInvoice($hash: String!, $hmac: String!) {
+      cancelInvoice(hash: $hash, hmac: $hmac) {
+        id
+      }
+    }
+  `)
+
+  const create = useCallback(async amount => {
+    const { data, error } = await createInvoice({ variables: { amount } })
+    if (error) {
+      throw error
+    }
+    const invoice = data.createInvoice
+    return invoice
+  }, [createInvoice])
+
+  const isPaid = useCallback(async id => {
+    const { data, error } = await client.query({ query: INVOICE, fetchPolicy: 'no-cache', variables: { id } })
+    if (error) {
+      throw error
+    }
+    const { hash, isHeld, satsReceived, cancelled } = data.invoice
+    // if we're polling for invoices, we're using JIT invoices so isHeld must be set
+    if (isHeld && satsReceived) {
+      return true
+    }
+    if (cancelled) {
+      throw new InvoiceCanceledError(hash)
+    }
+    return false
+  }, [client])
+
+  const waitUntilPaid = useCallback(async id => {
+    return await new Promise((resolve, reject) => {
+      const interval = setInterval(async () => {
+        try {
+          const paid = await isPaid(id)
+          if (paid) {
+            resolve()
+            clearInterval(interval)
+          }
+        } catch (err) {
+          reject(err)
+          clearInterval(interval)
+        }
+      }, FAST_POLL_INTERVAL)
+    })
+  }, [isPaid])
+
+  const cancel = useCallback(async ({ hash, hmac }) => {
+    return await cancelInvoice({ variables: { hash, hmac } })
+  }, [cancelInvoice])
+
+  return { create, isPaid, waitUntilPaid, cancel }
+}
+
+const useWebLnPayment = () => {
+  const invoice = useInvoice()
+  const provider = useWebLN()
+
+  const waitForWebLnPayment = useCallback(async ({ id, bolt11 }) => {
+    if (!provider) {
+      throw new WebLnNotEnabledError()
+    }
+    try {
+      return await new Promise((resolve, reject) => {
+        // can't use await here since we might pay JIT invoices and sendPaymentAsync is not supported yet.
+        // see https://www.webln.guide/building-lightning-apps/webln-reference/webln.sendpaymentasync
+        provider.sendPayment(bolt11)
+          // JIT invoice payments will never resolve here
+          // since they only get resolved after settlement which can't happen here
+          .then(resolve)
+          .catch(reject)
+        invoice.waitUntilPaid(id)
+          .then(resolve)
+          .catch(reject)
+      })
+    } catch (err) {
+      console.error('WebLN payment failed:', err)
+      throw err
+    }
+  }, [provider, invoice])
+
+  return waitForWebLnPayment
+}
+
+const useQrPayment = () => {
+  const invoice = useInvoice()
+  const showModal = useShowModal()
+
+  const waitForQrPayment = useCallback(async (inv) => {
+    return await new Promise((resolve, reject) => {
+      let paid
+      const cancelAndReject = async (onClose) => {
+        if (paid) return
+        await invoice.cancel(inv)
+        reject(new InvoiceCanceledError(inv.hash))
+      }
+      showModal(onClose =>
+        <Invoice
+          invoice={inv}
+          modal
+          successVerb='received'
+          webLn={false}
+          onPayment={() => { paid = true; onClose(); resolve() }}
+          poll
+        />,
+      { keepOpen: true, onClose: cancelAndReject })
+    })
+  }, [invoice])
+
+  return waitForQrPayment
+}
+
+export const PaymentProvider = ({ children }) => {
+  const me = useMe()
+  const feeButton = useFeeButton()
+  const invoice = useInvoice()
+  const waitForWebLnPayment = useWebLnPayment()
+  const waitForQrPayment = useQrPayment()
+
+  const waitForPayment = useCallback(async (invoice) => {
+    try {
+      return await waitForWebLnPayment(invoice)
+    } catch (err) {
+      if (err instanceof InvoiceCanceledError) {
+        // bail since qr code payment will also fail if invoice was canceled
+        throw err
+      }
+      // ignore any other error and fallback to QR code
+    }
+    return await waitForQrPayment(invoice)
+  }, [waitForWebLnPayment, waitForQrPayment])
+
+  const request = useCallback(async (amount) => {
+    amount ??= feeButton?.total
+    const free = feeButton?.free
+
+    // if user has enough funds in their custodial wallet or action is free, never prompt for payment
+    // XXX this will probably not work as intended for deposits < balance
+    //   which means you can't always fund your custodial wallet with attached wallets ...
+    //   but should this even be the case?
+    const insufficientFunds = !me || me.privates.sats < amount
+    if (free || !insufficientFunds) return [{ hash: null, hmac: null }, null]
+
+    const inv = await invoice.create(amount)
+
+    await waitForPayment(inv)
+
+    const cancel = () => invoice.cancel(inv).catch(console.error)
+    return [inv, cancel]
+  }, [me, feeButton?.total, invoice, waitForPayment])
+
+  const cancel = useCallback(({ hash, hmac }) => {
+    if (hash && hmac) {
+      invoice.cancel({ hash, hmac }).catch(console.error)
+    }
+  }, [invoice])
+
+  const value = useMemo(() => ({ request, cancel }), [request, cancel])
+  return (
+    <PaymentContext.Provider value={value}>
+      {children}
+    </PaymentContext.Provider>
+  )
+}
+
+export const usePayment = () => {
+  return useContext(PaymentContext)
+}

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -20,8 +20,12 @@ export function PollForm ({ item, sub, editThreshold, children }) {
   const me = useMe()
   const toaster = useToast()
   const schema = pollSchema({ client, me, existingBoost: item?.boost })
-
   const crossposter = useCrossposter()
+
+  const queryTitle = router.query.title
+  const queryText = router.query.text ? decodeURI(router.query.text) : undefined
+  const querySub = router.query.sub
+  const queryBoost = router.query.boost
 
   const [upsertPoll] = useMutation(
     gql`
@@ -87,13 +91,13 @@ export function PollForm ({ item, sub, editThreshold, children }) {
   return (
     <Form
       initial={{
-        title: item?.title || '',
-        text: item?.text || '',
+        title: item?.title || '' || queryTitle,
+        text: item?.text || '' || queryText,
         options: initialOptions || ['', ''],
         crosspost: item ? !!item.noteId : me?.privates?.nostrCrossposting,
         pollExpiresAt: item ? item.pollExpiresAt : datePivot(new Date(), { hours: 25 }),
-        ...AdvPostInitial({ forward: normalizeForwards(item?.forwards), boost: item?.boost }),
-        ...SubSelectInitial({ sub: item?.subName || sub?.name })
+        ...AdvPostInitial({ forward: normalizeForwards(item?.forwards), boost: item?.boost || queryBoost }),
+        ...SubSelectInitial({ sub: item?.subName || sub?.name || querySub })
       }}
       schema={schema}
       prepaid

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -32,6 +32,14 @@ export function PollForm ({ item, sub, editThreshold, children }) {
           id
           deleteScheduledAt
           reminderScheduledAt
+          invoice {
+            id
+            bolt11
+            hash
+            hmac
+            expiresAt
+            satsRequested
+          }
         }
       }`
   )
@@ -67,6 +75,8 @@ export function PollForm ({ item, sub, editThreshold, children }) {
         await router.push(prefix + '/recent')
       }
       toastUpsertSuccessMessages(toaster, data, 'upsertPoll', !!item, values.text)
+
+      return data.upsertPoll
     }, [upsertPoll, router]
   )
 
@@ -87,6 +97,7 @@ export function PollForm ({ item, sub, editThreshold, children }) {
       }}
       schema={schema}
       prepaid
+      postpaid
       onSubmit={onSubmit}
       storageKeyPrefix={storageKeyPrefix}
     >

--- a/components/poll-form.js
+++ b/components/poll-form.js
@@ -86,7 +86,7 @@ export function PollForm ({ item, sub, editThreshold, children }) {
         ...SubSelectInitial({ sub: item?.subName || sub?.name })
       }}
       schema={schema}
-      invoiceable
+      prepaid
       onSubmit={onSubmit}
       storageKeyPrefix={storageKeyPrefix}
     >

--- a/components/qr.js
+++ b/components/qr.js
@@ -14,7 +14,7 @@ export default function Qr ({ asIs, value, webLn, statusVariant, description, st
     async function effect () {
       if (webLn && provider) {
         try {
-          await provider.sendPayment({ bolt11: value })
+          await provider.sendPayment(value)
         } catch (e) {
           console.log(e?.message)
         }

--- a/components/qr.js
+++ b/components/qr.js
@@ -21,7 +21,7 @@ export default function Qr ({ asIs, value, webLn, statusVariant, description, st
       }
     }
     effect()
-  }, [provider])
+  }, [provider?.name])
 
   return (
     <>

--- a/components/reply.js
+++ b/components/reply.js
@@ -15,6 +15,7 @@ import { useShowModal } from './modal'
 import { Button } from 'react-bootstrap'
 import { useRoot } from './root'
 import { commentSubTreeRootId } from '@/lib/item'
+import { useRouter } from 'next/router'
 
 export function ReplyOnAnotherPage ({ item }) {
   const rootId = commentSubTreeRootId(item)
@@ -40,12 +41,18 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
   const showModal = useShowModal()
   const root = useRoot()
   const sub = item?.sub || root?.sub
+  const router = useRouter()
+
+  const prefill = router.query.text &&
+    (router.query.commentId
+      ? router.query.commentId === parentId
+      : router.query.id === parentId)
 
   useEffect(() => {
-    if (replyOpen || quote || !!window.localStorage.getItem('reply-' + parentId + '-' + 'text')) {
+    if (replyOpen || quote || !!window.localStorage.getItem('reply-' + parentId + '-' + 'text') || prefill) {
       setReply(true)
     }
-  }, [replyOpen, quote, parentId])
+  }, [replyOpen, quote, parentId, prefill])
 
   const [upsertComment] = useMutation(
     gql`
@@ -172,7 +179,7 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
           >
             <Form
               initial={{
-                text: ''
+                text: prefill ? router.query.text : ''
               }}
               schema={commentSchema}
               prepaid

--- a/components/reply.js
+++ b/components/reply.js
@@ -15,7 +15,6 @@ import { useShowModal } from './modal'
 import { Button } from 'react-bootstrap'
 import { useRoot } from './root'
 import { commentSubTreeRootId } from '@/lib/item'
-import { useRouter } from 'next/router'
 
 export function ReplyOnAnotherPage ({ item }) {
   const rootId = commentSubTreeRootId(item)
@@ -41,18 +40,12 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
   const showModal = useShowModal()
   const root = useRoot()
   const sub = item?.sub || root?.sub
-  const router = useRouter()
-
-  const prefill = router.query.text &&
-    (router.query.commentId
-      ? router.query.commentId === parentId
-      : router.query.id === parentId)
 
   useEffect(() => {
-    if (replyOpen || quote || !!window.localStorage.getItem('reply-' + parentId + '-' + 'text') || prefill) {
+    if (replyOpen || quote || !!window.localStorage.getItem('reply-' + parentId + '-' + 'text')) {
       setReply(true)
     }
-  }, [replyOpen, quote, parentId, prefill])
+  }, [replyOpen, quote, parentId])
 
   const [upsertComment] = useMutation(
     gql`
@@ -179,7 +172,7 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
           >
             <Form
               initial={{
-                text: prefill ? router.query.text : ''
+                text: ''
               }}
               schema={commentSchema}
               prepaid

--- a/components/reply.js
+++ b/components/reply.js
@@ -15,7 +15,6 @@ import { useShowModal } from './modal'
 import { Button } from 'react-bootstrap'
 import { useRoot } from './root'
 import { commentSubTreeRootId } from '@/lib/item'
-import { InvoiceCanceledError, usePayment } from './payment'
 
 export function ReplyOnAnotherPage ({ item }) {
   const rootId = commentSubTreeRootId(item)
@@ -41,7 +40,6 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
   const showModal = useShowModal()
   const root = useRoot()
   const sub = item?.sub || root?.sub
-  const payment = usePayment()
 
   useEffect(() => {
     if (replyOpen || quote || !!window.localStorage.getItem('reply-' + parentId + '-' + 'text')) {
@@ -100,19 +98,10 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
   )
 
   const onSubmit = useCallback(async ({ amount, hash, hmac, ...values }, { resetForm }) => {
-    try {
-      const { data } = await upsertComment({ variables: { parentId, hash, hmac, ...values } })
-      toastUpsertSuccessMessages(toaster, data, 'upsertComment', false, values.text)
-      resetForm({ text: '' })
-      setReply(replyOpen || false)
-    } catch (err) {
-      if (err instanceof InvoiceCanceledError) {
-        return
-      }
-      const msg = err.message || err.toString?.()
-      toaster.danger('reply error: ' + msg)
-      payment.cancel?.({ hash, hmac })
-    }
+    const { data } = await upsertComment({ variables: { parentId, hash, hmac, ...values } })
+    toastUpsertSuccessMessages(toaster, data, 'upsertComment', false, values.text)
+    resetForm({ text: '' })
+    setReply(replyOpen || false)
   }, [upsertComment, setReply, parentId])
 
   useEffect(() => {

--- a/components/reply.js
+++ b/components/reply.js
@@ -15,6 +15,7 @@ import { useShowModal } from './modal'
 import { Button } from 'react-bootstrap'
 import { useRoot } from './root'
 import { commentSubTreeRootId } from '@/lib/item'
+import { InvoiceCanceledError, usePayment } from './payment'
 
 export function ReplyOnAnotherPage ({ item }) {
   const rootId = commentSubTreeRootId(item)
@@ -40,6 +41,7 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
   const showModal = useShowModal()
   const root = useRoot()
   const sub = item?.sub || root?.sub
+  const payment = usePayment()
 
   useEffect(() => {
     if (replyOpen || quote || !!window.localStorage.getItem('reply-' + parentId + '-' + 'text')) {
@@ -98,10 +100,19 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
   )
 
   const onSubmit = useCallback(async ({ amount, hash, hmac, ...values }, { resetForm }) => {
-    const { data } = await upsertComment({ variables: { parentId, hash, hmac, ...values } })
-    toastUpsertSuccessMessages(toaster, data, 'upsertComment', false, values.text)
-    resetForm({ text: '' })
-    setReply(replyOpen || false)
+    try {
+      const { data } = await upsertComment({ variables: { parentId, hash, hmac, ...values } })
+      toastUpsertSuccessMessages(toaster, data, 'upsertComment', false, values.text)
+      resetForm({ text: '' })
+      setReply(replyOpen || false)
+    } catch (err) {
+      if (err instanceof InvoiceCanceledError) {
+        return
+      }
+      const msg = err.message || err.toString?.()
+      toaster.danger('reply error: ' + msg)
+      payment.cancel?.({ hash, hmac })
+    }
   }, [upsertComment, setReply, parentId])
 
   useEffect(() => {

--- a/components/reply.js
+++ b/components/reply.js
@@ -58,6 +58,14 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
           comments {
             ...CommentsRecursive
           }
+          invoice {
+            id
+            bolt11
+            hash
+            hmac
+            expiresAt
+            satsRequested
+          }
         }
       }`, {
       update (cache, { data: { upsertComment } }) {
@@ -97,11 +105,12 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
     }
   )
 
-  const onSubmit = useCallback(async ({ amount, hash, hmac, ...values }, { resetForm }) => {
-    const { data } = await upsertComment({ variables: { parentId, hash, hmac, ...values } })
+  const onSubmit = useCallback(async ({ amount, ...values }, { resetForm }) => {
+    const { data } = await upsertComment({ variables: { parentId, ...values } })
     toastUpsertSuccessMessages(toaster, data, 'upsertComment', false, values.text)
     resetForm({ text: '' })
     setReply(replyOpen || false)
+    return data.upsertComment
   }, [upsertComment, setReply, parentId])
 
   useEffect(() => {
@@ -166,7 +175,8 @@ export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children
                 text: ''
               }}
               schema={commentSchema}
-              invoiceable
+              prepaid
+              postpaid
               onSubmit={onSubmit}
               storageKeyPrefix={`reply-${parentId}`}
             >

--- a/components/territory-form.js
+++ b/components/territory-form.js
@@ -112,7 +112,7 @@ export default function TerritoryForm ({ sub }) {
           nsfw: sub?.nsfw || false
         }}
         schema={schema}
-        invoiceable
+        prepaid
         onSubmit={onSubmit}
         className='mb-5'
         storageKeyPrefix={sub ? undefined : 'territory'}

--- a/components/territory-payment-due.js
+++ b/components/territory-payment-due.js
@@ -56,7 +56,7 @@ export default function TerritoryPaymentDue ({ sub }) {
 
       <FeeButtonProvider baseLineItems={{ territory: TERRITORY_BILLING_OPTIONS('one')[sub.billingType.toLowerCase()] }}>
         <Form
-          invoiceable
+          prepaid
           initial={{
             name: sub.name
           }}

--- a/components/toast.module.css
+++ b/components/toast.module.css
@@ -21,20 +21,6 @@
   border-color: var(--bs-warning-border-subtle);
 }
 
-.toastUndo {
-  font-style: normal;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-}
-
-.toastCancel {
-  font-style: italic;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-}
-
 .toastClose {
   color: #fff;
   font-family: "lightning";

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -2,7 +2,7 @@ import UpBolt from '@/svgs/bolt.svg'
 import styles from './upvote.module.css'
 import { gql, useMutation } from '@apollo/client'
 import ActionTooltip from './action-tooltip'
-import ItemAct, { useAct, useZap } from './item-act'
+import ItemAct, { useZap } from './item-act'
 import { useMe } from './me'
 import getColor from '@/lib/rainbow'
 import { useCallback, useMemo, useRef, useState } from 'react'
@@ -125,7 +125,6 @@ export default function UpVote ({ item, className }) {
     }
   }, [me, tipShow, setWalkthrough])
 
-  const act = useAct()
   const zap = useZap()
 
   const disabled = useMemo(() => item?.mine || item?.meForward || item?.deletedAt,
@@ -175,7 +174,7 @@ export default function UpVote ({ item, className }) {
       }
       zap({ item, me })
     } else {
-      showModal(onClose => <ItemAct onClose={onClose} item={item} act={act} />, { onClose: handleModalClosed })
+      showModal(onClose => <ItemAct onClose={onClose} item={item} />, { onClose: handleModalClosed })
     }
   }
 

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -125,7 +125,7 @@ export default function UpVote ({ item, className }) {
     }
   }, [me, tipShow, setWalkthrough])
 
-  const [act] = useAct()
+  const act = useAct()
   const zap = useZap()
 
   const disabled = useMemo(() => item?.mine || item?.meForward || item?.deletedAt,
@@ -159,7 +159,7 @@ export default function UpVote ({ item, className }) {
       <ItemAct onClose={onClose} itemId={item.id} />, { onClose: handleModalClosed })
   }
 
-  const handleShortPress = () => {
+  const handleShortPress = async () => {
     if (me) {
       if (!item) return
 
@@ -173,7 +173,6 @@ export default function UpVote ({ item, className }) {
       } else {
         setTipShow(true)
       }
-
       zap({ item, me })
     } else {
       showModal(onClose => <ItemAct onClose={onClose} itemId={item.id} act={act} />, { onClose: handleModalClosed })

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -59,7 +59,7 @@ export function DropdownItemUpVote ({ item }) {
     <Dropdown.Item
       onClick={async () => {
         showModal(onClose =>
-          <ItemAct onClose={onClose} itemId={item.id} />)
+          <ItemAct onClose={onClose} item={item} />)
       }}
     >
       <span className='text-success'>zap</span>
@@ -156,7 +156,7 @@ export default function UpVote ({ item, className }) {
 
     setTipShow(false)
     showModal(onClose =>
-      <ItemAct onClose={onClose} itemId={item.id} />, { onClose: handleModalClosed })
+      <ItemAct onClose={onClose} item={item} />, { onClose: handleModalClosed })
   }
 
   const handleShortPress = async () => {
@@ -175,7 +175,7 @@ export default function UpVote ({ item, className }) {
       }
       zap({ item, me })
     } else {
-      showModal(onClose => <ItemAct onClose={onClose} itemId={item.id} act={act} />, { onClose: handleModalClosed })
+      showModal(onClose => <ItemAct onClose={onClose} item={item} act={act} />, { onClose: handleModalClosed })
     }
   }
 

--- a/components/upvote.module.css
+++ b/components/upvote.module.css
@@ -35,3 +35,17 @@
     left: 4px;
     width: 17px;
 }
+
+.pending {
+    animation-name: pulse;
+    animation-iteration-count: infinite;
+    animation-timing-function: linear;
+    animation-duration: 0.25s;
+    animation-direction: alternate;
+}
+
+@keyframes pulse {
+	0% {
+		fill: #a5a5a5;
+	}
+}

--- a/components/use-crossposter.js
+++ b/components/use-crossposter.js
@@ -5,6 +5,7 @@ import { DEFAULT_CROSSPOSTING_RELAYS, crosspost, callWithTimeout } from '@/lib/n
 import { gql, useMutation, useQuery, useLazyQuery } from '@apollo/client'
 import { SETTINGS } from '@/fragments/users'
 import { ITEM_FULL_FIELDS, POLL_FIELDS } from '@/fragments/items'
+import { determineItemType } from '@/lib/item'
 
 async function discussionToEvent (item) {
   const createdAt = Math.floor(Date.now() / 1000)
@@ -140,23 +141,6 @@ export default function useCrossposter () {
   }
 
   async function handleEventCreation (item) {
-    const determineItemType = (item) => {
-      const typeMap = {
-        url: 'link',
-        bounty: 'bounty',
-        pollCost: 'poll'
-      }
-
-      for (const [key, type] of Object.entries(typeMap)) {
-        if (item[key]) {
-          return type
-        }
-      }
-
-      // Default
-      return 'discussion'
-    }
-
     const itemType = determineItemType(item)
 
     switch (itemType) {

--- a/components/webln/index.js
+++ b/components/webln/index.js
@@ -1,8 +1,6 @@
-import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { LNbitsProvider, useLNbits } from './lnbits'
 import { NWCProvider, useNWC } from './nwc'
-import { useToast, withToastFlow } from '@/components/toast'
-import { gql, useMutation } from '@apollo/client'
 import { LNCProvider, useLNC } from './lnc'
 
 const WebLNContext = createContext({})
@@ -86,31 +84,6 @@ function RawWebLNProvider ({ children }) {
   // TODO: implement fallbacks via provider priority
   const provider = enabledProviders[0]
 
-  const toaster = useToast()
-  const [cancelInvoice] = useMutation(gql`
-    mutation cancelInvoice($hash: String!, $hmac: String!) {
-      cancelInvoice(hash: $hash, hmac: $hmac) {
-        id
-      }
-    }
-  `)
-
-  const sendPaymentWithToast = withToastFlow(toaster)(
-    ({ bolt11, hash, hmac, expiresAt, flowId }) => {
-      const expiresIn = (+new Date(expiresAt)) - (+new Date())
-      return {
-        flowId: flowId || hash,
-        type: 'payment',
-        onPending: async () => {
-          await provider.sendPayment(bolt11)
-        },
-        // hash and hmac are only passed for JIT invoices
-        onCancel: () => hash && hmac ? cancelInvoice({ variables: { hash, hmac } }) : undefined,
-        timeout: expiresIn
-      }
-    }
-  )
-
   const setProvider = useCallback((defaultProvider) => {
     // move provider to the start to set it as default
     setEnabledProviders(providers => {
@@ -129,8 +102,17 @@ function RawWebLNProvider ({ children }) {
     await lnc.clearConfig()
   }, [])
 
+  const value = useMemo(() => ({
+    provider: isEnabled(provider)
+      ? { name: provider.name, sendPayment: provider.sendPayment }
+      : null,
+    enabledProviders,
+    setProvider,
+    clearConfig
+  }), [provider, enabledProviders, setProvider])
+
   return (
-    <WebLNContext.Provider value={{ provider: isEnabled(provider) ? { name: provider.name, sendPayment: sendPaymentWithToast } : null, enabledProviders, setProvider, clearConfig }}>
+    <WebLNContext.Provider value={value}>
       {children}
     </WebLNContext.Provider>
   )

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -6,7 +6,7 @@ import { parseNwcUrl } from '@/lib/url'
 import { useWalletLogger } from '../logger'
 import { Status, migrateLocalStorage } from '.'
 import { bolt11Tags } from '@/lib/bolt11'
-import { Wallet } from '@/lib/constants'
+import { JIT_INVOICE_TIMEOUT_MS, Wallet } from '@/lib/constants'
 import { useMe } from '../me'
 import { InvoiceExpiredError } from '../payment'
 
@@ -206,7 +206,7 @@ export function NWCProvider ({ children }) {
         (async function () {
           // timeout since NWC is async (user needs to confirm payment in wallet)
           // timeout is same as invoice expiry
-          const timeout = 180_000
+          const timeout = JIT_INVOICE_TIMEOUT_MS
           const timer = setTimeout(() => {
             const msg = 'timeout waiting for payment'
             logger.error(msg)

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -207,7 +207,7 @@ export function NWCProvider ({ children }) {
           // timeout is same as invoice expiry
           const timeout = 180_000
           const timer = setTimeout(() => {
-            const msg = 'timeout waiting for info event'
+            const msg = 'timeout waiting for payment'
             logger.error(msg)
             reject(new Error(msg))
             sub?.close()

--- a/components/webln/nwc.js
+++ b/components/webln/nwc.js
@@ -8,6 +8,7 @@ import { Status, migrateLocalStorage } from '.'
 import { bolt11Tags } from '@/lib/bolt11'
 import { Wallet } from '@/lib/constants'
 import { useMe } from '../me'
+import { InvoiceExpiredError } from '../payment'
 
 const NWCContext = createContext()
 
@@ -209,7 +210,7 @@ export function NWCProvider ({ children }) {
           const timer = setTimeout(() => {
             const msg = 'timeout waiting for payment'
             logger.error(msg)
-            reject(new Error(msg))
+            reject(new InvoiceExpiredError())
             sub?.close()
           }, timeout)
 

--- a/fragments/notifications.js
+++ b/fragments/notifications.js
@@ -148,6 +148,13 @@ export const NOTIFICATIONS = gql`
             ...ItemFullFields
           }
         }
+        ... on FailedItem {
+          id
+          sortTime
+          item {
+            ...ItemFullFields
+          }
+        }
       }
     }
   } `

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -259,7 +259,7 @@ function getClient (uri) {
 export function optimisticUpdate ({ mutation, variables, optimisticResponse, update }) {
   const { cache, queryManager } = getApolloClient()
 
-  const mutationId = String(queryManager.mutationIdCounter)
+  const mutationId = String(queryManager.mutationIdCounter++)
   queryManager.markMutationOptimistic(optimisticResponse, {
     mutationId,
     document: mutation,

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -255,3 +255,17 @@ function getClient (uri) {
     }
   })
 }
+
+export function optimisticUpdate ({ mutation, variables, optimisticResponse, update }) {
+  const { cache, queryManager } = getApolloClient()
+
+  const mutationId = String(queryManager.mutationIdCounter)
+  queryManager.markMutationOptimistic(optimisticResponse, {
+    mutationId,
+    document: mutation,
+    variables,
+    update
+  })
+
+  return () => cache.removeOptimistic(mutationId)
+}

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -150,3 +150,5 @@ export const getWalletBy = (key, value) => {
   }
   throw new Error(`wallet not found: ${key}=${value}`)
 }
+
+export const ZAP_UNDO_DELAY_MS = 5_000

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -127,7 +127,7 @@ export const ITEM_ALLOW_EDITS = [
 
 export const INVOICE_RETENTION_DAYS = 7
 export const JIT_INVOICE_TIMEOUT_MS = 180_000 // 3 minutes
-export const DEFAULT_INVOICE_TIMEOUT_MS = 3600_000 // 1 hour
+export const DEFAULT_INVOICE_TIMEOUT_MS = 300_000 // 30 minutes
 
 export const FAST_POLL_INTERVAL = Number(process.env.NEXT_PUBLIC_FAST_POLL_INTERVAL)
 export const NORMAL_POLL_INTERVAL = Number(process.env.NEXT_PUBLIC_NORMAL_POLL_INTERVAL)

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -126,7 +126,8 @@ export const ITEM_ALLOW_EDITS = [
 ]
 
 export const INVOICE_RETENTION_DAYS = 7
-export const JIT_INVOICE_TIMEOUT_MS = 180_000
+export const JIT_INVOICE_TIMEOUT_MS = 180_000 // 3 minutes
+export const DEFAULT_INVOICE_TIMEOUT_MS = 3600_000 // 1 hour
 
 export const FAST_POLL_INTERVAL = Number(process.env.NEXT_PUBLIC_FAST_POLL_INTERVAL)
 export const NORMAL_POLL_INTERVAL = Number(process.env.NEXT_PUBLIC_NORMAL_POLL_INTERVAL)

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -126,6 +126,7 @@ export const ITEM_ALLOW_EDITS = [
 ]
 
 export const INVOICE_RETENTION_DAYS = 7
+export const JIT_INVOICE_TIMEOUT_MS = 180_000
 
 export const FAST_POLL_INTERVAL = Number(process.env.NEXT_PUBLIC_FAST_POLL_INTERVAL)
 export const NORMAL_POLL_INTERVAL = Number(process.env.NEXT_PUBLIC_NORMAL_POLL_INTERVAL)

--- a/lib/item.js
+++ b/lib/item.js
@@ -72,3 +72,20 @@ export const commentSubTreeRootId = (item) => {
   const path = item.path.split('.')
   return path.slice(-(COMMENT_DEPTH_LIMIT - 1))[0]
 }
+
+export const determineItemType = (item) => {
+  const typeMap = {
+    url: 'link',
+    bounty: 'bounty',
+    pollCost: 'poll'
+  }
+
+  for (const [key, type] of Object.entries(typeMap)) {
+    if (item[key]) {
+      return type
+    }
+  }
+
+  // Default
+  return 'discussion'
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -21,6 +21,7 @@ import { ChainFeeProvider } from '@/components/chain-fee.js'
 import { WebLNProvider } from '@/components/webln'
 import dynamic from 'next/dynamic'
 import { HasNewNotesProvider } from '@/components/use-has-new-notes'
+import { PaymentProvider } from '@/components/payment'
 
 const PWAPrompt = dynamic(() => import('react-ios-pwa-prompt'), { ssr: false })
 
@@ -111,14 +112,16 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
                         <ToastProvider>
                           <WebLNProvider>
                             <ShowModalProvider>
-                              <BlockHeightProvider blockHeight={blockHeight}>
-                                <ChainFeeProvider chainFee={chainFee}>
-                                  <ErrorBoundary>
-                                    <Component ssrData={ssrData} {...otherProps} />
-                                    {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
-                                  </ErrorBoundary>
-                                </ChainFeeProvider>
-                              </BlockHeightProvider>
+                              <PaymentProvider>
+                                <BlockHeightProvider blockHeight={blockHeight}>
+                                  <ChainFeeProvider chainFee={chainFee}>
+                                    <ErrorBoundary>
+                                      <Component ssrData={ssrData} {...otherProps} />
+                                      {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
+                                    </ErrorBoundary>
+                                  </ChainFeeProvider>
+                                </BlockHeightProvider>
+                              </PaymentProvider>
                             </ShowModalProvider>
                           </WebLNProvider>
                         </ToastProvider>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -21,6 +21,7 @@ import { ChainFeeProvider } from '@/components/chain-fee.js'
 import { WebLNProvider } from '@/components/webln'
 import dynamic from 'next/dynamic'
 import { HasNewNotesProvider } from '@/components/use-has-new-notes'
+import { ClientNotificationProvider } from '@/components/client-notifications'
 
 const PWAPrompt = dynamic(() => import('react-ios-pwa-prompt'), { ssr: false })
 
@@ -104,28 +105,30 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
           <ApolloProvider client={client}>
             <MeProvider me={me}>
               <HasNewNotesProvider>
-                <LoggerProvider>
-                  <ServiceWorkerProvider>
-                    <PriceProvider price={price}>
-                      <LightningProvider>
-                        <ToastProvider>
-                          <WebLNProvider>
-                            <ShowModalProvider>
-                              <BlockHeightProvider blockHeight={blockHeight}>
-                                <ChainFeeProvider chainFee={chainFee}>
-                                  <ErrorBoundary>
-                                    <Component ssrData={ssrData} {...otherProps} />
-                                    {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
-                                  </ErrorBoundary>
-                                </ChainFeeProvider>
-                              </BlockHeightProvider>
-                            </ShowModalProvider>
-                          </WebLNProvider>
-                        </ToastProvider>
-                      </LightningProvider>
-                    </PriceProvider>
-                  </ServiceWorkerProvider>
-                </LoggerProvider>
+                <ClientNotificationProvider>
+                  <LoggerProvider>
+                    <ServiceWorkerProvider>
+                      <PriceProvider price={price}>
+                        <LightningProvider>
+                          <ToastProvider>
+                            <WebLNProvider>
+                              <ShowModalProvider>
+                                <BlockHeightProvider blockHeight={blockHeight}>
+                                  <ChainFeeProvider chainFee={chainFee}>
+                                    <ErrorBoundary>
+                                      <Component ssrData={ssrData} {...otherProps} />
+                                      {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
+                                    </ErrorBoundary>
+                                  </ChainFeeProvider>
+                                </BlockHeightProvider>
+                              </ShowModalProvider>
+                            </WebLNProvider>
+                          </ToastProvider>
+                        </LightningProvider>
+                      </PriceProvider>
+                    </ServiceWorkerProvider>
+                  </LoggerProvider>
+                </ClientNotificationProvider>
               </HasNewNotesProvider>
             </MeProvider>
           </ApolloProvider>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -21,7 +21,6 @@ import { ChainFeeProvider } from '@/components/chain-fee.js'
 import { WebLNProvider } from '@/components/webln'
 import dynamic from 'next/dynamic'
 import { HasNewNotesProvider } from '@/components/use-has-new-notes'
-import { PaymentProvider } from '@/components/payment'
 
 const PWAPrompt = dynamic(() => import('react-ios-pwa-prompt'), { ssr: false })
 
@@ -112,16 +111,14 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
                         <ToastProvider>
                           <WebLNProvider>
                             <ShowModalProvider>
-                              <PaymentProvider>
-                                <BlockHeightProvider blockHeight={blockHeight}>
-                                  <ChainFeeProvider chainFee={chainFee}>
-                                    <ErrorBoundary>
-                                      <Component ssrData={ssrData} {...otherProps} />
-                                      {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
-                                    </ErrorBoundary>
-                                  </ChainFeeProvider>
-                                </BlockHeightProvider>
-                              </PaymentProvider>
+                              <BlockHeightProvider blockHeight={blockHeight}>
+                                <ChainFeeProvider chainFee={chainFee}>
+                                  <ErrorBoundary>
+                                    <Component ssrData={ssrData} {...otherProps} />
+                                    {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
+                                  </ErrorBoundary>
+                                </ChainFeeProvider>
+                              </BlockHeightProvider>
                             </ShowModalProvider>
                           </WebLNProvider>
                         </ToastProvider>

--- a/pages/api/lnurlp/[username]/pay.js
+++ b/pages/api/lnurlp/[username]/pay.js
@@ -84,7 +84,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
       models.$queryRaw`SELECT * FROM create_invoice(${invoice.id}, NULL, ${invoice.request},
         ${expiresAt}::timestamp, ${Number(amount)}, ${user.id}::INTEGER, ${noteStr || description},
         ${comment || null}, ${parsedPayerData || null}::JSONB, ${INV_PENDING_LIMIT}::INTEGER,
-        ${USER_IDS_BALANCE_NO_LIMIT.includes(Number(user.id)) ? 0 : BALANCE_LIMIT_MSATS})`,
+        ${USER_IDS_BALANCE_NO_LIMIT.includes(Number(user.id)) ? 0 : BALANCE_LIMIT_MSATS}, NULL, NULL)`,
       { models }
     )
 

--- a/pages/invoices/[id].js
+++ b/pages/invoices/[id].js
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/client'
-import { Invoice } from '@/components/invoice'
+import Invoice from '@/components/invoice'
 import { QrSkeleton } from '@/components/qr'
 import { CenterLayout } from '@/components/layout'
 import { useRouter } from 'next/router'
@@ -10,6 +10,7 @@ import { getGetServerSideProps } from '@/api/ssrApollo'
 // force SSR to include CSP nonces
 export const getServerSideProps = getGetServerSideProps({ query: null })
 
+// TODO: we can probably replace this component with <Invoice poll>
 export default function FullInvoice () {
   const router = useRouter()
   const { data, error } = useQuery(INVOICE, SSR

--- a/pages/rewards/index.js
+++ b/pages/rewards/index.js
@@ -174,7 +174,7 @@ export function DonateButton () {
               amount: 10000
             }}
             schema={amountSchema}
-            invoiceable
+            prepaid
             onSubmit={async ({ amount, hash, hmac }) => {
               const { error } = await donateToRewards({
                 variables: {

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -26,7 +26,7 @@ import { NostrAuth } from '@/components/nostr-auth'
 import { useToast } from '@/components/toast'
 import { useServiceWorkerLogger } from '@/components/logger'
 import { useMe } from '@/components/me'
-import { INVOICE_RETENTION_DAYS } from '@/lib/constants'
+import { INVOICE_RETENTION_DAYS, ZAP_UNDO_DELAY_MS } from '@/lib/constants'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 import DeleteIcon from '@/svgs/delete-bin-line.svg'
 import { useField } from 'formik'
@@ -1007,7 +1007,7 @@ const ZapUndosField = () => {
                 <Info>
                   <ul className='fw-bold'>
                     <li>An undo button is shown after every zap that exceeds or is equal to the threshold</li>
-                    <li>The button is shown for 5 seconds</li>
+                    <li>The button is shown for {ZAP_UNDO_DELAY_MS / 1000} seconds</li>
                     <li>The button is only shown for zaps from the custodial wallet</li>
                     <li>Use a budget or manual approval with attached wallets</li>
                   </ul>

--- a/prisma/migrations/20240518020747_pending_items/migration.sql
+++ b/prisma/migrations/20240518020747_pending_items/migration.sql
@@ -190,10 +190,6 @@ BEGIN
     -- if item is pending, user pays missing sats later.
     -- all remaining queries will run when invoice was paid and we update the item status.
     IF item."status" = 'PENDING'::"Status" THEN
-        -- here, we immediately deduct as many of the sats that are required for the payment
-        -- as possible to effectively "lock" them for it. the remainder will be paid via invoice.
-        -- if the payment fails, we release the locked sats by adding them to the balance again.
-        UPDATE users SET msats = GREATEST(msats - cost_msats - item.boost, 0) WHERE id = item."userId";
         RETURN item;
     END IF;
 

--- a/prisma/migrations/20240518020747_pending_items/migration.sql
+++ b/prisma/migrations/20240518020747_pending_items/migration.sql
@@ -191,7 +191,7 @@ BEGIN
     -- all remaining queries will run when invoice was paid and we update the item status.
     IF item."status" = 'PENDING'::"Status" THEN
         -- here, we immediately deduct as many of the sats that are required for the payment
-        -- to effectively "lock" them for it. the remainder will be paid via invoice.
+        -- as possible to effectively "lock" them for it. the remainder will be paid via invoice.
         -- if the payment fails, we release the locked sats by adding them to the balance again.
         UPDATE users SET msats = GREATEST(msats - cost_msats - item.boost, 0) WHERE id = item."userId";
         RETURN item;

--- a/prisma/migrations/20240518020747_pending_items/migration.sql
+++ b/prisma/migrations/20240518020747_pending_items/migration.sql
@@ -1,0 +1,219 @@
+-- CreateEnum
+CREATE TYPE "ActionType" AS ENUM ('ITEM');
+
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "Status" ADD VALUE 'PENDING';
+ALTER TYPE "Status" ADD VALUE 'FAILED';
+
+-- AlterTable
+ALTER TABLE "Invoice" ADD COLUMN     "actionId" INTEGER,
+ADD COLUMN     "actionType" "ActionType",
+ADD COLUMN     "actionData" JSONB;
+
+-- include actionType, actionId and action data during insert
+CREATE OR REPLACE FUNCTION create_invoice(hash TEXT, preimage TEXT, bolt11 TEXT, expires_at timestamp(3) without time zone,
+    msats_req BIGINT, user_id INTEGER, idesc TEXT, comment TEXT, lud18_data JSONB, inv_limit INTEGER, balance_limit_msats BIGINT,
+    action_type "ActionType", action_id INTEGER, action_data JSONB)
+RETURNS "Invoice"
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    invoice "Invoice";
+    inv_limit_reached BOOLEAN;
+    balance_limit_reached BOOLEAN;
+    inv_pending_msats BIGINT;
+    wdwl_pending_msats BIGINT;
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    -- prevent too many pending invoices
+    SELECT inv_limit > 0 AND count(*) >= inv_limit, COALESCE(sum("msatsRequested"), 0) INTO inv_limit_reached, inv_pending_msats
+    FROM "Invoice"
+    WHERE "userId" = user_id AND "expiresAt" > now_utc() AND "confirmedAt" IS NULL AND cancelled = false;
+
+    IF inv_limit_reached THEN
+        RAISE EXCEPTION 'SN_INV_PENDING_LIMIT';
+    END IF;
+
+    -- account for pending withdrawals
+    SELECT COALESCE(sum("msatsPaying"), 0) + COALESCE(sum("msatsFeePaying"), 0) INTO wdwl_pending_msats
+    FROM "Withdrawl"
+    WHERE "userId" = user_id AND status IS NULL;
+
+    -- prevent pending invoices + msats from exceeding the limit
+    SELECT balance_limit_msats > 0 AND inv_pending_msats+wdwl_pending_msats+msats_req+msats > balance_limit_msats INTO balance_limit_reached
+    FROM users
+    WHERE id = user_id;
+
+    IF balance_limit_reached THEN
+        RAISE EXCEPTION 'SN_INV_EXCEED_BALANCE';
+    END IF;
+
+    -- we good, proceed frens
+    INSERT INTO "Invoice" (hash, preimage, bolt11, "expiresAt", "msatsRequested", "userId", created_at, updated_at, "desc", comment, "lud18Data", "actionType", "actionId", "actionData")
+    VALUES (hash, preimage, bolt11, expires_at, msats_req, user_id, now_utc(), now_utc(), idesc, comment, lud18_data, action_type, action_id, action_data) RETURNING * INTO invoice;
+
+    IF preimage IS NOT NULL THEN
+        INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter)
+        VALUES ('finalizeHodlInvoice', jsonb_build_object('hash', hash), 21, true, expires_at);
+    END IF;
+
+    RETURN invoice;
+END;
+$$;
+
+-- include user_msats and cost_msats in SN_INSUFFICIENT_FUNDS error
+-- add logic to handle Status.PENDING
+CREATE OR REPLACE FUNCTION create_item(
+    jitem JSONB, forward JSONB, poll_options JSONB, spam_within INTERVAL, upload_ids INTEGER[])
+RETURNS "Item"
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    user_msats BIGINT;
+    cost_msats BIGINT := 1000;
+    base_cost_msats BIGINT := 1000;
+    freebie BOOLEAN;
+    allow_freebies BOOLEAN := true;
+    item "Item";
+    med_votes FLOAT;
+    select_clause TEXT;
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    -- access fields with appropriate types
+    item := jsonb_populate_record(NULL::"Item", jitem);
+
+    SELECT msats INTO user_msats FROM users WHERE id = item."userId";
+
+    -- if this is a post, get the base cost of the sub
+    IF item."parentId" IS NULL AND item."subName" IS NOT NULL THEN
+        SELECT "baseCost" * 1000, "baseCost" * 1000, "allowFreebies"
+        INTO base_cost_msats, cost_msats, allow_freebies
+        FROM "Sub"
+        WHERE name = item."subName";
+    END IF;
+
+    IF item."maxBid" IS NULL THEN
+        -- spam multiplier
+        cost_msats := cost_msats * POWER(10, item_spam(item."parentId", item."userId", spam_within));
+        IF item."userId" = 27 THEN
+            -- anon multiplier
+            cost_msats := cost_msats * 100;
+        END IF;
+    END IF;
+
+    -- add image fees
+    IF upload_ids IS NOT NULL THEN
+        cost_msats := cost_msats + (SELECT "nUnpaid" * "imageFeeMsats" FROM image_fees_info(item."userId", upload_ids));
+        UPDATE "Upload" SET paid = 't' WHERE id = ANY(upload_ids);
+    END IF;
+
+    -- it's only a freebie if it's no greater than the base cost, they have less than the cost, and boost = 0
+    freebie := allow_freebies
+        AND (cost_msats <= base_cost_msats)
+        AND (user_msats < cost_msats)
+        AND (item.boost IS NULL OR item.boost = 0)
+        AND item."userId" <> 27;
+
+    IF NOT freebie AND cost_msats > user_msats AND (item."status" IS NULL OR item."status" <> 'PENDING') THEN
+        -- we initiate the postpaid payment flow here.
+        -- the calling context will catch this error to create an invoice for the missing sats
+        -- and retry the item insertion as a pending item.
+        RAISE EXCEPTION 'SN_INSUFFICIENT_FUNDS - user_msats=% cost_msats=%', user_msats, cost_msats + COALESCE(item.boost, 0);
+    END IF;
+
+    -- get this user's median item score
+    SELECT COALESCE(
+        percentile_cont(0.5) WITHIN GROUP(
+            ORDER BY "weightedVotes" - "weightedDownVotes"), 0)
+        INTO med_votes FROM "Item" WHERE "userId" = item."userId";
+
+    -- if their median votes are positive, start at 0
+    -- if the median votes are negative, start their post with that many down votes
+    -- basically: if their median post is bad, presume this post is too
+    -- addendum: if they're an anon poster, always start at 0
+    IF med_votes >= 0 OR item."userId" = 27 THEN
+        med_votes := 0;
+    ELSE
+        med_votes := ABS(med_votes);
+    END IF;
+
+    -- there's no great way to set default column values when using json_populate_record
+    -- so we need to only select fields with non-null values that way when func input
+    -- does not include a value, the default value is used instead of null
+    SELECT string_agg(quote_ident(key), ',') INTO select_clause
+    FROM jsonb_object_keys(jsonb_strip_nulls(jitem)) k(key);
+    -- insert the item
+    EXECUTE format($fmt$
+        INSERT INTO "Item" (%s, "weightedDownVotes", freebie)
+        SELECT %1$s, %L, %L
+        FROM jsonb_populate_record(NULL::"Item", %L) RETURNING *
+    $fmt$, select_clause, med_votes, freebie, jitem) INTO item;
+
+    INSERT INTO "ItemForward" ("itemId", "userId", "pct")
+        SELECT item.id, "userId", "pct" FROM jsonb_populate_recordset(NULL::"ItemForward", forward);
+
+    -- Automatically subscribe to one's own posts
+    INSERT INTO "ThreadSubscription" ("itemId", "userId")
+    VALUES (item.id, item."userId");
+
+    -- Automatically subscribe forward recipients to the new post
+    INSERT INTO "ThreadSubscription" ("itemId", "userId")
+        SELECT item.id, "userId" FROM jsonb_populate_recordset(NULL::"ItemForward", forward);
+
+    INSERT INTO "PollOption" ("itemId", "option")
+        SELECT item.id, "option" FROM jsonb_array_elements_text(poll_options) o("option");
+
+    -- if this is a bio
+    IF item.bio THEN
+        UPDATE users SET "bioId" = item.id WHERE id = item."userId";
+    END IF;
+
+    -- record attachments
+    IF upload_ids IS NOT NULL THEN
+        INSERT INTO "ItemUpload" ("itemId", "uploadId")
+            SELECT item.id, * FROM UNNEST(upload_ids) ON CONFLICT DO NOTHING;
+    END IF;
+
+    -- schedule imgproxy job
+    INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter)
+    VALUES ('imgproxy', jsonb_build_object('id', item.id), 21, true, now() + interval '5 seconds');
+
+    -- if item is pending, user pays missing sats later.
+    -- all remaining queries will run when invoice was paid and we update the item status.
+    IF item."status" = 'PENDING'::"Status" THEN
+        -- here, we immediately deduct as many of the sats that are required for the payment
+        -- to effectively "lock" them for it. the remainder will be paid via invoice.
+        -- if the payment fails, we release the locked sats by adding them to the balance again.
+        UPDATE users SET msats = GREATEST(msats - cost_msats - item.boost, 0) WHERE id = item."userId";
+        RETURN item;
+    END IF;
+
+    IF NOT freebie THEN
+        UPDATE users SET msats = msats - cost_msats WHERE id = item."userId";
+
+        INSERT INTO "ItemAct" (msats, "itemId", "userId", act)
+        VALUES (cost_msats, item.id, item."userId", 'FEE');
+    END IF;
+
+    -- if this item has boost
+    IF item.boost > 0 THEN
+        PERFORM item_act(item.id, item."userId", 'BOOST', item.boost);
+    END IF;
+
+    -- if this is a job
+    IF item."maxBid" IS NOT NULL THEN
+        PERFORM run_auction(item.id);
+    END IF;
+
+    RETURN item;
+END;
+$$;

--- a/prisma/migrations/20240522235320_item_spam_ignore_failed_items/migration.sql
+++ b/prisma/migrations/20240522235320_item_spam_ignore_failed_items/migration.sql
@@ -1,0 +1,46 @@
+-- exclude failed items
+CREATE OR REPLACE FUNCTION item_spam(parent_id INTEGER, user_id INTEGER, within INTERVAL)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    repeats INTEGER;
+    self_replies INTEGER;
+BEGIN
+    -- no fee escalation
+    IF within = interval '0' THEN
+        RETURN 0;
+    END IF;
+
+    SELECT count(*) INTO repeats
+    FROM "Item"
+    WHERE (
+        (parent_id IS NULL AND "parentId" IS NULL)
+        OR
+        ("parentId" = parent_id AND user_id <> (SELECT i."userId" FROM "Item" i WHERE i.id = "Item"."rootId"))
+    )
+    AND "userId" = user_id
+    AND "bio" = 'f'
+    AND "status" <> 'FAILED'
+    AND created_at > now_utc() - within;
+
+    IF parent_id IS NULL THEN
+        RETURN repeats;
+    END IF;
+
+    WITH RECURSIVE base AS (
+        SELECT "Item".id, "Item"."parentId", "Item"."userId"
+        FROM "Item"
+        WHERE id = parent_id
+        AND "userId" = user_id
+        AND created_at > now_utc() - within
+        AND user_id <> (SELECT i."userId" FROM "Item" i WHERE i.id = "Item"."rootId")
+      UNION ALL
+        SELECT "Item".id, "Item"."parentId", "Item"."userId"
+        FROM base p
+        JOIN "Item" ON "Item".id = p."parentId" AND "Item"."userId" = p."userId" AND "Item".created_at > now_utc() - within)
+    SELECT count(*) INTO self_replies FROM base;
+
+    RETURN repeats + self_replies;
+END;
+$$;

--- a/prisma/migrations/20240524193236_invoice_action/migration.sql
+++ b/prisma/migrations/20240524193236_invoice_action/migration.sql
@@ -1,0 +1,71 @@
+-- create function so we can run handle_action inside the same tx as confirm_invoice
+CREATE OR REPLACE FUNCTION invoice_action(actionType "ActionType", actionId INTEGER, actionData JSONB)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    cost_msats BIGINT;
+    item "Item";
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    cost_msats := (actionData->>'cost')::BIGINT;
+
+    IF actionType = 'ITEM' THEN
+        UPDATE "Item" SET status = 'ACTIVE' WHERE id = actionId RETURNING * INTO item;
+
+        UPDATE users SET msats = msats - cost_msats WHERE id = item."userId";
+
+        INSERT INTO "ItemAct" (msats, "itemId", "userId", act)
+        VALUES (cost_msats, item.id, item."userId", 'FEE');
+
+        IF item.boost > 0 THEN
+            PERFORM item_act(item.id, item."userId", 'BOOST', item.boost);
+        END IF;
+
+        IF item."maxBid" IS NOT NULL THEN
+            PERFORM run_auction(item.id);
+        END IF;
+
+        RETURN 0;
+    END IF;
+
+    RETURN 1;
+END;
+$$;
+
+-- run invoice_action on confirmation
+CREATE OR REPLACE FUNCTION confirm_invoice(lnd_id TEXT, lnd_received BIGINT)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    user_id INTEGER;
+    confirmed_at TIMESTAMP;
+    actionType "ActionType";
+    actionId INTEGER;
+    actionData JSONB;
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    SELECT "userId", "confirmedAt", "actionType", "actionId", "actionData"
+    INTO user_id, confirmed_at, actionType, actionId, actionData
+    FROM "Invoice" WHERE hash = lnd_id;
+
+    IF confirmed_at IS NULL THEN
+        UPDATE "Invoice"
+        SET "msatsReceived" = lnd_received, "confirmedAt" = now_utc(), updated_at = now_utc()
+        WHERE hash = lnd_id;
+
+        UPDATE users SET msats = msats + lnd_received WHERE id = user_id;
+
+        IF actionType IS NOT NULL AND actionId IS NOT NULL THEN
+            PERFORM invoice_action(actionType, actionId, actionData);
+        END IF;
+
+        RETURN 0;
+    END IF;
+
+    RETURN 1;
+END;
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -660,6 +660,10 @@ model Mention {
   @@index([userId], map: "Mention.userId_index")
 }
 
+enum ActionType {
+  ITEM
+}
+
 model Invoice {
   id             Int       @id @default(autoincrement())
   createdAt      DateTime  @default(now()) @map("created_at")
@@ -678,6 +682,9 @@ model Invoice {
   desc           String?
   comment        String?
   lud18Data      Json?
+  actionType     ActionType?
+  actionId       Int?
+  actionData     Json?     @db.JsonB
   user           User      @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([createdAt], map: "Invoice.created_at_index")
@@ -884,6 +891,8 @@ enum Status {
   STOPPED
   NOSATS
   GRACE
+  PENDING
+  FAILED
 }
 
 enum PostType {

--- a/worker/action.js
+++ b/worker/action.js
@@ -6,3 +6,57 @@ export async function finalizeAction ({ data: { type, id }, models }) {
 
   await models.$transaction(queries)
 }
+
+export async function handleAction ({ data: { msatsReceived, actionType, actionId, actionData }, models }) {
+  if (!actionType || !actionId) return
+
+  if (actionType === 'ITEM') {
+    // update item status from PENDING to ACTIVE
+    // and run queries which were skipped during creation
+
+    const { cost } = actionData
+    const item = await models.item.findUnique({ where: { id: actionId } })
+
+    await serialize([
+      models.item.update({
+        where: {
+          id: item.id
+        },
+        data: {
+          status: 'ACTIVE'
+        }
+      }),
+      models.user.update({
+        where: {
+          id: item.userId
+        },
+        data: {
+          msats: {
+            decrement: cost
+          }
+        }
+      }),
+      // run skipped queries
+      models.itemAct.create({
+        data: { msats: cost, itemId: item.id, userId: item.userId, act: 'FEE' }
+      }),
+      item.boost > 0 && models.$executeRaw(`SELECT item_act(${item.id}::INTEGER, ${item.userId}::INTEGER, 'BOOST'::"ItemActType", ${item.boost}::INTEGER)`),
+      item.maxBid && models.$executeRaw(`SELECT run_auction(${item.id}::INTEGER)`)
+    ], { models })
+  }
+}
+
+export function handleActionError ({ data: { actionType, actionId }, models }) {
+  if (!actionType || !actionId) return []
+
+  if (actionType === 'ITEM') {
+    return [
+      models.$queryRaw`
+        UPDATE "Item"
+        SET status = 'FAILED'
+        WHERE id = ${actionId} AND status = 'PENDING'`
+    ]
+  }
+
+  return []
+}

--- a/worker/action.js
+++ b/worker/action.js
@@ -1,0 +1,8 @@
+import { handleActionError } from './wallet'
+
+export async function finalizeAction ({ data: { type, id }, models }) {
+  const queries = handleActionError({ data: { actionType: type, actionId: id }, models })
+  if (queries.length === 0) return
+
+  await models.$transaction(queries)
+}

--- a/worker/index.js
+++ b/worker/index.js
@@ -25,6 +25,7 @@ import { ofac } from './ofac.js'
 import { autoWithdraw } from './autowithdraw.js'
 import { saltAndHashEmails } from './saltAndHashEmails.js'
 import { remindUser } from './reminder.js'
+import { finalizeAction } from './action.js'
 
 const { loadEnvConfig } = nextEnv
 const { ApolloClient, HttpLink, InMemoryCache } = apolloClient
@@ -80,6 +81,7 @@ async function work () {
 
   await subscribeToWallet(args)
   await boss.work('finalizeHodlInvoice', jobWrapper(finalizeHodlInvoice))
+  await boss.work('finalizeAction', jobWrapper(finalizeAction))
   await boss.work('checkPendingDeposits', jobWrapper(checkPendingDeposits))
   await boss.work('checkPendingWithdrawals', jobWrapper(checkPendingWithdrawals))
   await boss.work('autoDropBolt11s', jobWrapper(autoDropBolt11s))

--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -182,7 +182,7 @@ async function checkInvoice ({ data: { hash }, boss, models, lnd }) {
           cancelled: true
         }
       }),
-      ...actionErrorQueries({ data: dbInv, models })
+      ...(await actionErrorQueries({ data: dbInv, models }))
     ], { models })
   }
 }

--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -135,6 +135,7 @@ async function checkInvoice ({ data: { hash }, boss, models, lnd }) {
     const firstConfirmation = code === 0
     if (firstConfirmation) {
       notifyDeposit(dbInv.userId, { comment: dbInv.comment, ...inv })
+      // ideally, we would run this in the same tx as confirm_invoice but handleAction is not idempotent
       await handleAction({ data: dbInv, models })
     }
 

--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -9,7 +9,7 @@ import { datePivot, sleep } from '@/lib/time.js'
 import retry from 'async-retry'
 import { addWalletLog } from '@/api/resolvers/wallet'
 import { msatsToSats, numWithUnits } from '@/lib/format'
-import { handleAction, handleActionError } from './action'
+import { handleAction, actionErrorQueries } from './action'
 
 export async function subscribeToWallet (args) {
   await subscribeToDeposits(args)
@@ -176,7 +176,7 @@ async function checkInvoice ({ data: { hash }, boss, models, lnd }) {
           cancelled: true
         }
       }),
-      ...handleActionError({ data: dbInv, models })
+      ...actionErrorQueries({ data: dbInv, models })
     ], { models })
   }
 }

--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -9,6 +9,7 @@ import { datePivot, sleep } from '@/lib/time.js'
 import retry from 'async-retry'
 import { addWalletLog } from '@/api/resolvers/wallet'
 import { msatsToSats, numWithUnits } from '@/lib/format'
+import { handleAction, handleActionError } from './action'
 
 export async function subscribeToWallet (args) {
   await subscribeToDeposits(args)
@@ -356,58 +357,4 @@ export async function checkPendingWithdrawals (args) {
       console.error('error checking withdrawal', w.hash)
     }
   }
-}
-
-async function handleAction ({ data: { msatsReceived, actionType, actionId, actionData }, models }) {
-  if (!actionType || !actionId) return
-
-  if (actionType === 'ITEM') {
-    // update item status from PENDING to ACTIVE
-    // and run queries which were skipped during creation
-
-    const { cost } = actionData
-    const item = await models.item.findUnique({ where: { id: actionId } })
-
-    await serialize([
-      models.item.update({
-        where: {
-          id: item.id
-        },
-        data: {
-          status: 'ACTIVE'
-        }
-      }),
-      models.user.update({
-        where: {
-          id: item.userId
-        },
-        data: {
-          msats: {
-            decrement: cost
-          }
-        }
-      }),
-      // run skipped queries
-      models.itemAct.create({
-        data: { msats: cost, itemId: item.id, userId: item.userId, act: 'FEE' }
-      }),
-      item.boost > 0 && models.$executeRaw(`SELECT item_act(${item.id}::INTEGER, ${item.userId}::INTEGER, 'BOOST'::"ItemActType", ${item.boost}::INTEGER)`),
-      item.maxBid && models.$executeRaw(`SELECT run_auction(${item.id}::INTEGER)`)
-    ], { models })
-  }
-}
-
-export function handleActionError ({ data: { actionType, actionId }, models }) {
-  if (!actionType || !actionId) return []
-
-  if (actionType === 'ITEM') {
-    return [
-      models.$queryRaw`
-        UPDATE "Item"
-        SET status = 'FAILED'
-        WHERE id = ${actionId} AND status = 'PENDING'`
-    ]
-  }
-
-  return []
 }


### PR DESCRIPTION
## Description

### Using undocumented Apollo API for optimistic behavior for zaps, poll votes and bounty payments

Every action which does not need a database id in the client now updates the UI optimistically even if payment is required. This includes (and is limited to) zaps, poll votes and bounty payments. This leads to a not-custodial UX that is equal to the familiar speed of the custodial UX since all payment delays are moved to the background, out of view from the user. When the invoice was paid, the action is submitted to the server as usual with payment hash + hmac.

To support this, the form component now supports `optimisticUpdate`. When this property is passed a function, its return value will be passed to the following function which calls [`QueryManager.markOptimisticMutation`](https://github.com/apollographql/apollo-client/blob/9c5a8cee40900125fe5037d573e6daedd619075f/src/core/QueryManager.ts#L587-L630) and [`cache.removeOptimistic`](https://github.com/apollographql/apollo-client/blob/9c5a8cee40900125fe5037d573e6daedd619075f/src/cache/inmemory/inMemoryCache.ts#L406-L412) to manually trigger the optimistic cache update and its revert:

```js
export function optimisticUpdate ({ mutation, variables, optimisticResponse, update }) {
  const { cache, queryManager } = getApolloClient()

  const mutationId = String(queryManager.mutationIdCounter)
  queryManager.markMutationOptimistic(optimisticResponse, {
    mutationId,
    document: mutation,
    variables,
    update
  })

  return () => cache.removeOptimistic(mutationId)
}
```

We call this function before triggering a payment. On payment or submit error, we rollback the optimistic update. The user is only informed in this case via notifications that are stored in `window.localStorage`.

_During the changes, it became clear that the property `invoiceable` should actually be called `prepaid`. This makes it purpose more clear._

### Optimistic replies and posts via post-paid support

For mutations where the id is required to update the UI in a sane way, the form component now supports a new property: `postpaid`.

If this property is passed, the form component will check the return value of the submit handler for an invoice. If one was found, it will try to pay it.

This allows us to use the server response to update the UI as fast as if it was paid via the custodial wallet. In the case a external payment is required, the item is inserted as "pending" which makes them only visible to the author and the server response will include an invoice. Since anons are not logged in and thus don't support this optimistic behavior, they don't have access to pending items but need to pay first. Therefore, forms and mutations support prepaid and postpaid simultaneously.

When the invoice is paid, we update the item status to active which makes it visible to everyone.

Based on and thus includes #1071 closes #849 closes #848 supersedes #1161.

## TODO

**Prepaid**

- [x] optimistic zaps
  - [x] optimism via `optimisticUpdate`
  - [x] ~persistence of optimistic update while payment is pending via `window.localStorage`~
  _we'll do this after #1178 since we need to be aware of pending stuff on the server anyway if proxy is used_
- [x] optimistic bounty payments
  - [x] optimism via `optimisticUpdate`
  - [x] ~persistence of optimistic update while payment is pending via `window.localStorage`~
  _we'll do this after #1178 since we need to be aware of pending stuff on the server anyway if proxy is used_
- [x] poll votes
  - [x] optimism via `optimisticUpdate`
  - [x] ~persistence of optimistic update while payment is pending via `window.localStorage`~
  _we'll do this after #1178 since we need to be aware of pending stuff on the server anyway if proxy is used_
- [x] error notification if payment failed
  _related to persistence to some degree since payment should also be considered "failed" if payment + associated action was lost due to page refresh, but we'll skip this case for now as mentioned above_   
- [x] ~error handling if payment failed (reverting persistence)~
  _see comments above_
- [x] zap undos

**Postpaid**

- [x] Add `payment.send` next to `payment.request` from #1071 
- [x] Add `postpaid` to form which checks for returned invoices and tries to pay them
- [x] insert pending items and return invoice
- [x] check for payments on server and update item status
- [x] check for payment failures and update item status
- [x] update queries to only show pending items to author
- [x] error notifications
- [x] on error notification click, navigate to prefilled replies/forms for good retry UX 
- [x] ignore failed items in spam calculation
- [x] make sure items transition to `ACTIVE` even if transition query failed after invoice confirmation 
- [x] don't notify users etc. if pending items are created
- [x] decide what to do with dead links in error notifications
- [x] ~update `updatedAt` manually in raw queries for notification red square to work~ _for some reason, this wasn't necessary_
- [ ] prevent replying to or zapping failed items

## TODO after [review](https://github.com/stackernews/stacker.news/pull/1184#issuecomment-2127919566)

- [ ] handle action in same tx as `confirm_invoice` to fix race conditions if autowithdrawals are enabled
- [ ] test edits of pending items:

> Editting a pending comment made a modal popup telling me the payment failed. Is that expected?

- [x] fix missing `resetForm`: 669ad67d

> When a top level comment failed, I clicked on the notification, then submitted the form to retry to the comment, it succeeded but the comment field did not clear 

## Videos

TBD

## Additional Context

- the idea of using `mutationIdCounter` and not `mutationIdCounter++` as in the library source code was that the mutation will also call an optimistic update with the same id to make sure the UI updates and overwrite the previous layer.  If I recall correctly, I found out it actually creates its own layer with its own (automated) revert. Therefore, I considered it not only be redundant but also a possible source of bugs. However, as mentioned, not sure, would need to check this behavior again.

## Checklist

**Are your changes backwards compatible? Please answer below:**

<!-- put your answer about backwards compatibility here -->

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

<!-- put your answer about QA here -->

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
