### PR TITLE
Fix inconsistency between walletTypeToResolveType and generateTypeDefName

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -13,7 +13,7 @@ import assertApiKeyNotPermitted from './apiKey'
 import { bolt11Tags } from '@/lib/bolt11'
 import { finalizeHodlInvoice } from 'worker/wallet'
 import walletDefs from 'wallets/server'
-import { generateResolverName, walletTypeToResolveType } from '@/lib/wallet'
+import { generateResolverName, generateTypeDefName } from '@/lib/wallet'
 import { lnAddrOptions } from '@/lib/lnurl'
 
 function injectResolvers (resolvers) {
@@ -353,7 +353,7 @@ const resolvers = {
     wallet: async (wallet) => {
       return {
         ...wallet.wallet,
-        __resolveType: walletTypeToResolveType(wallet.type)
+        __resolveType: generateTypeDefName(wallet.type)
       }
     }
   },

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -38,7 +38,7 @@ function rawTypeDefs () {
       .map(fieldToGqlArg)
       .map(s => '  ' + s)
       .join('\n')
-    const typeDefName = generateTypeDefName(w.walletField)
+    const typeDefName = generateTypeDefName(w.walletType)
     const typeDef = `type ${typeDefName} {\n${args}\n}`
     console.log(typeDef)
     return typeDef
@@ -46,7 +46,7 @@ function rawTypeDefs () {
 
   let union = 'union WalletDetails = '
   union += walletDefs.map((w) => {
-    const typeDefName = generateTypeDefName(w.walletField)
+    const typeDefName = generateTypeDefName(w.walletType)
     return typeDefName
   }).join(' | ')
   console.log(union)

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -11,12 +11,7 @@ export function generateResolverName (walletField) {
   return `upsert${capitalized}`
 }
 
-export function generateTypeDefName (walletField) {
-  return walletField[0].toUpperCase() + walletField.slice(1)
-}
-
-export function walletTypeToResolveType (walletType) {
-  // wallet type is in UPPER_CASE but __resolveType requires PascalCase
+export function generateTypeDefName (walletType) {
   const PascalCase = walletType.split('_').map(s => s[0].toUpperCase() + s.slice(1).toLowerCase()).join('')
   return `Wallet${PascalCase}`
 }


### PR DESCRIPTION
## Description

506bb364 fixed the query for LN addresses but it broke it for LND since now `__resolveType` returned `WalletLnd` but it should have been `WalletLND`.

With this PR, `__resolveType` will always return the same as `generateTypeDefName`.

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes, all wallets resolve now

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
