### PR TITLE
Fix onHide is not a function

### DIFF
--- a/components/modal.js
+++ b/components/modal.js
@@ -70,7 +70,7 @@ export default function useModal () {
 
     return (
       <Modal
-        onHide={keepOpen ? null : onClose} show={!!content}
+        onHide={keepOpen ? () => {} : onClose} show={!!content}
         className={className}
         dialogClassName={className}
         contentClassName={className}


### PR DESCRIPTION
## Description

If you open a modal where `onHide` is set to `null` (like when you click on "pending" for a comment) and then press ESC, this error is thrown and not caught: `TypeError: onHide is not a function`

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

tACK 1c1f8df1 10

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
