### PR TITLE
Fix litd healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -368,7 +368,8 @@ services:
         "
   litd:
     container_name: litd
-    image: lightninglabs/lightning-terminal:v0.12.4-alpha
+    build:
+      context: ./docker/litd
     profiles:
       - payments
     restart: unless-stopped

--- a/docker/litd/Dockerfile
+++ b/docker/litd/Dockerfile
@@ -1,0 +1,3 @@
+FROM lightninglabs/lightning-terminal:v0.12.4-alpha
+
+RUN apk add --no-cache curl


### PR DESCRIPTION
The `litd` container was always shown as unhealthy because `curl` wasn't installed.