### PR TITLE
Fix full config saved on client on priority change

### DIFF
--- a/wallets/index.js
+++ b/wallets/index.js
@@ -186,7 +186,10 @@ function useConfig (wallet) {
 
       let valid = true
       try {
-        newClientConfig = await walletValidate(wallet, newClientConfig)
+        const transformedConfig = await walletValidate(wallet, newClientConfig)
+        if (transformedConfig) {
+          newClientConfig = Object.assign(newClientConfig, transformedConfig)
+        }
       } catch {
         valid = false
       }

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -199,10 +199,10 @@ function useConfig (wallet) {
           setClientConfig(newClientConfig)
         } else {
           try {
-          // XXX: testSendPayment can return a new config (e.g. lnc)
+            // XXX: testSendPayment can return a new config (e.g. lnc)
             const newerConfig = await wallet.testSendPayment?.(newConfig, { me, logger })
             if (newerConfig) {
-              newClientConfig = newerConfig
+              newClientConfig = Object.assign(newClientConfig, newerConfig)
             }
           } catch (err) {
             logger.error(err.message)
@@ -222,7 +222,10 @@ function useConfig (wallet) {
 
       let valid = true
       try {
-        newServerConfig = await walletValidate(wallet, newServerConfig)
+        const transformedConfig = await walletValidate(wallet, newServerConfig)
+        if (transformedConfig) {
+          newServerConfig = Object.assign(newServerConfig, transformedConfig)
+        }
       } catch {
         valid = false
       }

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -193,7 +193,7 @@ function useConfig (wallet) {
 
       if (valid) {
         if (priorityOnly) {
-          setClientConfig(newConfig)
+          setClientConfig(newClientConfig)
         } else {
           try {
           // XXX: testSendPayment can return a new config (e.g. lnc)


### PR DESCRIPTION
## Description

When a wallet that supports send+recv, the full config was saved on the client on priority change. It didn't cause any issues but wasn't intended. It was fixed in 8e3f4ae4.

However, 8e3f4ae4 revealed a bug where we actually save an empty WebLN config because if we use a function for validation, the function has to return an object in the format Formik expects errors. So in case of no errors, it returns an empty object. So this means that all this time, only the `wallet.enablePayments()` call actually saved `enabled: true` for WebLN. This was fixed in 503d4de9 by not overwriting the config with the return value of `walletValidate` but merging it.

For consistency, the config is now always merged with return values in 27bcef9d.

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

tACK b241c4e0 level 9. I tested attaching WebLN, LNC, NWC send+recv, LNbits send+recv, LND and CLN without any issues.

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
