### PR TITLE
Fix notification indicator shown for own replies

### DIFF
--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -283,6 +283,7 @@ export default {
             '"ThreadSubscription"."userId" = $1',
             'r.created_at > $2',
             'r.created_at >= "ThreadSubscription".created_at',
+            'r."userId" <> $1',
             activeOrMine(me),
             await filterClause(me, models),
             muteClause(me),


### PR DESCRIPTION
## Description

Small bug I have found while looking into #1268. If you're subscribed to a thread and then reply in it, you would get a notification indicator with no notification.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
