### PR TITLE
Random CSS fixes

### DIFF
--- a/components/accordian-item.js
+++ b/components/accordian-item.js
@@ -4,6 +4,7 @@ import { useAccordionButton } from 'react-bootstrap/AccordionButton'
 import ArrowRight from '@/svgs/arrow-right-s-fill.svg'
 import ArrowDown from '@/svgs/arrow-down-s-fill.svg'
 import { useContext, useEffect, useState } from 'react'
+import classNames from 'classnames'
 
 const KEY_ID = '0'
 
@@ -30,7 +31,7 @@ function ContextAwareToggle ({ children, headerColor = 'var(--theme-grey)', even
   )
 }
 
-export default function AccordianItem ({ header, body, headerColor = 'var(--theme-grey)', show }) {
+export default function AccordianItem ({ header, body, className, headerColor = 'var(--theme-grey)', show }) {
   const [activeKey, setActiveKey] = useState()
 
   useEffect(() => {
@@ -44,7 +45,7 @@ export default function AccordianItem ({ header, body, headerColor = 'var(--them
   return (
     <Accordion defaultActiveKey={activeKey} activeKey={activeKey} onSelect={handleOnSelect}>
       <ContextAwareToggle show={show} eventKey={KEY_ID} headerColor={headerColor}><div style={{ color: headerColor }}>{header}</div></ContextAwareToggle>
-      <Accordion.Collapse eventKey={KEY_ID} className='mt-2'>
+      <Accordion.Collapse eventKey={KEY_ID} className={classNames('mt-2', className)}>
         <div>{body}</div>
       </Accordion.Collapse>
     </Accordion>

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -109,7 +109,8 @@ export default function Invoice ({ id, query = INVOICE, modal, onPayment, onCanc
             <div className='w-100'>
               <AccordianItem
                 header='sender information'
-                body={<PayerData data={lud18Data} className='text-muted ms-3 mb-3' />}
+                body={<PayerData data={lud18Data} className='text-muted ms-3' />}
+                className='mb-3'
               />
             </div>}
           {comment &&
@@ -117,6 +118,7 @@ export default function Invoice ({ id, query = INVOICE, modal, onPayment, onCanc
               <AccordianItem
                 header='sender comments'
                 body={<span className='text-muted ms-3'>{comment}</span>}
+                className='mb-3'
               />
             </div>}
           <Bolt11Info bolt11={bolt11} preimage={confirmedPreimage} />

--- a/pages/satistics/index.js
+++ b/pages/satistics/index.js
@@ -76,17 +76,17 @@ function Satus ({ status }) {
   const Icon = () => {
     switch (status) {
       case 'CONFIRMED':
-        return <Check width='20' height='20' className={`fill-${color}`} />
+        return <Check width='20' height='20' className={`fill-${color} ms-1`} />
       case 'PENDING':
-        return <Moon width='20' height='20' className={`fill-${color} spin`} />
+        return <Moon width='20' height='20' className={`fill-${color} ms-1 spin`} />
       default:
-        return <ThumbDown width='18' height='18' className={`fill-${color}`} />
+        return <ThumbDown width='18' height='18' className={`fill-${color} ms-1`} />
     }
   }
 
   return (
     <span className='d-inline-block'>
-      <Icon /><small className={`text-${color} fw-bold ms-2`}>{desc}</small>
+      <Icon /><small className={`text-${color} fw-bold ms-1`}>{desc}</small>
     </span>
   )
 }

--- a/pages/satistics/index.js
+++ b/pages/satistics/index.js
@@ -18,6 +18,7 @@ import PageLoading from '@/components/page-loading'
 import PayerData from '@/components/payer-data'
 import { Badge } from 'react-bootstrap'
 import navStyles from '../settings/settings.module.css'
+import classNames from 'classnames'
 
 export const getServerSideProps = getGetServerSideProps({ query: WALLET_HISTORY, authRequired: true })
 
@@ -36,7 +37,7 @@ function satusClass (status) {
   }
 }
 
-function Satus ({ status }) {
+function Satus ({ status, className }) {
   if (!status) {
     return null
   }
@@ -76,16 +77,16 @@ function Satus ({ status }) {
   const Icon = () => {
     switch (status) {
       case 'CONFIRMED':
-        return <Check width='20' height='20' className={`fill-${color} ms-1`} />
+        return <Check width='20' height='20' className={`fill-${color}`} />
       case 'PENDING':
-        return <Moon width='20' height='20' className={`fill-${color} ms-1 spin`} />
+        return <Moon width='20' height='20' className={`fill-${color} spin`} />
       default:
-        return <ThumbDown width='18' height='18' className={`fill-${color} ms-1`} />
+        return <ThumbDown width='18' height='18' className={`fill-${color}`} />
     }
   }
 
   return (
-    <span className='d-inline-block'>
+    <span className={classNames('d-inline-block', className)}>
       <Icon /><small className={`text-${color} fw-bold ms-1`}>{desc}</small>
     </span>
   )
@@ -141,7 +142,8 @@ function Detail ({ fact }) {
            (fact.description && <span className='d-block'>{fact.description}</span>)}
           <PayerData data={fact.invoicePayerData} className='text-muted' header />
           {fact.invoiceComment && <small className='text-muted'><b>sender says:</b> {fact.invoiceComment}</small>}
-          <Satus status={fact.status} />{fact.autoWithdraw && <Badge className={styles.badge} bg={null}>{fact.type === 'p2p' ? 'p2p' : 'autowithdraw'}</Badge>}
+          <Satus className={fact.invoiceComment ? 'ms-1' : ''} status={fact.status} />
+          {fact.autoWithdraw && <Badge className={styles.badge} bg={null}>{fact.type === 'p2p' ? 'p2p' : 'autowithdraw'}</Badge>}
         </Link>
       </div>
     )


### PR DESCRIPTION
## Screenshots

* fix missing `margin-left` when there is an invoice comment

before:

![2024-09-07-140356_316x75_scrot](https://github.com/user-attachments/assets/3e65422e-4cd0-4001-a8a8-63a840a6c967)

after:

![2024-09-07-140425_323x80_scrot](https://github.com/user-attachments/assets/9d3bd3bd-8112-4013-8762-69871f4b415d)

* fix `margin-bottom` not applied to accordian body

before:

![2024-09-07-141214_192x191_scrot](https://github.com/user-attachments/assets/20c021e3-c1c9-4e04-b363-b9569ce24343)

after:

![2024-09-07-141143_190x218_scrot](https://github.com/user-attachments/assets/36a4844c-9c74-4d6f-8bdf-676d6417198b)

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7.5`

**For frontend changes: Tested on mobile? Please answer below:**

yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
