### PR TITLE
Fix missing user invoice timeout

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -133,7 +133,7 @@ function timeoutPromise (timeout) {
     // if no timeout is specified, never settle
     if (!timeout) return
 
-    setTimeout(() => reject(new Error('timeout')), timeout)
+    setTimeout(() => reject(new Error(`timeout after ${timeout / 1000}s`)), timeout)
   })
 }
 


### PR DESCRIPTION
## Description

Fix #1378 

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9` I tested using two accounts. One has NWC send and other has LNbits recv attached. Since a timeout of 10 seconds succeeds locally (receiver sees a p2p zap in notifications), I used a timeout of 1 millisecond for testing and it correctly times out and falls back to a zap into the custodial wallet.

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
