### PR TITLE
Use <Alert> for auth banner in /settings

### DIFF
--- a/components/banners.js
+++ b/components/banners.js
@@ -138,3 +138,11 @@ export function WalletSecurityBanner () {
     </Alert>
   )
 }
+
+export function AuthBanner () {
+  return (
+    <Alert className={`${styles.banner} mt-0`} key='info' variant='danger'>
+      Please add a second auth method to avoid losing access to your account.
+    </Alert>
+  )
+}

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -30,6 +30,7 @@ import { INVOICE_RETENTION_DAYS, ZAP_UNDO_DELAY_MS } from '@/lib/constants'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 import { useField } from 'formik'
 import styles from './settings.module.css'
+import { AuthBanner } from '@/components/banners'
 
 export const getServerSideProps = getGetServerSideProps({ query: SETTINGS, authRequired: true })
 
@@ -106,7 +107,7 @@ export default function Settings ({ ssrData }) {
   return (
     <Layout>
       <div className='pb-3 w-100 mt-2' style={{ maxWidth: '600px' }}>
-        {hasOnlyOneAuthMethod(settings?.authMethods) && <div className={styles.alert}>Please add a second auth method to avoid losing access to your account.</div>}
+        {hasOnlyOneAuthMethod(settings?.authMethods) && <AuthBanner />}
         <SettingsHeader />
         <Form
           initial={{


### PR DESCRIPTION
## Screenshots

Before:

![localhost_3000_settings(iPhone SE) (2)](https://github.com/stackernews/stacker.news/assets/27162016/4207745e-bdb4-48c6-ba71-e31908a3a656)

Now:

![localhost_3000_settings(iPhone SE) (1)](https://github.com/stackernews/stacker.news/assets/27162016/f77ce4bb-6d22-4eee-aab9-6fa2301cf7a4)

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes
<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No
