### PR TITLE
Fix missing effect dependency for useZap

### DIFF
--- a/components/item-act.js
+++ b/components/item-act.js
@@ -277,7 +277,7 @@ export function useZap () {
       const reason = error?.message || error?.toString?.()
       toaster.danger(reason)
     }
-  }, [me?.id, strike])
+  }, [act, me?.id, strike])
 }
 
 export class ActCanceledError extends Error {


### PR DESCRIPTION
## Description

This didn't cause any bugs because `useWallet` returns everything we need on first render on `master`.

This caused a bug with the changes in #1373 though since there the wallet is loaded async.

This meant that during payment, the wallet config was undefined.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. This fixes the bug I encountered in #1373 when testing wallets.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
