### PR TITLE
Only validate tipRandom if enabled

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -542,17 +542,20 @@ export const actSchema = object({
 
 export const settingsSchema = object().shape({
   tipDefault: intValidator.required('required').positive('must be positive'),
+  tipRandom: boolean(),
   tipRandomMin: intValidator.nullable().positive('must be positive')
-    .when(['tipRandomMax'], ([max], schema) => {
+    .when(['tipRandom', 'tipRandomMax'], ([enabled, max], schema) => {
       let res = schema
+      if (!enabled) return res
       if (max) {
         res = schema.required('minimum and maximum must either both be omitted or specified').nonNullable()
       }
       return res.lessThan(max, 'must be less than maximum')
     }),
   tipRandomMax: intValidator.nullable().positive('must be positive')
-    .when(['tipRandomMin'], ([min], schema) => {
+    .when(['tipRandom', 'tipRandomMin'], ([enabled, min], schema) => {
       let res = schema
+      if (!enabled) return res
       if (min) {
         res = schema.required('minimum and maximum must either both be omitted or specified').nonNullable()
       }

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -1040,7 +1040,7 @@ const TipRandomField = () => {
         groupClassName='mb-0'
         label={
           <div className='d-flex align-items-center'>
-            Enable random zap values
+            random zaps
             <Info>
               <ul className='fw-bold'>
                 <li>Set a minimum and maximum zap amount</li>


### PR DESCRIPTION
## Description

My tip default was 1 and I didn't enable `tipRandom` so `tipRandomMax` was set to 1, too.

However, that meant I couldn't save my settings and I received no feedback why. I saw the validation errors below the input for `tipRandomMax` (`must be more than minimum`) only after I enabled `tipRandom`.

This is bad UX. This PR fixes that by only validating `tipRandomMin` and `tipRandomMax` if `tipRandom` is set.

## Additional changes

* changed label from `Enable random zap values` to `random zaps` since it's more consistent with how other zap settings are named

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes, `tipRandomMin` and `tipRandomMax` are only saved if `tipRandom` is set

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
