### PR TITLE
Remove strike delay

### DIFF
--- a/components/item-act.js
+++ b/components/item-act.js
@@ -113,6 +113,8 @@ export default function ItemAct ({ onClose, item, down, children, abortSignal })
   const act = useAct()
 
   const onSubmit = useCallback(async ({ amount, hash, hmac }) => {
+    strike()
+    onClose()
     await act({
       variables: {
         id: item.id,
@@ -128,8 +130,6 @@ export default function ItemAct ({ onClose, item, down, children, abortSignal })
     })
     if (!me) setItemMeAnonSats({ id: item.id, amount })
     addCustomTip(Number(amount))
-    strike()
-    onClose()
   }, [me, act, down, item.id, strike])
 
   // XXX avoid manual optimistic updates until
@@ -290,8 +290,8 @@ export function useZap () {
 
       // XXX related to comment above
       // await zap({ variables: { ...variables, hash, hmac } })
-      await zap({ variables: { ...variables, hash, hmac }, optimisticResponse, update })
       strike()
+      await zap({ variables: { ...variables, hash, hmac }, optimisticResponse, update })
     } catch (error) {
       revert?.()
 


### PR DESCRIPTION
## Description

There was some [discussion about zap responsiveness on SN](https://stacker.news/items/560966?commentId=562741). This PR changes the lightning strike to appear with the optimistic response. Before, the strike happened only after the mutation was successful. 

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
