### PR TITLE
Fix subscription ignores OP replies

### DIFF
--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -215,8 +215,7 @@ export async function onPaid ({ invoice, id }, context) {
       INSERT INTO "Reply" (created_at, updated_at, "ancestorId", "ancestorUserId", "itemId", "userId", level)
         SELECT comment.created_at, comment.updated_at, ancestors.id, ancestors."userId",
           comment.id, comment."userId", nlevel(comment.path) - nlevel(ancestors.path)
-        FROM ancestors, comment
-        WHERE ancestors."userId" <> comment."userId"`
+        FROM ancestors, comment`
 
     notifyItemParents({ item, models }).catch(console.error)
   }


### PR DESCRIPTION
## Description

Fix #1268

Found the bug:

https://github.com/stackernews/stacker.news/blob/de38a683d5bbcebad572cd161f701190dc3653f5/api/paidAction/itemCreate.js#L215-L219

Due to `WHERE ancestors."userId" <> comment."userId"`, OPs replying inside their own posts (to anyone, so at any level) are never stored in the `Reply` table as a reply to their post since own ancestors are ignored. So there is no notification for it since we use a join with this table for thread subscription notifications:

https://github.com/stackernews/stacker.news/blob/de38a683d5bbcebad572cd161f701190dc3653f5/api/resolvers/notifications.js#L77-L92

Afaict, this fix for #1268 has no other implications since I can only see that `Reply` is used for notifications. The discussion in https://github.com/stackernews/stacker.news/commit/a7b0272200c83a5d4c76b48460fc2aca084df3d7 and #1013 also suggests that including replies to self in `Reply` is safe and self-replies were only not included because they were deemed unnecessary (?). 

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
