### PR TITLE
Enable WebLN wallet on 'webln:enabled'

### DIFF
--- a/components/lightning-auth.js
+++ b/components/lightning-auth.js
@@ -27,6 +27,18 @@ function QrAuth ({ k1, encodedUrl, callbackUrl }) {
     }
   }, [data?.lnAuth])
 
+  useEffect(() => {
+    if (typeof window.webln === 'undefined') return
+
+    // optimistically use WebLN for authentication
+    async function effect () {
+      // this will also enable our WebLN wallet
+      await window.webln.enable()
+      await window.webln.lnurl(encodedUrl)
+    }
+    effect()
+  }, [encodedUrl])
+
   // output pubkey and k1
   return (
     <Qr value={encodedUrl} status='waiting for you' />

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -17,6 +17,9 @@
             "@/components/*": [
                 "components/*"
             ],
+            "@/wallets/*": [
+                "wallets/*"
+            ],
             "@/styles/*": [
                 "styles/*"
             ],

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -21,6 +21,7 @@ import { WalletLoggerProvider } from '@/components/wallet-logger'
 import { ChainFeeProvider } from '@/components/chain-fee.js'
 import dynamic from 'next/dynamic'
 import { HasNewNotesProvider } from '@/components/use-has-new-notes'
+import WebLnProvider from '@/wallets/webln'
 
 const PWAPrompt = dynamic(() => import('react-ios-pwa-prompt'), { ssr: false })
 
@@ -106,24 +107,26 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
               <HasNewNotesProvider>
                 <LoggerProvider>
                   <WalletLoggerProvider>
-                    <ServiceWorkerProvider>
-                      <PriceProvider price={price}>
-                        <LightningProvider>
-                          <ToastProvider>
-                            <ShowModalProvider>
-                              <BlockHeightProvider blockHeight={blockHeight}>
-                                <ChainFeeProvider chainFee={chainFee}>
-                                  <ErrorBoundary>
-                                    <Component ssrData={ssrData} {...otherProps} />
-                                    {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
-                                  </ErrorBoundary>
-                                </ChainFeeProvider>
-                              </BlockHeightProvider>
-                            </ShowModalProvider>
-                          </ToastProvider>
-                        </LightningProvider>
-                      </PriceProvider>
-                    </ServiceWorkerProvider>
+                    <WebLnProvider>
+                      <ServiceWorkerProvider>
+                        <PriceProvider price={price}>
+                          <LightningProvider>
+                            <ToastProvider>
+                              <ShowModalProvider>
+                                <BlockHeightProvider blockHeight={blockHeight}>
+                                  <ChainFeeProvider chainFee={chainFee}>
+                                    <ErrorBoundary>
+                                      <Component ssrData={ssrData} {...otherProps} />
+                                      {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
+                                    </ErrorBoundary>
+                                  </ChainFeeProvider>
+                                </BlockHeightProvider>
+                              </ShowModalProvider>
+                            </ToastProvider>
+                          </LightningProvider>
+                        </PriceProvider>
+                      </ServiceWorkerProvider>
+                    </WebLnProvider>
                   </WalletLoggerProvider>
                 </LoggerProvider>
               </HasNewNotesProvider>

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -412,9 +412,13 @@ export function useWallets () {
 
 function getStorageKey (name, me) {
   let storageKey = `wallet:${name}`
-  if (me) {
+
+  // WebLN has no credentials we need to scope to users
+  // so we can use the same storage key for all users
+  if (me && name !== 'webln') {
     storageKey = `${storageKey}:${me.id}`
   }
+
   return storageKey
 }
 

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -420,16 +420,14 @@ function getStorageKey (name, me) {
 
 function enableWallet (name, me) {
   const key = getStorageKey(name, me)
-  const config = JSON.parse(window.localStorage.getItem(key))
-  if (!config) return
+  const config = JSON.parse(window.localStorage.getItem(key)) || {}
   config.enabled = true
   window.localStorage.setItem(key, JSON.stringify(config))
 }
 
 function disableWallet (name, me) {
   const key = getStorageKey(name, me)
-  const config = JSON.parse(window.localStorage.getItem(key))
-  if (!config) return
+  const config = JSON.parse(window.localStorage.getItem(key)) || {}
   config.enabled = false
   window.localStorage.setItem(key, JSON.stringify(config))
 }

--- a/wallets/webln/index.js
+++ b/wallets/webln/index.js
@@ -1,3 +1,6 @@
+import { useEffect } from 'react'
+import { useWallet } from 'wallets'
+
 export const name = 'webln'
 
 export const fields = []
@@ -18,4 +21,28 @@ export const card = {
   title: 'WebLN',
   subtitle: 'use a [WebLN provider](https://www.webln.guide/ressources/webln-providers) for payments',
   badges: ['send only']
+}
+
+export default function WebLnProvider ({ children }) {
+  const webLnWallet = useWallet(name)
+
+  useEffect(() => {
+    const onEnable = () => {
+      webLnWallet.enablePayments()
+    }
+
+    const onDisable = () => {
+      webLnWallet.disablePayments()
+    }
+
+    window.addEventListener('webln:enabled', onEnable)
+    // event is not fired by Alby browser extension but added here for sake of completeness
+    window.addEventListener('webln:disabled', onDisable)
+    return () => {
+      window.removeEventListener('webln:enabled', onEnable)
+      window.removeEventListener('webln:disabled', onDisable)
+    }
+  }, [])
+
+  return children
 }

--- a/wallets/webln/index.js
+++ b/wallets/webln/index.js
@@ -24,15 +24,15 @@ export const card = {
 }
 
 export default function WebLnProvider ({ children }) {
-  const webLnWallet = useWallet(name)
+  const wallet = useWallet(name)
 
   useEffect(() => {
     const onEnable = () => {
-      webLnWallet.enablePayments()
+      wallet.enablePayments()
     }
 
     const onDisable = () => {
-      webLnWallet.disablePayments()
+      wallet.disablePayments()
     }
 
     window.addEventListener('webln:enabled', onEnable)


### PR DESCRIPTION
## Description

Close #945 

This listens for `webln:enabled` and enables the attached wallet responsible for WebLN. This means that stackers only need to enable WebLN once by logging in with lightning which will optimistically call the `window.webln` stuff or by clicking on the QR code during payments. After that, following payments will first try to use the WebLN wallet using our wallet code like any other wallet before showing any QR code.

I think only running WebLN optimistically during login and not also during payments is a good compromise since the user will be asked to enable WebLN during login. If they do, the WebLN wallet is also enabled which will then call the `window.webln` stuff optimistically because we use our attached wallets optimistically.

## Video

WebLN is optimistically called during Login with Lightning; enabling our WebLN wallet on connect:

https://github.com/user-attachments/assets/576cb6e7-2e33-4f81-b855-68b5750527cd

Clicking on QR code for payments prompts WebLN; also enabling our WebLN wallet on connect:

https://github.com/user-attachments/assets/c2eb93db-6e35-44d6-8dca-8f4abdb2ad87

## Additional Context

I've added a listener for `webln:disabled` even though it doesn't fire. Ideally, we would also disable the attached wallet since I think that would match user expectations.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9.99`

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
