### PR TITLE
fix: fetch price immediately after currency changes

### DIFF
--- a/api/resolvers/price.js
+++ b/api/resolvers/price.js
@@ -19,12 +19,16 @@ async function getPrice (fiat) {
   if (cache.has(fiat)) {
     const { price, createdAt } = cache.get(fiat)
     const expired = createdAt + expiresIn < Date.now()
-    if (expired) fetchPrice(fiat).catch(console.error) // update cache
-    return price // serve stale price (this on the SSR critical path)
+    if (expired) {
+      const newPrice = await fetchPrice(fiat);
+      return newPrice;
+    } else {
+      return price;
+    }
   } else {
-    fetchPrice(fiat).catch(console.error)
+    const newPrice = await fetchPrice(fiat);
+    return newPrice;
   }
-  return null
 }
 
 export default {

--- a/components/price.js
+++ b/components/price.js
@@ -21,7 +21,7 @@ export function usePrice () {
 export function PriceProvider ({ price, children }) {
   const me = useMe()
   const fiatCurrency = me?.privates?.fiatCurrency
-  const { data } = useQuery(PRICE, {
+  const { data, refetch } = useQuery(PRICE, {
     variables: { fiatCurrency },
     ...(SSR
       ? {}
@@ -29,8 +29,13 @@ export function PriceProvider ({ price, children }) {
           pollInterval: NORMAL_POLL_INTERVAL,
           nextFetchPolicy: 'cache-and-network'
         })
-  })
+  });
 
+  useEffect(() => {
+    if (fiatCurrency) {
+      refetch({ fiatCurrency });
+    }
+  }, [fiatCurrency, refetch]);
   const contextValue = useMemo(() => ({
     price: data?.price || price,
     fiatSymbol: CURRENCY_SYMBOLS[fiatCurrency] || '$'


### PR DESCRIPTION
## Description

as mentioned by @ekzyis [here](https://github.com/stackernews/stacker.news/pull/1264#pullrequestreview-2183230416), when we change the currency in settings, we don't immediately query the price, we wait for 30 seconds before doing so, which leaves us with a new currency symbol but with the old value. this PR aims to fix that.

## Screenshots

![Screenshot 2024-07-24 150633](https://github.com/user-attachments/assets/b6c2f4bd-dedd-4980-b7f6-f54d1e1b738d)


## Additional Context

<!--
You can mention here anything that you think is relevant for this PR. Some examples:
* You encountered something that you didn't understand while working on this PR
* You were not sure about something you did but did not find a better way
* You initially had a different approach but went with a different approach for some reason
-->

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes
**Did you QA this? Could we deploy this straight to production? Please answer below:**
Yes

**For frontend changes: Tested on mobile? Please answer below:**

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No
