### PR TITLE
Close related section

### DIFF
--- a/components/accordian-item.js
+++ b/components/accordian-item.js
@@ -3,7 +3,7 @@ import AccordionContext from 'react-bootstrap/AccordionContext'
 import { useAccordionButton } from 'react-bootstrap/AccordionButton'
 import ArrowRight from '@/svgs/arrow-right-s-fill.svg'
 import ArrowDown from '@/svgs/arrow-down-s-fill.svg'
-import { useContext, useEffect } from 'react'
+import { useContext, useEffect, useState } from 'react'
 
 function ContextAwareToggle ({ children, headerColor = 'var(--theme-grey)', eventKey, show }) {
   const { activeEventKey } = useContext(AccordionContext)
@@ -29,10 +29,16 @@ function ContextAwareToggle ({ children, headerColor = 'var(--theme-grey)', even
 }
 
 export default function AccordianItem ({ header, body, headerColor = 'var(--theme-grey)', show }) {
+  const [activeKey, setActiveKey] = useState()
+
+  useEffect(() => {
+    setActiveKey(show ? '0' : null)
+  }, [show])
+
   return (
-    <Accordion defaultActiveKey={show ? '0' : undefined}>
+    <Accordion defaultActiveKey={activeKey} activeKey={activeKey}>
       <ContextAwareToggle show={show} eventKey='0'><div style={{ color: headerColor }}>{header}</div></ContextAwareToggle>
-      <Accordion.Collapse eventKey='0' className='mt-2'>
+      <Accordion.Collapse eventKey='0' classNme='mt-2'>
         <div>{body}</div>
       </Accordion.Collapse>
     </Accordion>
@@ -41,7 +47,7 @@ export default function AccordianItem ({ header, body, headerColor = 'var(--them
 
 export function AccordianCard ({ header, children, show }) {
   return (
-    <Accordion defaultActiveKey={show ? '0' : undefined}>
+    <Accordion defaultActiveKey={show ? '0' : undefined} activeKey={show}>
       <Accordion.Item eventKey='0'>
         <Accordion.Header>{header}</Accordion.Header>
         <Accordion.Body>

--- a/components/accordian-item.js
+++ b/components/accordian-item.js
@@ -5,6 +5,8 @@ import ArrowRight from '@/svgs/arrow-right-s-fill.svg'
 import ArrowDown from '@/svgs/arrow-down-s-fill.svg'
 import { useContext, useEffect, useState } from 'react'
 
+const KEY_ID = '0'
+
 function ContextAwareToggle ({ children, headerColor = 'var(--theme-grey)', eventKey, show }) {
   const { activeEventKey } = useContext(AccordionContext)
   const decoratedOnClick = useAccordionButton(eventKey)
@@ -32,13 +34,17 @@ export default function AccordianItem ({ header, body, headerColor = 'var(--them
   const [activeKey, setActiveKey] = useState()
 
   useEffect(() => {
-    setActiveKey(show ? '0' : null)
+    setActiveKey(show ? KEY_ID : null)
   }, [show])
 
+  const handleOnSelect = () => {
+    setActiveKey(activeKey === KEY_ID ? null : KEY_ID)
+  }
+
   return (
-    <Accordion defaultActiveKey={activeKey} activeKey={activeKey}>
-      <ContextAwareToggle show={show} eventKey='0'><div style={{ color: headerColor }}>{header}</div></ContextAwareToggle>
-      <Accordion.Collapse eventKey='0' classNme='mt-2'>
+    <Accordion defaultActiveKey={activeKey} activeKey={activeKey} onSelect={handleOnSelect}>
+      <ContextAwareToggle show={show} eventKey={KEY_ID}><div style={{ color: headerColor }}>{header}</div></ContextAwareToggle>
+      <Accordion.Collapse eventKey={KEY_ID} classNme='mt-2'>
         <div>{body}</div>
       </Accordion.Collapse>
     </Accordion>

--- a/components/accordian-item.js
+++ b/components/accordian-item.js
@@ -53,7 +53,7 @@ export default function AccordianItem ({ header, body, headerColor = 'var(--them
 
 export function AccordianCard ({ header, children, show }) {
   return (
-    <Accordion defaultActiveKey={show ? '0' : undefined} activeKey={show}>
+    <Accordion defaultActiveKey={show ? '0' : undefined}>
       <Accordion.Item eventKey='0'>
         <Accordion.Header>{header}</Accordion.Header>
         <Accordion.Body>

--- a/components/accordian-item.js
+++ b/components/accordian-item.js
@@ -44,7 +44,7 @@ export default function AccordianItem ({ header, body, headerColor = 'var(--them
   return (
     <Accordion defaultActiveKey={activeKey} activeKey={activeKey} onSelect={handleOnSelect}>
       <ContextAwareToggle show={show} eventKey={KEY_ID}><div style={{ color: headerColor }}>{header}</div></ContextAwareToggle>
-      <Accordion.Collapse eventKey={KEY_ID} classNme='mt-2'>
+      <Accordion.Collapse eventKey={KEY_ID} className='mt-2'>
         <div>{body}</div>
       </Accordion.Collapse>
     </Accordion>

--- a/components/item-full.js
+++ b/components/item-full.js
@@ -176,7 +176,14 @@ function TopLevelItem ({ item, noReply, ...props }) {
       </article>
       {!noReply &&
         <>
-          <Reply item={item} replyOpen placeholder={item.ncomments > 3 ? 'fractions of a penny for your thoughts?' : 'early comments get more zaps'} onCancelQuote={cancelQuote} onQuoteReply={quoteReply} quote={quote} />
+          <Reply
+            item={item}
+            replyOpen
+            placeholder={item.ncomments > 3 ? 'fractions of a penny for your thoughts?' : 'early comments get more zaps'}
+            onCancelQuote={cancelQuote}
+            onQuoteReply={quoteReply}
+            quote={quote}
+          />
           {
           // Don't show related items for Saloon items (position is set but no subName)
           (!item.position && item.subName) &&

--- a/components/item-full.js
+++ b/components/item-full.js
@@ -195,7 +195,7 @@ function TopLevelItem ({ item, noReply, ...props }) {
           !item.deletedAt &&
           // Don't show related items for items with bounties, show past bounties instead
           !(item.bounty > 0) &&
-            <Related title={item.title} itemId={item.id} show={item.ncomments % 2 === 0} />
+            <Related title={item.title} itemId={item.id} show={item.ncomments === 0} />
           }
           {item.bounty > 0 && <PastBounties item={item} />}
         </>}

--- a/components/item-full.js
+++ b/components/item-full.js
@@ -195,7 +195,7 @@ function TopLevelItem ({ item, noReply, ...props }) {
           !item.deletedAt &&
           // Don't show related items for items with bounties, show past bounties instead
           !(item.bounty > 0) &&
-            <Related title={item.title} itemId={item.id} show={item.ncomments === 0} />
+            <Related title={item.title} itemId={item.id} show={item.ncomments % 2 === 0} />
           }
           {item.bounty > 0 && <PastBounties item={item} />}
         </>}

--- a/components/reply.js
+++ b/components/reply.js
@@ -31,7 +31,15 @@ export function ReplyOnAnotherPage ({ item }) {
   )
 }
 
-export default forwardRef(function Reply ({ item, onSuccess, replyOpen, children, placeholder, onQuoteReply, onCancelQuote, quote }, ref) {
+export default forwardRef(function Reply ({
+  item,
+  replyOpen,
+  children,
+  placeholder,
+  onQuoteReply,
+  onCancelQuote,
+  quote
+}, ref) {
   const [reply, setReply] = useState(replyOpen || quote)
   const me = useMe()
   const parentId = item.id


### PR DESCRIPTION
Fixes #837 

## Description
This PR ensures that the Related Posts section is closed once a comment is made.

This issue took me a while to find but eventually found the problem within Accordion component.
- Made use of `activeKey` and `onSelect` props
- Implemented `onSelect` handler to update `activeKey` value
- Set `activeKey` value on load
- Use `null` instead of `undefined` (Accordion doesn't seem to behave when using `undefined`)

## Video
https://github.com/stackernews/stacker.news/assets/7639854/cf6cb2a3-29fc-4428-848b-1889ceead087

## Testing
Please QA this if possible as I may have overlooked something.
