### PR TITLE
Fix embeds

### DIFF
--- a/components/media-or-link.js
+++ b/components/media-or-link.js
@@ -247,6 +247,49 @@ export const NostrEmbed = memo(function NostrEmbed ({ src, className, topLevel, 
   )
 })
 
+const SpotifyEmbed = function SpotifyEmbed ({ src, className }) {
+  const iframeRef = useRef(null)
+
+  // https://open.spotify.com/track/1KFxcj3MZrpBGiGA8ZWriv?si=f024c3aa52294aa1
+  // Remove any additional path segments
+  const url = new URL(src)
+  url.pathname = url.pathname.replace(/\/intl-\w+\//, '/')
+
+  useEffect(() => {
+    if (!iframeRef.current) return
+
+    const id = url.pathname.split('/').pop()
+
+    // https://developer.spotify.com/documentation/embeds/tutorials/using-the-iframe-api
+    window.onSpotifyIframeApiReady = (IFrameAPI) => {
+      const options = {
+        uri: `spotify:episode:${id}`
+      }
+      const callback = (EmbedController) => {}
+      IFrameAPI.createController(iframeRef.current, options, callback)
+    }
+
+    return () => { window.onSpotifyIframeApiReady = null }
+  }, [iframeRef.current, url.pathname])
+
+  return (
+    <div className={classNames(styles.spotifyWrapper, className)}>
+      <iframe
+        ref={iframeRef}
+        title='Spotify Web Player'
+        src={`https://open.spotify.com/embed${url.pathname}`}
+        width='100%'
+        height='152'
+        allowFullScreen
+        frameBorder='0'
+        allow='encrypted-media; clipboard-write;'
+        style={{ borderRadius: '12px' }}
+        sandbox='allow-scripts allow-popups allow-same-origin allow-presentation'
+      />
+    </div>
+  )
+}
+
 export const Embed = memo(function Embed ({ src, provider, id, meta, className, topLevel, onError }) {
   const [darkMode] = useDarkMode()
   const [overflowing, setOverflowing] = useState(true)
@@ -290,24 +333,8 @@ export const Embed = memo(function Embed ({ src, provider, id, meta, className, 
   }
 
   if (provider === 'spotify') {
-    // https://open.spotify.com/track/1KFxcj3MZrpBGiGA8ZWriv?si=f024c3aa52294aa1
-    // Remove any additional path segments
-    const url = new URL(src)
-    url.pathname = url.pathname.replace(/\/intl-\w+\//, '/')
     return (
-      <div className={classNames(styles.spotifyWrapper, className)}>
-        <iframe
-          title='Spotify Web Player'
-          src={`https://open.spotify.com/embed${url.pathname}`}
-          width='100%'
-          height='152'
-          allowFullScreen
-          frameBorder='0'
-          allow='encrypted-media; clipboard-write;'
-          style={{ borderRadius: '12px' }}
-          sandbox='allow-scripts'
-        />
-      </div>
+      <SpotifyEmbed src={src} className={className} />
     )
   }
 

--- a/components/media-or-link.js
+++ b/components/media-or-link.js
@@ -210,11 +210,18 @@ export const NostrEmbed = memo(function NostrEmbed ({ src, className, topLevel, 
   const iframeRef = useRef(null)
 
   useEffect(() => {
+    if (!iframeRef.current) return
+
     const setHeightFromIframe = (e) => {
       if (e.origin !== 'https://njump.me' || !e?.data?.height || e.source !== iframeRef.current.contentWindow) return
       iframeRef.current.height = `${e.data.height}px`
     }
+
     window?.addEventListener('message', setHeightFromIframe)
+
+    // https://github.com/vercel/next.js/issues/39451
+    iframeRef.current.src = `https://njump.me/${id}?embed=yes`
+
     return () => {
       window?.removeEventListener('message', setHeightFromIframe)
     }
@@ -224,7 +231,6 @@ export const NostrEmbed = memo(function NostrEmbed ({ src, className, topLevel, 
     <div className={classNames(styles.nostrContainer, !show && styles.twitterContained, className)}>
       <iframe
         ref={iframeRef}
-        src={`https://njump.me/${id}?embed=yes`}
         width={topLevel ? '550px' : '350px'}
         style={{ maxWidth: '100%' }}
         height={iframeRef.current?.height || (topLevel ? '200px' : '150px')}

--- a/components/media-or-link.js
+++ b/components/media-or-link.js
@@ -277,7 +277,7 @@ export const Embed = memo(function Embed ({ src, provider, id, meta, className, 
         <iframe
           src={`https://embed.wavlake.com/track/${id}`} width='100%' height='380' frameBorder='0'
           allow='encrypted-media'
-          sandbox='allow-scripts'
+          sandbox='allow-scripts allow-popups allow-forms allow-same-origin'
         />
       </div>
     )

--- a/components/media-or-link.js
+++ b/components/media-or-link.js
@@ -235,7 +235,7 @@ export const NostrEmbed = memo(function NostrEmbed ({ src, className, topLevel, 
         style={{ maxWidth: '100%' }}
         height={iframeRef.current?.height || (topLevel ? '200px' : '150px')}
         frameBorder='0'
-        sandbox='allow-scripts allow-same-origin allow-popups'
+        sandbox='allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox'
         allow=''
       />
       {!show &&
@@ -284,7 +284,7 @@ const SpotifyEmbed = function SpotifyEmbed ({ src, className }) {
         frameBorder='0'
         allow='encrypted-media; clipboard-write;'
         style={{ borderRadius: '12px' }}
-        sandbox='allow-scripts allow-popups allow-same-origin allow-presentation'
+        sandbox='allow-scripts allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-presentation'
       />
     </div>
   )
@@ -326,7 +326,7 @@ export const Embed = memo(function Embed ({ src, provider, id, meta, className, 
         <iframe
           src={`https://embed.wavlake.com/track/${id}`} width='100%' height='380' frameBorder='0'
           allow='encrypted-media'
-          sandbox='allow-scripts allow-popups allow-forms allow-same-origin'
+          sandbox='allow-scripts allow-popups allow-popups-to-escape-sandbox allow-forms allow-same-origin'
         />
       </div>
     )

--- a/components/media-or-link.js
+++ b/components/media-or-link.js
@@ -295,7 +295,7 @@ export const Embed = memo(function Embed ({ src, provider, id, meta, className, 
           src={`https://open.spotify.com/embed${url.pathname}`}
           width='100%'
           height='152'
-          allowfullscreen=''
+          allowFullScreen
           frameBorder='0'
           allow='encrypted-media; clipboard-write;'
           style={{ borderRadius: '12px' }}


### PR DESCRIPTION
## Description

This PR fixes various things around the new embeds.

For example, it fixes this issue with the nostr embed caused by https://github.com/vercel/next.js/issues/39451:

<details>
<summary>video</summary>

https://github.com/user-attachments/assets/7ae44b3e-9a4c-4b6e-92ec-b3996629ac48

</details>

## Additional Context

* The wavlake embed allows zaps using WebLN. Would be cool if we could get the bolt11 somehow and use the attached wallets instead.

* there is a warning that mentions that `allow-scripts` + `allow-same-origin` allows iframe to escape the sandbox during runtime but this only applies to embeds loaded by the same origin as the parent:

> Note, however, that you need to be very careful when dealing with framed content that comes from the same origin as the parent. If a page on https://example.com/ frames another page on the same origin with a sandbox that includes both the `allow-same-origin` and `allow-scripts` flags, then the framed page can reach up into the parent, and remove the sandbox attribute entirely.

-- https://web.dev/articles/sandboxed-iframes

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. There might still be some issues but 

**For frontend changes: Tested on mobile? Please answer below:**

yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
