### PR TITLE
Fix item mention ref pattern

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1185,7 +1185,7 @@ export default {
 }
 
 const namePattern = /\B@[\w_]+/gi
-const refPattern = new RegExp(`${process.env.NEXT_PUBLIC_URL}/items/\\d+.*`, 'gi')
+const refPattern = new RegExp(`${process.env.NEXT_PUBLIC_URL}/items/\\d+[a-zA-Z0-9/?=]*`, 'gi')
 
 export const createMentions = async (item, models) => {
   // if we miss a mention, in the rare circumstance there's some kind of


### PR DESCRIPTION
I noticed that I received no item mention notification for this: https://stacker.news/items/582653

Turns out that ~the cast to a number~ the check `isItemPath` in `parseInternalLinks` failed because the parentheses in the raw markdown were included in the match.

This PR fixes it by only matching characters that make part sense as part of the URL. Only matching `/items/\d+` is not enough since we also need to match any potential `commentId` query parameter.