### PR TITLE
Fix push notifications

### DIFF
--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -218,7 +218,7 @@ export async function onPaid ({ invoice, id }, context) {
         FROM ancestors, comment
         WHERE ancestors."userId" <> comment."userId"`
 
-    notifyItemParents({ item, me: item.userId, models }).catch(console.error)
+    notifyItemParents({ item, models }).catch(console.error)
   }
 
   for (const { userId } of item.mentions) {

--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -224,8 +224,8 @@ export async function onPaid ({ invoice, id }, context) {
   for (const { userId } of item.mentions) {
     notifyMention({ models, item, userId }).catch(console.error)
   }
-  for (const { referee } of item.itemReferrers) {
-    notifyItemMention({ models, referrerItem: item, refereeItem: referee }).catch(console.error)
+  for (const { refereeItem } of item.itemReferrers) {
+    notifyItemMention({ models, referrerItem: item, refereeItem }).catch(console.error)
   }
   notifyUserSubscribers({ models, item }).catch(console.error)
   notifyTerritorySubscribers({ models, item }).catch(console.error)

--- a/api/paidAction/itemUpdate.js
+++ b/api/paidAction/itemUpdate.js
@@ -133,13 +133,13 @@ export async function perform (args, context) {
 
   // TODO: referals for boost
 
-  // notify all the mentions if the mention is new
+  // compare timestamps to only notify if mention or item referral was just created to avoid duplicates on edits
   for (const { userId, createdAt } of item.mentions) {
-    if (item.updatedAt.getTime() === createdAt.getTime()) continue
+    if (item.updatedAt.getTime() !== createdAt.getTime()) continue
     notifyMention({ models, item, userId }).catch(console.error)
   }
   for (const { refereeItem, createdAt } of item.itemReferrers) {
-    if (item.updatedAt.getTime() === createdAt.getTime()) continue
+    if (item.updatedAt.getTime() !== createdAt.getTime()) continue
     notifyItemMention({ models, referrerItem: item, refereeItem }).catch(console.error)
   }
 

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -1,6 +1,6 @@
 import webPush from 'web-push'
 import removeMd from 'remove-markdown'
-import { USER_ID, COMMENT_DEPTH_LIMIT, FOUND_BLURBS, LOST_BLURBS } from './constants'
+import { COMMENT_DEPTH_LIMIT, FOUND_BLURBS, LOST_BLURBS } from './constants'
 import { msatsToSats, numWithUnits } from './format'
 import models from '@/api/models'
 import { isMuted } from '@/lib/user'
@@ -178,9 +178,9 @@ export const notifyTerritorySubscribers = async ({ models, item }) => {
   }
 }
 
-export const notifyItemParents = async ({ models, item, me }) => {
+export const notifyItemParents = async ({ models, item }) => {
   try {
-    const user = await models.user.findUnique({ where: { id: me?.id || USER_ID.anon } })
+    const user = await models.user.findUnique({ where: { id: item.userId } })
     const parents = await models.$queryRawUnsafe(
       'SELECT DISTINCT p."userId" FROM "Item" i JOIN "Item" p ON p.path @> i.path WHERE i.id = $1 and p."userId" <> $2 ' +
       'AND NOT EXISTS (SELECT 1 FROM "Mute" m WHERE m."muterId" = p."userId" AND m."mutedId" = $2)',

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -198,48 +198,48 @@ export const notifyItemParents = async ({ models, item }) => {
   }
 }
 
-export const notifyZapped = async ({ models, id }) => {
+export const notifyZapped = async ({ models, item }) => {
   try {
-    const updatedItem = await models.item.findUnique({ where: { id: Number(id) } })
-    const forwards = await models.itemForward.findMany({ where: { itemId: Number(id) } })
+    const forwards = await models.itemForward.findMany({ where: { itemId: item.id } })
     const userPromises = forwards.map(fwd => models.user.findUnique({ where: { id: fwd.userId } }))
     const userResults = await Promise.allSettled(userPromises)
     const mappedForwards = forwards.map((fwd, index) => ({ ...fwd, user: userResults[index].value ?? null }))
     let forwardedSats = 0
     let forwardedUsers = ''
     if (mappedForwards.length) {
-      forwardedSats = Math.floor(msatsToSats(updatedItem.msats) * mappedForwards.map(fwd => fwd.pct).reduce((sum, cur) => sum + cur) / 100)
+      forwardedSats = Math.floor(msatsToSats(item.msats) * mappedForwards.map(fwd => fwd.pct).reduce((sum, cur) => sum + cur) / 100)
       forwardedUsers = mappedForwards.map(fwd => `@${fwd.user.name}`).join(', ')
     }
     let notificationTitle
-    if (updatedItem.title) {
+    if (item.title) {
       if (forwards.length > 0) {
         notificationTitle = `your post forwarded ${numWithUnits(forwardedSats)} to ${forwardedUsers}`
       } else {
-        notificationTitle = `your post stacked ${numWithUnits(msatsToSats(updatedItem.msats))}`
+        notificationTitle = `your post stacked ${numWithUnits(msatsToSats(item.msats))}`
       }
     } else {
       if (forwards.length > 0) {
         // I don't think this case is possible
         notificationTitle = `your reply forwarded ${numWithUnits(forwardedSats)} to ${forwardedUsers}`
       } else {
-        notificationTitle = `your reply stacked ${numWithUnits(msatsToSats(updatedItem.msats))}`
+        notificationTitle = `your reply stacked ${numWithUnits(msatsToSats(item.msats))}`
       }
     }
-    await sendUserNotification(updatedItem.userId, {
+
+    await sendUserNotification(item.userId, {
       title: notificationTitle,
-      body: updatedItem.title ? updatedItem.title : updatedItem.text,
-      item: updatedItem,
-      tag: `TIP-${updatedItem.id}`
+      body: item.title ? item.title : item.text,
+      item,
+      tag: `TIP-${item.id}`
     })
 
     // send push notifications to forwarded recipients
     if (mappedForwards.length) {
       await Promise.allSettled(mappedForwards.map(forward => sendUserNotification(forward.user.id, {
-        title: `you were forwarded ${numWithUnits(Math.round(msatsToSats(updatedItem.msats) * forward.pct / 100))}`,
-        body: updatedItem.title ?? updatedItem.text,
-        item: updatedItem,
-        tag: `FORWARDEDTIP-${updatedItem.id}`
+        title: `you were forwarded ${numWithUnits(Math.round(msatsToSats(item.msats) * forward.pct / 100))}`,
+        body: item.title ?? item.text,
+        item,
+        tag: `FORWARDEDTIP-${item.id}`
       })))
     }
   } catch (err) {


### PR DESCRIPTION
* [x] fix wrong author in reply push notification
* [x] fix duplicate mention push notifications on edits
* [x] fix missing item mention push notifications on create
* [x] zaps push notifications use stale value because we didn't commit the transaction yet

I noticed that we can't fully eliminate duplicates if we delete existing mentions. For example, if I mention someone, then edit my comment to remove the mention and then edit again mentioning them again, they will receive another notification.

I think we didn't delete them before.