### PR TITLE
Item mention notifications

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -15,7 +15,7 @@ import { msatsToSats } from '@/lib/format'
 import { parse } from 'tldts'
 import uu from 'url-unshort'
 import { actSchema, advSchema, bountySchema, commentSchema, discussionSchema, jobSchema, linkSchema, pollSchema, ssValidate } from '@/lib/validate'
-import { notifyItemParents, notifyUserSubscribers, notifyZapped, notifyTerritorySubscribers, notifyMention } from '@/lib/webPush'
+import { notifyItemParents, notifyUserSubscribers, notifyZapped, notifyTerritorySubscribers, notifyMention, notifyItemMention } from '@/lib/webPush'
 import { defaultCommentSort, isJob, deleteItemByAuthor, getDeleteCommand, hasDeleteCommand, getReminderCommand, hasReminderCommand } from '@/lib/item'
 import { datePivot, whenRange } from '@/lib/time'
 import { imageFeesInfo, uploadIdsFromText } from './image'
@@ -1179,6 +1179,7 @@ export default {
 }
 
 const namePattern = /\B@[\w_]+/gi
+const refPattern = /\B#\d+/gi
 
 export const createMentions = async (item, models) => {
   // if we miss a mention, in the rare circumstance there's some kind of
@@ -1188,6 +1189,7 @@ export const createMentions = async (item, models) => {
     return
   }
 
+  // user mentions
   try {
     const mentions = item.text.match(namePattern)?.map(m => m.slice(1))
     if (mentions?.length > 0) {
@@ -1220,7 +1222,44 @@ export const createMentions = async (item, models) => {
       })
     }
   } catch (e) {
-    console.error('mention failure', e)
+    console.error('user mention failure', e)
+  }
+
+  // item mentions
+  try {
+    const refs = item.text.match(refPattern)?.map(m => Number(m.slice(1)))
+    if (refs?.length > 0) {
+      const referee = await models.item.findMany({
+        where: {
+          id: { in: refs },
+          // Don't create mentions for your own items
+          userId: { not: item.userId }
+
+        }
+      })
+
+      referee.forEach(async r => {
+        const data = {
+          referrerId: item.id,
+          refereeId: r.id
+        }
+
+        const mention = await models.itemMention.upsert({
+          where: {
+            referrerId_refereeId: data
+          },
+          update: data,
+          create: data
+        })
+
+        // only send if mention is new to avoid duplicates
+        if (mention.createdAt.getTime() === mention.updatedAt.getTime()) {
+          notifyItemMention({ models, userId: r.userId, item })
+        }
+      })
+    }
+  } catch (e) {
+    console.error('item mention failure', e)
   }
 }
 

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1259,7 +1259,7 @@ export const createMentions = async (item, models) => {
 
         // only send if mention is new to avoid duplicates
         if (mention.createdAt.getTime() === mention.updatedAt.getTime()) {
-          notifyItemMention({ models, userId: r.userId, item })
+          notifyItemMention({ models, referrerItem: item, refereeItem: r })
         }
       })
     }

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1179,7 +1179,7 @@ export default {
 }
 
 const namePattern = /\B@[\w_]+/gi
