### PR TITLE
Update wallet security banner

### DIFF
--- a/components/banners.js
+++ b/components/banners.js
@@ -129,8 +129,8 @@ export function WalletSecurityBanner () {
         Wallet Security Disclaimer
       </Alert.Heading>
       <p className='mb-1'>
-        Your wallet's credentials are stored in the browser and never go to the server.<br />
-        However, you should definitely <strong>set a budget in your wallet</strong>.
+        Your wallet's credentials for spending are stored in the browser and never go to the server.
+        However, you should definitely <strong>set a budget in your wallet</strong> if you can.
       </p>
       <p>
         Also, for the time being, you will have to reenter your credentials on other devices.

--- a/pages/settings/wallets/[wallet].js
+++ b/pages/settings/wallets/[wallet].js
@@ -42,7 +42,7 @@ export default function WalletSettings () {
     <CenterLayout>
       <h2 className='pb-2'>{wallet.card.title}</h2>
       <h6 className='text-muted text-center pb-3'><Text>{wallet.card.subtitle}</Text></h6>
-      {!wallet.walletType && wallet.hasConfig > 0 && <WalletSecurityBanner />}
+      {wallet.canSend && wallet.hasConfig > 0 && <WalletSecurityBanner />}
       <Form
         initial={initial}
         {...validateProps}


### PR DESCRIPTION
## Description

I have noticed  that the wallet security banner is missing for wallets that can spend and receive.

This PR adds it back if a wallet can spend and updates the text.

## Screenshots

![localhost_3000_(iPhone SE) (1)](https://github.com/user-attachments/assets/70630e06-b701-40e1-9ba7-dddb306ca327)

![2024-08-27-170625_1920x1200_scrot](https://github.com/user-attachments/assets/1568cfe8-e82e-46cf-8c18-f8f3b2d77f18)

## Additional context

The banner takes up a lot of space on mobile. Maybe it should be dismissable?

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

tACK 695620fb 10. Tested all wallets.

**For frontend changes: Tested on mobile? Please answer below:**

yes, see screenshot

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
