### PR TITLE
recognize video links

### DIFF
--- a/components/image.js
+++ b/components/image.js
@@ -22,6 +22,7 @@ export function decodeOriginalUrl (imgproxyUrl) {
 function ImageOriginal ({ src, topLevel, rel, tab, children, onClick, ...props }) {
   const me = useMe()
   const [showImage, setShowImage] = useState(false)
+  const [showVideo, setShowVideo] = useState(false)
 
   useEffect(() => {
     if (me?.privates?.imgproxyOnly && tab !== 'preview') return
@@ -29,10 +30,15 @@ function ImageOriginal ({ src, topLevel, rel, tab, children, onClick, ...props }
     const img = new window.Image()
     img.onload = () => setShowImage(true)
     img.src = src
+    const video = document.createElement('video')
+    video.onloadeddata = () => setShowVideo(true)
+    video.src = src
 
     return () => {
       img.onload = null
       img.src = ''
+      video.onloadeddata = null
+      video.src = ''
     }
   }, [src, showImage])
 
@@ -45,6 +51,8 @@ function ImageOriginal ({ src, topLevel, rel, tab, children, onClick, ...props }
         onError={() => setShowImage(false)}
       />
     )
+  } else if (showVideo) {
+    return <video src={src} controls />
   } else {
     // user is not okay with loading original url automatically or there was an error loading the image
 

--- a/components/text.module.css
+++ b/components/text.module.css
@@ -128,21 +128,24 @@
     margin-bottom: .5rem;
 }
 
-.text img {
+.text img, .text video {
     display: block;
     margin-top: .5rem;
     margin-bottom: .5rem;
     max-width: 100%;
-    cursor: zoom-in;
     height: auto;
     max-height: 25vh;
-    object-fit: contain;
-    object-position: left top;
     min-width: 50%;
     aspect-ratio: var(--aspect-ratio);
 }
 
-.text img.topLevel {
+.text img {
+    cursor: zoom-in;
+    object-fit: contain;
+    object-position: left top;
+}
+
+.text img.topLevel, .text video.topLevel {
     margin-top: .75rem;
     margin-bottom: .75rem;
     max-height: 35vh;


### PR DESCRIPTION
## Description

This is pretty straightfoward. Basically when we are determining if a link might be an image before falling back to an link, we do the same for video.

This is the first step toward supporting video uploads and gif to video conversions.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7. I tested both posts and comments with this link https://video.nostr.build/e5607f8cee909defe6276ab14cf2fe0c53630664f7630ef3e6986fca4f1f5881.mp4

P.S. This image code could use a refactor.