### PR TITLE
Fix upvote hover style not showing for first zap

### DIFF
--- a/components/upvote.js
+++ b/components/upvote.js
@@ -227,7 +227,7 @@ export default function UpVote ({ item, className }) {
     }
   }
 
-  const fillColor = meSats && (hover || pending ? nextColor : color)
+  const fillColor = hover || pending ? nextColor : color
 
   const style = useMemo(() => (fillColor
     ? {

--- a/lib/rainbow.js
+++ b/lib/rainbow.js
@@ -1,5 +1,9 @@
 export default function getColor (meSats) {
-  if (!meSats || meSats <= 10) {
+  if (!meSats || meSats === 0) {
+    return '#a5a5a5'
+  }
+
+  if (meSats <= 10) {
     return 'var(--bs-secondary)'
   }
 


### PR DESCRIPTION
## Description

Fix [this](https://stacker.news/items/692150?commentId=692635) and [this](https://stacker.news/items/692150?commentId=692268).

The changes in 5f0494de30f4730445a9b12361050c83deb40b65 in components/upvote.js made the `fill` style on hover or pending not show up if the item wasn't zapped before.

This PR fixes this. Instead of reverting to using `meSats` as a condition for when to show the style, I actually updated the `getColor` function since I believe it should actually return the default color if the item was clearly not zapped yet instead of always at least the first upvote color.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested that changes fix the mentioned bug that is clearly contained.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
