### PR TITLE
Add missing CANCELLED status

### DIFF
--- a/pages/satistics/index.js
+++ b/pages/satistics/index.js
@@ -51,6 +51,10 @@ function Satus ({ status }) {
       desc = 'expired'
       color = 'muted'
       break
+    case 'CANCELLED':
+      desc = 'cancelled'
+      color = 'muted'
+      break
     case 'PENDING':
       desc = 'pending'
       color = 'muted'


### PR DESCRIPTION
Invoices that were cancelled but did not expire yet showed `unknown failure` in /satistics.