### PR TITLE
Fix preimage undefined in wallet logs

### DIFF
--- a/wallets/README.md
+++ b/wallets/README.md
@@ -163,11 +163,11 @@ This function must throw an error if the configuration was found to be invalid.
 
 The `context` argument is an object. It makes the wallet logger for this wallet as returned by `useWalletLogger` available under `context.logger`. See [components/wallet-logger.js](../components/wallet-logger.js).
 
-- `sendPayment: async (bolt11: string, config, context) => Promise<{ preimage: string }>`
+- `sendPayment: async (bolt11: string, config, context) => Promise<string>`
 
 `sendPayment` will be called if a payment is required. Therefore, this function should implement the code to pay invoices from this wallet.
 
-The first argument is the [BOLT11 payment request](https://github.com/lightning/bolts/blob/master/11-payment-encoding.md). The `config` argument is the current configuration of this wallet (that was validated before). The `context` argument is the same as for `testSendPayment`.
+The first argument is the [BOLT11 payment request](https://github.com/lightning/bolts/blob/master/11-payment-encoding.md). The `config` argument is the current configuration of this wallet (that was validated before). The `context` argument is the same as for `testSendPayment`. The function should return the preimage on payment success.
 
 > [!IMPORTANT]
 > As mentioned above, this file must exist for every wallet and at least reexport everything in index.js so make sure that the following line is included:

--- a/wallets/blink/client.js
+++ b/wallets/blink/client.js
@@ -10,8 +10,7 @@ export async function testSendPayment ({ apiKey, currency }, { logger }) {
 
 export async function sendPayment (bolt11, { apiKey, currency }) {
   const wallet = await getWallet(apiKey, currency)
-  const preImage = await payInvoice(apiKey, wallet, bolt11)
-  return { preImage }
+  return await payInvoice(apiKey, wallet, bolt11)
 }
 
 async function payInvoice (authToken, wallet, invoice) {

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -59,7 +59,7 @@ export function useWallet (name) {
     const hash = bolt11Tags(bolt11).payment_hash
     logger.info('sending payment:', `payment_hash=${hash}`)
     try {
-      const { preimage } = await wallet.sendPayment(bolt11, config, { me, logger, status, showModal })
+      const preimage = await wallet.sendPayment(bolt11, config, { me, logger, status, showModal })
       logger.ok('payment successful:', `payment_hash=${hash}`, `preimage=${preimage}`)
     } catch (err) {
       const message = err.message || err.toString?.()

--- a/wallets/lnbits/client.js
+++ b/wallets/lnbits/client.js
@@ -19,8 +19,7 @@ export async function sendPayment (bolt11, { url, adminKey }) {
     throw new Error('No preimage')
   }
 
-  const preimage = checkResponse.preimage
-  return { preimage }
+  return checkResponse.preimage
 }
 
 async function getWallet ({ url, adminKey, invoiceKey }) {

--- a/wallets/lnc/client.js
+++ b/wallets/lnc/client.js
@@ -67,7 +67,7 @@ export async function sendPayment (bolt11, credentials, { logger }) {
       if (paymentError) throw new Error(paymentError)
       if (!preimage) throw new Error('No preimage in response')
 
-      return { preimage }
+      return preimage
     } catch (err) {
       const msg = err.message || err.toString?.()
       if (msg.includes('invoice expired')) {

--- a/wallets/nwc/client.js
+++ b/wallets/nwc/client.js
@@ -11,11 +11,10 @@ export async function testSendPayment ({ nwcUrl }, { logger }) {
 }
 
 export async function sendPayment (bolt11, { nwcUrl }, { logger }) {
-  const result = await nwcCall({
+  return await nwcCall({
     nwcUrl,
     method: 'pay_invoice',
     params: { invoice: bolt11 }
   },
   { logger })
-  return result.preimage
 }

--- a/wallets/nwc/client.js
+++ b/wallets/nwc/client.js
@@ -11,10 +11,11 @@ export async function testSendPayment ({ nwcUrl }, { logger }) {
 }
 
 export async function sendPayment (bolt11, { nwcUrl }, { logger }) {
-  return await nwcCall({
+  const result = await nwcCall({
     nwcUrl,
     method: 'pay_invoice',
     params: { invoice: bolt11 }
   },
   { logger })
+  return result.preimage
 }

--- a/wallets/phoenixd/client.js
+++ b/wallets/phoenixd/client.js
@@ -35,5 +35,5 @@ export async function sendPayment (bolt11, { url, primaryPassword }) {
     throw new Error(payment.reason)
   }
 
-  return payment.paymentPreimage
+  return preimage
 }


### PR DESCRIPTION
## Description

NWC wallet logs contained `preimage=undefined` because `sendPayment` returned it as a string while the caller expected an `{ preimage }` object.

I've noticed that this expectation lead to undefined preimages in two more cases: Blink returned `{ preImage }` (note the wrong case) and phoenixd returned it as a string like NWC.

I have therefore decided to change the interface to return preimage as plain strings now. An object was only originally chosen to match the [WebLN interface of `sendPayment`](https://www.webln.guide/building-lightning-apps/webln-reference/webln.sendpayment).

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

tACK 86b18bb0 8. I didn't test Blink and phoenixd because I can't but simply reading the code makes me confident enough this works as expected.

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
