### PR TITLE
Fix WebLN checkbox unclickable

### DIFF
--- a/components/use-local-state.js
+++ b/components/use-local-state.js
@@ -1,10 +1,9 @@
 import { SSR } from '@/lib/constants'
 import { useCallback, useState } from 'react'
 
-export default function useLocalState (storageKey, initialValue = '') {
+export default function useLocalState (storageKey, defaultValue) {
   const [value, innerSetValue] = useState(
-    initialValue ||
-    (SSR ? null : JSON.parse(window.localStorage.getItem(storageKey)))
+    (SSR ? null : JSON.parse(window.localStorage.getItem(storageKey))) || defaultValue
   )
 
   const setValue = useCallback((newValue) => {

--- a/pages/settings/wallets/[wallet].js
+++ b/pages/settings/wallets/[wallet].js
@@ -31,7 +31,7 @@ export default function WalletSettings () {
       ...acc,
       [field.name]: wallet.config?.[field.name] || ''
     }
-  }, wallet.config || {})
+  }, wallet.config)
 
   // check if wallet uses the form-level validation built into Formik or a Yup schema
   const validateProps = typeof wallet.fieldValidation === 'function'

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -158,7 +158,7 @@ function useConfig (wallet) {
   const me = useMe()
 
   const storageKey = getStorageKey(wallet?.name, me)
-  const [clientConfig, setClientConfig, clearClientConfig] = useClientConfig(storageKey)
+  const [clientConfig, setClientConfig, clearClientConfig] = useClientConfig(storageKey, {})
 
   const [serverConfig, setServerConfig, clearServerConfig] = useServerConfig(wallet)
 


### PR DESCRIPTION
## Description

In #1278, I changed the logic in `useConfig` such that `wallet.config` is set to `clientConfig` (see [this line](https://github.com/stackernews/stacker.news/pull/1278/files#diff-fe57f778594fcebe6b8d96b7e6e0355bec7f8ca042a8397dc6a7fb508674344fR169)) which is null if no entry exists for WebLN in local storage.

This meant that the WebLN check became unclickable because `wallet.isConfigured` is false if `wallet.config` was null.

## Additional Context

* reverted ddb32e0b because it was treating a symptom but this PR fixes the underlying issue
* I considered also adding this in this PR since `wallet.config` should now never be `null` but an empty object if no config exists (even during SSR for all wallets):

```diff
diff --git a/wallets/index.js b/wallets/index.js
index ba249678..cddd0a0e 100644
--- a/wallets/index.js
+++ b/wallets/index.js
@@ -229,11 +229,9 @@ function useConfig (wallet) {
 }

 function isConfigured ({ fields, config }) {
-  if (!config || !fields) return false
-
   // a wallet is configured if all of its required fields are set
   const val = fields.every(field => {
-    return field.optional ? true : !!config?.[field.name]
+    return field.optional ? true : !!config[field.name]
   })

   return val
```

but I didn't to stay safe and we use `config?.[name]` all over the place so to be consistent, I'd have to change these occurrences to `config[name]`, too. 

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
