### PR TITLE
Support Tor for LNbits recv

### DIFF
--- a/lib/cln.js
+++ b/lib/cln.js
@@ -1,28 +1,9 @@
 import fetch from 'cross-fetch'
-import https from 'https'
 import crypto from 'crypto'
-import { HttpProxyAgent, HttpsProxyAgent } from '@/lib/proxy'
-import { TOR_REGEXP } from '@/lib/url'
+import { getAgent } from '@/lib/proxy'
 
 export const createInvoice = async ({ socket, rune, cert, label, description, msats, expiry }) => {
-  let protocol, agent
-  const httpsAgentOptions = { ca: cert ? Buffer.from(cert, 'base64') : undefined }
-  const isOnion = TOR_REGEXP.test(socket)
-  if (isOnion) {
-    // we support HTTP and HTTPS over Tor
-    protocol = cert ? 'https:' : 'http:'
-    // we need to use our Tor proxy to resolve onion addresses
-    const proxyOptions = { proxy: process.env.TOR_PROXY }
-    agent = protocol === 'https:'
-      ? new HttpsProxyAgent({ ...proxyOptions, ...httpsAgentOptions, rejectUnauthorized: false })
-      : new HttpProxyAgent(proxyOptions)
-  } else if (process.env.NODE_ENV === 'development' && !cert) {
-    protocol = 'http:'
-  } else {
-    // we only support HTTPS over clearnet
-    agent = new https.Agent(httpsAgentOptions)
-    protocol = 'https:'
-  }
+  const { protocol, agent } = getAgent({ hostname: socket, cert })
 
   const url = `${protocol}//${socket}/v1/invoice`
   const res = await fetch(url, {

--- a/lib/cln.js
+++ b/lib/cln.js
@@ -3,9 +3,9 @@ import crypto from 'crypto'
 import { getAgent } from '@/lib/proxy'
 
 export const createInvoice = async ({ socket, rune, cert, label, description, msats, expiry }) => {
-  const { protocol, agent } = getAgent({ hostname: socket, cert })
+  const agent = getAgent({ hostname: socket, cert })
 
-  const url = `${protocol}//${socket}/v1/invoice`
+  const url = `${agent.protocol}//${socket}/v1/invoice`
   const res = await fetch(url, {
     method: 'POST',
     headers: {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -121,26 +121,26 @@ export class HttpsProxyAgent extends https.Agent {
 }
 
 export function getAgent ({ hostname, cert }) {
-  let protocol, agent
+  let agent
 
   const httpsAgentOptions = { ca: cert ? Buffer.from(cert, 'base64') : undefined }
 
   const isOnion = TOR_REGEXP.test(hostname)
   if (isOnion) {
     // we support HTTP and HTTPS over Tor
-    protocol = cert ? 'https:' : 'http:'
+    const protocol = cert ? 'https:' : 'http:'
     // we need to use our Tor proxy to resolve onion addresses
     const proxyOptions = { proxy: process.env.TOR_PROXY }
     agent = protocol === 'https:'
       ? new HttpsProxyAgent({ ...proxyOptions, ...httpsAgentOptions, rejectUnauthorized: false })
       : new HttpProxyAgent(proxyOptions)
-  } else if (process.env.NODE_ENV === 'development' && !cert) {
-    protocol = 'http:'
-  } else {
-    // we only support HTTPS over clearnet
-    agent = new https.Agent(httpsAgentOptions)
-    protocol = 'https:'
+    return agent
   }
 
-  return { protocol, agent }
+  if (process.env.NODE_ENV === 'development' && !cert) {
+    return new http.Agent()
+  }
+
+  // we only support HTTPS over clearnet
+  return new https.Agent(httpsAgentOptions)
 }

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -1,5 +1,6 @@
 import http from 'http'
 import https from 'https'
+import { TOR_REGEXP } from '@/lib/url'
 
 // from https://github.com/delvedor/hpagent
 
@@ -117,4 +118,29 @@ export class HttpsProxyAgent extends https.Agent {
 
     request.end()
   }
+}
+
+export function getAgent ({ hostname, cert }) {
+  let protocol, agent
+
+  const httpsAgentOptions = { ca: cert ? Buffer.from(cert, 'base64') : undefined }
+
+  const isOnion = TOR_REGEXP.test(hostname)
+  if (isOnion) {
+    // we support HTTP and HTTPS over Tor
+    protocol = cert ? 'https:' : 'http:'
+    // we need to use our Tor proxy to resolve onion addresses
+    const proxyOptions = { proxy: process.env.TOR_PROXY }
+    agent = protocol === 'https:'
+      ? new HttpsProxyAgent({ ...proxyOptions, ...httpsAgentOptions, rejectUnauthorized: false })
+      : new HttpProxyAgent(proxyOptions)
+  } else if (process.env.NODE_ENV === 'development' && !cert) {
+    protocol = 'http:'
+  } else {
+    // we only support HTTPS over clearnet
+    agent = new https.Agent(httpsAgentOptions)
+    protocol = 'https:'
+  }
+
+  return { protocol, agent }
 }

--- a/wallets/lnbits/server.js
+++ b/wallets/lnbits/server.js
@@ -1,4 +1,5 @@
 import { msatsToSats } from '@/lib/format'
+import { getAgent } from '@/lib/proxy'
 
 export * from 'wallets/lnbits'
 
@@ -27,7 +28,15 @@ export async function createInvoice (
     out: false
   })
 
-  const res = await fetch(url + path, { method: 'POST', headers, body })
+  const hostname = url.replace(/^https?:\/\//, '')
+  const { protocol, agent } = getAgent({ hostname })
+
+  const res = await fetch(`${protocol}//${hostname}${path}`, {
+    method: 'POST',
+    headers,
+    agent,
+    body
+  })
   if (!res.ok) {
     const errBody = await res.json()
     throw new Error(errBody.detail)

--- a/wallets/lnbits/server.js
+++ b/wallets/lnbits/server.js
@@ -29,9 +29,9 @@ export async function createInvoice (
   })
 
   const hostname = url.replace(/^https?:\/\//, '')
-  const { protocol, agent } = getAgent({ hostname })
+  const agent = getAgent({ hostname })
 
-  const res = await fetch(`${protocol}//${hostname}${path}`, {
+  const res = await fetch(`${agent.protocol}//${hostname}${path}`, {
     method: 'POST',
     headers,
     agent,


### PR DESCRIPTION
## Description

Close #1166 

This adds the agent that is used to withdraw to a CLN node on Tor to LNbits.

## Additional Context

This will only work for receive because our Tor proxy is only available on the server.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

tACK 662b18ed 8. I tested attaching CLN and LNbits for receiving and made sure that the correct agent is selected depending on the given socket/URL. Both attach successfully if given `stacker_cln:3010` or `lnbits:5000`.

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
