### PR TITLE
Fix inverted lnbitsSchema env check

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -601,7 +601,7 @@ export const lnAddrSchema = ({ payerData, min, max, commentAllowed } = {}) =>
   }, {})))
 
 export const lnbitsSchema = object({
-  url: process.env.NODE_ENV !== 'development'
+  url: process.env.NODE_ENV === 'development'
     ? string()
       .or([string().matches(/^(http:\/\/)?localhost:\d+$/), string().url()], 'invalid url')
       .required('required').trim()


### PR DESCRIPTION
I accidentally inverted the env check in a585ba7f, see https://github.com/stackernews/stacker.news/commit/a585ba7f0aa0eb8050142661f23da2253c8a3607#r142166222