### PR TITLE
Fix recv wallet deleted on logout

### DIFF
--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -209,8 +209,8 @@ export const WalletLoggerProvider = ({ children }) => {
     setLogs((prevLogs) => [log, ...prevLogs])
   }, [saveLog])
 
-  const deleteLogs = useCallback(async (wallet) => {
-    if (!wallet || wallet.walletType) {
+  const deleteLogs = useCallback(async (wallet, options) => {
+    if ((!wallet || wallet.walletType) && !options?.clientOnly) {
       await deleteServerWalletLogs({ variables: { wallet: wallet?.walletType } })
     }
     if (!wallet || wallet.sendPayment) {
@@ -262,7 +262,9 @@ export function useWalletLogger (wallet) {
     error: (...message) => log('error')(message.join(' '))
   }), [log, wallet?.name])
 
-  const deleteLogs = useCallback((w) => innerDeleteLogs(w || wallet), [innerDeleteLogs, wallet])
+  const deleteLogs = useCallback((walletOverride, options = {}) => {
+    return innerDeleteLogs(walletOverride || wallet, options)
+  }, [innerDeleteLogs, wallet])
 
   return { logger, deleteLogs }
 }

--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -262,8 +262,8 @@ export function useWalletLogger (wallet) {
     error: (...message) => log('error')(message.join(' '))
   }), [log, wallet?.name])
 
-  const deleteLogs = useCallback((walletOverride, options = {}) => {
-    return innerDeleteLogs(walletOverride || wallet, options)
+  const deleteLogs = useCallback((options) => {
+    return innerDeleteLogs(wallet, options)
   }, [innerDeleteLogs, wallet])
 
   return { logger, deleteLogs }

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -89,7 +89,7 @@ export function useWallet (name) {
 
   const deleteLogs_ = useCallback(async (options) => {
     // first argument is to override the wallet
-    return await deleteLogs(null, options)
+    return await deleteLogs(options)
   }, [deleteLogs])
 
   if (!wallet) return null

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -87,6 +87,11 @@ export function useWallet (name) {
     }
   }, [clearConfig, logger, disablePayments])
 
+  const deleteLogs_ = useCallback(async (options) => {
+    // first argument is to override the wallet
+    return await deleteLogs(null, options)
+  }, [deleteLogs])
+
   if (!wallet) return null
 
   // Assign everything to wallet object so every function that is passed this wallet object in this
@@ -102,7 +107,7 @@ export function useWallet (name) {
   wallet.config = config
   wallet.save = save
   wallet.delete = delete_
-  wallet.deleteLogs = deleteLogs
+  wallet.deleteLogs = deleteLogs_
   wallet.setPriority = setPriority
   wallet.hasConfig = hasConfig
   wallet.status = status
@@ -406,7 +411,7 @@ export function useWallets () {
       if (w.canSend) {
         await w.delete({ clientOnly: true })
       }
-      await w.deleteLogs()
+      await w.deleteLogs({ clientOnly: true })
     }
   }, [wallets])
 

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -77,9 +77,9 @@ export function useWallet (name) {
   }, [saveConfig, me, logger])
 
   // delete is a reserved keyword
-  const delete_ = useCallback(async () => {
+  const delete_ = useCallback(async (options) => {
     try {
-      await clearConfig({ logger })
+      await clearConfig({ logger, ...options })
     } catch (err) {
       const message = err.message || err.toString?.()
       logger.error(message)
@@ -237,13 +237,13 @@ function useConfig (wallet) {
     }
   }, [hasClientConfig, hasServerConfig, setClientConfig, setServerConfig, wallet])
 
-  const clearConfig = useCallback(async ({ logger }) => {
+  const clearConfig = useCallback(async ({ logger, clientOnly }) => {
     if (hasClientConfig) {
       clearClientConfig()
       wallet.disablePayments()
       logger.ok('wallet detached for payments')
     }
-    if (hasServerConfig) await clearServerConfig()
+    if (hasServerConfig && !clientOnly) await clearServerConfig()
   }, [hasClientConfig, hasServerConfig, clearClientConfig, clearServerConfig, wallet])
 
   return [config, saveConfig, clearConfig]
@@ -404,7 +404,7 @@ export function useWallets () {
   const resetClient = useCallback(async (wallet) => {
     for (const w of wallets) {
       if (w.canSend) {
-        await w.delete()
+        await w.delete({ clientOnly: true })
       }
       await w.deleteLogs()
     }


### PR DESCRIPTION
## Description

I noticed that I lost my phoenixd wallet because it can send so it got completely deleted on logout. It should only delete the send config. I probably forgot to update this code after we started to support wallets which can send and receive at the same time.

Also added that logic to wallet logs deletion.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`.

* tested that a wallet that has send+recv configured only loses send on logout
* tested that only send logs are deleted on logout
* tested that deleting logs while on a wallet config page only deletes logs of that wallet
* tested that deleting logs on the page that has all wallet logs deletes logs from every wallet

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
