### PR TITLE
Catch s3 upload errors

### DIFF
--- a/api/resolvers/upload.js
+++ b/api/resolvers/upload.js
@@ -29,11 +29,12 @@ export default {
         }
       }
 
+      // width and height is 0 for videos
       if (width * height > IMAGE_PIXELS_MAX) {
         throw new GqlInputError(`image must be less than ${IMAGE_PIXELS_MAX} pixels`)
       }
 
-      const imgParams = {
+      const fileParams = {
         type,
         size,
         width,
@@ -44,10 +45,10 @@ export default {
 
       if (avatar) {
         if (!me) throw new GqlAuthenticationError()
-        imgParams.paid = undefined
+        fileParams.paid = undefined
       }
 
-      const upload = await models.upload.create({ data: { ...imgParams } })
+      const upload = await models.upload.create({ data: { ...fileParams } })
       return createPresignedPost({ key: String(upload.id), type, size })
     }
   }

--- a/components/file-upload.js
+++ b/components/file-upload.js
@@ -101,7 +101,7 @@ export const FileUpload = forwardRef(({ children, className, onSelect, onUpload,
               if (onSelect) await onSelect?.(file, s3Upload)
               else await s3Upload(file)
             } catch (e) {
-              toaster.danger('upload failed: ' + e.message || e.toString?.())
+              toaster.danger(`upload of '${file.name}' failed: ` + e.message || e.toString?.())
               continue
             }
           }

--- a/components/file-upload.js
+++ b/components/file-upload.js
@@ -39,8 +39,8 @@ export const FileUpload = forwardRef(({ children, className, onSelect, onUpload,
         try {
           ({ data } = await getSignedPOST({ variables }))
         } catch (e) {
-          toaster.danger('error initiating upload: ' + e.message || e.toString?.())
           onError?.({ ...variables, name: file.name, file })
+          reject(e)
           return
         }
 
@@ -58,10 +58,8 @@ export const FileUpload = forwardRef(({ children, className, onSelect, onUpload,
 
         if (!res.ok) {
           // TODO make sure this is actually a helpful error message and does not expose anything to the user we don't want
-          const err = res.statusText
-          toaster.danger('error uploading: ' + err)
           onError?.({ ...variables, name: file.name, file })
-          reject(err)
+          reject(new Error(res.statusText))
           return
         }
 
@@ -96,16 +94,20 @@ export const FileUpload = forwardRef(({ children, className, onSelect, onUpload,
         onChange={async (e) => {
           const fileList = e.target.files
           for (const file of Array.from(fileList)) {
-            if (accept.indexOf(file.type) === -1) {
-              toaster.danger(`image must be ${accept.map(t => t.replace('image/', '').replace('video/', '')).join(', ')}`)
+            try {
+              if (accept.indexOf(file.type) === -1) {
+                throw new Error(`image must be ${accept.map(t => t.replace('image/', '').replace('video/', '')).join(', ')}`)
+              }
+              if (onSelect) await onSelect?.(file, s3Upload)
+              else await s3Upload(file)
+            } catch (e) {
+              toaster.danger('upload failed: ' + e.message || e.toString?.())
               continue
             }
-            if (onSelect) await onSelect?.(file, s3Upload)
-            else await s3Upload(file)
-            // reset file input
-            // see https://bobbyhadz.com/blog/react-reset-file-input#reset-a-file-input-in-react
-            e.target.value = null
           }
+          // reset file input
+          // see https://bobbyhadz.com/blog/react-reset-file-input#reset-a-file-input-in-react
+          e.target.value = null
         }}
       />
       <div

--- a/components/file-upload.js
+++ b/components/file-upload.js
@@ -96,7 +96,7 @@ export const FileUpload = forwardRef(({ children, className, onSelect, onUpload,
           for (const file of Array.from(fileList)) {
             try {
               if (accept.indexOf(file.type) === -1) {
-                throw new Error(`image must be ${accept.map(t => t.replace('image/', '').replace('video/', '')).join(', ')}`)
+                throw new Error(`file must be ${accept.map(t => t.replace(/^(image|video)\//, '')).join(', ')}`)
               }
               if (onSelect) await onSelect?.(file, s3Upload)
               else await s3Upload(file)


### PR DESCRIPTION
## Description

Upload errors were toasted but still bubbled up. This PR fixes that by stopping errors from bubbling up.

Also renamed more stuff that assumed we're only dealing with images.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested by setting upload limit to 1MB and uploaded a file >1MB.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
