### PR TITLE
Use X-Forwarded-Proto to detect scheme

### DIFF
--- a/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
@@ -22,4 +22,5 @@ location / {
      proxy_set_header    Host                $host;
      proxy_set_header    X-Real-IP           $remote_addr;
      proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+     proxy_set_header    X-Forwarded-Proto   $scheme;
 }

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -118,10 +118,11 @@ function setMultiAuthCookies (req, res, { id, jwt, name, photoId }) {
 
   // default expiration for next-auth JWTs is in 1 month
   const expiresAt = datePivot(new Date(), { months: 1 })
+  const secure = req.headers['x-forwarded-proto'] === 'https'
   const cookieOptions = {
     path: '/',
     httpOnly: true,
-    secure: req.secure,
+    secure,
     sameSite: 'lax',
     expires: expiresAt
   }

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -88,8 +88,10 @@ function multiAuthMiddleware (request) {
   const cookiePointerName = 'multi_auth.user-id'
   const hasCookiePointer = !!request.cookies[cookiePointerName]
 
+  const secure = request.headers['x-forwarded-proto'] === 'https'
+
   // is there a session?
-  const sessionCookieName = request.secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
+  const sessionCookieName = secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
   const hasSession = !!request.cookies[sessionCookieName]
 
   if (!hasCookiePointer || !hasSession) {

--- a/pages/api/signout.js
+++ b/pages/api/signout.js
@@ -11,8 +11,10 @@ export default (req, res) => {
   const cookiePointerName = 'multi_auth.user-id'
   const userId = req.cookies[cookiePointerName]
 
+  const secure = req.headers['x-forwarded-proto'] === 'https'
+
   // is there a session?
-  const sessionCookieName = req.secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
+  const sessionCookieName = secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
   const sessionJWT = req.cookies[sessionCookieName]
 
   if (!userId && !sessionJWT) {
@@ -25,7 +27,7 @@ export default (req, res) => {
 
   const cookieOptions = {
     path: '/',
-    secure: req.secure,
+    secure,
     httpOnly: true,
     sameSite: 'lax',
     expires: datePivot(new Date(), { months: 1 })


### PR DESCRIPTION
## Description

I have noticed that `Secure` isn't set for the multi auth cookies in prod as they should here for connections that use TLS:

https://github.com/stackernews/stacker.news/blob/c8975038bdee5ce4cd4c5655724ac0baada9b21a/pages/api/auth/%5B...nextauth%5D.js#L121-L127

This means that these checks that use `request.secure` are most likely not working as intended:

https://github.com/stackernews/stacker.news/blob/c8975038bdee5ce4cd4c5655724ac0baada9b21a/pages/api/graphql.js#L91-L98

https://github.com/stackernews/stacker.news/blob/c8975038bdee5ce4cd4c5655724ac0baada9b21a/pages/api/signout.js#L14-L22

This explains why switching doesn't work because the multi auth middleware never looks up the correct session cookie and think there is nothing to do for it.

This is most likely caused by TLS termination at the load balancer. Additionally, `request.secure` might not even exist since I don't see it as a property of [`http.IncomingMessage`](https://nodejs.org/api/http.html#class-httpincomingmessage).

This PR hopefully fixes this issue by setting the `X-Forwarded-Proto` header and using that header to determine if the connection is using TLS.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

not tested with `X-Forwarded-Proto` but continues to work without

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
