### PR TITLE
Avoid manual optimistic updates for now

### DIFF
--- a/components/item-act.js
+++ b/components/item-act.js
@@ -10,7 +10,7 @@ import { useToast } from './toast'
 import { useLightning } from './lightning'
 import { nextTip } from './upvote'
 import { InvoiceCanceledError, usePayment } from './payment'
-import { optimisticUpdate } from '@/lib/apollo'
+// import { optimisticUpdate } from '@/lib/apollo'
 import { Types as ClientNotification, ClientNotifyProvider, useClientNotifications } from './client-notifications'
 import { ZAP_UNDO_DELAY_MS } from '@/lib/constants'
 
@@ -120,23 +120,31 @@ export default function ItemAct ({ onClose, item, down, children, abortSignal })
         act: down ? 'DONT_LIKE_THIS' : 'TIP',
         hash,
         hmac
-      }
+      },
+      optimisticResponse: {
+        act: { id: item.id, sats: Number(amount), act: down ? 'DONT_LIKE_THIS' : 'TIP', path: item.path }
+      },
+      update: actUpdate({ me })
     })
     if (!me) setItemMeAnonSats({ id: item.id, amount })
     addCustomTip(Number(amount))
-  }, [me, act, down, item.id, strike])
-
-  const optimisticUpdate = useCallback(({ amount }) => {
-    const variables = {
-      id: item.id,
-      sats: Number(amount),
-      act: down ? 'DONT_LIKE_THIS' : 'TIP'
-    }
-    const optimisticResponse = { act: { ...variables, path: item.path } }
     strike()
     onClose()
-    return { mutation: ACT_MUTATION, variables, optimisticResponse, update: actUpdate({ me }) }
-  }, [item.id, down, !!me, strike])
+  }, [me, act, down, item.id, strike])
+
+  // XXX avoid manual optimistic updates until
+  //   https://github.com/stackernews/stacker.news/issues/1218 is fixed
+  // const optimisticUpdate = useCallback(({ amount }) => {
+  //   const variables = {
+  //     id: item.id,
+  //     sats: Number(amount),
+  //     act: down ? 'DONT_LIKE_THIS' : 'TIP'
+  //   }
+  //   const optimisticResponse = { act: { ...variables, path: item.path } }
+  //   strike()
+  //   onClose()
+  //   return { mutation: ACT_MUTATION, variables, optimisticResponse, update: actUpdate({ me }) }
+  // }, [item.id, down, !!me, strike])
 
   return (
     <ClientNotifyProvider additionalProps={{ itemId: item.id }}>
@@ -147,7 +155,7 @@ export default function ItemAct ({ onClose, item, down, children, abortSignal })
         }}
         schema={amountSchema}
         prepaid
-        optimisticUpdate={optimisticUpdate}
+        // optimisticUpdate={optimisticUpdate}
         onSubmit={onSubmit}
         clientNotification={ClientNotification.Zap}
         signal={abortSignal}
@@ -266,8 +274,10 @@ export function useZap () {
 
     let revert, cancel, nid
     try {
-      revert = optimisticUpdate({ mutation: ZAP_MUTATION, variables, optimisticResponse, update })
-      strike()
+      // XXX avoid manual optimistic updates until
+      //   https://github.com/stackernews/stacker.news/issues/1218 is fixed
+      // revert = optimisticUpdate({ mutation: ZAP_MUTATION, variables, optimisticResponse, update })
+      // strike()
 
       await abortSignal.pause({ me, amount: satsDelta })
 
@@ -277,7 +287,11 @@ export function useZap () {
 
       let hash, hmac;
       [{ hash, hmac }, cancel] = await payment.request(satsDelta)
-      await zap({ variables: { ...variables, hash, hmac } })
+
+      // XXX related to comment above
+      // await zap({ variables: { ...variables, hash, hmac } })
+      await zap({ variables: { ...variables, hash, hmac }, optimisticResponse, update })
+      strike()
     } catch (error) {
       revert?.()
 


### PR DESCRIPTION
## Description

Related to #1218 

Manual optimistic updates break cache updates for comments (probably updates for all following mutations). This PR comments out the code that breaks them for now.

TODO:
- [x] ~also comment out~ delete manual optimistic update code for bounty and poll votes

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes, tested zaps and custom zap with commenting afterwards, bounty payments, polls

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
