### PR TITLE
Always set Secure for multi auth cookies in prod

### DIFF
--- a/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/00_application.conf
@@ -22,5 +22,4 @@ location / {
      proxy_set_header    Host                $host;
      proxy_set_header    X-Real-IP           $remote_addr;
      proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
-     proxy_set_header    X-Forwarded-Proto   $scheme;
 }

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -118,7 +118,7 @@ function setMultiAuthCookies (req, res, { id, jwt, name, photoId }) {
 
   // default expiration for next-auth JWTs is in 1 month
   const expiresAt = datePivot(new Date(), { months: 1 })
-  const secure = req.headers['x-forwarded-proto'] === 'https'
+  const secure = process.env.NODE_ENV === 'production'
   const cookieOptions = {
     path: '/',
     httpOnly: true,

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -88,7 +88,7 @@ function multiAuthMiddleware (request) {
   const cookiePointerName = 'multi_auth.user-id'
   const hasCookiePointer = !!request.cookies[cookiePointerName]
 
-  const secure = request.headers['x-forwarded-proto'] === 'https'
+  const secure = process.env.NODE_ENV === 'production'
 
   // is there a session?
   const sessionCookieName = secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'

--- a/pages/api/signout.js
+++ b/pages/api/signout.js
@@ -11,7 +11,7 @@ export default (req, res) => {
   const cookiePointerName = 'multi_auth.user-id'
   const userId = req.cookies[cookiePointerName]
 
-  const secure = req.headers['x-forwarded-proto'] === 'https'
+  const secure = process.env.NODE_ENV === 'production'
 
   // is there a session?
   const sessionCookieName = secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'


### PR DESCRIPTION
## Description

#1403 didn't fix #644 in prod. This PR simply always sets  `Secure` for the multi auth cookies in prod using `NODE_ENV` instead of relying on a `X-Forwarded-Proto` header.


## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

not tested

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
