### PR TITLE
Fix missing commentId parsing for item mentions

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -213,7 +213,7 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
                 )
               } else if (href.startsWith('/') || url?.origin === internalURL) {
                 try {
-                  const linkText = parseInternalLinks(href)
+                  const { linkText } = parseInternalLinks(href)
                   if (linkText) {
                     return (
                       <ItemPopover id={linkText.replace('#', '').split('/')[0]}>
@@ -241,7 +241,7 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
             }
 
             try {
-              const linkText = parseInternalLinks(href)
+              const { linkText } = parseInternalLinks(href)
               if (linkText) {
                 return (
                   <ItemPopover id={linkText.replace('#', '').split('/')[0]}>

--- a/lib/url.js
+++ b/lib/url.js
@@ -52,12 +52,14 @@ export function parseInternalLinks (href) {
       // and not #2
       // since commentId will be ignored anyway
       const linkText = `#${itemId}/${itemPage}`
-      return linkText
+      return { itemId, linkText }
     }
     const commentId = searchParams.get('commentId')
     const linkText = `#${commentId || itemId}`
-    return linkText
+    return { itemId, commentId, linkText }
   }
+
+  return {}
 }
 
 export function parseEmbedUrl (href) {

--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -24,7 +24,7 @@ describe('internal links', () => {
     'parses %p as %p',
     (href, expected) => {
       process.env.NEXT_PUBLIC_URL = 'https://stacker.news'
-      const actual = parseInternalLinks(href)
+      const { linkText: actual } = parseInternalLinks(href)
       expect(actual).toBe(expected)
     }
   )


### PR DESCRIPTION
## Description

The code for item mentions in the backend didn't parse internal links properly. Links like `https://stacker.news/items/560297?commentId=561109` didn't use the comment id but the item id.

Item mentions should always use the id the frontend would show for the link when parsed. 

## Additional Context

Going to test the code for item mentions more since [there might be more wrong](https://stacker.news/items/560297?commentId=561120)

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

<!-- put your answer about QA here -->

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
