### PR TITLE
Prevent Disguised Links

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -12,7 +12,7 @@ import Thumb from '@/svgs/thumb-up-fill.svg'
 import { toString } from 'mdast-util-to-string'
 import copy from 'clipboard-copy'
 import MediaOrLink from './media-or-link'
-import { IMGPROXY_URL_REGEXP, parseInternalLinks, decodeProxyUrl } from '@/lib/url'
+import { IMGPROXY_URL_REGEXP, isMisleadingLink, parseInternalLinks, decodeProxyUrl } from '@/lib/url'
 import reactStringReplace from 'react-string-replace'
 import { rehypeInlineCodeProperty, rehypeStyler } from '@/lib/md'
 import { Button } from 'react-bootstrap'
@@ -176,17 +176,11 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
         return href
       }
 
-      // If [text](url) was parsed as <a> and text is not empty and not a link itself,
-      // we don't render it as an image since it was probably a conscious choice to include text.
-      let text
+      let text = children[0]
 
-      // This prevents "stacker.news" string being used in text part of link
-      // to make it look like a stackernews link - text part will be stripped out
-      // used a regex to allow for easy improvements
-      if (children.length > 0 && children[0].match(/stacker.news/)) {
-        children[0] = href
-      } else {
-        text = children[0]
+      // Prevents text being used to appear like a link
+      if (isMisleadingLink(text, href)) {
+        text = href
       }
 
       let url
@@ -264,7 +258,7 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
       }
 
       // assume the link is an image which will fallback to link if it's not
-      return <TextMediaOrLink src={href} rel={rel ?? UNKNOWN_LINK_REL} {...props}>{children}</TextMediaOrLink>
+      return <TextMediaOrLink src={href} rel={rel ?? UNKNOWN_LINK_REL} {...props}>{text}</TextMediaOrLink>
     },
     img: TextMediaOrLink
   }), [outlawed, rel, itemId, Code, P, Heading, Table, TextMediaOrLink])

--- a/components/text.js
+++ b/components/text.js
@@ -263,7 +263,6 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
         // ignore errors like invalid URLs
       }
 
-      console.log('HIT 1')
       // assume the link is an image which will fallback to link if it's not
       return <TextMediaOrLink src={href} rel={rel ?? UNKNOWN_LINK_REL} {...props}>{children}</TextMediaOrLink>
     },

--- a/components/text.js
+++ b/components/text.js
@@ -178,7 +178,17 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
 
       // If [text](url) was parsed as <a> and text is not empty and not a link itself,
       // we don't render it as an image since it was probably a conscious choice to include text.
-      const text = children[0]
+      let text
+
+      // This prevents "stacker.news" string being used in text part of link
+      // to make it look like a stackernews link - text part will be stripped out
+      const regex = /stacker.news/ // used a regex to allow for easy improvements
+      if (children[0].match(regex)) {
+        children[0] = href
+      } else {
+        text = children[0]
+      }
+
       let url
       try {
         url = !href.startsWith('/') && new URL(href)
@@ -253,6 +263,7 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
         // ignore errors like invalid URLs
       }
 
+      console.log('HIT 1')
       // assume the link is an image which will fallback to link if it's not
       return <TextMediaOrLink src={href} rel={rel ?? UNKNOWN_LINK_REL} {...props}>{children}</TextMediaOrLink>
     },

--- a/components/text.js
+++ b/components/text.js
@@ -182,8 +182,8 @@ export default memo(function Text ({ rel, imgproxyUrls, children, tab, itemId, o
 
       // This prevents "stacker.news" string being used in text part of link
       // to make it look like a stackernews link - text part will be stripped out
-      const regex = /stacker.news/ // used a regex to allow for easy improvements
-      if (children[0].match(regex)) {
+      // used a regex to allow for easy improvements
+      if (children.length > 0 && children[0].match(/stacker.news/)) {
         children[0] = href
       } else {
         text = children[0]

--- a/lib/url.js
+++ b/lib/url.js
@@ -183,6 +183,22 @@ export function parseEmbedUrl (href) {
   return null
 }
 
+export function isMisleadingLink (text, href) {
+  let misleading = false
+
+  if (/^\s*(\w+\.)+\w+/.test(text)) {
+    try {
+      const hrefUrl = new URL(href)
+
+      if (new URL(hrefUrl.protocol + text).origin !== hrefUrl.origin) {
+        misleading = true
+      }
+    } catch {}
+  }
+
+  return misleading
+}
+
 export function stripTrailingSlash (uri) {
   return uri.endsWith('/') ? uri.slice(0, -1) : uri
 }


### PR DESCRIPTION
## Description
Fixes #1397 

When adding links with a "text part" and an "href part" to the editor, if the text part contains a string that resembles a link then ensure that it's the same as the href part. If it isn't, then render the href part only.