### PR TITLE
disable freebies setting

### DIFF
--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -21,8 +21,10 @@ export async function getCost ({ subName, parentId, uploadIds, boost = 0, bio },
           FROM image_fees_info(${me?.id || USER_ID.anon}::INTEGER, ${uploadIds}::INTEGER[]))
       + ${satsToMsats(boost)}::INTEGER as cost`
 
-  // sub allows freebies (or is a bio or a comment), cost is less than baseCost, not anon, and cost must be greater than user's balance
-  const freebie = (parentId || bio || sub?.allowFreebies) && cost <= baseCost && !!me && cost > me?.msats
+  // sub allows freebies (or is a bio or a comment), cost is less than baseCost, not anon,
+  // cost must be greater than user's balance, and user has not disabled freebies
+  const freebie = (parentId || bio || sub?.allowFreebies) && cost <= baseCost && !!me &&
+    cost > me?.msats && !me?.disableFreebies
 
   return freebie ? BigInt(0) : BigInt(cost)
 }

--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -628,10 +628,10 @@ export default {
       }
 
       // disable freebies if it hasn't been set yet
-      models.user.update({
+      await models.user.update({
         where: { id: me.id, disableFreebies: null },
         data: { disableFreebies: true }
-      }).catch()
+      })
 
       return true
     },

--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -622,6 +622,19 @@ export default {
   },
 
   Mutation: {
+    disableFreebies: async (parent, args, { me, models }) => {
+      if (!me) {
+        throw new GraphQLError('you must be logged in', { extensions: { code: 'UNAUTHENTICATED' } })
+      }
+
+      // disable freebies if it hasn't been set yet
+      models.user.update({
+        where: { id: me.id, disableFreebies: null },
+        data: { disableFreebies: true }
+      }).catch()
+
+      return true
+    },
     setName: async (parent, data, { me, models }) => {
       if (!me) {
         throw new GraphQLError('you must be logged in', { extensions: { code: 'UNAUTHENTICATED' } })

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -43,6 +43,7 @@ export default gql`
     toggleMute(id: ID): User
     generateApiKey(id: ID!): String
     deleteApiKey(id: ID!): User
