### PR TITLE
Fix different slugs in ToC vs text

### DIFF
--- a/components/table-of-contents.js
+++ b/components/table-of-contents.js
@@ -5,7 +5,7 @@ import TocIcon from '@/svgs/list-unordered.svg'
 import { fromMarkdown } from 'mdast-util-from-markdown'
 import { visit } from 'unist-util-visit'
 import { toString } from 'mdast-util-to-string'
-import GithubSlugger from 'github-slugger'
+import { slug } from 'github-slugger'
 import { useRouter } from 'next/router'
 
 export default function Toc ({ text }) {
@@ -17,11 +17,11 @@ export default function Toc ({ text }) {
   const toc = useMemo(() => {
     const tree = fromMarkdown(text)
     const toc = []
-    const slugger = new GithubSlugger()
     visit(tree, 'heading', (node, position, parent) => {
       const str = toString(node)
-      toc.push({ heading: str, slug: slugger.slug(str.replace(/[^\w\-\s]+/gi, '')), depth: node.depth })
+      toc.push({ heading: str, slug: slug(str.replace(/[^\w\-\s]+/gi, '')), depth: node.depth })
     })
+
     return toc
   }, [text])
 

--- a/components/text.js
+++ b/components/text.js
@@ -6,7 +6,7 @@ import atomDark from 'react-syntax-highlighter/dist/cjs/styles/prism/atom-dark'
 import mention from '@/lib/remark-mention'
 import sub from '@/lib/remark-sub'
 import React, { useState, memo, useRef, useCallback, useMemo, useEffect } from 'react'
-import GithubSlugger from 'github-slugger'
+import { slug } from 'github-slugger'
 import LinkIcon from '@/svgs/link.svg'
 import Thumb from '@/svgs/thumb-up-fill.svg'
 import { toString } from 'mdast-util-to-string'
@@ -82,12 +82,10 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
     }
   }, [containerRef.current, setOverflowing])
 
-  const slugger = useMemo(() => new GithubSlugger(), [])
-
   const Heading = useCallback(({ children, node, ...props }) => {
     const [copied, setCopied] = useState(false)
     const nodeText = toString(node)
-    const id = useMemo(() => noFragments ? undefined : slugger?.slug(nodeText.replace(/[^\w\-\s]+/gi, '')), [nodeText, noFragments, slugger])
+    const id = useMemo(() => noFragments ? undefined : slug(nodeText.replace(/[^\w\-\s]+/gi, '')), [nodeText, noFragments])
     const h = useMemo(() => {
       if (topLevel) {
         return node?.TagName
@@ -120,7 +118,7 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
           </a>}
       </span>
     )
-  }, [topLevel, noFragments, slugger])
+  }, [topLevel, noFragments])
 
   const Table = useCallback(({ node, ...props }) =>
     <span className='table-responsive'>


### PR DESCRIPTION
## Description

I've noticed that the slugs generated in the FAQ are not always consistent with the slugs that are used in the Table of Contents. This means that if you click on an entry in the ToC, you might not get scrolled anywhere. This seems to happen if you move from a post to the FAQ. I assume that's the case since that case triggers a lot of changes in the `<Text>` component; calling `GithubSlugger.slug` a lot of times with the same inputs which always generates unique slugs.

At first I thought this is caused by strict mode but strict mode isn't enabled in production afaik and it also still happens if it's disabled locally.

To reproduce:

1. Go to https://stacker.news/items/683598
2. Click link to FAQ in the footer
3. Notice how site loads slow because a lot of renders are triggered
4. Click on a heading and see it ends with a number
5. Click on ToC and see they don't end with a number

## Additional Context

This PR assumes that headings are unique since using the `slug` function instead of `GithubSlugger` does not generate unique slugs on repeated calls; fixing the inconsistency between the slugs in the text and ToC but might cause duplicate slugs getting generated for different headings with same text.

However, I believe this is rarely the case.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
