### PR TITLE
automate meme monday, fact friday, what work wednesday

### DIFF
--- a/prisma/migrations/20240910000406_auto_weekly_posts/migration.sql
+++ b/prisma/migrations/20240910000406_auto_weekly_posts/migration.sql
@@ -1,0 +1,37 @@
+CREATE OR REPLACE FUNCTION schedule_weekly_posts_job()
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+BEGIN
+    INSERT INTO pgboss.schedule (name, cron, timezone, data)
+    VALUES
+    (
+        'weeklyPost-meme-mon', '0 10 * * 1', 'America/Chicago',
+        jsonb_build_object(
+            'title', 'Meme Monday - Best Bitcoin Meme Gets 10,000 Sats',
+            'text',  E'Time for another round of Meme Monday!\n\nWe have another 10,000 sats up for grabs for this week''s winner.\n\nThe sats will be given to the stacker with the best Bitcoin meme as voted by the "top" filter on this thread at 10am CT tomorrow.\n\nTo post an image on SN, check out our docs [here](https://stacker.news/faq#how-do-i-post-images-on-stacker-news).\n\nSend your best 👇',
+            'bounty', 10000)
+    ),
+    (
+        'weeklyPost-what-wed', '0 10 * * 3', 'America/Chicago',
+        jsonb_build_object(
+            'title', 'What are you working on this week?',
+            'text',  E'Calling all stackers!\n\nLeave a comment below to let the SN community know what you''re working on this week. It doesn''t matter how big or small your project is, or how much progress you''ve made.\n\nJust share what you''re up to, and let the community know if you want any feedback or help.'
+        )
+    ),
+    (
+        'weeklyPost-fact-fri', '0 10 * * 5', 'America/Chicago',
+        jsonb_build_object(
+            'title', 'Fun Fact Friday - Best Fun Fact Gets 10,000 Sats',
+            'text',  E'Let''s hear all your best fun facts, any topic counts!\n\nThe best comment as voted by the "top" filter at 10am CT tomorrow gets 10,000 sats.\n\nBonus sats for including a source link to your fun fact!\n\nSend your best 👇',
+            'bounty', 10000)
+    ) ON CONFLICT DO NOTHING;
+    return 0;
+EXCEPTION WHEN OTHERS THEN
+    return 0;
+END;
+$$;
+
+SELECT schedule_weekly_posts_job();
+DROP FUNCTION IF EXISTS schedule_weekly_posts_job;

--- a/worker/index.js
+++ b/worker/index.js
@@ -34,6 +34,7 @@ import {
 } from './paidAction.js'
 import { thisDay } from './thisDay.js'
 import { isServiceEnabled } from '@/lib/sndev.js'
+import { payWeeklyPostBounty, weeklyPost } from './weeklyPosts.js'
 
 const { ApolloClient, HttpLink, InMemoryCache } = apolloClient
 
@@ -116,6 +117,8 @@ async function work () {
     await boss.work('imgproxy', jobWrapper(imgproxy))
     await boss.work('deleteUnusedImages', jobWrapper(deleteUnusedImages))
   }
+  await boss.work('weeklyPost-*', jobWrapper(weeklyPost))
+  await boss.work('payWeeklyPostBounty', jobWrapper(payWeeklyPostBounty))
   await boss.work('repin-*', jobWrapper(repin))
   await boss.work('trust', jobWrapper(trust))
   await boss.work('timestampItem', jobWrapper(timestampItem))

--- a/worker/weeklyPosts.js
+++ b/worker/weeklyPosts.js
@@ -1,0 +1,51 @@
+import performPaidAction from '@/api/paidAction'
+import { USER_ID } from '@/lib/constants'
+import { datePivot } from '@/lib/time'
+import gql from 'graphql-tag'
+
+export async function autoPost ({ data: item, models, apollo, lnd, boss }) {
+  return await performPaidAction('ITEM_CREATE',
+    { ...item, subName: 'meta', userId: USER_ID.sn, apiKey: true },
+    { models, me: { id: USER_ID.sn }, lnd, forceFeeCredits: true })
+}
+
+export async function weeklyPost (args) {
+  const { result: { id, bounty } } = await autoPost(args)
+
+  if (bounty) {
+    args.boss.send('payWeeklyPostBounty', { id }, { startAfter: datePivot(new Date(), { hours: 24 }) })
+  }
+}
+
+export async function payWeeklyPostBounty ({ data: { id }, models, apollo, lnd }) {
+  const itemQ = await apollo.query({
+    query: gql`
+      query item($id: ID!) {
+        item(id: $id) {
+          userId
+          bounty
+          bountyPaidTo
+          comments(sort: "top") {
+            id
+          }
+        }
+      }`,
+    variables: { id }
+  })
+
+  const item = itemQ.data.item
+
+  if (item.bountyPaidTo?.length > 0) {
+    throw new Error('Bounty already paid')
+  }
+
+  const winner = item.comments[0]
+
+  if (!winner) {
+    throw new Error('No winner')
+  }
+
+  await performPaidAction('ZAP',
+    { id: winner.id, sats: item.bounty },
+    { models, me: { id: USER_ID.sn }, lnd, forceFeeCredits: true })
+}


### PR DESCRIPTION
## Description

Does what title says. 

- It also makes them all have a `bot` tag and does the same for `thisDay` posts
- `thisDay` doesn't "skip" paying anymore either. It pays like anyone else.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Ran all jobs manually and they worked. Didn't test paying a bounty a real top comment thread, but it worked with some test comments.
