### PR TITLE
useWallet hook cleanup

### DIFF
--- a/wallets/index.js
+++ b/wallets/index.js
@@ -98,6 +98,7 @@ export function useWallet (name) {
   wallet.enablePayments = enablePayments
   wallet.disablePayments = disablePayments
   wallet.canSend = !!wallet.sendPayment
+  wallet.canReceive = !!wallet.createInvoice
   wallet.config = config
   wallet.save = save
   wallet.delete = delete_

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -45,12 +45,6 @@ export function useWallet (name) {
     logger.info('payments disabled')
   }, [name, me, logger])
 
-  if (wallet) {
-    wallet.isConfigured = _isConfigured
-    wallet.enablePayments = enablePayments
-    wallet.disablePayments = disablePayments
-  }
-
   const status = config?.enabled ? Status.Enabled : Status.Initialized
   const enabled = status === Status.Enabled
   const priority = config?.priority
@@ -95,21 +89,29 @@ export function useWallet (name) {
 
   if (!wallet) return null
 
-  return {
-    ...wallet,
-    canSend: !!wallet.sendPayment,
-    sendPayment,
-    config,
-    save,
-    delete: delete_,
-    deleteLogs,
-    setPriority,
-    hasConfig,
-    status,
-    enabled,
-    priority,
-    logger
-  }
+  // Assign everything to wallet object so every function that is passed this wallet object in this
+  // `useWallet` hook has access to all others via the reference to it.
+  // Essentially, you can now use functions like `enablePayments` _inside_ of functions that are
+  // called by `useWallet` even before enablePayments is defined and not only in functions
+  // that use the return value of `useWallet`.
+  wallet.isConfigured = _isConfigured
+  wallet.enablePayments = enablePayments
+  wallet.disablePayments = disablePayments
+  wallet.canSend = !!wallet.sendPayment
+  wallet.config = config
+  wallet.save = save
+  wallet.delete = delete_
+  wallet.deleteLogs = deleteLogs
+  wallet.setPriority = setPriority
+  wallet.hasConfig = hasConfig
+  wallet.status = status
+  wallet.enabled = enabled
+  wallet.priority = priority
+  wallet.logger = logger
+
+  // can't assign sendPayment to wallet object because it already exists
+  // as an imported function and thus can't be overwritten
+  return { ...wallet, sendPayment }
 }
 
 function extractConfig (fields, config, client) {


### PR DESCRIPTION
## Description

This removes the inconsistent exclusivity of assigning only `isConfigured`, `enablePayments` and `disablePayments` to the wallet object in `useWallet`

## Additional context

Why I even started doing this in the first place: https://github.com/stackernews/stacker.news/pull/1278#discussion_r1703313506

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. I've tested that attaching wallets and paying from them still works.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
