### PR TITLE
Fix duplicate push notification as reply and subscription

### DIFF
--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -227,7 +227,7 @@ export async function onPaid ({ invoice, id }, context) {
   for (const { refereeItem } of item.itemReferrers) {
     notifyItemMention({ models, referrerItem: item, refereeItem }).catch(console.error)
   }
-  notifyUserSubscribers({ models, item }).catch(console.error)
+  notifyUserSubscribers({ models: tx, item }).catch(console.error)
   notifyTerritorySubscribers({ models, item }).catch(console.error)
 }
 

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -129,7 +129,15 @@ export const notifyUserSubscribers = async ({ models, item }) => {
     INNER JOIN users ON users.id = "UserSubscription"."followeeId"
     WHERE "followeeId" = $1 AND ${isPost ? '"postsSubscribedAt"' : '"commentsSubscribedAt"'} IS NOT NULL
     AND NOT EXISTS (SELECT 1 FROM "Mute" WHERE "Mute"."muterId" = "UserSubscription"."followerId" AND "Mute"."mutedId" = $1)
-    `, Number(item.userId))
+    -- ignore subscription if user was already notified of item as a reply
+    AND NOT EXISTS (
+      SELECT 1 FROM "Reply"
+      INNER JOIN users follower ON follower.id = "UserSubscription"."followerId"
+      WHERE "Reply"."itemId" = $2
+      AND "Reply"."ancestorUserId" = follower.id
+      AND follower."noteAllDescendants"
+    )
+    `, Number(item.userId), Number(item.id))
     const subType = isPost ? 'POST' : 'COMMENT'
     const tag = `FOLLOW-${item.userId}-${subType}`
     await Promise.allSettled(userSubsExcludingMutes.map(({ followerId, followeeName }) => sendUserNotification(followerId, {


### PR DESCRIPTION
## Description

If someone with reply notifications enabled is subscribed to a user and that user replies to them, they will receive two push notifications for the same item; once as a reply and once as a subscription. However, only one notification will show up in /notifications.

This PR fixes that by only sending a push notification for a user subscription if that user wasn't already notified of the item as a reply; making the experience consistent with what they will see on /notifications.

## Additional Context

I noticed that push notifications are not fully consistent with /notifications since even if the setting `someone replies to someone who replied to me` is disabled, we still receive notifications if someone replies directly to us but no push notification. Essentially, that setting encompasses all replies for push notifications but only `r.level > 1` for notifications (as the text explains[^1]). Direct replies always show up in /notifications and cannot be disabled.

Even though it's inconsistent, I think this behavior actually makes sense because push notifications are more intrusive so that the setting is more broad for them is good.

[^1]: I always thought that setting text is just a complicated way to say "all replies in a thread" but TIL that it actually is very precise about what it's for, lol.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8` tested all combinations of user subscription and setting. 

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
