### PR TITLE
Biopage userheader popover

### DIFF
--- a/components/user-header.js
+++ b/components/user-header.js
@@ -284,7 +284,11 @@ function HeaderHeader ({ user }) {
         </Button>
         <div className='d-flex flex-column mt-1 ms-0'>
           <small className='text-muted d-flex-inline'>stacking since: {user.since
-            ? <Link href={`/items/${user.since}`} className='ms-1'>#{user.since}</Link>
+            ? (
+              <ItemPopover id={user.since}>
+                <Link href={`/items/${user.since}`} className='ms-1'>#{user.since}</Link>
+              </ItemPopover>
+            )
             : <span>never</span>}
           </small>
           {user.optional.maxStreak !== null &&

--- a/components/user-header.js
+++ b/components/user-header.js
@@ -29,6 +29,7 @@ import NostrIcon from '@/svgs/nostr.svg'
 import GithubIcon from '@/svgs/github-fill.svg'
 import TwitterIcon from '@/svgs/twitter-fill.svg'
 import { UNKNOWN_LINK_REL, MEDIA_URL } from '@/lib/constants'
+import ItemPopover from './item-popover'
 
 export default function UserHeader ({ user }) {
   const router = useRouter()


### PR DESCRIPTION
## Description

Wrapped the <Link> for "user.since" with <ItemPopover> to replicate the mouseover behavior on other pages. 

closes #1180

## Screenshots

![image](https://github.com/stackernews/stacker.news/assets/5414285/a301fd13-8edd-436b-a41a-1574469f79a9)

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes. Minor fix; no new component created.

**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes. Works as expected.

**For frontend changes: Tested on mobile? Please answer below:**

Yes.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.
