### PR TITLE
replace greeter mode with investment filter

### DIFF
--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -1,7 +1,7 @@
 import { ANON_ITEM_SPAM_INTERVAL, ITEM_SPAM_INTERVAL, USER_ID } from '@/lib/constants'
 import { notifyItemMention, notifyItemParents, notifyMention, notifyTerritorySubscribers, notifyUserSubscribers } from '@/lib/webPush'
 import { getItemMentions, getMentions, performBotBehavior } from './lib/item'
-import { satsToMsats } from '@/lib/format'
+import { msatsToSats, satsToMsats } from '@/lib/format'
 
 export const anonable = true
 export const supportsPessimism = true
@@ -51,6 +51,7 @@ export async function perform (args, context) {
     itemActs.push({
       msats: cost - boostMsats, act: 'FEE', userId: data.userId, ...invoiceData
     })
+    data.cost = msatsToSats(cost - boostMsats)
   } else {
     data.freebie = true
   }

--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -52,8 +52,6 @@ export async function perform (args, context) {
       msats: cost - boostMsats, act: 'FEE', userId: data.userId, ...invoiceData
     })
     data.cost = msatsToSats(cost - boostMsats)
-  } else {
-    data.freebie = true
   }
 
   const mentions = await getMentions(args, context)

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -229,7 +229,7 @@ export async function filterClause (me, models, type) {
   if (me) {
     const user = await models.user.findUnique({ where: { id: me.id } })
 
-    investmentClause = `(("Item".cost + "Item".boost + ("Item".msats / 1000)) >= ${user.investmentFilter} OR "Item"."userId" = ${me.id})`
+    investmentClause = `(("Item".cost + "Item".boost + ("Item".msats / 1000)) >= ${user.satsFilter} OR "Item"."userId" = ${me.id})`
 
     if (user.wildWestMode) {
       return investmentClause

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -71,7 +71,7 @@ export default gql`
     diagnostics: Boolean!
     noReferralLinks: Boolean!
     fiatCurrency: String!
-    investmentFilter: Int!
+    satsFilter: Int!
     hideBookmarks: Boolean!
     hideCowboyHat: Boolean!
     hideGithub: Boolean!
@@ -140,7 +140,7 @@ export default gql`
     diagnostics: Boolean!
     noReferralLinks: Boolean!
     fiatCurrency: String!
-    investmentFilter: Int!
+    satsFilter: Int!
     hideBookmarks: Boolean!
     hideCowboyHat: Boolean!
     hideGithub: Boolean!

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -71,7 +71,7 @@ export default gql`
     diagnostics: Boolean!
     noReferralLinks: Boolean!
     fiatCurrency: String!
-    greeterMode: Boolean!
+    investmentFilter: Int!
     hideBookmarks: Boolean!
     hideCowboyHat: Boolean!
     hideGithub: Boolean!
@@ -140,7 +140,7 @@ export default gql`
     diagnostics: Boolean!
     noReferralLinks: Boolean!
     fiatCurrency: String!
-    greeterMode: Boolean!
+    investmentFilter: Int!
     hideBookmarks: Boolean!
     hideCowboyHat: Boolean!
     hideGithub: Boolean!
@@ -192,7 +192,7 @@ export default gql`
     twitterId: String
     nostrAuthPubkey: String
   }
-  
+
   type NameValue {
     name: String!
     value: Float!

--- a/components/comment.js
+++ b/components/comment.js
@@ -97,7 +97,7 @@ export default function Comment ({
 }) {
   const [edit, setEdit] = useState()
   const me = useMe()
-  const isHiddenFreebie = me?.privates?.investmentFilter !== 0 && !item.mine && item.freebie && !item.freedFreebie
+  const isHiddenFreebie = me?.privates?.satsFilter !== 0 && !item.mine && item.freebie && !item.freedFreebie
   const [collapse, setCollapse] = useState(
     (isHiddenFreebie || item?.user?.meMute || (item?.outlawed && !me?.privates?.wildWestMode)) && !includeParent
       ? 'yep'

--- a/components/comment.js
+++ b/components/comment.js
@@ -97,7 +97,7 @@ export default function Comment ({
 }) {
   const [edit, setEdit] = useState()
   const me = useMe()
-  const isHiddenFreebie = !me?.privates?.wildWestMode && !me?.privates?.greeterMode && !item.mine && item.freebie && !item.freedFreebie
+  const isHiddenFreebie = me?.privates?.investmentFilter !== 0 && !item.mine && item.freebie && !item.freedFreebie
   const [collapse, setCollapse] = useState(
     (isHiddenFreebie || item?.user?.meMute || (item?.outlawed && !me?.privates?.wildWestMode)) && !includeParent
       ? 'yep'

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -15,7 +15,7 @@ export const ME = gql`
         diagnostics
         noReferralLinks
         fiatCurrency
-        greeterMode
+        investmentFilter
         hideCowboyHat
         hideFromTopUsers
         hideGithub
@@ -104,7 +104,7 @@ export const SETTINGS_FIELDS = gql`
       nostrCrossposting
       nostrRelays
       wildWestMode
-      greeterMode
+      investmentFilter
       nsfwMode
       authMethods {
         lightning

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -15,7 +15,7 @@ export const ME = gql`
         diagnostics
         noReferralLinks
         fiatCurrency
-        investmentFilter
+        satsFilter
         hideCowboyHat
         hideFromTopUsers
         hideGithub
@@ -104,7 +104,7 @@ export const SETTINGS_FIELDS = gql`
       nostrCrossposting
       nostrRelays
       wildWestMode
-      investmentFilter
+      satsFilter
       nsfwMode
       authMethods {
         lightning

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -579,6 +579,7 @@ export const settingsSchema = object().shape({
   diagnostics: boolean(),
   noReferralLinks: boolean(),
   hideIsContributor: boolean(),
+  investmentFilter: intValidator.required('required').min(0, 'must be at least 0').max(1000, 'must be at most 1000'),
   zapUndos: intValidator.nullable().min(0, 'must be greater or equal to 0')
   // exclude from cyclic analysis. see https://github.com/jquense/yup/issues/720
 }, [['tipRandomMax', 'tipRandomMin']])

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -579,7 +579,7 @@ export const settingsSchema = object().shape({
   diagnostics: boolean(),
   noReferralLinks: boolean(),
   hideIsContributor: boolean(),
-  investmentFilter: intValidator.required('required').min(0, 'must be at least 0').max(1000, 'must be at most 1000'),
+  satsFilter: intValidator.required('required').min(0, 'must be at least 0').max(1000, 'must be at most 1000'),
   zapUndos: intValidator.nullable().min(0, 'must be greater or equal to 0')
   // exclude from cyclic analysis. see https://github.com/jquense/yup/issues/720
 }, [['tipRandomMax', 'tipRandomMin']])

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -140,7 +140,7 @@ export default function Settings ({ ssrData }) {
             hideTwitter: settings?.hideTwitter,
             imgproxyOnly: settings?.imgproxyOnly,
             wildWestMode: settings?.wildWestMode,
-            investmentFilter: settings?.investmentFilter,
+            satsFilter: settings?.satsFilter,
             nsfwMode: settings?.nsfwMode,
             nostrPubkey: settings?.nostrPubkey ? bech32encode(settings.nostrPubkey) : '',
             nostrCrossposting: settings?.nostrCrossposting,
@@ -154,7 +154,7 @@ export default function Settings ({ ssrData }) {
           schema={settingsSchema}
           onSubmit={async ({
             tipDefault, tipRandom, tipRandomMin, tipRandomMax, withdrawMaxFeeDefault,
-            zapUndos, zapUndosEnabled, nostrPubkey, nostrRelays, investmentFilter,
+            zapUndos, zapUndosEnabled, nostrPubkey, nostrRelays, satsFilter,
             ...values
           }) => {
             if (nostrPubkey.length === 0) {
@@ -176,7 +176,7 @@ export default function Settings ({ ssrData }) {
                     tipRandomMin: tipRandom ? Number(tipRandomMin) : null,
                     tipRandomMax: tipRandom ? Number(tipRandomMax) : null,
                     withdrawMaxFeeDefault: Number(withdrawMaxFeeDefault),
-                    investmentFilter: Number(investmentFilter),
+                    satsFilter: Number(satsFilter),
                     zapUndos: zapUndosEnabled ? Number(zapUndos) : null,
                     nostrPubkey,
                     nostrRelays: nostrRelaysFiltered,
@@ -475,7 +475,7 @@ export default function Settings ({ ssrData }) {
           <h4>content</h4>
           <Input
             label={
-              <div className='d-flex align-items-center'>filter posts with fewer than this many sats invested
+              <div className='d-flex align-items-center'>filter by sats
                 <Info>
                   <ul className='fw-bold'>
                     <li>hide the post if the sum of these is less than your setting:</li>
@@ -489,7 +489,7 @@ export default function Settings ({ ssrData }) {
                 </Info>
               </div>
             }
-            name='investmentFilter'
+            name='satsFilter'
             required
             append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
           />

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -140,7 +140,7 @@ export default function Settings ({ ssrData }) {
             hideTwitter: settings?.hideTwitter,
             imgproxyOnly: settings?.imgproxyOnly,
             wildWestMode: settings?.wildWestMode,
-            greeterMode: settings?.greeterMode,
+            investmentFilter: settings?.investmentFilter,
             nsfwMode: settings?.nsfwMode,
             nostrPubkey: settings?.nostrPubkey ? bech32encode(settings.nostrPubkey) : '',
             nostrCrossposting: settings?.nostrCrossposting,
@@ -152,7 +152,11 @@ export default function Settings ({ ssrData }) {
             noReferralLinks: settings?.noReferralLinks
           }}
           schema={settingsSchema}
-          onSubmit={async ({ tipDefault, tipRandom, tipRandomMin, tipRandomMax, withdrawMaxFeeDefault, zapUndos, zapUndosEnabled, nostrPubkey, nostrRelays, ...values }) => {
+          onSubmit={async ({
+            tipDefault, tipRandom, tipRandomMin, tipRandomMax, withdrawMaxFeeDefault,
+            zapUndos, zapUndosEnabled, nostrPubkey, nostrRelays, investmentFilter,
+            ...values
+          }) => {
             if (nostrPubkey.length === 0) {
               nostrPubkey = null
             } else {
@@ -172,6 +176,7 @@ export default function Settings ({ ssrData }) {
                     tipRandomMin: tipRandom ? Number(tipRandomMin) : null,
                     tipRandomMax: tipRandom ? Number(tipRandomMax) : null,
                     withdrawMaxFeeDefault: Number(withdrawMaxFeeDefault),
+                    investmentFilter: Number(investmentFilter),
                     zapUndos: zapUndosEnabled ? Number(zapUndos) : null,
                     nostrPubkey,
                     nostrRelays: nostrRelaysFiltered,
@@ -467,7 +472,27 @@ export default function Settings ({ ssrData }) {
             label={<>don't create referral links on copy</>}
             name='noReferralLinks'
           />
-          <div className='form-label'>content</div>
+          <h4>content</h4>
+          <Input
+            label={
+              <div className='d-flex align-items-center'>filter posts with fewer than this many sats invested
+                <Info>
+                  <ul className='fw-bold'>
+                    <li>hide the post if the sum of these is less than your setting:</li>
+                    <ul>
+                      <li>posting cost</li>
+                      <li>total sats from zaps</li>
+                      <li>boost</li>
+                    </ul>
+                    <li>set to zero to be a greeter, with the tradeoff of seeing more spam</li>
+                  </ul>
+                </Info>
+              </div>
+            }
+            name='investmentFilter'
+            required
+            append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
+          />
           <Checkbox
             label={
               <div className='d-flex align-items-center'>wild west mode
@@ -480,21 +505,6 @@ export default function Settings ({ ssrData }) {
               </div>
             }
             name='wildWestMode'
-            groupClassName='mb-0'
-          />
-          <Checkbox
-            label={
-              <div className='d-flex align-items-center'>greeter mode
-                <Info>
-                  <ul className='fw-bold'>
-                    <li>see and screen free posts and comments</li>
-                    <li>help onboard new stackers to SN and Lightning</li>
-                    <li>you might be subject to more spam</li>
-                  </ul>
-                </Info>
-              </div>
-            }
-            name='greeterMode'
             groupClassName='mb-0'
           />
           <Checkbox

--- a/prisma/migrations/20240808234214_investment_filter/migration.sql
+++ b/prisma/migrations/20240808234214_investment_filter/migration.sql
@@ -6,8 +6,8 @@ UPDATE "Item" SET "cost" = "ItemAct"."msats" / 1000
 FROM "ItemAct"
 WHERE "Item"."id" = "ItemAct"."itemId" AND "ItemAct"."act" = 'FEE' AND "Item"."userId" = "ItemAct"."userId";
 
-ALTER TABLE "users" ADD COLUMN "investmentFilter" INTEGER NOT NULL DEFAULT 10;
+ALTER TABLE "users" ADD COLUMN "satsFilter" INTEGER NOT NULL DEFAULT 10;
 
-UPDATE "users" SET "investmentFilter" = 0 WHERE "greeterMode";
+UPDATE "users" SET "satsFilter" = 0 WHERE "greeterMode";
 
 ALTER TABLE "users" DROP COLUMN "greeterMode";

--- a/prisma/migrations/20240808234214_investment_filter/migration.sql
+++ b/prisma/migrations/20240808234214_investment_filter/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable
+ALTER TABLE "Item" ADD COLUMN "cost" INTEGER NOT NULL DEFAULT 0;
+
+-- use existing "ItemAct".act = FEE AND "Item"."userId" = "ItemAct"."userId" to calculate the cost for existing "Item"s
+UPDATE "Item" SET "cost" = "ItemAct"."msats" / 1000
+FROM "ItemAct"
+WHERE "Item"."id" = "ItemAct"."itemId" AND "ItemAct"."act" = 'FEE' AND "Item"."userId" = "ItemAct"."userId";
+
+ALTER TABLE "users" ADD COLUMN "investmentFilter" INTEGER NOT NULL DEFAULT 10;
+
+UPDATE "users" SET "investmentFilter" = 0 WHERE "greeterMode";
+
+ALTER TABLE "users" DROP COLUMN "greeterMode";

--- a/prisma/migrations/20240808234214_sats_filter/migration.sql
+++ b/prisma/migrations/20240808234214_sats_filter/migration.sql
@@ -12,10 +12,5 @@ UPDATE "users" SET "satsFilter" = 0 WHERE "greeterMode";
 
 ALTER TABLE "users" DROP COLUMN "greeterMode";
 
-DROP INDEX "Item.freebie_index";
-
--- AlterTable
-ALTER TABLE "Item" DROP COLUMN "freebie";
-
 -- CreateIndex
 CREATE INDEX "Item_cost_idx" ON "Item"("cost");

--- a/prisma/migrations/20240808234214_sats_filter/migration.sql
+++ b/prisma/migrations/20240808234214_sats_filter/migration.sql
@@ -11,3 +11,11 @@ ALTER TABLE "users" ADD COLUMN "satsFilter" INTEGER NOT NULL DEFAULT 10;
 UPDATE "users" SET "satsFilter" = 0 WHERE "greeterMode";
 
 ALTER TABLE "users" DROP COLUMN "greeterMode";
+
+DROP INDEX "Item.freebie_index";
+
+-- AlterTable
+ALTER TABLE "Item" DROP COLUMN "freebie";
+
+-- CreateIndex
+CREATE INDEX "Item_cost_idx" ON "Item"("cost");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,7 +54,7 @@ model User {
   upvoteTrust               Float                @default(0)
   hideInvoiceDesc           Boolean              @default(false)
   wildWestMode              Boolean              @default(false)
-  greeterMode               Boolean              @default(false)
+  investmentFilter          Int                  @default(10)
   nsfwMode                  Boolean              @default(false)
   fiatCurrency              String               @default("USD")
   withdrawMaxFeeDefault     Int                  @default(10)
@@ -425,6 +425,7 @@ model Item {
   lastZapAt           DateTime?
   ncomments           Int                   @default(0)
   msats               BigInt                @default(0)
+  cost                Int                   @default(0)
   weightedDownVotes   Float                 @default(0)
   bio                 Boolean               @default(false)
   freebie             Boolean               @default(false)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,7 +54,7 @@ model User {
   upvoteTrust               Float                @default(0)
   hideInvoiceDesc           Boolean              @default(false)
   wildWestMode              Boolean              @default(false)
-  investmentFilter          Int                  @default(10)
+  satsFilter                Int                  @default(10)
   nsfwMode                  Boolean              @default(false)
   fiatCurrency              String               @default("USD")
   withdrawMaxFeeDefault     Int                  @default(10)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -428,6 +428,7 @@ model Item {
   cost                Int                   @default(0)
   weightedDownVotes   Float                 @default(0)
   bio                 Boolean               @default(false)
+  freebie             Boolean               @default(false)
   deletedAt           DateTime?
   otsFile             Bytes?
   otsHash             String?
@@ -474,6 +475,7 @@ model Item {
   @@index([lastZapAt])
   @@index([bio], map: "Item.bio_index")
   @@index([createdAt], map: "Item.created_at_index")
+  @@index([freebie], map: "Item.freebie_index")
   @@index([maxBid], map: "Item.maxBid_index")
   @@index([parentId], map: "Item.parentId_index")
   @@index([path], map: "Item.path_index", type: Gist)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -428,7 +428,6 @@ model Item {
   cost                Int                   @default(0)
   weightedDownVotes   Float                 @default(0)
   bio                 Boolean               @default(false)
-  freebie             Boolean               @default(false)
   deletedAt           DateTime?
   otsFile             Bytes?
   otsHash             String?
@@ -475,7 +474,6 @@ model Item {
   @@index([lastZapAt])
   @@index([bio], map: "Item.bio_index")
   @@index([createdAt], map: "Item.created_at_index")
-  @@index([freebie], map: "Item.freebie_index")
   @@index([maxBid], map: "Item.maxBid_index")
   @@index([parentId], map: "Item.parentId_index")
   @@index([path], map: "Item.path_index", type: Gist)
@@ -490,6 +488,7 @@ model Item {
   @@index([weightedVotes], map: "Item.weightedVotes_index")
   @@index([invoiceId])
   @@index([invoiceActionState])
+  @@index([cost])
 }
 
 // we use this to denormalize a user's aggregated interactions (zaps) with an item


### PR DESCRIPTION
closes #690

This basically turns greeter mode from `yes, see freebies` or `no, don't see freebies` -to-> only see *posts* with at least X sats "invested." For comments, if `investmentFilter` > 0, freebies are collapsed unless they've been upvoted.

This is also compatible with wild west mode.

By default `investmentFilter = 10` and also applies to lurkers, giving them better spam filtering. We can increase this default for lurkers and new stackers as needed.
