### PR TITLE
paid action limits

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,6 +3,7 @@
 export const DEFAULT_SUBS = ['bitcoin', 'nostr', 'tech', 'meta', 'jobs']
 export const DEFAULT_SUBS_NO_JOBS = DEFAULT_SUBS.filter(s => s !== 'jobs')
 
+export const PAID_ACTION_TERMINAL_STATES = ['FAILED', 'PAID', 'RETRYING']
 export const NOFOLLOW_LIMIT = 1000
 export const UNKNOWN_LINK_REL = 'noreferrer nofollow noopener'
 export const BOOST_MULT = 5000

--- a/worker/paidAction.js
+++ b/worker/paidAction.js
@@ -1,6 +1,6 @@
 import { getPaymentFailureStatus, hodlInvoiceCltvDetails } from '@/api/lnd'
 import { paidActions } from '@/api/paidAction'
-import { LND_PATHFINDING_TIMEOUT_MS } from '@/lib/constants'
+import { LND_PATHFINDING_TIMEOUT_MS, PAID_ACTION_TERMINAL_STATES } from '@/lib/constants'
 import { datePivot } from '@/lib/time'
 import { toPositiveNumber } from '@/lib/validate'
 import { Prisma } from '@prisma/client'
@@ -21,7 +21,7 @@ async function transitionInvoice (jobName, { invoiceId, fromState, toState, tran
     const currentDbInvoice = await models.invoice.findUnique({ where: { id: invoiceId } })
     console.log('invoice is in state', currentDbInvoice.actionState)
 
-    if (['FAILED', 'PAID', 'RETRYING'].includes(currentDbInvoice.actionState)) {
+    if (PAID_ACTION_TERMINAL_STATES.includes(currentDbInvoice.actionState)) {
       console.log('invoice is already in a terminal state, skipping transition')
       return
     }


### PR DESCRIPTION
closes #1314 

This limits pending *incoming* paid actions per *stacker* to 100.

This limits pending *outgoing* paid actions/autowithdraws per *wallet* to 25.

If you lower the limits to 0, or close to 0, they behave as expected:

- new paid actions are rejected
- `createInvoice` throws

I also tested that prisma does not count `null` in `notIn` queries.
