### PR TITLE
Fix margin on row overflow

### DIFF
--- a/pages/settings/settings.module.css
+++ b/pages/settings/settings.module.css
@@ -2,14 +2,11 @@
     margin: 1rem 0;
     justify-content: start;
     font-size: 110%;
+    gap: 0 0.5rem;
 }
 
 .nav :global .nav-link {
     padding-left: 0;
-}
-
-.nav :global .nav-item:not(:first-child) {
-    margin-left: 1rem;
 }
 
 .nav :global .active {


### PR DESCRIPTION
## Description

The tabs in /settings were overflowing and `margin-left` caused the next row to appear unexpectedly indented. I fixed this using `gap`, see screenshots.

## Screenshots

This changes this:

![localhost_3000_settings_subscriptions(iPhone SE)](https://github.com/user-attachments/assets/14180be9-2554-47e5-b5c7-2e7ed35be2b5)

to this + if row overflows, there is no indentation:

![localhost_3000_settings_subscriptions(iPhone SE) (1)](https://github.com/user-attachments/assets/3ef89f6a-8751-4fdd-98fe-e30e6b957a77)

## Additional Context

I used `gap: 0 0.5rem` instead of  `gap: 0 1rem` to keep the original margin because I found the original margin to be too much.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`. settings.module.css is only used in /settings and /satistics and both look fine/better with the change.

**For frontend changes: Tested on mobile? Please answer below:**

yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