+    disableFreebies: Boolean
   }
 
   type User {
@@ -72,6 +73,7 @@ export default gql`
     noReferralLinks: Boolean!
     fiatCurrency: String!
     satsFilter: Int!
+    disableFreebies: Boolean
     hideBookmarks: Boolean!
     hideCowboyHat: Boolean!
     hideGithub: Boolean!
@@ -141,6 +143,7 @@ export default gql`
     noReferralLinks: Boolean!
     fiatCurrency: String!
     satsFilter: Int!
+    disableFreebies: Boolean
     greeterMode: Boolean!
     hideBookmarks: Boolean!
     hideCowboyHat: Boolean!

--- a/components/fee-button.js
+++ b/components/fee-button.js
@@ -79,7 +79,7 @@ export function FeeButtonProvider ({ baseLineItems = {}, useRemoteLineItems = ()
     const lines = { ...baseLineItems, ...lineItems, ...remoteLineItems }
     const total = Object.values(lines).reduce((acc, { modifier }) => modifier(acc), 0)
     // freebies: there's only a base cost and we don't have enough sats
-    const free = total === lines.baseCost?.modifier(0) && lines.baseCost?.allowFreebies && me?.privates?.sats < total
+    const free = total === lines.baseCost?.modifier(0) && lines.baseCost?.allowFreebies && me?.privates?.sats < total && !me?.privates?.disableFreebies
     return {
       lines,
       merge: mergeLineItems,
@@ -88,7 +88,7 @@ export function FeeButtonProvider ({ baseLineItems = {}, useRemoteLineItems = ()
       setDisabled,
       free
     }
-  }, [me?.privates?.sats, baseLineItems, lineItems, remoteLineItems, mergeLineItems, disabled, setDisabled])
+  }, [me?.privates?.sats, me?.privates?.disableFreebies, baseLineItems, lineItems, remoteLineItems, mergeLineItems, disabled, setDisabled])
 
   return (
     <FeeButtonContext.Provider value={value}>

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -53,6 +53,7 @@ export const ME = gql`
         lnAddr
         autoWithdrawMaxFeePercent
         autoWithdrawThreshold
+        disableFreebies
       }
       optional {
         isContributor
@@ -105,6 +106,7 @@ export const SETTINGS_FIELDS = gql`
       nostrRelays
       wildWestMode
       satsFilter
+      disableFreebies
       nsfwMode
       authMethods {
         lightning

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -602,6 +602,7 @@ export const settingsSchema = object().shape({
   diagnostics: boolean(),
   noReferralLinks: boolean(),
   hideIsContributor: boolean(),
+  disableFreebies: boolean().nullable(),
   satsFilter: intValidator.required('required').min(0, 'must be at least 0').max(1000, 'must be at most 1000'),
   zapUndos: intValidator.nullable().min(0, 'must be greater or equal to 0')
   // exclude from cyclic analysis. see https://github.com/jquense/yup/issues/720

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -259,9 +259,9 @@ export default function Settings ({ ssrData }) {
                 <Info>
                   <p>Some posts and comments can be created without paying. However, that content has limited visibility.</p>
 
-                  <p>If you disable freebies, you will always be prompted to pay for your posts and comments.</p>
+                  <p>If you disable freebies, you will always pay for your posts and comments and get standard visibility.</p>
 
-                  <p>If you attach a sending wallet, we disable freebies for you unless you have unchecked this box.</p>
+                  <p>If you attach a sending wallet, we disable freebies for you unless you have checked/unchecked this value already.</p>
                 </Info>
               </div>
             }

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -116,6 +116,7 @@ export default function Settings ({ ssrData }) {
             tipRandomMin: settings?.tipRandomMin || 1,
             tipRandomMax: settings?.tipRandomMax || 10,
             turboTipping: settings?.turboTipping,
+            disableFreebies: settings?.disableFreebies,
             zapUndos: settings?.zapUndos || (settings?.tipDefault ? 100 * settings.tipDefault : 2100),
             zapUndosEnabled: settings?.zapUndos !== null,
             fiatCurrency: settings?.fiatCurrency || 'USD',
@@ -251,6 +252,20 @@ export default function Settings ({ ssrData }) {
             name='withdrawMaxFeeDefault'
             required
             append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
+          />
+          <Checkbox
+            label={
+              <div className='d-flex align-items-center'>disable freebies
+                <Info>
+                  <p>Some posts and comments can be created without paying. However, that content has limited visibility.</p>
+
+                  <p>If you disable freebies, you will always be prompted to pay for your posts and comments.</p>
+
+                  <p>If you attach a sending wallet, we disable freebies for you unless you have unchecked this box.</p>
+                </Info>
+              </div>
+            }
+            name='disableFreebies'
           />
           <div className='form-label'>notify me when ...</div>
           <Checkbox

--- a/prisma/migrations/20240819233308_disable_freebies/migration.sql
+++ b/prisma/migrations/20240819233308_disable_freebies/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "disableFreebies" BOOLEAN;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,6 +64,7 @@ model User {
   zapUndos                  Int?
   imgproxyOnly              Boolean              @default(false)
   hideWalletBalance         Boolean              @default(false)
+  disableFreebies           Boolean?
   referrerId                Int?
   nostrPubkey               String?
   greeterMode               Boolean              @default(false)

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -6,7 +6,7 @@ import { SSR } from '@/lib/constants'
 import { bolt11Tags } from '@/lib/bolt11'
 
 import walletDefs from 'wallets/client'
-import { gql, useApolloClient, useQuery } from '@apollo/client'
+import { gql, useApolloClient, useMutation, useQuery } from '@apollo/client'
 import { REMOVE_WALLET, WALLET_BY_TYPE } from '@/fragments/wallet'
 import { autowithdrawInitial } from '@/components/autowithdraw-shared'
 import { useShowModal } from '@/components/modal'
@@ -25,6 +25,7 @@ export function useWallet (name) {
   const me = useMe()
   const showModal = useShowModal()
   const toaster = useToast()
+  const [disableFreebies] = useMutation(gql`mutation { disableFreebies }`)
 
   const wallet = name ? getWalletByName(name) : getEnabledWallet(me)
   const { logger, deleteLogs } = useWalletLogger(wallet)
@@ -36,6 +37,7 @@ export function useWallet (name) {
   const enablePayments = useCallback(() => {
     enableWallet(name, me)
     logger.ok('payments enabled')
+    disableFreebies().catch(console.error)
   }, [name, me, logger])
 
   const disablePayments = useCallback(() => {


### PR DESCRIPTION
Introduces a setting for disabling freebies. By default, this is null. When the first sending wallet is attached, `disableFreebies` is set to true IFF `disableFreebies` is null, otherwise the setting is completely controlled by the stacker.