### PR TITLE
Fix all wallets deleted on logout

### DIFF
--- a/wallets/index.js
+++ b/wallets/index.js
@@ -105,6 +105,7 @@ export function useWallet (name) {
 
   return {
     ...wallet,
+    canSend: !!wallet.sendPayment,
     sendPayment,
     config,
     save,
@@ -375,7 +376,7 @@ export function useWallets () {
 
   const resetClient = useCallback(async (wallet) => {
     for (const w of wallets) {
-      if (w.sendPayment) {
+      if (w.canSend) {
         await w.delete()
       }
       await w.deleteLogs()


### PR DESCRIPTION
## Description

Every wallet returned by the `useWallet` hook has `sendPayment` set even if it doesn't support payments since `wallet.sendPayment` is wrapped with a `useCallback` hook. This lead to every wallet getting deleted on logout.

This PR fixes that by exposing `canSend` in `useWallet` which is then used to check if this wallet should get deleted.

## Additional Context

Looked into this because of https://stacker.news/items/651050

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
