### PR TITLE
Fix nwc error message

### DIFF
--- a/lib/nostr.js
+++ b/lib/nostr.js
@@ -22,7 +22,7 @@ export class Relay {
   constructor (relayUrl) {
     const ws = new WebSocket(relayUrl)
 
-    ws.onmessage = function (msg) {
+    ws.onmessage = (msg) => {
       const [type, notice] = JSON.parse(msg.data)
       if (type === 'NOTICE') {
         console.log('relay notice:', notice)

--- a/lib/nostr.js
+++ b/lib/nostr.js
@@ -29,7 +29,7 @@ export class Relay {
       }
     }
 
-    ws.onerror = function (err) {
+    ws.onerror = (err) => {
       console.error('websocket error:', err.message)
       this.error = err.message
     }


### PR DESCRIPTION
## Description

I have noticed that `this.error` in the `onerror` websocket callback assigns the error to the websocket object, not the `Relay` instance. So it was available at `this.ws.error`.

This PR fixes it by using arrow functions which don't rebind `this`.

## Additional Context

I digged into this because of the discussion about NWC and Coinos [here](https://stacker.news/items/691917) but this isn't going to fix whatever is the issue, only fix that we might show `null` as the error.

Strangely, I noticed that I get HTTP 403 Forbidden errors from the Coinos relay when trying to connect to it for NWC receives but I don't when I connect to it for NWC sends. The only difference is client vs server who initiates the connection.

But since this also happens locally, I am confused what the difference is for the relay. Maybe [`isomorphic-ws`](https://www.npmjs.com/package/isomorphic-ws) isn't 100% isomorphic.

https://github.com/user-attachments/assets/b0ec4df5-3315-46dd-866c-66e2686889c1

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. I now see the Coinos relay error for NWC receives.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
