### PR TITLE
Allow API key access by default

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1341,6 +1341,9 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
     item.url = removeTracking(item.url)
   }
 
+  // mark item as created with API key
+  item.apiKey = me?.apiKey
+
   const uploadIds = uploadIdsFromText(item.text, { models })
   const { totalFees: imgFees } = await imageFeesInfo(uploadIds, { models, me })
 
@@ -1463,7 +1466,7 @@ export const SELECT =
   "Item".ncomments, "Item"."commentMsats", "Item"."lastCommentAt", "Item"."weightedVotes",
   "Item"."weightedDownVotes", "Item".freebie, "Item".bio, "Item"."otsHash", "Item"."bountyPaidTo",
   ltree2text("Item"."path") AS "path", "Item"."weightedComments", "Item"."imgproxyUrls", "Item".outlawed,
-  "Item"."pollExpiresAt"`
+  "Item"."pollExpiresAt", "Item"."apiKey"`
 
 function topOrderByWeightedSats (me, models) {
   return `ORDER BY ${orderByNumerator(models)} DESC NULLS LAST, "Item".id DESC`

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -125,6 +125,7 @@ export default gql`
     forwards: [ItemForward]
     imgproxyUrls: JSONObject
     rel: String
+    apiKey: Boolean
   }
 
   input ItemForwardInput {

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -136,6 +136,9 @@ export default function ItemInfo ({
             {' '}<Badge className={styles.newComment} bg={null}>freebie</Badge>
           </Link>
         )}
+      {(item.apiKey &&
+        <>{' '}<Badge className={styles.newComment} bg={null}>bot</Badge></>
+        )}
       {extraBadges}
       {canEdit && !item.deletedAt &&
         <>

--- a/fragments/comments.js
+++ b/fragments/comments.js
@@ -34,6 +34,7 @@ export const COMMENT_FIELDS = gql`
     ncomments
     imgproxyUrls
     rel
+    apiKey
   }
 `
 

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -59,6 +59,7 @@ export const ITEM_FIELDS = gql`
     mine
     imgproxyUrls
     rel
+    apiKey
   }`
 
 export const ITEM_FULL_FIELDS = gql`

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -27,8 +27,6 @@ import { useToast } from '@/components/toast'
 import { useServiceWorkerLogger } from '@/components/logger'
 import { useMe } from '@/components/me'
 import { INVOICE_RETENTION_DAYS, ZAP_UNDO_DELAY_MS } from '@/lib/constants'
-import { OverlayTrigger, Tooltip } from 'react-bootstrap'
-import DeleteIcon from '@/svgs/delete-bin-line.svg'
 import { useField } from 'formik'
 import styles from './settings.module.css'
 
@@ -836,42 +834,29 @@ function ApiKey ({ enabled, apiKey }) {
   )
   const toaster = useToast()
 
