### PR TITLE
new referral scheme

### DIFF
--- a/api/resolvers/rewards.js
+++ b/api/resolvers/rewards.js
@@ -157,6 +157,12 @@ export default {
         SELECT date_trunc('day',  (now() AT TIME ZONE 'America/Chicago')) AT TIME ZONE 'America/Chicago' as from,
                (date_trunc('day',  (now() AT TIME ZONE 'America/Chicago')) AT TIME ZONE 'America/Chicago') + interval '1 day - 1 second' as to`
       return await topUsers(parent, { when: 'custom', to: new Date(to).getTime().toString(), from: new Date(from).getTime().toString(), limit: 100 }, { models, ...context })
+    },
+    total: async (parent, args, { models }) => {
+      if (!parent.total) {
+        return 0
+      }
+      return parent.total
     }
   },
   Mutation: {

--- a/api/ssrApollo.js
+++ b/api/ssrApollo.js
@@ -68,7 +68,7 @@ function oneDayReferral (request, { me }) {
       getData = item => ({
         referrerId: item.userId,
         refereeId: parseInt(me.id),
-        type: 'ITEM',
+        type: item.parentId ? 'COMMENT' : 'POST',
         typeId: String(item.id)
       })
     } else if (referrer.startsWith('profile-')) {
@@ -86,14 +86,6 @@ function oneDayReferral (request, { me }) {
         refereeId: parseInt(me.id),
         type: 'TERRITORY',
         typeId: sub.name
-      })
-    } else if (referrer.startsWith('comment-')) {
-      prismaPromise = models.item.findUnique({ where: { id: parseInt(referrer.slice(8)) } })
-      getData = item => ({
-        referrerId: item.userId,
-        refereeId: parseInt(me.id),
-        type: 'COMMENT',
-        typeId: String(item.id)
       })
     } else {
       prismaPromise = models.user.findUnique({ where: { name: referrer } })

--- a/api/ssrApollo.js
+++ b/api/ssrApollo.js
@@ -88,7 +88,7 @@ function oneDayReferral (request, { me }) {
         typeId: sub.name
       })
     } else if (referrer.startsWith('comment-')) {
-      prismaPromise = models.item.findUnique({ where: { id: parseInt(referrer.slice(7)) } })
+      prismaPromise = models.item.findUnique({ where: { id: parseInt(referrer.slice(8)) } })
       getData = item => ({
         referrerId: item.userId,
         refereeId: parseInt(me.id),
@@ -107,9 +107,10 @@ function oneDayReferral (request, { me }) {
 
     prismaPromise?.then(ref => {
       if (ref && getData) {
-        models.oneDayReferral.create({
-          data: getData(ref)
-        }).catch(console.error)
+        const data = getData(ref)
+        // can't refer yourself
+        if (data.refereeId === data.referrerId) return
+        models.oneDayReferral.create({ data }).catch(console.error)
       }
     }).catch(console.error)
   }

--- a/middleware.js
+++ b/middleware.js
@@ -1,7 +1,7 @@
 import { NextResponse, URLPattern } from 'next/server'
 
 const referrerPattern = new URLPattern({ pathname: ':pathname(*)/r/:referrer([\\w_]+)' })
-const itemPattern = new URLPattern({ pathname: '/items/:id(\\d+)' })
+const itemPattern = new URLPattern({ pathname: '/items/:id(\\d+){/:other(\\w+)}?' })
 const profilePattern = new URLPattern({ pathname: '/:name([\\w_]+){/:type(\\w+)}?' })
 const territoryPattern = new URLPattern({ pathname: '/~:name([\\w_]+){/*}?' })
 
@@ -35,12 +35,11 @@ function referrerMiddleware (request) {
 
   let contentReferrer
   if (itemPattern.test(request.url)) {
-    if (request.nextUrl.searchParams.has('commentId')) {
-      contentReferrer = `comment-${request.nextUrl.searchParams.get('commentId')}`
-    } else {
-      const { id } = itemPattern.exec(request.url).pathname.groups
-      contentReferrer = `item-${id}`
+    let id = request.nextUrl.searchParams.get('commentId')
+    if (!id) {
+      ({ id } = itemPattern.exec(request.url).pathname.groups)
     }
+    contentReferrer = `item-${id}`
   } else if (profilePattern.test(request.url)) {
     const { name } = profilePattern.exec(request.url).pathname.groups
     contentReferrer = `profile-${name}`

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -36,6 +36,20 @@ function getEventCallbacks () {
   }
 }
 
+async function getReferrerId (referrer) {
+  if (referrer.startsWith('item-')) {
+    return (await prisma.item.findUnique({ where: { id: parseInt(referrer.slice(5)) } }))?.userId
+  } else if (referrer.startsWith('profile-')) {
+    return (await prisma.user.findUnique({ where: { name: referrer.slice(8) } }))?.id
+  } else if (referrer.startsWith('territory-')) {
+    return (await prisma.sub.findUnique({ where: { name: referrer.slice(10) } }))?.userId
+  } else if (referrer.startsWith('comment-')) {
+    return (await prisma.item.findUnique({ where: { id: parseInt(referrer.slice(7)) } }))?.userId
+  } else {
+    return (await prisma.user.findUnique({ where: { name: referrer } }))?.id
+  }
+}
+
 /** @returns {Partial<import('next-auth').CallbacksOptions>} */
 function getCallbacks (req) {
   return {
@@ -57,10 +71,10 @@ function getCallbacks (req) {
         // isNewUser doesn't work for nostr/lightning auth because we create the user before nextauth can
         // this means users can update their referrer if they don't have one, which is fine
         if (req.cookies.sn_referrer && user?.id) {
-          const referrer = await prisma.user.findUnique({ where: { name: req.cookies.sn_referrer } })
-          if (referrer && referrer.id !== Number(user.id)) {
-            await prisma.user.updateMany({ where: { id: user.id, referrerId: null }, data: { referrerId: referrer.id } })
-            notifyReferral(referrer.id)
+          const referrerId = await getReferrerId(req.cookies.sn_referrer)
+          if (referrerId) {
+            await prisma.user.updateMany({ where: { id: user.id, referrerId: null }, data: { referrerId } })
+            notifyReferral(referrerId)
           }
         }
       }

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -37,16 +37,20 @@ function getEventCallbacks () {
 }
 
 async function getReferrerId (referrer) {
-  if (referrer.startsWith('item-')) {
-    return (await prisma.item.findUnique({ where: { id: parseInt(referrer.slice(5)) } }))?.userId
-  } else if (referrer.startsWith('profile-')) {
-    return (await prisma.user.findUnique({ where: { name: referrer.slice(8) } }))?.id
-  } else if (referrer.startsWith('territory-')) {
-    return (await prisma.sub.findUnique({ where: { name: referrer.slice(10) } }))?.userId
-  } else if (referrer.startsWith('comment-')) {
-    return (await prisma.item.findUnique({ where: { id: parseInt(referrer.slice(7)) } }))?.userId
-  } else {
-    return (await prisma.user.findUnique({ where: { name: referrer } }))?.id
+  try {
+    if (referrer.startsWith('item-')) {
+      return (await prisma.item.findUnique({ where: { id: parseInt(referrer.slice(5)) } }))?.userId
+    } else if (referrer.startsWith('profile-')) {
+      return (await prisma.user.findUnique({ where: { name: referrer.slice(8) } }))?.id
+    } else if (referrer.startsWith('territory-')) {
+      return (await prisma.sub.findUnique({ where: { name: referrer.slice(10) } }))?.userId
+    } else if (referrer.startsWith('comment-')) {
+      return (await prisma.item.findUnique({ where: { id: parseInt(referrer.slice(8)) } }))?.userId
+    } else {
+      return (await prisma.user.findUnique({ where: { name: referrer } }))?.id
+    }
+  } catch (error) {
+    console.error('error getting referrer id', error)
   }
 }
 
@@ -72,7 +76,7 @@ function getCallbacks (req) {
         // this means users can update their referrer if they don't have one, which is fine
         if (req.cookies.sn_referrer && user?.id) {
           const referrerId = await getReferrerId(req.cookies.sn_referrer)
-          if (referrerId) {
+          if (referrerId && referrerId !== parseInt(user?.id)) {
             await prisma.user.updateMany({ where: { id: user.id, referrerId: null }, data: { referrerId } })
             notifyReferral(referrerId)
           }

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -44,8 +44,6 @@ async function getReferrerId (referrer) {
       return (await prisma.user.findUnique({ where: { name: referrer.slice(8) } }))?.id
     } else if (referrer.startsWith('territory-')) {
       return (await prisma.sub.findUnique({ where: { name: referrer.slice(10) } }))?.userId
-    } else if (referrer.startsWith('comment-')) {
-      return (await prisma.item.findUnique({ where: { id: parseInt(referrer.slice(8)) } }))?.userId
     } else {
       return (await prisma.user.findUnique({ where: { name: referrer } }))?.id
     }

--- a/prisma/migrations/20240706000412_one_day_referrals/migration.sql
+++ b/prisma/migrations/20240706000412_one_day_referrals/migration.sql
@@ -1,5 +1,5 @@
 -- CreateEnum
-CREATE TYPE "OneDayReferralType" AS ENUM ('REFERRAL', 'ITEM', 'COMMENT', 'PROFILE', 'TERRITORY');
+CREATE TYPE "OneDayReferralType" AS ENUM ('REFERRAL', 'POST', 'COMMENT', 'PROFILE', 'TERRITORY');
 
 -- CreateTable
 CREATE TABLE "OneDayReferral" (

--- a/prisma/migrations/20240706000412_one_day_referrals/migration.sql
+++ b/prisma/migrations/20240706000412_one_day_referrals/migration.sql
@@ -1,0 +1,33 @@
+-- CreateEnum
+CREATE TYPE "OneDayReferralType" AS ENUM ('REFERRAL', 'ITEM', 'COMMENT', 'PROFILE', 'TERRITORY');
+
+-- CreateTable
+CREATE TABLE "OneDayReferral" (
+    "id" SERIAL NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "referrerId" INTEGER NOT NULL,
+    "refereeId" INTEGER NOT NULL,
+    "type" "OneDayReferralType" NOT NULL,
+    "typeId" TEXT NOT NULL,
+
+    CONSTRAINT "OneDayReferral_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "OneDayReferral_created_at_idx" ON "OneDayReferral"("created_at");
+
+-- CreateIndex
+CREATE INDEX "OneDayReferral_referrerId_idx" ON "OneDayReferral"("referrerId");
+
+-- CreateIndex
+CREATE INDEX "OneDayReferral_refereeId_idx" ON "OneDayReferral"("refereeId");
+
+-- CreateIndex
+CREATE INDEX "OneDayReferral_type_typeId_idx" ON "OneDayReferral"("type", "typeId");
+
+-- AddForeignKey
+ALTER TABLE "OneDayReferral" ADD CONSTRAINT "OneDayReferral_referrerId_fkey" FOREIGN KEY ("referrerId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OneDayReferral" ADD CONSTRAINT "OneDayReferral_refereeId_fkey" FOREIGN KEY ("refereeId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -138,7 +138,7 @@ model User {
 
 enum OneDayReferralType {
   REFERRAL
-  ITEM
+  POST
   COMMENT
   PROFILE
   TERRITORY

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,11 +127,38 @@ model User {
   Reminder                  Reminder[]
   PollBlindVote             PollBlindVote[]
   ItemUserAgg               ItemUserAgg[]
+  oneDayReferrals           OneDayReferral[]     @relation("OneDayReferral_referrer")
+  oneDayReferrees           OneDayReferral[]     @relation("OneDayReferral_referrees")
 
   @@index([photoId])
   @@index([createdAt], map: "users.created_at_index")
   @@index([inviteId], map: "users.inviteId_index")
   @@map("users")
+}
+
+enum OneDayReferralType {
+  REFERRAL
+  ITEM
+  COMMENT
+  PROFILE
+  TERRITORY
+}
+
+model OneDayReferral {
+  id         Int                @id @default(autoincrement())
+  createdAt  DateTime           @default(now()) @map("created_at")
+  updatedAt  DateTime           @default(now()) @updatedAt @map("updated_at")
+  referrerId Int
+  refereeId  Int
+  referrer   User               @relation("OneDayReferral_referrer", fields: [referrerId], references: [id], onDelete: Cascade)
+  referee    User               @relation("OneDayReferral_referrees", fields: [refereeId], references: [id], onDelete: Cascade)
+  type       OneDayReferralType
+  typeId     String
+
+  @@index([createdAt])
+  @@index([referrerId])
+  @@index([refereeId])
+  @@index([type, typeId])
 }
 
 enum WalletType {


### PR DESCRIPTION
So far this captures the relevant referral data in `middleware.js`, storing it in cookies (for a future login), and passing it in the request headers (for logged in stackers) for storage in the db.

#### how this is going to work

- referrals can be earned the following ways:
    - explicit referrals by sharing links with `/r/<referrer name>` at the end or invite links
    - implicit referrals:
        - every item link attributes a referral to the OP
        - every item link with a `commentId` attributes a referral to the comment's OP
        - every profile page link attributes a referral to the stacker on the profile
        - every territory link attributes a referral to the territory founder
- for logged out stackers, we store referrals in their cookies to be used on signup:
    -  `sn_referrer` is set by either explicit or implicit referrals for 24 hours
    -  if a stacker is referred again by an explicit referral within that 24 hour period, it is overwritten
    -  if a stacker is referred again by an implicit referral within that 24 hour period, it is NOT overwritten
- for logged in stackers, in addition to the signup referrals, we catalog every explicit and implicit referral they receive in the `OneDayReferral` table
    - at the end of the day, for each `referee`, the most frequent `referrer` of the `referee` (ie contributed the most rows to the `OneDayReferral` table for the `referee`)  is crowned the "one day referrer" of the `referee`
    - the "one day referrer" of the `referee` gets 50% of the `referee`'s referral rewards, and the `referee`'s original referrer (ie `users.referrerId`) get the other 50%
- 20% of all daily rewards will be distributed to the referrers of the daily reward earners (ie the people on the rewards leaderboard)

#### todos
- [x] attribute either implicit or explicit referrer on signup
- [ ] use the `OneDayReferrral` table and `users.referrerId` to dole out daily referral rewards