### PR TITLE
add `fund_user` sndev command

### DIFF
--- a/sndev
+++ b/sndev
@@ -238,7 +238,7 @@ sndev__fund_user() {
    exit 3
   fi
   docker__exec db psql -U sn -d stackernews -q <<EOF
-    UPDATE users set msats = msats + $2 where name = '$1';
+    UPDATE users set msats = $2 where name = '$1';
 EOF
 }
 
@@ -250,7 +250,7 @@ USAGE
   $ sndev fund_user <nym> <msats>
 
   <nym> - the name of the user you want to fund
-  <msats> - the amount of millisatoshis to add to the account. Must be a positive integer
+  <msats> - the amount of millisatoshis to set the account to. Must be >= 0
 "
 
   echo "$help"
@@ -553,6 +553,7 @@ COMMANDS
 
   sn:
     login         login as a nym
+    fund_user     fund a nym without using an LN invoice
 
   lnd:
     fund          pay a bolt11 for funding

--- a/sndev
+++ b/sndev
@@ -219,6 +219,43 @@ USAGE
   echo "$help"
 }
 
+sndev__fund_user() {
+  shift
+  if [ -z "$1" ]; then
+    echo "<nym> argument required"
+    sndev__help_fund_user
+    exit 1
+  fi
+  if [ -z "$2" ]; then
+    echo "<msats> argument required"
+    sndev__help_fund_user
+    exit 2
+  fi
+  re='^[0-9]+$'
+  if ! [[ $2 =~ $re ]]; then
+   echo "<msats> is not a positive integer"
+   sndev__help_fund_user
+   exit 3
+  fi
+  docker__exec db psql -U sn -d stackernews -q <<EOF
+    UPDATE users set msats = msats + $2 where name = '$1';
+EOF
+}
+
+sndev__help_fund_user() {
+  help="
+fund a nym without using an LN invoice (local only)
+
+USAGE
+  $ sndev fund_user <nym> <msats>
+
+  <nym> - the name of the user you want to fund
+  <msats> - the amount of millisatoshis to add to the account. Must be a positive integer
+"
+
+  echo "$help"
+}
+
 sndev__fund() {
   shift
   docker__stacker_lnd -t payinvoice "$@"


### PR DESCRIPTION
## Description
Adds a `fund_user` command to `./sndev` that allows you to fund a user without having to use a LN invoice, so you can easily fund users without running the payments containers.

## Screenshots
N/A

## Additional Context
As discussed [here](https://chat.sndev.team/#/room/!dhqketVrbDjhGqdqtp:sndev.team/$0MBiw_ZFjKP697TWGfvV3Rn4Sp9cV4e5eXkuutzJjlI?via=sndev.team)

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**Did you QA this? Could we deploy this straight to production? Please answer below:**
Yes

**For frontend changes: Tested on mobile? Please answer below:**
N/A

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No