### PR TITLE
Undelete bio items

### DIFF
--- a/prisma/migrations/20240902125646_undelete_bios/migration.sql
+++ b/prisma/migrations/20240902125646_undelete_bios/migration.sql
@@ -1,0 +1,4 @@
+-- we had a bug where it was possible to delete bios, this migration will restore them
+UPDATE "Item"
+SET "deletedAt" = NULL
+WHERE "bio"


### PR DESCRIPTION
## Description

In #1295, I only fixed that the bio marker was missing for old bio items.

However, I didn't fix that some bio items were already deleted (since the marker was missing). This PR fixes that.

## Additional Context

https://stacker.news/items/668143

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

tACK 348610f0 10. Ran the migration locally and a deleted bio item was no longer deleted and thus editable.

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
