### PR TITLE
Use default-src 'self' a.stacker.news

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -83,7 +83,7 @@ export function middleware (request) {
 
   const cspHeader = [
     // if something is not explicitly allowed, we don't allow it.
-    "default-src 'none'",
+    "default-src 'self' a.stacker.news",
     "font-src 'self' a.stacker.news",
     // we want to load images from everywhere but we can limit to HTTPS at least
     "img-src 'self' a.stacker.news m.stacker.news https: data: blob:" + devSrc,


### PR DESCRIPTION
## Description

This should fix CSP errors in Firefox because scripts fetched via `<link rel="prefetch">` don't use `script-src`.

Potential fix for #1332 

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

not QA'd since CSP errors only happen in prod build
