### PR TITLE
CSS animation for toasts and offcanvas

### DIFF
--- a/components/nav/mobile/offcanvas.js
+++ b/components/nav/mobile/offcanvas.js
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { LoginButtons, LogoutDropdownItem, NavWalletSummary } from '../common'
 import AnonIcon from '@/svgs/spy-fill.svg'
 import styles from './footer.module.css'
+import canvasStyles from './offcanvas.module.css'
 import classNames from 'classnames'
 
 export default function OffCanvas ({ me, dropNavKey }) {
@@ -28,7 +29,7 @@ export default function OffCanvas ({ me, dropNavKey }) {
     <>
       <MeImage onClick={handleShow} />
 
-      <Offcanvas style={{ maxWidth: '250px', zIndex: '10000' }} show={show} onHide={handleClose} placement='end'>
+      <Offcanvas className={canvasStyles.offcanvas} show={show} onHide={handleClose} placement='end'>
         <Offcanvas.Header closeButton>
           <Offcanvas.Title><NavWalletSummary /></Offcanvas.Title>
         </Offcanvas.Header>

--- a/components/nav/mobile/offcanvas.module.css
+++ b/components/nav/mobile/offcanvas.module.css
@@ -2,7 +2,7 @@
     max-width: 250px;
     z-index: 10000;
     right: -100%;
-    animation: slide ease-out 0.25s;
+    animation: slide ease-out 0.2s;
 }
 
 @keyframes slide {

--- a/components/nav/mobile/offcanvas.module.css
+++ b/components/nav/mobile/offcanvas.module.css
@@ -1,0 +1,15 @@
+.offcanvas {
+    max-width: 250px;
+    z-index: 10000;
+    right: -100%;
+    animation: slide ease-out 0.25s;
+}
+
+@keyframes slide {
+    0% {
+        transform: translateX(100%);
+    }
+    100% {
+        transform: translateX(0%)
+    }
+}

--- a/components/toast.module.css
+++ b/components/toast.module.css
@@ -8,19 +8,19 @@
   width: fit-content;
   justify-self: right;
   color: #fff;
-  right: -100%;
+  bottom: -100%;
   border-width: 1px;
   border-style: solid;
   text-overflow: ellipsis;
-  animation: slide ease-out 0.25s;
+  animation: slide ease-out 0.2s;
 }
 
 @keyframes slide {
   0% {
-    transform: translateX(100%);
+    transform: translateY(100%);
   }
   100% {
-    transform: translateX(0%)
+    transform: translateY(0%)
   }
 }
 

--- a/components/toast.module.css
+++ b/components/toast.module.css
@@ -5,9 +5,20 @@
 .toast {
   width: auto;
   color: #fff;
+  right: -100%;
   border-width: 1px;
   border-style: solid;
   text-overflow: ellipsis;
+  animation: slide ease-out 0.25s;
+}
+
+@keyframes slide {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(0%)
+  }
 }
 
 .success {
@@ -69,10 +80,4 @@
 
 .toastClose:hover {
   opacity: 0.7;
-}
-
-@media screen and (min-width: 400px) {
-  .toast {
-    width: var(--bs-toast-max-width);
-  }
 }

--- a/components/toast.module.css
+++ b/components/toast.module.css
@@ -1,9 +1,12 @@
 .toastContainer {
   transform: translate3d(0, 0, 0);
+  display: grid;
 }
 
 .toast {
-  width: auto;
+  font-size: small;
+  width: fit-content;
+  justify-self: right;
   color: #fff;
   right: -100%;
   border-width: 1px;


### PR DESCRIPTION
## Description

This adds a slide-in animation for toasts and the offcanvas.

## Video

https://github.com/user-attachments/assets/780da5b5-4445-4356-a264-0ef6feedf855

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested as seen in the viode.

**For frontend changes: Tested on mobile? Please answer below:**

Yes, see video.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No
