### PR TITLE
Fix hat contrast in profile

### DIFF
--- a/components/hat.js
+++ b/components/hat.js
@@ -14,7 +14,7 @@ export default function Hat ({ user, badge, className = 'ms-1', height = 16, wid
         {badge
           ? (
             <Badge bg='grey-medium' className='ms-2 d-inline-flex align-items-center'>
-              <AnonIcon className={`${className} align-middle`} height={height} width={width} />
+              <AnonIcon className={`${className} fill-dark align-middle`} height={height} width={width} />
             </Badge>)
           : <span><AnonIcon className={`${className} align-middle`} height={height} width={width} /></span>}
       </HatTooltip>
@@ -34,7 +34,7 @@ export default function Hat ({ user, badge, className = 'ms-1', height = 16, wid
       {badge
         ? (
           <Badge bg='grey-medium' className='ms-2 d-inline-flex align-items-center'>
-            <CowboyHatIcon className={className} height={height} width={width} />
+            <CowboyHatIcon className={`${className} fill-dark`} height={height} width={width} />
             <span className='ms-1 text-dark'>{streak || 'new'}</span>
           </Badge>)
         : <span><CowboyHatIcon className={className} height={height} width={width} /></span>}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -784,6 +784,10 @@ div[contenteditable]:focus,
   fill: white;
 }
 
+.fill-dark {
+  fill: #212529;
+}
+
 .fill-success {
   fill: var(--bs-success);
 }


### PR DESCRIPTION
## Description

The contrast for the hat in the profile is bad in dark mode:

![2024-09-13-225529_361x167_scrot](https://github.com/user-attachments/assets/401278aa-f9c4-44e0-8332-6f77c1f9535a)

It's okay in light mode:

![2024-09-13-225613_354x161_scrot](https://github.com/user-attachments/assets/66e53694-2893-4ffd-9335-623d5003a74c)

This is caused by the hat assuming it's put against the background but in the profile, it's inside a badge that always uses `bg='grey-medium'`.

This can be fixed by always using the color that light mode uses. This is `#212529`.

## Screenshots

![2024-09-13-230854_355x162_scrot](https://github.com/user-attachments/assets/4d9ba18b-4049-4a21-9d37-8daa44605455)

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

 `9`. `fill-dark` is only used when the icon is inside a badge with `bg-medium`.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
