### PR TITLE
Skip wallets tests on priority update

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -22,18 +22,20 @@ function injectResolvers (resolvers) {
     const resolverName = generateResolverName(w.walletField)
     console.log(resolverName)
 
-    resolvers.Mutation[resolverName] = async (parent, { settings, ...data }, { me, models }) => {
+    resolvers.Mutation[resolverName] = async (parent, { settings, priorityOnly, ...data }, { me, models }) => {
       // allow transformation of the data on validation (this is optional ... won't do anything if not implemented)
-      const validData = await walletValidate(w, { ...data, ...settings })
-      if (validData) {
-        Object.keys(validData).filter(key => key in data).forEach(key => { data[key] = validData[key] })
-        Object.keys(validData).filter(key => key in settings).forEach(key => { settings[key] = validData[key] })
+      if (!priorityOnly) {
+        const validData = await walletValidate(w, { ...data, ...settings })
+        if (validData) {
+          Object.keys(validData).filter(key => key in data).forEach(key => { data[key] = validData[key] })
+          Object.keys(validData).filter(key => key in settings).forEach(key => { settings[key] = validData[key] })
+        }
       }
 
       return await upsertWallet({
         wallet: { field: w.walletField, type: w.walletType },
         testCreateInvoice: (data) => w.testCreateInvoice(data, { me, models })
-      }, { settings, data }, { me, models })
+      }, { settings, data, priorityOnly }, { me, models })
     }
   }
   console.groupEnd()
@@ -571,13 +573,13 @@ export const addWalletLog = async ({ wallet, level, message }, { models }) => {
 }
 
 async function upsertWallet (
-  { wallet, testCreateInvoice }, { settings, data }, { me, models }) {
+  { wallet, testCreateInvoice }, { settings, data, priorityOnly }, { me, models }) {
   if (!me) {
     throw new GraphQLError('you must be logged in', { extensions: { code: 'UNAUTHENTICATED' } })
   }
   assertApiKeyNotPermitted({ me })
 
-  if (testCreateInvoice) {
+  if (testCreateInvoice && !priorityOnly) {
     try {
       await testCreateInvoice(data)
     } catch (err) {

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -17,7 +17,7 @@ function mutationTypeDefs () {
     args += w.fields
       .filter(isServerField)
       .map(fieldToGqlArg).join(', ')
-    args += ', settings: AutowithdrawSettings!'
+    args += ', settings: AutowithdrawSettings!, priorityOnly: Boolean'
     const resolverName = generateResolverName(w.walletField)
     const typeDef = `${resolverName}(${args}): Boolean`
     console.log(typeDef)

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -161,13 +161,16 @@ function useConfig (wallet) {
   let config = {}
   if (hasClientConfig) config = clientConfig
   if (hasServerConfig) {
-    const { enabled } = config || {}
+    const { enabled, priority } = config || {}
     config = {
       ...config,
       ...serverConfig
     }
     // wallet is enabled if enabled is set in client or server config
     config.enabled ||= enabled
+    // priority might only be set on client or server
+    // ie. if send+recv is available but only one is configured
+    config.priority ||= priority
   }
 
   const saveConfig = useCallback(async (newConfig, { logger, priorityOnly }) => {


### PR DESCRIPTION
## Description

This fixes that priority updates reuse the wallet save logic which means that the wallet gets unnecessarily tested again.

## Additional context

I didn't create a new mutation because `saveConfig` contains the logic to determine if client and/or server needs to be updated. I therefore only added a flag `priorityOnly` that then skips the wallet tests (`testSendPayment`, `testCreateInvoice`). It does not skip validation since validation is used to check if we should save the configuration on the client or server. Since all saved configurations are already valid this shouldn't ever be a problem when only priority is changed.

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes, very backwards compatible, much wow

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

9\. I tested changing priority between three wallets: LNC only sending, WebLN no config, NWC send+recv.

I also read through the code and the changes are quite simple: I basically only skip `testSendPayment` and `testCreateInovice`. Everything else stayed the same. 

<!-- put your answer about QA here -->

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
