### PR TITLE
Generate more server wallet code

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -353,7 +353,7 @@ const resolvers = {
     __resolveType (wallet) {
       // XXX [WALLET] this needs to be updated if another server wallet is added
       return wallet.address
-        ? 'WalletLNAddr'
+        ? 'WalletLightningAddress'
         : wallet.macaroon
           ? 'WalletLND'
           : wallet.rune

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -351,7 +351,14 @@ const resolvers = {
   },
   WalletDetails: {
     __resolveType (wallet) {
-      return wallet.address ? 'WalletLNAddr' : wallet.macaroon ? 'WalletLND' : wallet.rune ? 'WalletCLN' : 'WalletLNbits'
+      // XXX [WALLET] this needs to be updated if another server wallet is added
+      return wallet.address
+        ? 'WalletLNAddr'
+        : wallet.macaroon
+          ? 'WalletLND'
+          : wallet.rune
+            ? 'WalletCLN'
+            : 'WalletLNbits'
     }
   },
   Mutation: {

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -13,7 +13,7 @@ import assertApiKeyNotPermitted from './apiKey'
 import { bolt11Tags } from '@/lib/bolt11'
 import { finalizeHodlInvoice } from 'worker/wallet'
 import walletDefs from 'wallets/server'
-import { generateResolverName } from '@/lib/wallet'
+import { generateResolverName, walletTypeToResolveType } from '@/lib/wallet'
 import { lnAddrOptions } from '@/lib/lnurl'
 
 function injectResolvers (resolvers) {
@@ -349,17 +349,16 @@ const resolvers = {
       })
     }
   },
-  WalletDetails: {
-    __resolveType (wallet) {
-      // XXX [WALLET] this needs to be updated if another server wallet is added
-      return wallet.address
-        ? 'WalletLightningAddress'
-        : wallet.macaroon
-          ? 'WalletLND'
-          : wallet.rune
-            ? 'WalletCLN'
-            : 'WalletLNbits'
+  Wallet: {
+    wallet: async (wallet) => {
+      return {
+        ...wallet.wallet,
+        __resolveType: walletTypeToResolveType(wallet.type)
+      }
     }
+  },
+  WalletDetails: {
+    __resolveType: wallet => wallet.__resolveType
   },
   Mutation: {
     createInvoice: async (parent, { amount, hodlInvoice = false, expireSecs = 3600 }, { me, models, lnd, headers }) => {

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -107,6 +107,7 @@ mutation removeWallet($id: ID!) {
 }
 `
 
+// XXX [WALLET] this needs to be updated if another server wallet is added
 export const WALLET = gql`
   query Wallet($id: ID!) {
     wallet(id: $id) {
@@ -138,6 +139,7 @@ export const WALLET = gql`
   }
 `
 
+// XXX [WALLET] this needs to be updated if another server wallet is added
 export const WALLET_BY_TYPE = gql`
   query WalletByType($type: String!) {
     walletByType(type: $type) {

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -117,7 +117,7 @@ export const WALLET = gql`
       type
       wallet {
         __typename
-        ... on WalletLNAddr {
+        ... on WalletLightningAddress {
           address
         }
         ... on WalletLND {
@@ -150,7 +150,7 @@ export const WALLET_BY_TYPE = gql`
       type
       wallet {
         __typename
-        ... on WalletLNAddr {
+        ... on WalletLightningAddress {
           address
         }
         ... on WalletLND {

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -1,4 +1,16 @@
+export function fieldToGqlArg (field) {
+  let arg = `${field.name}: String`
+  if (!field.optional) {
+    arg += '!'
+  }
+  return arg
+}
+
 export function generateResolverName (walletField) {
   const capitalized = walletField[0].toUpperCase() + walletField.slice(1)
   return `upsert${capitalized}`
+}
+
+export function generateTypeDefName (walletField) {
+  return walletField[0].toUpperCase() + walletField.slice(1)
 }

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -14,3 +14,9 @@ export function generateResolverName (walletField) {
 export function generateTypeDefName (walletField) {
   return walletField[0].toUpperCase() + walletField.slice(1)
 }
+
+export function walletTypeToResolveType (walletType) {
+  // wallet type is in UPPER_CASE but __resolveType requires PascalCase
+  const PascalCase = walletType.split('_').map(s => s[0].toUpperCase() + s.slice(1)).join()
+  return `Wallet${PascalCase}`
+}


### PR DESCRIPTION
## Description

This PR makes it easier to add server wallets by generating more boilerplate plumbing code:

* generate `type WalletLND { ... }` etc.
* generate `union WalletDetails = WalletLND | ...`
* I could unfortunately not see a way to generate `__resolveType` with its fourth argument as mentioned [here](https://github.com/stackernews/stacker.news/pull/1278/files#r1707709821) so I left a comment there

<details>
<summary>info object</summary>

```
GraphQLUnionType {
  name: 'WalletDetails',
  description: undefined,
  resolveType: [Function: __resolveType],
  extensions: [Object: null prototype] {},
  astNode: {
    kind: 'UnionTypeDefinition',
    description: undefined,
    name: { kind: 'Name', value: 'WalletDetails' },
    directives: [],
    types: [ [Object], [Object], [Object], [Object] ]
  },
  extensionASTNodes: [],
  _types: [
    GraphQLObjectType {
      name: 'WalletLND',
      description: undefined,
      isTypeOf: undefined,
      extensions: [Object: null prototype] {},
      astNode: [Object],
      extensionASTNodes: [],
      _fields: [Object: null prototype],
      _interfaces: []
    },
    GraphQLObjectType {
      name: 'WalletCLN',
      description: undefined,
      isTypeOf: undefined,
      extensions: [Object: null prototype] {},
      astNode: [Object],
      extensionASTNodes: [],
      _fields: [Object: null prototype],
      _interfaces: []
    },
    GraphQLObjectType {
      name: 'WalletLightningAddress',
      description: undefined,
      isTypeOf: undefined,
      extensions: [Object: null prototype] {},
      astNode: [Object],
      extensionASTNodes: [],
      _fields: [Object: null prototype],
      _interfaces: []
    },
    GraphQLObjectType {
      name: 'WalletLNbits',
      description: undefined,
      isTypeOf: undefined,
      extensions: [Object: null prototype] {},
      astNode: [Object],
      extensionASTNodes: [],
      _fields: [Object: null prototype],
      _interfaces: []
    }
  ]
}

```

</details>

* I was able to generate wallet fragments (`... on WalletLND { ... }` etc.) but that broke client imports because `fragments/wallet` is imported on the client and I imported `wallets` from `wallets/server` in there so I also only left a comment

## Additional Context

There probably is a way to generate `__resolveType` which involves iterating over the field of every server wallet and eliminating all fields that are shared to find which are unique and thus can be used to determine the type but that sounds pretty complicated instead of simply writing it manually.

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No
