### PR TITLE
Embed youtube shorts

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -79,13 +79,23 @@ export function parseEmbedUrl (href) {
   try {
     const { hostname, pathname, searchParams } = new URL(href)
 
-    if (hostname.endsWith('youtube.com') && pathname.includes('/watch')) {
-      return {
-        provider: 'youtube',
-        id: searchParams.get('v'),
-        meta: {
-          href,
-          start: searchParams.get('t')
+    if (hostname.endsWith('youtube.com')) {
+      if (pathname.includes('/watch')) {
+        return {
+          provider: 'youtube',
+          id: searchParams.get('v'),
+          meta: {
+            href,
+            start: searchParams.get('t')
+          }
+        }
+      }
+
+      if (pathname.includes('/shorts')) {
+        const id = pathname.split('/').slice(-1).join()
+        return {
+          provider: 'youtube',
+          id
         }
       }
     }


### PR DESCRIPTION
## Description

This is a small and simple change to embed YT shorts.

I actually wanted to embed YT clips like [this](https://stacker.news/items/486787) but I haven't found a simple way. The embed URL requires the video id which is not available if given only the clip URL. I found this working embed URL in the document head:

```
<meta property="og:video:url" content="https://www.youtube.com/embed/2LKwnQJXngU?clip=Ugkx1bqCjGlspRX3VC5hWobnDQDIPdbPYu6b&amp;clipt=EM2f-AEYpcf6AQ">
```

Interestingly, YT does not seem to expose this embed URL when clicking on Share > Embed but uses [this](https://www.youtube.com/embed/2LKwnQJXngU?si=BOfZ4bgen7SPEMTN&amp;start=4069) as the iframe src.

Fetching the document in the browser does not work ~due to CORS policy~ 403 errors.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

yes, tested with https://youtube.com/shorts/BcezUqtzPd8

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
