### PR TITLE
Never update author of item on edit

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1315,15 +1315,18 @@ export const updateItem = async (parent, { sub: subName, forward, hash, hmac, ..
 
   if (old.bio) {
     // prevent editing a bio like a regular item
-    item = { id: Number(item.id), text: item.text, title: `@${user.name}'s bio`, userId: meId }
+    item = { id: Number(item.id), text: item.text, title: `@${user.name}'s bio` }
   } else if (old.parentId) {
     // prevent editing a comment like a post
-    item = { id: Number(item.id), text: item.text, userId: meId }
+    item = { id: Number(item.id), text: item.text }
   } else {
-    item = { subName, userId: meId, ...item }
+    item = { subName, ...item }
     item.forwardUsers = await getForwardUsers(models, forward)
   }
   item.uploadIds = uploadIdsFromText(item.text, { models })
+
+  // never change author of item
+  item.userId = old.userId
 
   const resultItem = await performPaidAction('ITEM_UPDATE', item, { models, me, lnd })
 

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -49,9 +49,11 @@ export default function ItemInfo ({
   }, [item])
 
   useEffect(() => {
-    const invoice = window.localStorage.getItem(`item:${item.id}:hash:hmac`)
-    setCanEdit((item.mine || invoice) && (Date.now() < editThreshold))
-  }, [item.id, item.mine, editThreshold])
+    const authorEdit = item.mine
+    const invParams = window.localStorage.getItem(`item:${item.id}:hash:hmac`)
+    const hmacEdit = !!invParams && !me && Number(item.user.id) === USER_ID.anon
+    setCanEdit((authorEdit || hmacEdit) && (Date.now() < editThreshold))
+  }, [me, item.id, item.mine, editThreshold])
 
   // territory founders can pin any post in their territory
   // and OPs can pin any root reply in their post


### PR DESCRIPTION
## Description

The combination of #1393 + #644 made it possible that the author of an item could change from anon to a user and vice versa.

This PR makes sure that during item updates, the author is never changed. 

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes
<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`

* switched accounts and edited item with different author and made sure author doesn't change (using e04f64e8 before edit option disappears on switch)
* made sure hash+hmac edit only shows for anonymous items if anonymous

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
