### PR TITLE
More zap undo fixes IV

### DIFF
--- a/components/item-act.js
+++ b/components/item-act.js
@@ -246,7 +246,7 @@ export class ZapUndoController extends AbortController {
     this.signal.done = onDone
     this.signal.pause = async ({ me, amount }) => {
       if (zapUndoTrigger({ me, amount })) {
-        await zapUndo(this.signal)
+        await zapUndo(this.signal, amount)
       }
     }
   }
@@ -258,9 +258,9 @@ const zapUndoTrigger = ({ me, amount }) => {
   return enabled ? amount >= me.privates.zapUndos : false
 }
 
-const zapUndo = async (signal) => {
+const zapUndo = async (signal, amount) => {
   return await new Promise((resolve, reject) => {
-    signal.start()
+    signal.start(amount)
     const abortHandler = () => {
       reject(new ActCanceledError())
       signal.done()

--- a/components/upvote.js
+++ b/components/upvote.js
@@ -107,7 +107,7 @@ export default function UpVote ({ item, className }) {
   )
 
   const [controller, setController] = useState(null)
-  const [pending, setPending] = useState(false)
+  const [pending, setPending] = useState(0)
 
   const setVoteShow = useCallback((yes) => {
     if (!me) return
@@ -146,7 +146,7 @@ export default function UpVote ({ item, className }) {
     const meSats = (item?.meSats || item?.meAnonSats || 0)
 
     // what should our next tip be?
-    const sats = nextTip(meSats, { ...me?.privates })
+    const sats = pending || nextTip(meSats, { ...me?.privates })
     let overlayTextContent
     if (me) {
       overlayTextContent = me.privates?.tipRandom ? 'random' : numWithUnits(sats, { abbreviate: false })
@@ -157,7 +157,9 @@ export default function UpVote ({ item, className }) {
     return [
       meSats, overlayTextContent,
       getColor(meSats), getColor(meSats + sats)]
-  }, [item?.meSats, item?.meAnonSats, me?.privates?.tipDefault, me?.privates?.turboDefault, me?.privates?.tipRandom, me?.privates?.tipRandomMin, me?.privates?.tipRandomMax])
+  }, [
+    item?.meSats, item?.meAnonSats, me?.privates?.tipDefault, me?.privates?.turboDefault,
+    me?.privates?.tipRandom, me?.privates?.tipRandomMin, me?.privates?.tipRandomMax, pending])
 
   const handleModalClosed = () => {
     setHover(false)
@@ -178,7 +180,7 @@ export default function UpVote ({ item, className }) {
       setController(null)
       return
     }
-    const c = new ZapUndoController({ onStart: () => setPending(true), onDone: () => setPending(false) })
+    const c = new ZapUndoController({ onStart: (sats) => setPending(sats), onDone: () => setPending(0) })
     setController(c)
 
     showModal(onClose =>
@@ -205,7 +207,7 @@ export default function UpVote ({ item, className }) {
         setController(null)
         return
       }
-      const c = new ZapUndoController({ onStart: () => setPending(true), onDone: () => setPending(false) })
+      const c = new ZapUndoController({ onStart: (sats) => setPending(sats), onDone: () => setPending(0) })
       setController(c)
 
       await zap({ item, me, abortSignal: c.signal })

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -1023,6 +1023,7 @@ const ZapUndosField = () => {
           name='zapUndos'
           append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
           hint={<small className='text-muted'>threshold at which undo button is shown</small>}
+          groupClassName='mt-1'
         />}
     </>
   )

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -1022,7 +1022,7 @@ const ZapUndosField = () => {
         <Input
           name='zapUndos'
           append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
-          hint={<small className='text-muted'>threshold at which undo button is shown</small>}
+          hint={<small className='text-muted'>threshold at which undos will be possible</small>}
           groupClassName='mt-1'
         />}
     </>


### PR DESCRIPTION
This fixes following things:

- top margin for zap undo input was missing
- zap undo input hint was outdated
- pulse color did not use zap amount, it always used the zap defalut

_Fixing stuff around zap undos is becoming a meme_

