### PR TITLE
Remove TODO about errors in createInvoice

### DIFF
--- a/wallets/lnd/server.js
+++ b/wallets/lnd/server.js
@@ -11,19 +11,25 @@ export const createInvoice = async (
   { msats, description, descriptionHash, expiry },
   { cert, macaroon, socket }
 ) => {
-  const { lnd } = await authenticatedLndGrpc({
-    cert,
-    macaroon,
-    socket
-  })
+  try {
+    const { lnd } = await authenticatedLndGrpc({
+      cert,
+      macaroon,
+      socket
+    })
 
-  const invoice = await lndCreateInvoice({
-    lnd,
-    description,
-    description_hash: descriptionHash,
-    mtokens: String(msats),
-    expires_at: datePivot(new Date(), { seconds: expiry })
-  })
+    const invoice = await lndCreateInvoice({
+      lnd,
+      description,
+      description_hash: descriptionHash,
+      mtokens: String(msats),
+      expires_at: datePivot(new Date(), { seconds: expiry })
+    })
 
-  return invoice.request
+    return invoice.request
+  } catch (err) {
+    // LND errors can be in this shape: [code, type, { err: { code, details, metadata } }]
+    const details = err[2]?.err?.details || err.message || err.toString?.()
+    throw new Error(details)
+  }
 }

--- a/wallets/server.js
+++ b/wallets/server.js
@@ -59,15 +59,10 @@ export async function createInvoice (userId, { msats, description, descriptionHa
       return { invoice, wallet }
     } catch (error) {
       console.error(error)
-
-      // TODO: I think this is a bug, `createInvoice` should parse the error
-
-      // LND errors are in this shape: [code, type, { err: { code, details, metadata } }]
-      const details = error[2]?.err?.details || error.message || error.toString?.()
       await addWalletLog({
         wallet,
         level: 'ERROR',
-        message: `creating invoice for ${description ?? ''} failed: ` + details
+        message: `creating invoice for ${description ?? ''} failed: ` + error
       }, { models })
     }
   }


### PR DESCRIPTION
## Description

This was a pending TODO from #1243. `createInvoice` in wallets/server.js shouldn't need to parse LND errors. `createInvoice` in wallets/lnd/server.js should do that.

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
