### PR TITLE
Fix layout shift between setting tabs

### DIFF
--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -107,8 +107,8 @@ export default function Settings ({ ssrData }) {
   return (
     <Layout>
       <div className='pb-3 w-100 mt-2' style={{ maxWidth: '600px' }}>
-        {hasOnlyOneAuthMethod(settings?.authMethods) && <AuthBanner />}
         <SettingsHeader />
+        {hasOnlyOneAuthMethod(settings?.authMethods) && <AuthBanner />}
         <Form
           initial={{
             tipDefault: settings?.tipDefault || 21,


### PR DESCRIPTION
I noticed this while reviewing #1373 that if the banner is shown and we switch tabs, there's an ugly layout shift.

