### PR TITLE
Add bot badge to items created with API key

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1311,6 +1311,9 @@ export const createItem = async (parent, { forward, options, ...item }, { me, mo
     item.url = removeTracking(item.url)
   }
 
+  // mark item as created with API key
+  item.apiKey = me?.apiKey
+
   const uploadIds = uploadIdsFromText(item.text, { models })
   const { totalFees: imgFees } = await imageFeesInfo(uploadIds, { models, me })
 
@@ -1433,7 +1436,7 @@ export const SELECT =
   "Item".ncomments, "Item"."commentMsats", "Item"."lastCommentAt", "Item"."weightedVotes",
   "Item"."weightedDownVotes", "Item".freebie, "Item".bio, "Item"."otsHash", "Item"."bountyPaidTo",
   ltree2text("Item"."path") AS "path", "Item"."weightedComments", "Item"."imgproxyUrls", "Item".outlawed,
-  "Item"."pollExpiresAt"`
+  "Item"."pollExpiresAt", "Item"."apiKey"`
 
 function topOrderByWeightedSats (me, models) {
   return `ORDER BY ${orderByNumerator(models)} DESC NULLS LAST, "Item".id DESC`

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -125,6 +125,7 @@ export default gql`
     forwards: [ItemForward]
     imgproxyUrls: JSONObject
     rel: String
+    apiKey: Boolean
   }
 
   input ItemForwardInput {

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -136,6 +136,9 @@ export default function ItemInfo ({
             {' '}<Badge className={styles.newComment} bg={null}>freebie</Badge>
           </Link>
         )}
+      {(item.apiKey &&
+        <>{' '}<Badge className={styles.newComment} bg={null}>bot</Badge></>
+        )}
       {extraBadges}
       {canEdit && !item.deletedAt &&
         <>

--- a/fragments/comments.js
+++ b/fragments/comments.js
@@ -34,6 +34,7 @@ export const COMMENT_FIELDS = gql`
     ncomments
     imgproxyUrls
     rel
+    apiKey
   }
 `
 

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -59,6 +59,7 @@ export const ITEM_FIELDS = gql`
     mine
     imgproxyUrls
     rel
+    apiKey
   }`
 
 export const ITEM_FULL_FIELDS = gql`

--- a/prisma/migrations/20240529074650_item_bot_badge/migration.sql
+++ b/prisma/migrations/20240529074650_item_bot_badge/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Item" ADD COLUMN     "apiKey" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -419,6 +419,7 @@ model Item {
   ItemUpload         ItemUpload[]
   uploadId           Int?
   outlawed           Boolean               @default(false)
+  apiKey             Boolean               @default(false)
   pollExpiresAt      DateTime?
   Ancestors          Reply[]               @relation("AncestorReplyItem")
   Replies            Reply[]


### PR DESCRIPTION
## Description

This adds a `bot` badge to any item that was created with an API key.

## Screenshots

![2024-05-29-025646_594x85_scrot](https://github.com/stackernews/stacker.news/assets/27162016/8abe44cc-8da5-48b2-8982-0eb765a832be)


## Additional Context

See https://github.com/stackernews/stacker.news/pull/1205#issuecomment-2138546513

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes, I only added a column with a default and `apiKey` is nullable in the GraphQL typedef.

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No
