### PR TITLE
Fix callback set to NextJS data URL

### DIFF
--- a/api/ssrApollo.js
+++ b/api/ssrApollo.js
@@ -142,7 +142,11 @@ export function getGetServerSideProps (
     const { data: { me } } = await client.query({ query: ME })
 
     if (authRequired && !me) {
-      const callback = process.env.NEXT_PUBLIC_URL + req.url
+      let callback = process.env.NEXT_PUBLIC_URL + req.url
+      // On client-side routing, the callback is a NextJS URL
+      // so we need to remove the NextJS stuff.
+      // Example: /_next/data/development/territory.json
+      callback = callback.replace(/\/_next\/data\/\w+\//, '/').replace(/\.json$/, '')
       return {
         redirect: {
           destination: `/signup?callbackUrl=${encodeURIComponent(callback)}`


### PR DESCRIPTION
## Description

If you're getting redirected to the signup page because you're logged out, the callback is to a NextJS data URL.

For example, if you go to /territory and get redirected to /signup, the callback is `/_next/data/development/territory.json`.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**Did you QA this? Could we deploy this straight to production? Please answer below:**

yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
