### PR TITLE
Ignore no rows found in disableFreebies

### DIFF
--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -628,10 +628,17 @@ export default {
       }
 
       // disable freebies if it hasn't been set yet
-      await models.user.update({
-        where: { id: me.id, disableFreebies: null },
-        data: { disableFreebies: true }
-      })
+      try {
+        await models.user.update({
+          where: { id: me.id, disableFreebies: null },
+          data: { disableFreebies: true }
+        })
+      } catch (err) {
+        // ignore 'record not found' errors
+        if (err.code !== 'P2025') {
+          throw err
+        }
+      }
 
       return true
     },


### PR DESCRIPTION
On every wallet save if `disableFreebies <> NULL`, this would show up in the logs:

```
Invalid `prisma.user.update()` invocation:


An operation failed because it depends on one or more records that were required but not found. Record to update not found.
    at _n.handleRequestError (/app/node_modules/@prisma/client/runtime/library.js:121:7749)
    at _n.handleAndLogRequestError (/app/node_modules/@prisma/client/runtime/library.js:121:7057)
    at _n.request (/app/node_modules/@prisma/client/runtime/library.js:121:6741)
    at async l (/app/node_modules/@prisma/client/runtime/library.js:130:9355)
    at async Object.disableFreebies (webpack-internal:///(api)/./api/resolvers/user.js:612:17) {
  code: 'P2025',
  clientVersion: '5.17.0',
  meta: { modelName: 'User', cause: 'Record to update not found.' }
}
```