### PR TITLE
batch zap requests

### DIFF
--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -1,4 +1,5 @@
-import { ApolloClient, InMemoryCache, HttpLink, makeVar } from '@apollo/client'
+import { ApolloClient, InMemoryCache, HttpLink, makeVar, split } from '@apollo/client'
+import { BatchHttpLink } from '@apollo/client/link/batch-http'
 import { decodeCursor, LIMIT } from './cursor'
 import { SSR } from './constants'
 
@@ -28,8 +29,15 @@ export default function getApolloClient () {
 export const meAnonSats = {}
 
 function getClient (uri) {
+  const link = split(
+    // batch zaps if wallet is enabled so they can be executed serially in a single request
+    operation => operation.operationName === 'act' && operation.variables.act === 'TIP' && operation.getContext().batch,
+    new BatchHttpLink({ uri, batchInterval: 1000, batchDebounce: true, batchMax: 0, batchKey: op => op.variables.id }),
+    new HttpLink({ uri })
+  )
+
   return new ApolloClient({
-    link: new HttpLink({ uri }),
+    link,
     ssrMode: SSR,
     connectToDevTools: process.env.NODE_ENV !== 'production',
     cache: new InMemoryCache({

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -16,6 +16,7 @@ const apolloServer = new ApolloServer({
   typeDefs,
   resolvers,
   introspection: true,
+  allowBatchedHttpRequests: true,
   plugins: [{
     requestDidStart (initialRequestContext) {
       return {


### PR DESCRIPTION
This uses a conditional batching apollo link if successive zaps are made so they can be serially/batch executed so updating the client cache doesn't race.

This batching link is only used if there's a wallet attached or using custodial sats so that QR popup isn't delayed by the debounce.

fixes #1389 

QA: `7`
