### PR TITLE
Donate sats forwarded to anon

### DIFF
--- a/prisma/migrations/20240612085341_fix_anon_fwds/migration.sql
+++ b/prisma/migrations/20240612085341_fix_anon_fwds/migration.sql
@@ -1,0 +1,93 @@
+-- fix anon forwards: don't add sats forwarded to anon to anon's balance
+CREATE OR REPLACE FUNCTION item_act(item_id INTEGER, user_id INTEGER, act "ItemActType", act_sats INTEGER)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    user_msats BIGINT;
+    act_msats BIGINT;
+    fee_msats BIGINT;
+    item_act_id INTEGER;
+    fwd_entry record; -- for loop iterator variable to iterate across forward recipients
+    fwd_msats BIGINT; -- for loop variable calculating how many msats to give each forward recipient
+    total_fwd_msats BIGINT := 0; -- accumulator to see how many msats have been forwarded for the act
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    IF act_sats <= 0 THEN
+        RETURN 0;
+    END IF;
+
+    act_msats := act_sats * 1000;
+    SELECT msats INTO user_msats FROM users WHERE id = user_id;
+    IF act_msats > user_msats THEN
+        RAISE EXCEPTION 'SN_INSUFFICIENT_FUNDS';
+    END IF;
+
+    -- deduct msats from actor
+    UPDATE users SET msats = msats - act_msats WHERE id = user_id;
+
+    IF act = 'TIP' THEN
+        -- call to influence weightedVotes ... we need to do this before we record the acts because
+        -- the priors acts are taken into account
+        PERFORM weighted_votes_after_tip(item_id, user_id, act_sats);
+        -- call to denormalize sats and commentSats
+        PERFORM sats_after_tip(item_id, user_id, act_msats);
+
+        -- take 10% and insert as FEE
+        fee_msats := CEIL(act_msats * 0.1);
+        act_msats := act_msats - fee_msats;
+
+        -- save the fee act into item_act_id so we can record referral acts
+        INSERT INTO "ItemAct" (msats, "itemId", "userId", act, created_at, updated_at)
+            VALUES (fee_msats, item_id, user_id, 'FEE', now_utc(), now_utc())
+            RETURNING id INTO item_act_id;
+
+        -- leave the rest as a tip
+        INSERT INTO "ItemAct" (msats, "itemId", "userId", act, created_at, updated_at)
+            VALUES (act_msats, item_id, user_id, 'TIP', now_utc(), now_utc());
+
+        -- denormalize bounty paid (if applicable)
+        PERFORM bounty_paid_after_act(item_id, user_id);
+
+        -- add sats to actees' balance and stacked count
+        FOR fwd_entry IN SELECT "userId", "pct" FROM "ItemForward" WHERE "itemId" = item_id
+        LOOP
+            -- fwd_msats represents the sats for this forward recipient from this particular tip action
+            fwd_msats := act_msats * fwd_entry.pct / 100;
+            -- keep track of how many msats have been forwarded, so we can give any remaining to OP
+            total_fwd_msats := fwd_msats + total_fwd_msats;
+
+            UPDATE users
+            SET msats = msats + fwd_msats, "stackedMsats" = "stackedMsats" + fwd_msats
+            WHERE id = fwd_entry."userId";
+
+            IF fwd_entry."userId" = 27 THEN
+                -- anon forwards go to rewards as donations
+                PERFORM donate((fwd_msats / 1000)::INTEGER, "fwd_entry"."userId");
+            END IF;
+        END LOOP;
+
+        -- Give OP any remaining msats after forwards have been applied
+        IF act_msats - total_fwd_msats > 0 THEN
+            UPDATE users
+            SET msats = msats + act_msats - total_fwd_msats, "stackedMsats" = "stackedMsats" + act_msats - total_fwd_msats
+            WHERE id = (SELECT "userId" FROM "Item" WHERE id = item_id);
+        END IF;
+    ELSE -- BOOST, POLL, DONT_LIKE_THIS, STREAM
+        -- call to influence if DONT_LIKE_THIS weightedDownVotes
+        IF act = 'DONT_LIKE_THIS' THEN
+            PERFORM weighted_downvotes_after_act(item_id, user_id, act_sats);
+        END IF;
+
+        INSERT INTO "ItemAct" (msats, "itemId", "userId", act, created_at, updated_at)
+            VALUES (act_msats, item_id, user_id, act, now_utc(), now_utc())
+            RETURNING id INTO item_act_id;
+    END IF;
+
+    -- store referral effects
+    PERFORM referral_act(item_act_id);
+
+    RETURN 0;
+END;
+$$;


### PR DESCRIPTION
## Description

Fix #1232 by donating any sats forwarded to anon.

Diff of `item_act` function:

```diff
@@ -61,6 +61,11 @@ BEGIN
             UPDATE users
             SET msats = msats + fwd_msats, "stackedMsats" = "stackedMsats" + fwd_msats
             WHERE id = fwd_entry."userId";
+
+            IF fwd_entry."userId" = 27 THEN
+                -- anon forwards go to rewards as donations
+                PERFORM donate((fwd_msats / 1000)::INTEGER, "fwd_entry"."userId");
+            END IF;
         END LOOP;

         -- Give OP any remaining msats after forwards have been applied
```

## Additional Context

I initially wanted to include anon forwards in anon's stack in rewards. However, after looking in the code and considering the required changes, I think it's better to simply show them as donations.

I considered following approaches:

**1. no changes to rewards query**

In `item_act`, pretend that anon was zapped instead of adding forwarded sats to anon's balance. This would mean adding a row to `ItemAct`. But this would then mean that for anon forwards, three `ItemAct` rows are inserted (2x `TIP` + `FEE`) with their msats sum being higher than the zap itself. This might break some assumptions in queries but decreasing the amount of msats for the original `TIP` might as well.

So this approach seems to complicated for this requirement.

**2. changes to rewards query**

We could add a column  `forwarded` to the `Donations` table. Donations as part of anon forwards are marked with forwarded whereas normal donations are not. We then query the rows with forwarded set separately as part of anon's stack in the rewards query. This is a lot simpler but adds a column to `Donations` for something very specific.

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

tACK 3ca6fe1e

- Tested zaps and custom zaps from custodial balance, from attached wallet and as anon
- Tested replying as stacker and anon, editing as stacker
- Tested posting as stacker and anon

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No