-const refPattern = /\B#\d+/gi
+const refPattern = new RegExp(`(?:#|${process.env.NEXT_PUBLIC_URL}/items/)(?<id>\\d+)`, 'gi')
 
 export const createMentions = async (item, models) => {
   // if we miss a mention, in the rare circumstance there's some kind of
@@ -1227,7 +1227,12 @@ export const createMentions = async (item, models) => {
 
   // item mentions
   try {
-    const refs = item.text.match(refPattern)?.map(m => Number(m.slice(1)))
+    const refs = item.text.match(refPattern)?.map(m => {
+      if (m.startsWith('#')) return Number(m.slice(1))
+      // is not #<id> syntax but full URL
+      return Number(m.split('/').slice(-1)[0])
+    })
+
     if (refs?.length > 0) {
       const referee = await models.item.findMany({
         where: {

--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -347,6 +347,26 @@ export default {
         }
       }
 
+      if (user.noteItemMentions) {
+        const [newMentions] = await models.$queryRawUnsafe(`
+        SELECT EXISTS(
+          SELECT *
+          FROM "ItemMention"
+          JOIN "Item" "Referee" ON "ItemMention"."refereeId" = "Referee".id
+          JOIN "Item" ON "ItemMention"."referrerId" = "Item".id
+          ${whereClause(
+            '"ItemMention".created_at < $2',
+            '"Item"."userId" <> $1',
+            '"Referee"."userId" = $1',
+            await filterClause(me, models),
+            muteClause(me)
+          )})`, me.id, lastChecked)
+        if (newMentions.exists) {
+          foundNotes()
+          return true
+        }
+      }
+
       if (user.noteForwardedSats) {
         const [newFwdSats] = await models.$queryRawUnsafe(`
         SELECT EXISTS(

--- a/api/typeDefs/notifications.js
+++ b/api/typeDefs/notifications.js
@@ -43,6 +43,12 @@ export default gql`
     sortTime: Date!
   }
 
+  type ItemMention {
+    id: ID!
+    item: Item!
+    sortTime: Date!
+  }
+
   type Invitification {
     id: ID!
     invite: Invite!
@@ -130,7 +136,7 @@ export default gql`
   union Notification = Reply | Votification | Mention
     | Invitification | Earn | JobChanged | InvoicePaid | WithdrawlPaid | Referral
     | Streak | FollowActivity | ForwardedVotification | Revenue | SubStatus
-    | TerritoryPost | TerritoryTransfer | Reminder
+    | TerritoryPost | TerritoryTransfer | Reminder | ItemMention
 
   type Notifications {
     lastChecked: Date

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -95,6 +95,7 @@ export default gql`
     noteItemSats: Boolean!
     noteJobIndicator: Boolean!
     noteMentions: Boolean!
+    noteItemMentions: Boolean!
     nsfwMode: Boolean!
     tipDefault: Int!
     turboTipping: Boolean!
@@ -161,6 +162,7 @@ export default gql`
     noteItemSats: Boolean!
     noteJobIndicator: Boolean!
     noteMentions: Boolean!
+    noteItemMentions: Boolean!
     nsfwMode: Boolean!
     tipDefault: Int!
     turboTipping: Boolean!

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -404,7 +404,7 @@ function ItemMention ({ n }) {
           : (
             <div className='pb-2'>
               <RootProvider root={n.item.root}>
-                <Comment item={n.item} noReply includeParent rootText={n.__typename === 'Reply' ? 'replying on:' : undefined} clickToContext />
+                <Comment item={n.item} noReply includeParent rootText='replying on:' clickToContext />
               </RootProvider>
             </div>)}
       </div>

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -396,7 +396,7 @@ function ItemMention ({ n }) {
   return (
     <>
       <small className='fw-bold text-info ms-2'>
-        one of your {n.title ? 'posts' : 'comments'} was mentioned
+        your item was mentioned in
       </small>
       <div>
         {n.item?.title

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -54,6 +54,7 @@ function Notification ({ n, fresh }) {
         (type === 'Votification' && <Votification n={n} />) ||
         (type === 'ForwardedVotification' && <ForwardedVotification n={n} />) ||
         (type === 'Mention' && <Mention n={n} />) ||
+        (type === 'ItemMention' && <ItemMention n={n} />) ||
         (type === 'JobChanged' && <JobChanged n={n} />) ||
         (type === 'Reply' && <Reply n={n} />) ||
         (type === 'SubStatus' && <SubStatus n={n} />) ||
@@ -379,6 +380,26 @@ function Mention ({ n }) {
       </small>
       <div>
         {n.item.title
+          ? <Item item={n.item} />
+          : (
+            <div className='pb-2'>
+              <RootProvider root={n.item.root}>
+                <Comment item={n.item} noReply includeParent rootText={n.__typename === 'Reply' ? 'replying on:' : undefined} clickToContext />
+              </RootProvider>
+            </div>)}
+      </div>
+    </>
+  )
+}
+
+function ItemMention ({ n }) {
+  return (
+    <>
+      <small className='fw-bold text-info ms-2'>
+        one of your {n.title ? 'posts' : 'comments'} was mentioned
+      </small>
+      <div>
+        {n.item?.title
           ? <Item item={n.item} />
           : (
             <div className='pb-2'>

--- a/components/text.js
+++ b/components/text.js
@@ -23,6 +23,7 @@ import { UNKNOWN_LINK_REL } from '@/lib/constants'
 import isEqual from 'lodash/isEqual'
 import UserPopover from './user-popover'
 import ItemPopover from './item-popover'
+import ref from '@/lib/remark-ref2link'
 
 export function SearchText ({ text }) {
   return (
@@ -284,7 +285,7 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
           },
           img: Img
         }}
-        remarkPlugins={[gfm, mention, sub]}
+        remarkPlugins={[gfm, mention, sub, ref]}
         rehypePlugins={[rehypeInlineCodeProperty]}
       >
         {children}

--- a/fragments/notifications.js
+++ b/fragments/notifications.js
@@ -25,6 +25,14 @@ export const NOTIFICATIONS = gql`
             text
           }
         }
+        ... on ItemMention {
+          id
+          sortTime
+          item { 
+            ...ItemFullFields
+            text
+          }
+        }
         ... on Votification {
           id
           sortTime

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -38,6 +38,7 @@ export const ME = gql`
         noteItemSats
         noteJobIndicator
         noteMentions
+        noteItemMentions
         sats
         tipDefault
         tipPopover
@@ -73,6 +74,7 @@ export const SETTINGS_FIELDS = gql`
       noteEarning
       noteAllDescendants
       noteMentions
+      noteItemMentions
       noteDeposits
       noteWithdrawals
       noteInvites

--- a/lib/remark-ref2link.js
+++ b/lib/remark-ref2link.js
@@ -1,0 +1,26 @@
+import { findAndReplace } from 'mdast-util-find-and-replace'
+
+const refRegex = /#(\d+(\/(edit|related|ots))?)/gi
+
+export default function ref (options) {
+  return function transformer (tree) {
+    findAndReplace(
+      tree,
+      [
+        [refRegex, replaceRef]
+      ],
+      { ignore: ['link', 'linkReference'] }
+    )
+  }
+
+  function replaceRef (value, itemId, match) {
+    const node = { type: 'text', value }
+
+    return {
+      type: 'link',
+      title: null,
+      url: `/items/${itemId}`,
+      children: [node]
+    }
+  }
+}

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -268,9 +268,13 @@ export const notifyItemMention = async ({ models, referrerItem, refereeItem }) =
     const muted = await isMuted({ models, muterId: refereeItem.userId, mutedId: referrerItem.userId })
     if (!muted) {
       const referrer = await models.user.findUnique({ where: { id: referrerItem.userId } })
+
+      // replace full links to #<id> syntax as rendered on site
+      const body = referrerItem.text.replace(new RegExp(`${process.env.NEXT_PUBLIC_URL}/items/(\\d+)`, 'gi'), '#$1')
+
       await sendUserNotification(refereeItem.userId, {
         title: `@${referrer.name} mentioned one of your items`,
-        body: referrerItem.text,
+        body,
         item: referrerItem,
         tag: 'ITEM_MENTION'
       })

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -268,15 +268,11 @@ export const notifyItemMention = async ({ models, referrerItem, refereeItem }) =
     const muted = await isMuted({ models, muterId: refereeItem.userId, mutedId: referrerItem.userId })
     if (!muted) {
       const referrer = await models.user.findUnique({ where: { id: referrerItem.userId } })
-      const isPost = !!refereeItem.title
-      const subType = isPost ? 'POST' : 'COMMENT'
-      const tag = `ITEM_MENTION-${subType}`
       await sendUserNotification(refereeItem.userId, {
-        title: `@${referrer.name} mentioned one of your ${isPost ? 'posts' : 'comments'}`,
+        title: `@${referrer.name} mentioned one of your items`,
         body: referrerItem.text,
         item: referrerItem,
-        data: { subType },
-        tag
+        tag: 'ITEM_MENTION'
       })
     }
   } catch (err) {

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -38,6 +38,7 @@ const createUserFilter = (tag) => {
   const tagMap = {
     REPLY: 'noteAllDescendants',
     MENTION: 'noteMentions',
+    ITEM_MENTION: 'noteItemMentions',
     TIP: 'noteItemSats',
     FORWARDEDTIP: 'noteForwardedSats',
     REFERRAL: 'noteInvites',
@@ -255,6 +256,27 @@ export const notifyMention = async ({ models, userId, item }) => {
         body: item.text,
         item,
         tag: 'MENTION'
+      })
+    }
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+export const notifyItemMention = async ({ models, userId, item }) => {
+  try {
+    const muted = await isMuted({ models, muterId: userId, mutedId: item.userId })
+    if (!muted) {
+      const user = await models.user.findUnique({ where: { id: item.userId } })
+      const isPost = !!item.title
+      const subType = isPost ? 'POST' : 'COMMENT'
+      const tag = `ITEM_MENTION-${subType}`
+      await sendUserNotification(userId, {
+        title: `@${user.name} mentioned one of your ${isPost ? 'posts' : 'comments'}`,
+        body: item.text,
+        item,
+        data: { subType },
+        tag
       })
     }
   } catch (err) {

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -263,18 +263,18 @@ export const notifyMention = async ({ models, userId, item }) => {
   }
 }
 
-export const notifyItemMention = async ({ models, userId, item }) => {
+export const notifyItemMention = async ({ models, referrerItem, refereeItem }) => {
   try {
-    const muted = await isMuted({ models, muterId: userId, mutedId: item.userId })
+    const muted = await isMuted({ models, muterId: refereeItem.userId, mutedId: referrerItem.userId })
     if (!muted) {
-      const user = await models.user.findUnique({ where: { id: item.userId } })
-      const isPost = !!item.title
+      const referrer = await models.user.findUnique({ where: { id: referrerItem.userId } })
+      const isPost = !!refereeItem.title
       const subType = isPost ? 'POST' : 'COMMENT'
       const tag = `ITEM_MENTION-${subType}`
-      await sendUserNotification(userId, {
-        title: `@${user.name} mentioned one of your ${isPost ? 'posts' : 'comments'}`,
-        body: item.text,
-        item,
+      await sendUserNotification(refereeItem.userId, {
+        title: `@${referrer.name} mentioned one of your ${isPost ? 'posts' : 'comments'}`,
+        body: referrerItem.text,
+        item: referrerItem,
         data: { subType },
         tag
       })

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -120,6 +120,7 @@ export default function Settings ({ ssrData }) {
             noteEarning: settings?.noteEarning,
             noteAllDescendants: settings?.noteAllDescendants,
             noteMentions: settings?.noteMentions,
+            noteItemMentions: settings?.noteItemMentions,
             noteDeposits: settings?.noteDeposits,
             noteWithdrawals: settings?.noteWithdrawals,
             noteInvites: settings?.noteInvites,
@@ -278,6 +279,11 @@ export default function Settings ({ ssrData }) {
           <Checkbox
             label='someone mentions me'
             name='noteMentions'
+            groupClassName='mb-0'
+          />
+          <Checkbox
+            label='someone mentions one of my posts or comments'
+            name='noteItemMentions'
             groupClassName='mb-0'
           />
           <Checkbox

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -282,7 +282,7 @@ export default function Settings ({ ssrData }) {
             groupClassName='mb-0'
           />
           <Checkbox
-            label='someone mentions one of my posts or comments'
+            label='someone mentions one of my items'
             name='noteItemMentions'
             groupClassName='mb-0'
           />

--- a/prisma/migrations/20240529105359_item_mentions/migration.sql
+++ b/prisma/migrations/20240529105359_item_mentions/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "ItemMention" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "referrerId" INTEGER NOT NULL,
+    "refereeId" INTEGER NOT NULL,
+
+    CONSTRAINT "ItemMention_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ItemMention.created_at_index" ON "ItemMention"("created_at");
+
+-- CreateIndex
+CREATE INDEX "ItemMention.referrerId_index" ON "ItemMention"("referrerId");
+
+-- CreateIndex
+CREATE INDEX "ItemMention.refereeId_index" ON "ItemMention"("refereeId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ItemMention.referrerId_refereeId_unique" ON "ItemMention"("referrerId", "refereeId");
+
+-- AddForeignKey
+ALTER TABLE "ItemMention" ADD CONSTRAINT "ItemMention_referrerId_fkey" FOREIGN KEY ("referrerId") REFERENCES "Item"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ItemMention" ADD CONSTRAINT "ItemMention_refereeId_fkey" FOREIGN KEY ("refereeId") REFERENCES "Item"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "noteItemMentions" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,7 @@ model User {
   noteInvites               Boolean              @default(true)
   noteItemSats              Boolean              @default(true)
   noteMentions              Boolean              @default(true)
+  noteItemMentions          Boolean              @default(true)
   noteForwardedSats         Boolean              @default(true)
   lastCheckedJobs           DateTime?
   noteJobIndicator          Boolean              @default(true)
@@ -411,6 +412,8 @@ model Item {
   user               User                  @relation("UserItems", fields: [userId], references: [id], onDelete: Cascade)
   actions            ItemAct[]
   mentions           Mention[]
+  referrer           ItemMention[]         @relation("referrer")
+  referee            ItemMention[]         @relation("referee")
   PollOption         PollOption[]
   PollVote           PollVote[]
   ThreadSubscription ThreadSubscription[]
@@ -659,6 +662,21 @@ model Mention {
   @@index([createdAt], map: "Mention.created_at_index")
   @@index([itemId], map: "Mention.itemId_index")
   @@index([userId], map: "Mention.userId_index")
+}
+
+model ItemMention {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+  referrerId Int
+  refereeId  Int
+  referrerItem      Item     @relation("referrer", fields: [referrerId], references: [id], onDelete: Cascade)
+  refereeItem       Item     @relation("referee", fields: [refereeId], references: [id], onDelete: Cascade)
+
+  @@unique([referrerId, refereeId], map: "ItemMention.referrerId_refereeId_unique")
+  @@index([createdAt], map: "ItemMention.created_at_index")
+  @@index([referrerId], map: "ItemMention.referrerId_index")
+  @@index([refereeId], map: "ItemMention.refereeId_index")
 }
 
 model Invoice {

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -144,7 +144,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
     } else if (compareTag === 'MENTION') {
       title = `you were mentioned ${amount} times`
     } else if (compareTag === 'ITEM_MENTION') {
-      title = `your ${subType === 'POST' ? 'posts' : 'comments'} were mentioned ${amount} times`
+      title = `your items were mentioned ${amount} times`
     } else if (compareTag === 'REFERRAL') {
       title = `${amount} stackers joined via your referral links`
     } else if (compareTag === 'INVITE') {

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -114,7 +114,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
   // merge notifications into single notification payload
   // ---
   // tags that need to know the amount of notifications with same tag for merging
-  const AMOUNT_TAGS = ['REPLY', 'MENTION', 'REFERRAL', 'INVITE', 'FOLLOW', 'TERRITORY_POST']
+  const AMOUNT_TAGS = ['REPLY', 'MENTION', 'ITEM_MENTION', 'REFERRAL', 'INVITE', 'FOLLOW', 'TERRITORY_POST']
   // tags that need to know the sum of sats of notifications with same tag for merging
   const SUM_SATS_TAGS = ['DEPOSIT', 'WITHDRAWAL']
   // this should reflect the amount of notifications that were already merged before
@@ -143,6 +143,8 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
       title = `you have ${amount} new replies`
     } else if (compareTag === 'MENTION') {
       title = `you were mentioned ${amount} times`
+    } else if (compareTag === 'ITEM_MENTION') {
+      title = `your ${subType === 'POST' ? 'posts' : 'comments'} were mentioned ${amount} times`
     } else if (compareTag === 'REFERRAL') {
       title = `${amount} stackers joined via your referral links`
     } else if (compareTag === 'INVITE') {


### PR DESCRIPTION
## Description

This adds notifications if one of your posts or comments were mentioned.

I also added parsing of references as `#<itemId>` to links so internal references are now linked both ways. This means that `#1234` will now be parsed as a link to https://stacker.news/items/1234 (see d449d8bf).

Related to https://github.com/stackernews/stacker.news/issues/667 but doesn't close it since this PR is only about notifications

## Screenshots

![2024-05-31-102231_514x83_scrot](https://github.com/stackernews/stacker.news/assets/27162016/ca4328dc-7562-4873-83e9-2f3beaf0e62b)

## Additional Context

I initially wanted to include the type of item that was referred in the title. So if someone referred to a post of yours, it would show `one of your posts was mentioned` instead of `one of your comments was mentioned`. However, that made the code more complicated (see d9740250).

I now use `items` to mean both but I think that's not a good name since it might be confusing for stackers what we mean by that. I thought about using "submissions" instead but that's a completely new term so maybe even more confusing.

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