-  const disabled = !enabled || apiKey
-
   return (
     <>
       <div className='form-label mt-3'>api key</div>
       <div className='mt-2 d-flex align-items-center'>
-        <OverlayTrigger
-          placement='bottom'
-          overlay={disabled ? <Tooltip>{apiKey ? 'you can have only one API key at a time' : 'request access to API keys in ~meta'}</Tooltip> : <></>}
-          trigger={['hover', 'focus']}
-        >
-          <div>
-            <Button
-              disabled={disabled}
-              variant='secondary'
-              onClick={async () => {
-                try {
-                  const { data } = await generateApiKey({ variables: { id: me.id } })
-                  const { generateApiKey: apiKey } = data
-                  showModal(() => <ApiKeyModal apiKey={apiKey} />, { keepOpen: true })
-                } catch (err) {
-                  console.error(err)
-                  toaster.danger('error generating api key')
-                }
-              }}
-            >Generate API key
-            </Button>
-          </div>
-        </OverlayTrigger>
-        {apiKey &&
-          <DeleteIcon
-            style={{ cursor: 'pointer' }} className='fill-danger mx-1' width={24} height={24}
-            onClick={async () => {
+        <Button
+          variant={apiKey ? 'danger' : 'secondary'}
+          onClick={async () => {
+            if (apiKey) {
               showModal((onClose) => <ApiKeyDeleteObstacle onClose={onClose} />)
-            }}
-          />}
+              return
+            }
+
+            try {
+              const { data } = await generateApiKey({ variables: { id: me.id } })
+              const { generateApiKey: apiKey } = data
+              showModal(() => <ApiKeyModal apiKey={apiKey} />, { keepOpen: true })
+            } catch (err) {
+              console.error(err)
+              toaster.danger('error generating api key')
+            }
+          }}
+        >{apiKey ? 'Delete' : 'Generate'} API key
+        </Button>
         <Info>
           <ul className='fw-bold'>
             <li>use API keys with our <Link target='_blank' href='/api/graphql'>GraphQL API</Link> for authentication</li>

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -836,29 +836,6 @@ function ApiKey ({ enabled, apiKey }) {
   )
   const toaster = useToast()
 
-  const subject = '[API Key Request] <your title here>'
-  const body =
-  encodeURI(`**[API Key Request]**
-
-Hi, I would like to use API keys with the [Stacker News GraphQL API](/api/graphql) for the following reasons:
-
-...
-
-I expect to call the following GraphQL queries or mutations:
-
-... (you can leave empty if unknown)
-
-I estimate that I will call the GraphQL API this many times (rough estimate is fine):
-
-... (you can leave empty if unknown)
-`)
-  const metaLink = encodeURI(`/~meta/post?type=discussion&title=${subject}&text=${body}`)
-  const mailto = `mailto:hello@stacker.news?subject=${subject}&body=${body}`
-  // link to DM with k00b on Telegram
-  const telegramLink = 'https://t.me/k00bideh'
-  // link to DM with ek on SimpleX
-  const simplexLink = 'https://simplex.chat/contact#/?v=1-2&smp=smp%3A%2F%2F6iIcWT_dF2zN_w5xzZEY7HI2Prbh3ldP07YTyDexPjE%3D%40smp10.simplex.im%2FxNnPk9DkTbQJ6NckWom9mi5vheo_VPLm%23%2F%3Fv%3D1-2%26dh%3DMCowBQYDK2VuAyEAnFUiU0M8jS1JY34LxUoPr7mdJlFZwf3pFkjRrhprdQs%253D%26srv%3Drb2pbttocvnbrngnwziclp2f4ckjq65kebafws6g4hy22cdaiv5dwjqd.onion'
-
   const disabled = !enabled || apiKey
 
   return (
@@ -899,25 +876,7 @@ I estimate that I will call the GraphQL API this many times (rough estimate is f
           <ul className='fw-bold'>
             <li>use API keys with our <Link target='_blank' href='/api/graphql'>GraphQL API</Link> for authentication</li>
             <li>you need to add the API key to the <span className='text-monospace'>X-API-Key</span> header of your requests</li>
-            <li>you can currently only generate API keys if we enabled it for your account</li>
-            <li>
-              you can{' '}
-              <Link target='_blank' href={metaLink} rel='noreferrer'>create a post in ~meta</Link> to request access
-              or reach out to us via
-              <ul>
-                <li><Link target='_blank' href={mailto} rel='noreferrer'>email</Link></li>
-                <li><Link target='_blank' href={telegramLink} rel='noreferrer'>Telegram</Link></li>
-                <li><Link target='_blank' href={simplexLink} rel='noreferrer'>SimpleX</Link></li>
-              </ul>
-            </li>
-            <li>please include following information in your request:
-              <ul>
-                <li>your nym on SN</li>
-                <li>what you want to achieve with authenticated API access</li>
-                <li>which GraphQL queries or mutations you expect to call</li>
-                <li>your (rough) estimate how often you will call the GraphQL API</li>
-              </ul>
-            </li>
+            <li>we reserve the right to disable your API key access at any time</li>
           </ul>
         </Info>
       </div>

--- a/prisma/migrations/20240529074650_item_bot_badge/migration.sql
+++ b/prisma/migrations/20240529074650_item_bot_badge/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Item" ADD COLUMN     "apiKey" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20240529080656_api_key_allow_all/migration.sql
+++ b/prisma/migrations/20240529080656_api_key_allow_all/migration.sql
@@ -1,0 +1,2 @@
+-- allow everyone access to API keys by default
+UPDATE users SET "apiKeyEnabled" = 't';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -419,6 +419,7 @@ model Item {
   ItemUpload         ItemUpload[]
   uploadId           Int?
   outlawed           Boolean               @default(false)
+  apiKey             Boolean               @default(false)
   pollExpiresAt      DateTime?
   Ancestors          Reply[]               @relation("AncestorReplyItem")
   Replies            Reply[]


### PR DESCRIPTION
## Description

This PR updates every user to allow them API key access by default. The info was also updated to mention that this access can be disabled at any time.

Motivation for this is to allow anyone to build on SN without having to ask for permission in ~meta. API key access was disabled by default in #915 to limit our exposure to this new auth method. With #980 and #989 in place and after having gauged initial interest, I think it's safe to remove this requirement now.

Additionally, any item created with API keys will now be marked as `bot`. 

## Screenshots

![2024-05-29-025646_594x85_scrot](https://github.com/stackernews/stacker.news/assets/27162016/b17cb06c-8bad-4ec9-a0a6-5bab3d17c316)

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
