### PR TITLE
Fix wallet.createInvoice signature

### DIFF
--- a/wallets/cln/server.js
+++ b/wallets/cln/server.js
@@ -22,7 +22,7 @@ export const testConnectServer = async (
 }
 
 export const createInvoice = async (
-  { amount },
+  amount,
   { socket, rune, cert },
   { me, models, lnd }
 ) => {

--- a/wallets/lightning-address/server.js
+++ b/wallets/lightning-address/server.js
@@ -13,11 +13,12 @@ export const testConnectServer = async (
 }
 
 export const createInvoice = async (
-  { amount, maxFee },
+  amount,
   { address },
   { me, models, lnd, lnService }
 ) => {
-  const res = await fetchLnAddrInvoice({ addr: address, amount, maxFee }, {
+  // maxFee is only required to pass schema validation
+  const res = await fetchLnAddrInvoice({ addr: address, amount, maxFee: 0 }, {
     me,
     models,
     lnd,

--- a/wallets/lnd/server.js
+++ b/wallets/lnd/server.js
@@ -38,7 +38,7 @@ export const testConnectServer = async (
 }
 
 export const createInvoice = async (
-  { amount },
+  amount,
   { cert, macaroon, socket },
   { me }
 ) => {

--- a/worker/autowithdraw.js
+++ b/worker/autowithdraw.js
@@ -96,7 +96,7 @@ async function autowithdraw (
   }
 
   const bolt11 = await walletCreateInvoice(
-    { amount, maxFee },
+    amount,
     wallet[walletField],
     {
       me,


### PR DESCRIPTION
Originally, only `amount` was intended to be first argument of `createInvoice` (see README).

However, `createInvoice` for LN addresses required `maxFee` to be passed in so the schema validation succeeds.

It's dumb that `maxFee` has to be part of the signature for every wallet just because of this.

`createInvoice` for LN addresses now simply passes in `maxFee: 0` to pass schema validation.

This is still dumb but less and works.