### PR TITLE
Fix missing stackedMsats update + wrong sybil fee

### DIFF
--- a/api/paidAction/zap.js
+++ b/api/paidAction/zap.js
@@ -84,7 +84,9 @@ export async function onPaid ({ invoice, actIds }, { models, tx }) {
       WHERE users.id = forwardees."userId"
     )
     UPDATE users
-    SET msats = msats + ${itemAct.msats}::BIGINT - (SELECT msats FROM total_forwarded)::BIGINT
+    SET
+      msats = msats + ${itemAct.msats}::BIGINT - (SELECT msats FROM total_forwarded)::BIGINT,
+      "stackedMsats" = "stackedMsats" + ${itemAct.msats}::BIGINT - (SELECT msats FROM total_forwarded)::BIGINT
     WHERE id = ${itemAct.item.userId}::INTEGER`
 
   // perform denomormalized aggregates: weighted votes, upvotes, msats, lastZapAt

--- a/api/paidAction/zap.js
+++ b/api/paidAction/zap.js
@@ -11,7 +11,7 @@ export async function getCost ({ sats }) {
 }
 
 export async function perform ({ invoiceId, sats, id: itemId, ...args }, { me, cost, tx }) {
-  const feeMsats = cost / BigInt(100)
+  const feeMsats = cost / BigInt(10) // 10% fee
   const zapMsats = cost - feeMsats
   itemId = parseInt(itemId)
 


### PR DESCRIPTION
## Description

A stacker reported to me that even though [this stacker](https://stacker.news/vostrnad) stacked 20k+ sats on [their post](https://stacker.news/items/600187), `stacked` in their profile still showed 0 sats.

I noticed that the new zap code introduced in #1195 is missing the update to the `users.stackedMsats` column:

https://github.com/stackernews/stacker.news/blob/371084016740fc29751e5964e17c687420c6ea57/api/paidAction/zap.js#L86-L88

After I fixed that, I noticed that 99 sats were added to `stackedMsats` instead of the expected 90 sats for a 100 sat zap.

Then I also noticed that the sybil fee is calculated wrong. It divides by 100 which is equal to 1% instead of dividing by 10 for 10% since `x * 0.1 = x * 1/10`.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
