### PR TITLE
Hide wallet name in logs for only a single wallet

### DIFF
--- a/components/log-message.js
+++ b/components/log-message.js
@@ -1,13 +1,13 @@
 import { timeSince } from '@/lib/time'
 import styles from './log-message.module.css'
 
-export default function LogMessage ({ wallet, level, message, ts }) {
+export default function LogMessage ({ showWallet, wallet, level, message, ts }) {
   level = level.toLowerCase()
   const levelClassName = ['ok', 'success'].includes(level) ? 'text-success' : level === 'error' ? 'text-danger' : level === 'info' ? 'text-info' : ''
   return (
     <tr className={styles.line}>
       <td className={styles.timestamp}>{timeSince(new Date(ts))}</td>
-      <td className={styles.wallet}>[{wallet}]</td>
+      {showWallet ? <td className={styles.wallet}>[{wallet}]</td> : <td className='mx-1' />}
       <td className={`${styles.level} ${levelClassName}`}>{level === 'success' ? 'ok' : level}</td>
       <td>{message}</td>
     </tr>

--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -30,7 +30,13 @@ export function WalletLogs ({ wallet, embedded }) {
         {logs.length === 0 && <div className='w-100 text-center'>empty</div>}
         <table>
           <tbody>
-            {logs.map((log, i) => <LogMessage key={i} {...log} />)}
+            {logs.map((log, i) => (
+              <LogMessage
+                key={i}
+                showWallet={!wallet}
+                {...log}
+              />
+            ))}
           </tbody>
         </table>
         <div className='w-100 text-center'>------ start of logs ------</div>


### PR DESCRIPTION
## Description

Showing the wallet name if logs for only a single wallet are shown is redundant. This PR hides the wallet name in that case.

## Screenshots

Before

![2024-08-16-012516_682x206_scrot](https://github.com/user-attachments/assets/c0d76882-b20c-4c96-b47d-02a266fb505a)

After

![2024-08-16-012456_718x219_scrot](https://github.com/user-attachments/assets/d27e5da6-6279-43fc-8d50-e7efa16d5066)

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
