### PR TITLE
Fix duplicate 'Wallet' in resolver name

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -1,4 +1,4 @@
 export function generateResolverName (walletField) {
   const capitalized = walletField[0].toUpperCase() + walletField.slice(1)
-  return `upsertWallet${capitalized}`
+  return `upsert${capitalized}`
 }


### PR DESCRIPTION
This removes the duplicate `Wallet` in the app logs:

```
injected GraphQL resolvers:
  upsertWalletWalletLND
  upsertWalletWalletCLN
  upsertWalletWalletLightningAddress
injected GraphQL type defs:
  upsertWalletWalletLND(id: ID, socket: String!, macaroon: String!, cert: String, settings: AutowithdrawSettings!): Boolean
  upsertWalletWalletCLN(id: ID, socket: String!, rune: String!, cert: String, settings: AutowithdrawSettings!): Boolean
  upsertWalletWalletLightningAddress(id: ID, address: String!, settings: AutowithdrawSettings!): Boolean
```

It's just aesthetics, it has no other effects.