### PR TITLE
Include extension in S3 key

### DIFF
--- a/api/resolvers/upload.js
+++ b/api/resolvers/upload.js
@@ -49,7 +49,10 @@ export default {
       }
 
       const upload = await models.upload.create({ data: { ...fileParams } })
-      return createPresignedPost({ key: String(upload.id), type, size })
+
+      const extension = type.split('/')[1]
+      const key = `${upload.id}.${extension}`
+      return createPresignedPost({ key, type, size })
     }
   }
 }


### PR DESCRIPTION
## Description

It's annoying when downloading pictures from m.stacker.news that the extension is not included in the URL.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested locally with one image.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
