### PR TITLE
More zap undo fixes III

### DIFF
--- a/components/upvote.js
+++ b/components/upvote.js
@@ -160,6 +160,7 @@ export default function UpVote ({ item, className }) {
 
     if (pending) {
       controller.abort()
+      setController(null)
       return
     }
     const c = new ZapUndoController()
@@ -186,6 +187,7 @@ export default function UpVote ({ item, className }) {
 
       if (pending) {
         controller.abort()
+        setController(null)
         return
       }
       const c = new ZapUndoController()

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -199,7 +199,7 @@ export default function UpVote ({ item, className }) {
     }
   }
 
-  const fillColor = hover ? nextColor : color
+  const fillColor = hover || pending ? nextColor : color
 
   return (
     <div ref={ref} className='upvoteParent'>
@@ -224,7 +224,7 @@ export default function UpVote ({ item, className }) {
                       ${meSats ? styles.voted : ''}
                       ${pending ? styles.pending : ''}`
                     }
-              style={meSats || hover
+              style={meSats || hover || pending
                 ? {
                     fill: fillColor,
                     filter: `drop-shadow(0 0 6px ${fillColor}90)`


### PR DESCRIPTION
## Description

Fixed two issues with the pulse animation for zap undos. See c2a526284f8cb9eba1092be39f93dd1e3d1dd680 and 173852a35bd58a4b6354be42aa7da73293f837ce.

## Additional Context

I think the bug that 173852a3 fixes is what nout experienced [here](https://stacker.news/items/563298) with delayed zaps not showing anything. It didn't show anything if you didn't zap before since the animation used the previous color for the pulse which is the same as no color in that case.

This PR is part three of a series of PRs related to fixing stuff around zap undos (#872, #962) but since this PR is really small, I am still confident that the new code for zap undos is a lot better than what we had before. I just missed these two bugs before for some reason but they made immediately sense.

_The size of this PR might even be a confirmation that it's maintainable code._

update: Oh, and #1227 broke zap undos for custom zaps since now the modal isn't immediately closed so you can't undo a zap while it's pending. Will fix this while adding visual feedback back in a way that doesn't mess with the cache and thus doesn't break replies.

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
