### PR TITLE
Throw errors which extend GraphQLError

### DIFF
--- a/api/resolvers/apiKey.js
+++ b/api/resolvers/apiKey.js
@@ -1,7 +1,7 @@
-import { GraphQLError } from 'graphql'
+import { GqlAuthorizationError } from '@/lib/error'
 
 export default function assertApiKeyNotPermitted ({ me }) {
   if (me?.apiKey === true) {
-    throw new GraphQLError('this operation is not allowed to be performed via API Key', { extensions: { code: 'FORBIDDEN' } })
+    throw new GqlAuthorizationError('this operation is not allowed to be performed via API Key')
   }
 }

--- a/api/resolvers/invite.js
+++ b/api/resolvers/invite.js
@@ -1,13 +1,13 @@
-import { GraphQLError } from 'graphql'
 import { inviteSchema, ssValidate } from '@/lib/validate'
 import { msatsToSats } from '@/lib/format'
 import assertApiKeyNotPermitted from './apiKey'
+import { GqlAuthenticationError } from '@/lib/error'
 
 export default {
   Query: {
     invites: async (parent, args, { me, models }) => {
       if (!me) {
-        throw new GraphQLError('you must be logged in', { extensions: { code: 'FORBIDDEN' } })
+        throw new GqlAuthenticationError()
       }
 
       return await models.invite.findMany({
@@ -31,7 +31,7 @@ export default {
   Mutation: {
     createInvite: async (parent, { gift, limit }, { me, models }) => {
       if (!me) {
-        throw new GraphQLError('you must be logged in', { extensions: { code: 'FORBIDDEN' } })
+        throw new GqlAuthenticationError()
       }
       assertApiKeyNotPermitted({ me })
 
@@ -43,7 +43,7 @@ export default {
     },
     revokeInvite: async (parent, { id }, { me, models }) => {
       if (!me) {
-        throw new GraphQLError('you must be logged in', { extensions: { code: 'FORBIDDEN' } })
+        throw new GqlAuthenticationError()
       }
 
       return await models.invite.update({

--- a/api/resolvers/lnurl.js
+++ b/api/resolvers/lnurl.js
@@ -1,8 +1,8 @@
 import { randomBytes } from 'crypto'
 import { bech32 } from 'bech32'
-import { GraphQLError } from 'graphql'
 import assertGofacYourself from './ofac'
 import assertApiKeyNotPermitted from './apiKey'
+import { GqlAuthenticationError } from '@/lib/error'
 
 function encodedUrl (iurl, tag, k1) {
   const url = new URL(iurl)
@@ -35,7 +35,7 @@ export default {
       await assertGofacYourself({ models, headers })
 
       if (!me) {
-        throw new GraphQLError('you must be logged in', { extensions: { code: 'UNAUTHENTICATED' } })
+        throw new GqlAuthenticationError()
       }
 
       assertApiKeyNotPermitted({ me })

--- a/api/resolvers/message.js
+++ b/api/resolvers/message.js
@@ -1,4 +1,4 @@
-import { GraphQLError } from 'graphql'
+import { GqlInputError } from '@/lib/error'
 
 export default {
   Query: {
@@ -11,7 +11,7 @@ export default {
   Mutation: {
     createMessage: async (parent, { text }, { me, models }) => {
       if (!text) {
-        throw new GraphQLError('Must have text', { extensions: { code: 'BAD_INPUT' } })
+        throw new GqlInputError('must have text')
       }
 
       return await models.message.create({

--- a/api/resolvers/ofac.js
+++ b/api/resolvers/ofac.js
@@ -1,13 +1,11 @@
-import { GraphQLError } from 'graphql'
+import { GqlAuthorizationError } from '@/lib/error'
 
 // this function makes america more secure apparently
 export default async function assertGofacYourself ({ models, headers, ip }) {
   const country = await gOFACYourself({ models, headers, ip })
   if (!country) return
 
-  throw new GraphQLError(
-    `Your IP address is in ${country}. We cannot provide financial services to residents of ${country}.`,
-    { extensions: { code: 'FORBIDDEN' } })
+  throw new GqlAuthorizationError(`Your IP address is in ${country}. We cannot provide financial services to residents of ${country}.`)
 }
 
 export async function gOFACYourself ({ models, headers = {}, ip }) {

--- a/api/resolvers/referrals.js
+++ b/api/resolvers/referrals.js
@@ -1,12 +1,12 @@
-import { GraphQLError } from 'graphql'
 import { timeUnitForRange, whenRange } from '@/lib/time'
 import { viewGroup } from './growth'
+import { GqlAuthenticationError } from '@/lib/error'
 
 export default {
   Query: {
     referrals: async (parent, { when, from, to }, { models, me }) => {
       if (!me) {
-        throw new GraphQLError('you must be logged in', { extensions: { code: 'UNAUTHENTICATED' } })
+        throw new GqlAuthenticationError()
       }
 
       const range = whenRange(when, from, to)

--- a/api/resolvers/rewards.js
+++ b/api/resolvers/rewards.js
@@ -1,8 +1,8 @@
-import { GraphQLError } from 'graphql'
 import { amountSchema, ssValidate } from '@/lib/validate'
 import { getItem } from './item'
 import { topUsers } from './user'
 import performPaidAction from '../paidAction'
+import { GqlInputError } from '@/lib/error'
 
 let rewardCache
 
@@ -63,21 +63,21 @@ async function getMonthlyRewards (when, models) {
 async function getRewards (when, models) {
   if (when) {
     if (when.length > 1) {
-      throw new GraphQLError('too many dates', { extensions: { code: 'BAD_USER_INPUT' } })
+      throw new GqlInputError('too many dates')
     }
     when.forEach(w => {
       if (isNaN(new Date(w))) {
-        throw new GraphQLError('invalid date', { extensions: { code: 'BAD_USER_INPUT' } })
+        throw new GqlInputError('invalid date')
       }
     })
     if (new Date(when[0]) > new Date(when[when.length - 1])) {
-      throw new GraphQLError('bad date range', { extensions: { code: 'BAD_USER_INPUT' } })
+      throw new GqlInputError('bad date range')
     }
 
     if (new Date(when[0]).getTime() > new Date('2024-03-01').getTime() && new Date(when[0]).getTime() < new Date('2024-05-02').getTime()) {
       // after 3/1/2024 and until 5/1/2024, we reward monthly on the 1st
       if (new Date(when[0]).getUTCDate() !== 1) {
-        throw new GraphQLError('invalid reward date', { extensions: { code: 'BAD_USER_INPUT' } })
+        throw new GqlInputError('bad reward date')
       }
 
       return await getMonthlyRewards(when, models)
@@ -119,11 +119,11 @@ export default {
       }
 
       if (!when || when.length > 2) {
-        throw new GraphQLError('invalid date range', { extensions: { code: 'BAD_USER_INPUT' } })
+        throw new GqlInputError('bad date range')
       }
       for (const w of when) {
         if (isNaN(new Date(w))) {
-          throw new GraphQLError('invalid date', { extensions: { code: 'BAD_USER_INPUT' } })
+          throw new GqlInputError('invalid date')
         }
       }
 

--- a/api/resolvers/serial.js
+++ b/api/resolvers/serial.js
@@ -1,8 +1,8 @@
-import { GraphQLError } from 'graphql'
 import retry from 'async-retry'
 import Prisma from '@prisma/client'
 import { msatsToSats, numWithUnits } from '@/lib/format'
 import { BALANCE_LIMIT_MSATS } from '@/lib/constants'
+import { GqlInputError } from '@/lib/error'
 
 export default async function serialize (trx, { models, lnd }) {
   // wrap first argument in array if not array already
@@ -28,7 +28,7 @@ export default async function serialize (trx, { models, lnd }) {
       // have to check the error message
       if (error.message.includes('SN_INSUFFICIENT_FUNDS') ||
         error.message.includes('\\"users\\" violates check constraint \\"msats_positive\\"')) {
-        bail(new GraphQLError('insufficient funds', { extensions: { code: 'BAD_INPUT' } }))
+        bail(new GqlInputError('insufficient funds'))
       }
       if (error.message.includes('SN_NOT_SERIALIZABLE')) {
         bail(new Error('wallet balance transaction is not serializable'))

--- a/api/resolvers/upload.js
+++ b/api/resolvers/upload.js
@@ -1,24 +1,24 @@
-import { GraphQLError } from 'graphql'
 import { USER_ID, IMAGE_PIXELS_MAX, UPLOAD_SIZE_MAX, UPLOAD_SIZE_MAX_AVATAR, UPLOAD_TYPES_ALLOW } from '@/lib/constants'
 import { createPresignedPost } from '@/api/s3'
+import { GqlAuthenticationError, GqlInputError } from '@/lib/error'
 
 export default {
   Mutation: {
     getSignedPOST: async (parent, { type, size, width, height, avatar }, { models, me }) => {
       if (UPLOAD_TYPES_ALLOW.indexOf(type) === -1) {
-        throw new GraphQLError(`image must be ${UPLOAD_TYPES_ALLOW.map(t => t.replace('image/', '')).join(', ')}`, { extensions: { code: 'BAD_INPUT' } })
+        throw new GqlInputError(`image must be ${UPLOAD_TYPES_ALLOW.map(t => t.replace('image/', '')).join(', ')}`)
       }
 
       if (size > UPLOAD_SIZE_MAX) {
-        throw new GraphQLError(`image must be less than ${UPLOAD_SIZE_MAX / (1024 ** 2)} megabytes`, { extensions: { code: 'BAD_INPUT' } })
+        throw new GqlInputError(`image must be less than ${UPLOAD_SIZE_MAX / (1024 ** 2)} megabytes`)
       }
 
       if (avatar && size > UPLOAD_SIZE_MAX_AVATAR) {
-        throw new GraphQLError(`image must be less than ${UPLOAD_SIZE_MAX_AVATAR / (1024 ** 2)} megabytes`, { extensions: { code: 'BAD_INPUT' } })
+        throw new GqlInputError(`image must be less than ${UPLOAD_SIZE_MAX_AVATAR / (1024 ** 2)} megabytes`)
       }
 
       if (width * height > IMAGE_PIXELS_MAX) {
-        throw new GraphQLError(`image must be less than ${IMAGE_PIXELS_MAX} pixels`, { extensions: { code: 'BAD_INPUT' } })
+        throw new GqlInputError(`image must be less than ${IMAGE_PIXELS_MAX} pixels`)
       }
 
       const imgParams = {
@@ -31,7 +31,7 @@ export default {
       }
 
       if (avatar) {
-        if (!me) throw new GraphQLError('you must be logged in', { extensions: { code: 'FORBIDDEN' } })
+        if (!me) throw new GqlAuthenticationError()
         imgParams.paid = undefined
       }
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,0 +1,23 @@
+import { GraphQLError } from 'graphql'
+
+export const E_FORBIDDEN = 'E_FORBIDDEN'
+export const E_UNAUTHENTICATED = 'E_UNAUTHENTICATED'
+export const E_BAD_INPUT = 'E_BAD_INPUT'
+
+export class GqlAuthorizationError extends GraphQLError {
+  constructor (message) {
+    super(message, { extensions: { code: E_FORBIDDEN } })
+  }
+}
+
+export class GqlAuthenticationError extends GraphQLError {
+  constructor () {
+    super('you must be logged in', { extensions: { code: E_UNAUTHENTICATED } })
+  }
+}
+
+export class GqlInputError extends GraphQLError {
+  constructor (message) {
+    super(message, { extensions: { code: E_BAD_INPUT } })
+  }
+}


### PR DESCRIPTION
## Description

_cherry-pick of commit c27eafdcdb28d5af77847d5fb19befb35400a655 from #644_

All these changes were included in #644 but are easier reviewed independently.

There is actually not much to review, I simply replaced all usage of `GraphQLError` with a custom instance for less repetition / more consistency. I did this because I wanted to be sure that there are no typos for the error code since I use it [here](https://github.com/stackernews/stacker.news/pull/644/files#diff-740636f0d82955f9b0b7681e3c7920fbc93821a10c25722b7eb04061ea43daa2R157-R159) in #644.

When this is merged, I will rebase #644 which will make the change set smaller.

## Checklist

**Are your changes backwards compatible? Please answer below:**

<!-- put your answer about backwards compatibility here -->

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`. Code runs fine, there are no more instances of `throw new GraphQLError` and looking over the diff, every instance was replaced with the corresponding new error.

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
