### PR TITLE
CTRL+U for uploads

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -255,6 +255,11 @@ export function MarkdownInput ({ label, topLevel, groupClassName, onChange, onKe
           e.preventDefault()
           insertMarkdownItalicFormatting(innerRef.current, helpers.setValue, setSelectionRange)
         }
+        if (e.key === 'u') {
+          // some browsers might use CTRL+U to do something else so prevent that behavior too
+          e.preventDefault()
+          imageUploadRef.current?.click()
+        }
         if (e.key === 'Tab' && e.altKey) {
           e.preventDefault()
           insertMarkdownTabFormatting(innerRef.current, helpers.setValue, setSelectionRange)


### PR DESCRIPTION
## Description

With this change, one can open the file browser to upload something with CTRL+U.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
