### PR TITLE
Fix user popover if mention inside link

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -200,8 +200,10 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
                 )
               }
               if (text.startsWith?.('@')) {
+                // user mention might be within a markdown link like this: [@user foo bar](url)
+                const name = text.replace('@', '').split(' ')[0]
                 return (
-                  <UserPopover name={text.replace('@', '')}>
+                  <UserPopover name={name}>
                     <Link
                       id={props.id}
                       href={href}


### PR DESCRIPTION
User popovers showed "user not found" if users were mentioned within a markdown link.

I noticed this while writing [this comment](https://stacker.news/items/582556). I initially wrote this:

```
[@Natalia be like](https://stacker.news/items/549152):

![](https://m.stacker.news/36436)
```

but then I realized that it shows "user not found" because `name` was set to `@Natalia be like`.

This PR fixes that.