### PR TITLE
Optout of display of images and video (show them as links)

### DIFF
--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -84,6 +84,7 @@ export default gql`
     hideIsContributor: Boolean!
     hideWalletBalance: Boolean!
     imgproxyOnly: Boolean!
+    showImagesAndVideos: Boolean!
     nostrCrossposting: Boolean!
     nostrPubkey: String
     nostrRelays: [String!]
@@ -155,6 +156,7 @@ export default gql`
     hideIsContributor: Boolean!
     hideWalletBalance: Boolean!
     imgproxyOnly: Boolean!
+    showImagesAndVideos: Boolean!
     nostrCrossposting: Boolean!
     nostrPubkey: String
     nostrRelays: [String!]

--- a/components/image.js
+++ b/components/image.js
@@ -177,7 +177,7 @@ export default function ZoomableImage ({ src, srcSet, ...props }) {
   if (!src) return null
 
   if (trustedDomain) {
-    if (me?.privates?.showImagesAndVideos !== false) {
+    if (props.tab === 'preview' || !me || me.privates.showImagesAndVideos) {
       return (
         <TrustedImage
           src={src} srcSet={srcSet}

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -26,6 +26,7 @@ export const ME = gql`
         hideWalletBalance
         hideWelcomeBanner
         imgproxyOnly
+        showImagesAndVideos
         lastCheckedJobs
         nostrCrossposting
         noteAllDescendants
@@ -98,6 +99,7 @@ export const SETTINGS_FIELDS = gql`
       hideTwitter
       hideIsContributor
       imgproxyOnly
+      showImagesAndVideos
       hideWalletBalance
       diagnostics
       noReferralLinks

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -140,6 +140,7 @@ export default function Settings ({ ssrData }) {
             hideNostr: settings?.hideNostr,
             hideTwitter: settings?.hideTwitter,
             imgproxyOnly: settings?.imgproxyOnly,
+            showImagesAndVideos: settings?.showImagesAndVideos,
             wildWestMode: settings?.wildWestMode,
             satsFilter: settings?.satsFilter,
             nsfwMode: settings?.nsfwMode,
@@ -507,6 +508,17 @@ export default function Settings ({ ssrData }) {
             name='satsFilter'
             required
             append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
+          />
+          <Checkbox
+            label={
+              <div className='d-flex align-items-center'>show images and video
+                <Info>
+                  <p>disable to show images and videos as links instead of embedding them</p>
+                </Info>
+              </div>
+            }
+            name='showImagesAndVideos'
+            groupClassName='mb-0'
           />
           <Checkbox
             label={

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -116,7 +116,7 @@ export default function Settings ({ ssrData }) {
             tipRandomMin: settings?.tipRandomMin || 1,
             tipRandomMax: settings?.tipRandomMax || 10,
             turboTipping: settings?.turboTipping,
-            disableFreebies: settings?.disableFreebies,
+            disableFreebies: settings?.disableFreebies || undefined,
             zapUndos: settings?.zapUndos || (settings?.tipDefault ? 100 * settings.tipDefault : 2100),
             zapUndosEnabled: settings?.zapUndos !== null,
             fiatCurrency: settings?.fiatCurrency || 'USD',

--- a/prisma/migrations/20240903235340_hide_images/migration.sql
+++ b/prisma/migrations/20240903235340_hide_images/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "showImagesAndVideos" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,6 +63,7 @@ model User {
   turboTipping              Boolean              @default(false)
   zapUndos                  Int?
   imgproxyOnly              Boolean              @default(false)
+  showImagesAndVideos       Boolean              @default(true)
   hideWalletBalance         Boolean              @default(false)
   disableFreebies           Boolean?
   referrerId                Int?


### PR DESCRIPTION
closes #610 

## Description
This introduces a new setting to render images/video as links instead of images/video. They open like a link when clicked - in a new tab.

By default and for anon, images and videos are shown.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6` Tested image and video links anon/logged in with all combos of imgproxy only and show images and videos.

I did not test proxied images.
