### PR TITLE
Show item details via context menu

### DIFF
--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -146,6 +146,7 @@ export default gql`
     rel: String
     apiKey: Boolean
     invoice: Invoice
+    cost: Int!
   }
 
   input ItemForwardInput {

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -294,7 +294,7 @@ function InfoDropdownItem ({ item }) {
               <div>{item.meSats}</div>
             </>
           )}
-          <div>upvotes</div>
+          <div>zappers</div>
           <div>{item.upvotes}</div>
         </div>
       )

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -25,6 +25,7 @@ import UserPopover from './user-popover'
 import { useQrPayment } from './payment'
 import { useRetryCreateItem } from './use-item-submit'
 import { useToast } from './toast'
+import { useShowModal } from './modal'
 
 export default function ItemInfo ({
   item, full, commentsText = 'comments',
@@ -210,6 +211,7 @@ export default function ItemInfo ({
             <EditInfo />
             <ActionDropdown>
               <CopyLinkDropdownItem item={item} />
+              <InfoDropdownItem item={item} />
               {(item.parentId || item.text) && onQuoteReply &&
                 <Dropdown.Item onClick={onQuoteReply}>quote reply</Dropdown.Item>}
               {me && <BookmarkDropdownItem item={item} />}
@@ -267,5 +269,41 @@ export default function ItemInfo ({
       }
       {extraInfo}
     </div>
+  )
+}
+
+function InfoDropdownItem ({ item }) {
+  const me = useMe()
+  const showModal = useShowModal()
+
+  const onClick = () => {
+    showModal((onClose) => {
+      return (
+        <div className={styles.details}>
+          <div>id</div>
+          <div>{item.id}</div>
+          <div>created at</div>
+          <div>{item.createdAt}</div>
+          <div>cost</div>
+          <div>{item.cost}</div>
+          <div>sats</div>
+          <div>{item.sats}</div>
+          {me && (
+            <>
+              <div>sats from me</div>
+              <div>{item.meSats}</div>
+            </>
+          )}
+          <div>upvotes</div>
+          <div>{item.upvotes}</div>
+        </div>
+      )
+    })
+  }
+
+  return (
+    <Dropdown.Item onClick={onClick}>
+      details
+    </Dropdown.Item>
   )
 }

--- a/components/item.module.css
+++ b/components/item.module.css
@@ -154,6 +154,12 @@ a.link:visited {
     grid-template-columns: auto minmax(0, 1fr);
 }
 
+.details {
+    display: grid;
+    grid-template-columns: auto auto;
+    column-gap: 1rem;
+}
+
 /* .itemJob .hunk {
     align-self: center;
 }

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -65,6 +65,7 @@ export const ITEM_FIELDS = gql`
       actionState
       confirmedAt
     }
+    cost
   }`
 
 export const ITEM_FULL_FIELDS = gql`


### PR DESCRIPTION
## Description

This PR fixes the accessibility issue that `item.meSats`, `item.upvotes` or the exact timestamp is only visible on hover which isn't available on mobile. It introduces `details` as a new entry in the item context menu. On click, it opens this modal:

![2024-08-21-191009_519x272_scrot](https://github.com/user-attachments/assets/4fbb1598-582c-4a79-8e28-de3a2b863947)

I also added `item.cost` for everyone to see even though it was only visible to the author before since I don't consider it sensitive. 

## Screenshots

Mobile:

![localhost_3000_(iPhone SE)](https://github.com/user-attachments/assets/0b6ff8ac-e7ce-4169-8e38-7991a5fc239d)


## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes, I only additionally resolve `item.cost` in item queries now which isn't a breaking change

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**Did you QA this? Could we deploy this straight to production? Please answer below:**

Yes, tested logged in and logged out.

**For frontend changes: Tested on mobile? Please answer below:**

Yes, see screenshot

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No
