### PR TITLE
Improve freebies

### DIFF
--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -23,7 +23,7 @@ export async function getCost ({ subName, parentId, uploadIds, boost = 0, bio },
 
   // sub allows freebies (or is a bio or a comment), cost is less than baseCost, not anon,
   // cost must be greater than user's balance, and user has not disabled freebies
-  const freebie = (parentId || bio || sub?.allowFreebies) && cost <= baseCost && !!me &&
+  const freebie = (parentId || bio) && cost <= baseCost && !!me &&
     cost > me?.msats && !me?.disableFreebies
 
   return freebie ? BigInt(0) : BigInt(cost)

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1290,11 +1290,7 @@ export const updateItem = async (parent, { sub: subName, forward, ...item }, { m
   const differentSub = subName && old.subName !== subName
   if (differentSub) {
     const sub = await models.sub.findUnique({ where: { name: subName } })
-    if (old.cost === 0) {
-      if (!sub.allowFreebies) {
-        throw new GraphQLError(`~${subName} does not allow freebies`, { extensions: { code: 'BAD_INPUT' } })
-      }
-    } else if (sub.baseCost > old.sub.baseCost) {
+    if (sub.baseCost > old.sub.baseCost) {
       throw new GraphQLError('cannot change to a more expensive sub', { extensions: { code: 'BAD_INPUT' } })
     }
   }

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -23,19 +23,19 @@ import performPaidAction from '../paidAction'
 
 function commentsOrderByClause (me, models, sort) {
   if (sort === 'recent') {
-    return 'ORDER BY "Item".created_at DESC, "Item".id DESC'
+    return 'ORDER BY ("Item"."deletedAt" IS NULL) DESC, ("Item".cost > 0 OR "Item"."weightedVotes" - "Item"."weightedDownVotes" > 0) DESC, "Item".created_at DESC, "Item".id DESC'
   }
 
   if (me && sort === 'hot') {
-    return `ORDER BY COALESCE(
+    return `ORDER BY ("Item"."deletedAt" IS NULL) DESC, COALESCE(
         personal_hot_score,
         ${orderByNumerator(models, 0)}/POWER(GREATEST(3, EXTRACT(EPOCH FROM (now_utc() - "Item".created_at))/3600), 1.3)) DESC NULLS LAST,
         "Item".msats DESC, ("Item".cost > 0) DESC, "Item".id DESC`
   } else {
     if (sort === 'top') {
-      return `ORDER BY ${orderByNumerator(models, 0)} DESC NULLS LAST, "Item".msats DESC, ("Item".cost > 0) DESC,  "Item".id DESC`
+      return `ORDER BY ("Item"."deletedAt" IS NULL) DESC, ${orderByNumerator(models, 0)} DESC NULLS LAST, "Item".msats DESC, ("Item".cost > 0) DESC,  "Item".id DESC`
     } else {
-      return `ORDER BY ${orderByNumerator(models, 0)}/POWER(GREATEST(3, EXTRACT(EPOCH FROM (now_utc() - "Item".created_at))/3600), 1.3) DESC NULLS LAST, "Item".msats DESC, ("Item".cost > 0) DESC, "Item".id DESC`
+      return `ORDER BY ("Item"."deletedAt" IS NULL) DESC, ${orderByNumerator(models, 0)}/POWER(GREATEST(3, EXTRACT(EPOCH FROM (now_utc() - "Item".created_at))/3600), 1.3) DESC NULLS LAST, "Item".msats DESC, ("Item".cost > 0) DESC, "Item".id DESC`
     }
   }
 }

--- a/api/typeDefs/sub.js
+++ b/api/typeDefs/sub.js
@@ -16,7 +16,7 @@ export default gql`
 
   extend type Mutation {
     upsertSub(oldName: String, name: String!, desc: String, baseCost: Int!,
-      postTypes: [String!]!, allowFreebies: Boolean!,
+      postTypes: [String!]!,
       billingType: String!, billingAutoRenew: Boolean!,
       moderated: Boolean!, nsfw: Boolean!): SubPaidAction!
     paySub(name: String!): SubPaidAction!
@@ -24,7 +24,7 @@ export default gql`
     toggleSubSubscription(name: String!): Boolean!
     transferTerritory(subName: String!, userName: String!): Sub
     unarchiveTerritory(name: String!, desc: String, baseCost: Int!,
-      postTypes: [String!]!, allowFreebies: Boolean!,
+      postTypes: [String!]!,
       billingType: String!, billingAutoRenew: Boolean!,
       moderated: Boolean!, nsfw: Boolean!): SubPaidAction!
   }

--- a/components/fee-button.js
+++ b/components/fee-button.js
@@ -14,7 +14,7 @@ import { SubmitButton } from './form'
 
 const FeeButtonContext = createContext()
 
-export function postCommentBaseLineItems ({ baseCost = 1, comment = false, allowFreebies = true, me }) {
+export function postCommentBaseLineItems ({ baseCost = 1, comment = false, me }) {
   const anonCharge = me
     ? {}
     : {
@@ -29,7 +29,7 @@ export function postCommentBaseLineItems ({ baseCost = 1, comment = false, allow
       term: baseCost,
       label: `${comment ? 'comment' : 'post'} cost`,
       modifier: (cost) => cost + baseCost,
-      allowFreebies
+      allowFreebies: comment
     },
     ...anonCharge
   }

--- a/components/post.js
+++ b/components/post.js
@@ -149,7 +149,7 @@ export function PostForm ({ type, sub, children }) {
 
   return (
     <FeeButtonProvider
-      baseLineItems={sub ? postCommentBaseLineItems({ baseCost: sub.baseCost, allowFreebies: sub.allowFreebies, me: !!me }) : undefined}
+      baseLineItems={sub ? postCommentBaseLineItems({ baseCost: sub.baseCost, me: !!me }) : undefined}
       useRemoteLineItems={postCommentUseRemoteLineItems({ me: !!me })}
     >
       <FormType sub={sub}>{children}</FormType>

--- a/components/territory-form.js
+++ b/components/territory-form.js
@@ -91,7 +91,6 @@ export default function TerritoryForm ({ sub }) {
           desc: sub?.desc || '',
           baseCost: sub?.baseCost || 10,
           postTypes: sub?.postTypes || POST_TYPES,
-          allowFreebies: typeof sub?.allowFreebies === 'undefined' ? true : sub?.allowFreebies,
           billingType: sub?.billingType || 'MONTHLY',
           billingAutoRenew: sub?.billingAutoRenew || false,
           moderated: sub?.moderated || false,
@@ -133,14 +132,8 @@ export default function TerritoryForm ({ sub }) {
           label='post cost'
           name='baseCost'
           type='number'
-          groupClassName='mb-2'
           required
           append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
-        />
-        <Checkbox
-          label='allow free posts'
-          name='allowFreebies'
-          groupClassName='ms-1'
         />
         <CheckboxGroup label='post types' name='postTypes'>
           <Row>

--- a/fragments/paidAction.js
+++ b/fragments/paidAction.js
@@ -223,10 +223,10 @@ export const UPDATE_COMMENT = gql`
 export const UPSERT_SUB = gql`
   ${PAID_ACTION}
   mutation upsertSub($oldName: String, $name: String!, $desc: String, $baseCost: Int!,
-    $postTypes: [String!]!, $allowFreebies: Boolean!, $billingType: String!,
+    $postTypes: [String!]!, $billingType: String!,
     $billingAutoRenew: Boolean!, $moderated: Boolean!, $nsfw: Boolean!) {
       upsertSub(oldName: $oldName, name: $name, desc: $desc, baseCost: $baseCost,
-        postTypes: $postTypes, allowFreebies: $allowFreebies, billingType: $billingType,
+        postTypes: $postTypes, billingType: $billingType,
         billingAutoRenew: $billingAutoRenew, moderated: $moderated, nsfw: $nsfw) {
       result {
         name
@@ -238,10 +238,10 @@ export const UPSERT_SUB = gql`
 export const UNARCHIVE_TERRITORY = gql`
   ${PAID_ACTION}
   mutation unarchiveTerritory($name: String!, $desc: String, $baseCost: Int!,
-    $postTypes: [String!]!, $allowFreebies: Boolean!, $billingType: String!,
+    $postTypes: [String!]!, $billingType: String!,
     $billingAutoRenew: Boolean!, $moderated: Boolean!, $nsfw: Boolean!) {
       unarchiveTerritory(name: $name, desc: $desc, baseCost: $baseCost,
-        postTypes: $postTypes, allowFreebies: $allowFreebies, billingType: $billingType,
+        postTypes: $postTypes, billingType: $billingType,
         billingAutoRenew: $billingAutoRenew, moderated: $moderated, nsfw: $nsfw) {
       result {
         name

--- a/fragments/subs.js
+++ b/fragments/subs.js
@@ -7,7 +7,6 @@ export const SUB_FIELDS = gql`
     name
     createdAt
     postTypes
-    allowFreebies
     rankingType
     billingType
     billingCost

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -257,9 +257,9 @@ export default function Settings ({ ssrData }) {
             label={
               <div className='d-flex align-items-center'>disable freebies
                 <Info>
-                  <p>Some posts and comments can be created without paying. However, that content has limited visibility.</p>
+                  <p>Some comments can be created without paying. However, those comments have limited visibility.</p>
 
-                  <p>If you disable freebies, you will always pay for your posts and comments and get standard visibility.</p>
+                  <p>If you disable freebies, you will always pay for your comments and get standard visibility.</p>
 
                   <p>If you attach a sending wallet, we disable freebies for you unless you have checked/unchecked this value already.</p>
                 </Info>


### PR DESCRIPTION
## Description
- removes freebie posts (and removed from territory form)
- ranks unfreed freebie and deleted comments at bottom regardless of sort (e.g. recent)

## Additional Context

I left the `allowFreebies` territory setting for backwards compat.

## Checklist

**Are your changes backwards compatible? Please answer below:**

Should be.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`: I didn't test unarchiving territories or anon posts/comments.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
