### PR TITLE
Update zap undos info

### DIFF
--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -1007,10 +1007,9 @@ const ZapUndosField = () => {
                 zap undos
                 <Info>
                   <ul className='fw-bold'>
-                    <li>An undo button is shown after every zap that exceeds or is equal to the threshold</li>
-                    <li>The button is shown for {ZAP_UNDO_DELAY_MS / 1000} seconds</li>
-                    <li>The button is only shown for zaps from the custodial wallet</li>
-                    <li>Use a budget or manual approval with attached wallets</li>
+                    <li>After every zap that exceeds or is equal to the threshold, the bolt will pulse</li>
+                    <li>You can undo the zap if you click the bolt while it's pulsing</li>
+                    <li>The bolt will pulse for {ZAP_UNDO_DELAY_MS / 1000} seconds</li>
                   </ul>
                 </Info>
               </div>


### PR DESCRIPTION
## Description

The info for zap undos was still using the old text even though we use a pulse animation instead of toasts now.

## Screenshots

![localhost_3000_settings(iPhone SE)](https://github.com/stackernews/stacker.news/assets/27162016/71c3149e-1449-4c5e-9786-bd4181a2b90b)

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No
