### PR TITLE
Msats to sats floor

### DIFF
--- a/api/paidAction/index.js
+++ b/api/paidAction/index.js
@@ -231,7 +231,7 @@ export async function createLightningInvoice (actionType, args, context) {
       }, { models })
 
       const { invoice: wrappedInvoice, maxFee } = await wrapInvoice(
-        bolt11, { description }, { lnd })
+        bolt11, { msats: cost, description }, { lnd })
 
       return {
         bolt11,

--- a/lib/format.js
+++ b/lib/format.js
@@ -63,6 +63,8 @@ export const satsToMsats = sats => {
   return BigInt(sats) * 1000n
 }
 
+export const msatsSatsFloor = msats => satsToMsats(msatsToSats(msats))
+
 export const msatsToSatsDecimal = msats => {
   if (msats === null || msats === undefined) {
     return null

--- a/lib/format.js
+++ b/lib/format.js
@@ -52,6 +52,7 @@ export const msatsToSats = msats => {
   if (msats === null || msats === undefined) {
     return null
   }
+  // implicitly floors the result
   return Number(BigInt(msats) / 1000n)
 }
 

--- a/wallets/cln/server.js
+++ b/wallets/cln/server.js
@@ -3,7 +3,7 @@ import { createInvoice as clnCreateInvoice } from '@/lib/cln'
 export * from 'wallets/cln'
 
 export const testConnectServer = async ({ socket, rune, cert }) => {
-  return await createInvoice({ msats: 1, expiry: 1, description: '' }, { socket, rune, cert })
+  return await createInvoice({ msats: 1000, expiry: 1, description: '' }, { socket, rune, cert })
 }
 
 export const createInvoice = async (

--- a/wallets/lightning-address/server.js
+++ b/wallets/lightning-address/server.js
@@ -1,4 +1,4 @@
-import { msatsToSats, satsToMsats } from '@/lib/format'
+import { msatsSatsFloor } from '@/lib/format'
 import { lnAddrOptions } from '@/lib/lnurl'
 
 export * from 'wallets/lightning-address'
@@ -15,7 +15,7 @@ export const createInvoice = async (
   const callbackUrl = new URL(callback)
 
   // most lnurl providers suck nards so we have to floor to nearest sat
-  msats = satsToMsats(msatsToSats(msats))
+  msats = msatsSatsFloor(msats)
 
   callbackUrl.searchParams.append('amount', msats)
 

--- a/wallets/lightning-address/server.js
+++ b/wallets/lightning-address/server.js
@@ -1,3 +1,4 @@
+import { msatsToSats, satsToMsats } from '@/lib/format'
 import { lnAddrOptions } from '@/lib/lnurl'
 
 export * from 'wallets/lightning-address'
@@ -12,6 +13,10 @@ export const createInvoice = async (
 ) => {
   const { callback, commentAllowed } = await lnAddrOptions(address)
   const callbackUrl = new URL(callback)
+
+  // most lnurl providers suck nards so we have to floor to nearest sat
+  msats = satsToMsats(msatsToSats(msats))
+
   callbackUrl.searchParams.append('amount', msats)
 
   if (commentAllowed >= description?.length) {

--- a/wallets/lnbits/server.js
+++ b/wallets/lnbits/server.js
@@ -1,7 +1,7 @@
 export * from 'wallets/lnbits'
 
 export async function testConnectServer ({ url, invoiceKey }) {
-  return await createInvoice({ msats: 1, expiry: 1 }, { url, invoiceKey })
+  return await createInvoice({ msats: 1000, expiry: 1 }, { url, invoiceKey })
 }
 
 export async function createInvoice (

--- a/wallets/lnd/server.js
+++ b/wallets/lnd/server.js
@@ -4,7 +4,7 @@ import { authenticatedLndGrpc, createInvoice as lndCreateInvoice } from 'ln-serv
 export * from 'wallets/lnd'
 
 export const testConnectServer = async ({ cert, macaroon, socket }) => {
-  return await createInvoice({ msats: 1, expiry: 1 }, { cert, macaroon, socket })
+  return await createInvoice({ msats: 1000, expiry: 1 }, { cert, macaroon, socket })
 }
 
 export const createInvoice = async (

--- a/wallets/server.js
+++ b/wallets/server.js
@@ -53,7 +53,21 @@ export async function createInvoice (userId, { msats, description, descriptionHa
 
       const bolt11 = await parsePaymentRequest({ request: invoice })
       if (BigInt(bolt11.mtokens) !== BigInt(msats)) {
-        throw new Error(`invoice has incorrect amount ${bolt11.mtokens} !== ${msats}`)
+        if (BigInt(bolt11.mtokens) > BigInt(msats)) {
+          throw new Error(`invoice is for an amount greater than requested ${bolt11.mtokens} > ${msats}`)
+        }
+        if (BigInt(bolt11.mtokens) === 0n) {
+          throw new Error('invoice is for 0 msats')
+        }
+        if (BigInt(msats) - BigInt(bolt11.mtokens) >= 1000n) {
+          throw new Error(`invoice has a different satoshi amount ${bolt11.mtokens} !== ${msats}`)
+        }
+
+        await addWalletLog({
+          wallet,
+          level: 'INFO',
+          message: `wallet does not support msats so we floored ${msats} msats to nearest sat ${BigInt(bolt11.mtokens)} msats`
+        }, { models })
       }
 
       return { invoice, wallet }

--- a/wallets/server.js
+++ b/wallets/server.js
@@ -53,7 +53,7 @@ export async function createInvoice (userId, { msats, description, descriptionHa
 
       const bolt11 = await parsePaymentRequest({ request: invoice })
       if (BigInt(bolt11.mtokens) !== BigInt(msats)) {
-        throw new Error('invoice has incorrect amount')
+        throw new Error(`invoice has incorrect amount ${bolt11.mtokens} !== ${msats}`)
       }
 
       return { invoice, wallet }

--- a/worker/autowithdraw.js
+++ b/worker/autowithdraw.js
@@ -1,4 +1,4 @@
-import { msatsToSats, satsToMsats } from '@/lib/format'
+import { msatsSatsFloor, msatsToSats, satsToMsats } from '@/lib/format'
 import { createWithdrawal } from '@/api/resolvers/wallet'
 import { createInvoice } from 'wallets/server'
 
@@ -12,10 +12,9 @@ export async function autoWithdraw ({ data: { id }, models, lnd }) {
   // excess must be greater than 10% of threshold
   if (excess < Number(threshold) * 0.1) return
 
-  // round these to nearest sat because lightning developers denominate in msats
-  // but only because they like 3 extra zeros at the end of numbers and forbid us
-  // from using the precision they suggest they want
-  const maxFeeMsats = satsToMsats(msatsToSats(Math.ceil(excess * (user.autoWithdrawMaxFeePercent / 100.0))))
+  // floor fee to nearest sat but still denominated in msats
+  const maxFeeMsats = msatsSatsFloor(Math.ceil(excess * (user.autoWithdrawMaxFeePercent / 100.0)))
+  // msats will be floored by createInvoice if it needs to be
   const msats = BigInt(excess) - maxFeeMsats
 
   // must be >= 1 sat


### PR DESCRIPTION
fixes #1303

Mostly this floors any msats passed to lnaddr's `createInvoice`. This change also required modify `wrapInvoice` to take the served invoice's msats as a parameter (as it can't be induced anymore). For p2p zaps, the excess msats effectively get paid to SN.
