### PR TITLE
Fix issue with popover on full sn links

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -13,7 +13,7 @@ import Thumb from '@/svgs/thumb-up-fill.svg'
 import { toString } from 'mdast-util-to-string'
 import copy from 'clipboard-copy'
 import ZoomableImage, { decodeOriginalUrl } from './image'
-import { IMGPROXY_URL_REGEXP, parseInternalLinks, parseEmbedUrl, isItemPath } from '@/lib/url'
+import { IMGPROXY_URL_REGEXP, parseInternalLinks, parseEmbedUrl } from '@/lib/url'
 import reactStringReplace from 'react-string-replace'
 import { rehypeInlineCodeProperty } from '@/lib/md'
 import { Button } from 'react-bootstrap'
@@ -188,7 +188,7 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
             }
 
             const internalURL = process.env.NEXT_PUBLIC_URL
-            if (!!text && !/^https?:\/\//.test(text) && !isItemPath(url.pathname)) {
+            if (!!text && !/^https?:\/\//.test(text)) {
               if (props['data-footnote-ref'] || typeof props['data-footnote-backref'] !== 'undefined') {
                 return (
                   <Link
@@ -211,6 +211,19 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
                   </UserPopover>
                 )
               } else if (href.startsWith('/') || url?.origin === internalURL) {
+                try {
+                  const linkText = parseInternalLinks(href)
+                  if (linkText) {
+                    return (
+                      <ItemPopover id={linkText.replace('#', '').split('/')[0]}>
+                        <Link href={href}>{text}</Link>
+                      </ItemPopover>
+                    )
+                  }
+                } catch {
+                  // ignore errors like invalid URLs
+                }
+
                 return (
                   <Link
                     id={props.id}

--- a/components/text.js
+++ b/components/text.js
@@ -13,7 +13,7 @@ import Thumb from '@/svgs/thumb-up-fill.svg'
 import { toString } from 'mdast-util-to-string'
 import copy from 'clipboard-copy'
 import ZoomableImage, { decodeOriginalUrl } from './image'
-import { IMGPROXY_URL_REGEXP, parseInternalLinks, parseEmbedUrl } from '@/lib/url'
+import { IMGPROXY_URL_REGEXP, parseInternalLinks, parseEmbedUrl, isItemPath } from '@/lib/url'
 import reactStringReplace from 'react-string-replace'
 import { rehypeInlineCodeProperty } from '@/lib/md'
 import { Button } from 'react-bootstrap'
@@ -186,8 +186,9 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
             } catch {
               // ignore invalid URLs
             }
+
             const internalURL = process.env.NEXT_PUBLIC_URL
-            if (!!text && !/^https?:\/\//.test(text)) {
+            if (!!text && !/^https?:\/\//.test(text) && !isItemPath(url.pathname)) {
               if (props['data-footnote-ref'] || typeof props['data-footnote-backref'] !== 'undefined') {
                 return (
                   <Link

--- a/lib/url.js
+++ b/lib/url.js
@@ -26,14 +26,22 @@ export function removeTracking (value) {
 /**
  * parse links like https://stacker.news/items/123456 as #123456
  */
+
+export function isItemPath (pathname) {
+  if (!pathname) return false
+
+  const [page, id] = pathname.split('/').filter(part => !!part)
+  return page === 'items' && /^[0-9]+$/.test(id)
+}
+
 export function parseInternalLinks (href) {
   const url = new URL(href)
   const internalURL = process.env.NEXT_PUBLIC_URL
   const { pathname, searchParams } = url
+
   // ignore empty parts which exist due to pathname starting with '/'
-  const emptyPart = part => !!part
-  const parts = pathname.split('/').filter(emptyPart)
-  if (parts[0] === 'items' && /^[0-9]+$/.test(parts[1]) && url.origin === internalURL) {
+  if (isItemPath(pathname) && url.origin === internalURL) {
+    const parts = pathname.split('/').filter(part => !!part)
     const itemId = parts[1]
     // check for valid item page due to referral links like /items/123456/r/ekzyis
     const itemPages = ['edit', 'ots', 'related']


### PR DESCRIPTION
Fixes #1213 

## Description

This PR ensures a popover is seen for internal links that include a text part.

## Tests

These links were tested and are working as expected:

| Link    | Comment |
| -------- | ------- |
|`http://localhost:3000/items/459356`|shows popover and renders internal link|
|`[link](http://localhost:3000/items/458213`|shows popover and renders internal link|
|`[link](https://stacker.news)`|opens in new tab (this is external relative to localhost)|
|`https://stacker.news`|opens in new tab (this is external relative to localhost)|
|`[link](http://localhost:3000/settings)`|renders internal link (no popover)|
|`[link](/settings)`|renders internal link (no popover)|

## Screenshots

**Preview**
![Screenshot 2024-06-03 at 07 47 26](https://github.com/stackernews/stacker.news/assets/7639854/7aa74024-2691-46e1-80f0-4bb6d217db96)

**Popover visible on second link**
![Screenshot 2024-06-03 at 07 47 34](https://github.com/stackernews/stacker.news/assets/7639854/fdb6cd10-a1c2-4f92-b91e-ee8dbc4b5dd9)
