### PR TITLE
Be kind to lnd

### DIFF
--- a/api/lnd/index.js
+++ b/api/lnd/index.js
@@ -81,16 +81,31 @@ export function getPaymentFailureStatus (withdrawal) {
   }
 
   if (withdrawal?.failed.is_insufficient_balance) {
-    return 'INSUFFICIENT_BALANCE'
+    return {
+      status: 'INSUFFICIENT_BALANCE',
+      message: 'you didn\'t have enough sats'
+    }
   } else if (withdrawal?.failed.is_invalid_payment) {
-    return 'INVALID_PAYMENT'
+    return {
+      status: 'INVALID_PAYMENT',
+      message: 'invalid payment'
+    }
   } else if (withdrawal?.failed.is_pathfinding_timeout) {
-    return 'PATHFINDING_TIMEOUT'
+    return {
+      status: 'PATHFINDING_TIMEOUT',
+      message: 'no route found'
+    }
   } else if (withdrawal?.failed.is_route_not_found) {
-    return 'ROUTE_NOT_FOUND'
+    return {
+      status: 'ROUTE_NOT_FOUND',
+      message: 'no route found'
+    }
   }
 
-  return 'UNKNOWN_FAILURE'
+  return {
+    status: 'UNKNOWN_FAILURE',
+    message: 'unknown failure'
+  }
 }
 
 export const getBlockHeight = cachedFetcher(async () => {

--- a/api/paidAction/index.js
+++ b/api/paidAction/index.js
@@ -309,7 +309,7 @@ async function createDbInvoice (actionType, args, context,
   const invoiceData = {
     hash: servedInvoice.id,
     msatsRequested: BigInt(servedInvoice.mtokens),
-    preimage: optimistic ? undefined : preimage,
+    preimage,
     bolt11: servedBolt11,
     userId: me?.id ?? USER_ID.anon,
     actionType,

--- a/api/resolvers/blockHeight.js
+++ b/api/resolvers/blockHeight.js
@@ -1,39 +1,26 @@
-import lndService from 'ln-service'
-import lnd from '@/api/lnd'
 import { isServiceEnabled } from '@/lib/sndev'
+import { cachedFetcher } from '@/lib/fetch'
+import { getHeight } from 'ln-service'
 
-const cache = new Map()
-const expiresIn = 1000 * 30 // 30 seconds in milliseconds
-
-async function fetchBlockHeight () {
-  let blockHeight = 0
-  if (!isServiceEnabled('payments')) return blockHeight
+const getBlockHeight = cachedFetcher(async ({ lnd }) => {
   try {
-    const height = await lndService.getHeight({ lnd })
-    blockHeight = height.current_block_height
-    cache.set('block', { height: blockHeight, createdAt: Date.now() })
+    const { current_block_height: height } = await getHeight({ lnd })
+    return height
   } catch (err) {
-    console.error('fetchBlockHeight', err)
+    console.error('getBlockHeight', err)
+    return 0
   }
-  return blockHeight
-}
-
-async function getBlockHeight () {
-  if (cache.has('block')) {
-    const { height, createdAt } = cache.get('block')
-    const expired = createdAt + expiresIn < Date.now()
-    if (expired) fetchBlockHeight().catch(console.error) // update cache
-    return height // serve stale block height (this on the SSR critical path)
-  } else {
-    fetchBlockHeight().catch(console.error)
-  }
-  return 0
-}
+}, {
+  maxSize: 1,
+  cacheExpiry: 60 * 1000, // 1 minute
+  forceRefreshThreshold: 0
+})
 
 export default {
   Query: {
-    blockHeight: async (parent, opts, ctx) => {
-      return await getBlockHeight()
+    blockHeight: async (parent, opts, { lnd }) => {
+      if (!isServiceEnabled('payments')) return 0
+      return await getBlockHeight({ lnd }) || 0
     }
   }
 }

--- a/api/resolvers/chainFee.js
+++ b/api/resolvers/chainFee.js
@@ -1,36 +1,25 @@
-const cache = new Map()
-const expiresIn = 1000 * 30 // 30 seconds in milliseconds
+import { cachedFetcher } from '@/lib/fetch'
 
-async function fetchChainFeeRate () {
+const getChainFeeRate = cachedFetcher(async () => {
   const url = 'https://mempool.space/api/v1/fees/recommended'
-  const chainFee = await fetch(url)
-    .then((res) => res.json())
-    .then((body) => body.hourFee)
-    .catch((err) => {
-      console.error('fetchChainFee', err)
-      return 0
-    })
-
-  cache.set('fee', { fee: chainFee, createdAt: Date.now() })
-  return chainFee
-}
-
-async function getChainFeeRate () {
-  if (cache.has('fee')) {
-    const { fee, createdAt } = cache.get('fee')
-    const expired = createdAt + expiresIn < Date.now()
-    if (expired) fetchChainFeeRate().catch(console.error) // update cache
-    return fee
-  } else {
-    fetchChainFeeRate().catch(console.error)
+  try {
+    const res = await fetch(url)
+    const body = await res.json()
+    return body.hourFee
+  } catch (err) {
+    console.error('fetchChainFee', err)
+    return 0
   }
-  return 0
-}
+}, {
+  maxSize: 1,
+  cacheExpiry: 60 * 1000, // 1 minute
+  forceRefreshThreshold: 0 // never force refresh
+})
 
 export default {
   Query: {
     chainFee: async (parent, opts, ctx) => {
-      return await getChainFeeRate()
+      return await getChainFeeRate() || 0
     }
   }
 }

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -82,7 +82,7 @@ export async function getInvoice (parent, { id }, { me, models, lnd }) {
 
   try {
     if (inv.confirmedAt) {
-      inv.confirmedPreimage = (await getInvoiceFromLnd({ id: inv.hash, lnd })).secret
+      inv.confirmedPreimage = inv.preimage ?? (await getInvoiceFromLnd({ id: inv.hash, lnd })).secret
     }
   } catch (err) {
     console.error('error fetching invoice from LND', err)
@@ -407,7 +407,7 @@ const resolvers = {
         })
 
         const [inv] = await serialize(
-          models.$queryRaw`SELECT * FROM create_invoice(${invoice.id}, ${hodlInvoice ? invoice.secret : null}::TEXT, ${invoice.request},
+          models.$queryRaw`SELECT * FROM create_invoice(${invoice.id}, ${invoice.secret}::TEXT, ${invoice.request},
             ${expiresAt}::timestamp, ${amount * 1000}, ${user.id}::INTEGER, ${description}, NULL, NULL,
             ${invLimit}::INTEGER, ${balanceLimit})`,
           { models }
@@ -506,7 +506,7 @@ const resolvers = {
     preimage: async (withdrawl, args, { lnd }) => {
       try {
         if (withdrawl.status === 'CONFIRMED') {
-          return (await getPayment({ id: withdrawl.hash, lnd })).payment.secret
+          return withdrawl.preimage ?? (await getPayment({ id: withdrawl.hash, lnd })).payment.secret
         }
       } catch (err) {
         console.error('error fetching payment from LND', err)

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -711,6 +711,10 @@ export async function createWithdrawal (parent, { invoice, maxFee }, { me, model
     throw new GqlInputError('your invoice must specify an amount')
   }
 
+  if (decoded.mtokens > Number.MAX_SAFE_INTEGER) {
+    throw new GqlInputError('your invoice amount is too large')
+  }
+
   const msatsFee = Number(maxFee) * 1000
 
   const user = await models.user.findUnique({ where: { id: me.id } })

--- a/components/use-paid-mutation.js
+++ b/components/use-paid-mutation.js
@@ -85,7 +85,7 @@ export function usePaidMutation (mutation,
         // onCompleted is called before the invoice is paid for optimistic updates
         ourOnCompleted?.(data)
         // don't wait to pay the invoice
-        waitForPayment(invoice, { persistOnNavigate }).then(() => {
+        waitForPayment(invoice, { persistOnNavigate, waitFor }).then(() => {
           onPaid?.(client.cache, { data })
         }).catch(e => {
           console.error('usePaidMutation: failed to pay invoice', e)

--- a/components/use-paid-mutation.js
+++ b/components/use-paid-mutation.js
@@ -178,7 +178,8 @@ export const paidActionCacheMods = {
       id: `Invoice:${invoice.id}`,
       fields: {
         actionState: () => 'PAID',
-        confirmedAt: () => new Date().toISOString()
+        confirmedAt: () => new Date().toISOString(),
+        satsReceived: () => invoice.satsRequested
       }
     })
   }

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -16,7 +16,6 @@ export const INVOICE_FIELDS = gql`
     isHeld
     comment
     lud18Data
-    confirmedPreimage
     actionState
     actionType
     actionError
@@ -29,6 +28,7 @@ export const INVOICE_FULL = gql`
   query Invoice($id: ID!) {
     invoice(id: $id) {
       ...InvoiceFields
+      confirmedPreimage
       item {
         ...ItemFullFields
       }

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -19,6 +19,7 @@ export const INVOICE_FIELDS = gql`
     actionState
     actionType
     actionError
+    confirmedPreimage
   }`
 
 export const INVOICE_FULL = gql`
@@ -28,7 +29,6 @@ export const INVOICE_FULL = gql`
   query Invoice($id: ID!) {
     invoice(id: $id) {
       ...InvoiceFields
-      confirmedPreimage
       item {
         ...ItemFullFields
       }

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,0 +1,70 @@
+export async function fetchWithTimeout (resource, { timeout = 1000, ...options } = {}) {
+  const controller = new AbortController()
+  const id = setTimeout(() => controller.abort(), timeout)
+
+  const response = await fetch(resource, {
+    ...options,
+    signal: controller.signal
+  })
+  clearTimeout(id)
+
+  return response
+}
+
+class LRUCache {
+  constructor (maxSize = 100) {
+    this.maxSize = maxSize
+    this.cache = new Map()
+  }
+
+  get (key) {
+    if (!this.cache.has(key)) return undefined
+    const value = this.cache.get(key)
+    // refresh the entry
+    this.cache.delete(key)
+    this.cache.set(key, value)
+    return value
+  }
+
+  set (key, value) {
+    if (this.cache.has(key)) this.cache.delete(key)
+    else if (this.cache.size >= this.maxSize) {
+      // Remove the least recently used item
+      this.cache.delete(this.cache.keys().next().value)
+    }
+    this.cache.set(key, value)
+  }
+}
+
+export function cachedFetcher (fetcher, { maxSize = 100, cacheExpiry, forceRefreshThreshold }) {
+  const cache = new LRUCache(maxSize)
+
+  return async function cachedFetch (...args) {
+    const key = JSON.stringify(args)
+    const now = Date.now()
+
+    async function fetchAndCache () {
+      const result = await fetcher(...args)
+      cache.set(key, { data: result, createdAt: now })
+      return result
+    }
+
+    const cached = cache.get(key)
+
+    if (cached) {
+      const age = now - cached.createdAt
+
+      if (cacheExpiry === 0 || age < cacheExpiry) {
+        return cached.data
+      } else if (forceRefreshThreshold === 0 || age < forceRefreshThreshold) {
+        fetchAndCache().catch(console.error)
+        return cached.data
+      }
+    } else if (forceRefreshThreshold === 0) {
+      fetchAndCache().catch(console.error)
+      return null
+    }
+
+    return await fetchAndCache()
+  }
+}

--- a/pages/api/lnurlp/[username]/pay.js
+++ b/pages/api/lnurlp/[username]/pay.js
@@ -81,7 +81,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
     })
 
     await serialize(
-      models.$queryRaw`SELECT * FROM create_invoice(${invoice.id}, NULL, ${invoice.request},
+      models.$queryRaw`SELECT * FROM create_invoice(${invoice.id}, ${invoice.secret}::TEXT, ${invoice.request},
         ${expiresAt}::timestamp, ${Number(amount)}, ${user.id}::INTEGER, ${noteStr || description},
         ${comment || null}, ${parsedPayerData || null}::JSONB, ${INV_PENDING_LIMIT}::INTEGER,
         ${USER_IDS_BALANCE_NO_LIMIT.includes(Number(user.id)) ? 0 : BALANCE_LIMIT_MSATS})`,

--- a/pages/api/lnurlp/[username]/verify/[hash].js
+++ b/pages/api/lnurlp/[username]/verify/[hash].js
@@ -1,11 +1,8 @@
-import lnd from '@/api/lnd'
-import { getInvoice } from 'ln-service'
-
-export default async ({ query: { hash } }, res) => {
+export default async ({ query: { hash }, models }, res) => {
   try {
-    const inv = await getInvoice({ id: hash, lnd })
-    const settled = inv.is_confirmed
-    return res.status(200).json({ status: 'OK', settled, preimage: settled ? inv.secret : null, pr: inv.request })
+    const inv = await models.invoice.findUnique({ where: { hash } })
+    const settled = inv.confirmedAt
+    return res.status(200).json({ status: 'OK', settled, preimage: settled ? inv.preimage : null, pr: inv.bolt11 })
   } catch (err) {
     if (err[1] === 'UnexpectedLookupInvoiceErr') {
       return res.status(404).json({ status: 'ERROR', reason: 'not found' })

--- a/pages/api/lnurlp/[username]/verify/[hash].js
+++ b/pages/api/lnurlp/[username]/verify/[hash].js
@@ -1,12 +1,15 @@
-export default async ({ query: { hash }, models }, res) => {
+import models from '@/api/models'
+
+export default async ({ query: { hash } }, res) => {
   try {
     const inv = await models.invoice.findUnique({ where: { hash } })
-    const settled = inv.confirmedAt
-    return res.status(200).json({ status: 'OK', settled, preimage: settled ? inv.preimage : null, pr: inv.bolt11 })
-  } catch (err) {
-    if (err[1] === 'UnexpectedLookupInvoiceErr') {
+    if (!inv) {
       return res.status(404).json({ status: 'ERROR', reason: 'not found' })
     }
+    const settled = inv.confirmedAt
+    return res.status(200).json({ status: 'OK', settled: !!settled, preimage: settled ? inv.preimage : null, pr: inv.bolt11 })
+  } catch (err) {
+    console.log('error', err)
     return res.status(500).json({ status: 'ERROR', reason: 'internal server error' })
   }
 }

--- a/prisma/migrations/20241002145114_create_invoice_update/migration.sql
+++ b/prisma/migrations/20241002145114_create_invoice_update/migration.sql
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION create_invoice(hash TEXT, preimage TEXT, bolt11 TEXT, expires_at timestamp(3) without time zone,
+    msats_req BIGINT, user_id INTEGER, idesc TEXT, comment TEXT, lud18_data JSONB, inv_limit INTEGER, balance_limit_msats BIGINT)
+RETURNS "Invoice"
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    invoice "Invoice";
+    inv_limit_reached BOOLEAN;
+    balance_limit_reached BOOLEAN;
+    inv_pending_msats BIGINT;
+    wdwl_pending_msats BIGINT;
+BEGIN
+    PERFORM ASSERT_SERIALIZED();
+
+    -- prevent too many pending invoices
+    SELECT inv_limit > 0 AND count(*) >= inv_limit, COALESCE(sum("msatsRequested"), 0) INTO inv_limit_reached, inv_pending_msats
+    FROM "Invoice"
+    WHERE "userId" = user_id AND "expiresAt" > now_utc() AND "confirmedAt" IS NULL AND cancelled = false;
+
+    IF inv_limit_reached THEN
+        RAISE EXCEPTION 'SN_INV_PENDING_LIMIT';
+    END IF;
+
+    -- account for pending withdrawals
+    SELECT COALESCE(sum("msatsPaying"), 0) + COALESCE(sum("msatsFeePaying"), 0) INTO wdwl_pending_msats
+    FROM "Withdrawl"
+    WHERE "userId" = user_id AND status IS NULL;
+
+    -- prevent pending invoices + msats from exceeding the limit
+    SELECT balance_limit_msats > 0 AND inv_pending_msats+wdwl_pending_msats+msats_req+msats > balance_limit_msats INTO balance_limit_reached
+    FROM users
+    WHERE id = user_id;
+
+    IF balance_limit_reached THEN
+        RAISE EXCEPTION 'SN_INV_EXCEED_BALANCE';
+    END IF;
+
+    -- we good, proceed frens
+    INSERT INTO "Invoice" (hash, preimage, bolt11, "expiresAt", "msatsRequested", "userId", created_at, updated_at, "desc", comment, "lud18Data")
+    VALUES (hash, preimage, bolt11, expires_at, msats_req, user_id, now_utc(), now_utc(), idesc, comment, lud18_data) RETURNING * INTO invoice;
+
+    RETURN invoice;
+END;
+$$;

--- a/wallets/wrap.js
+++ b/wallets/wrap.js
@@ -1,5 +1,5 @@
-import { createHodlInvoice, getHeight, parsePaymentRequest } from 'ln-service'
-import { estimateRouteFee } from '../api/lnd'
+import { createHodlInvoice, parsePaymentRequest } from 'ln-service'
+import { estimateRouteFee, getBlockHeight } from '../api/lnd'
 import { toPositiveNumber } from '@/lib/validate'
 
 const MIN_OUTGOING_MSATS = BigInt(900) // the minimum msats we'll allow for the outgoing invoice
@@ -131,7 +131,7 @@ export default async function wrapInvoice (bolt11, { msats, description, descrip
         timeout: FEE_ESTIMATE_TIMEOUT_SECS
       })
 
-    const { current_block_height: blockHeight } = await getHeight({ lnd })
+    const blockHeight = await getBlockHeight()
     /*
       we want the incoming invoice to have MIN_SETTLEMENT_CLTV_DELTA higher final cltv delta than
       the expected ctlv_delta of the outgoing invoice's entire route

--- a/wallets/wrap.js
+++ b/wallets/wrap.js
@@ -44,7 +44,7 @@ export default async function wrapInvoice (bolt11, { msats, description, descrip
       if (outgoingMsat < MIN_OUTGOING_MSATS) {
         throw new Error(`Invoice amount is too low: ${outgoingMsat}`)
       }
-      if (inv.mtokens > MAX_OUTGOING_MSATS) {
+      if (outgoingMsat > MAX_OUTGOING_MSATS) {
         throw new Error(`Invoice amount is too high: ${outgoingMsat}`)
       }
     } else {

--- a/worker/imgproxy.js
+++ b/worker/imgproxy.js
@@ -3,6 +3,7 @@ import { extractUrls } from '@/lib/md.js'
 import { isJob } from '@/lib/item.js'
 import path from 'node:path'
 import { decodeProxyUrl } from '@/lib/url'
+import { fetchWithTimeout } from '@/lib/fetch'
 
 const imgProxyEnabled = process.env.NODE_ENV === 'production' ||
   (process.env.NEXT_PUBLIC_IMGPROXY_URL && process.env.IMGPROXY_SALT && process.env.IMGPROXY_KEY)
@@ -131,19 +132,6 @@ const createImgproxyPath = ({ url, pathname = '/', options }) => {
   const target = path.join(options, b64Url)
   const signature = sign(target)
   return path.join(pathname, signature, target)
-}
-
-async function fetchWithTimeout (resource, { timeout = 1000, ...options } = {}) {
-  const controller = new AbortController()
-  const id = setTimeout(() => controller.abort(), timeout)
-
-  const response = await fetch(resource, {
-    ...options,
-    signal: controller.signal
-  })
-  clearTimeout(id)
-
-  return response
 }
 
 const isMediaURL = async (url, { forceFetch }) => {

--- a/worker/paidAction.js
+++ b/worker/paidAction.js
@@ -260,6 +260,7 @@ export async function paidActionForwarded ({ data: { invoiceId, withdrawal, ...a
       await settleHodlInvoice({ secret: payment.secret, lnd })
 
       return {
+        preimage: payment.secret,
         invoiceForward: {
           update: {
             withdrawl: {

--- a/worker/paidAction.js
+++ b/worker/paidAction.js
@@ -14,7 +14,7 @@ import { MIN_SETTLEMENT_CLTV_DELTA } from 'wallets/wrap'
 // aggressive finalization retry options
 const FINALIZE_OPTIONS = { retryLimit: 2 ** 31 - 1, retryBackoff: false, retryDelay: 5, priority: 1000 }
 
-async function transitionInvoice (jobName, { invoiceId, fromState, toState, transition }, { models, lnd, boss }) {
+async function transitionInvoice (jobName, { invoiceId, fromState, toState, transition, invoice }, { models, lnd, boss }) {
   console.group(`${jobName}: transitioning invoice ${invoiceId} from ${fromState} to ${toState}`)
 
   try {
@@ -30,7 +30,7 @@ async function transitionInvoice (jobName, { invoiceId, fromState, toState, tran
       fromState = [fromState]
     }
 
-    const lndInvoice = await getInvoice({ id: currentDbInvoice.hash, lnd })
+    const lndInvoice = invoice ?? await getInvoice({ id: currentDbInvoice.hash, lnd })
 
     const transitionedInvoice = await models.$transaction(async tx => {
       const include = {
@@ -133,7 +133,7 @@ async function performPessimisticAction ({ lndInvoice, dbInvoice, tx, models, ln
   }
 }
 
-export async function paidActionPaid ({ data: { invoiceId }, models, lnd, boss }) {
+export async function paidActionPaid ({ data: { invoiceId, ...args }, models, lnd, boss }) {
   return await transitionInvoice('paidActionPaid', {
     invoiceId,
     fromState: ['HELD', 'PENDING', 'FORWARDED'],
@@ -153,12 +153,13 @@ export async function paidActionPaid ({ data: { invoiceId }, models, lnd, boss }
         confirmedIndex: lndInvoice.confirmed_index,
         msatsReceived: BigInt(lndInvoice.received_mtokens)
       }
-    }
+    },
+    ...args
   }, { models, lnd, boss })
 }
 
 // this performs forward creating the outgoing payment
-export async function paidActionForwarding ({ data: { invoiceId }, models, lnd, boss }) {
+export async function paidActionForwarding ({ data: { invoiceId, ...args }, models, lnd, boss }) {
   const transitionedInvoice = await transitionInvoice('paidActionForwarding', {
     invoiceId,
     fromState: 'PENDING_HELD',
@@ -213,7 +214,8 @@ export async function paidActionForwarding ({ data: { invoiceId }, models, lnd, 
           }
         }
       }
-    }
+    },
+    ...args
   }, { models, lnd, boss })
 
   // only pay if we successfully transitioned which can only happen once
@@ -238,7 +240,7 @@ export async function paidActionForwarding ({ data: { invoiceId }, models, lnd, 
 }
 
 // this finalizes the forward by settling the incoming invoice after the outgoing payment is confirmed
-export async function paidActionForwarded ({ data: { invoiceId }, models, lnd, boss }) {
+export async function paidActionForwarded ({ data: { invoiceId, withdrawal, ...args }, models, lnd, boss }) {
   return await transitionInvoice('paidActionForwarded', {
     invoiceId,
     fromState: 'FORWARDING',
@@ -249,7 +251,7 @@ export async function paidActionForwarded ({ data: { invoiceId }, models, lnd, b
       }
 
       const { hash, msatsPaying } = dbInvoice.invoiceForward.withdrawl
-      const { payment, is_confirmed: isConfirmed } = await getPayment({ id: hash, lnd })
+      const { payment, is_confirmed: isConfirmed } = withdrawal ?? await getPayment({ id: hash, lnd })
       if (!isConfirmed) {
         throw new Error('payment is not confirmed')
       }
@@ -271,12 +273,13 @@ export async function paidActionForwarded ({ data: { invoiceId }, models, lnd, b
           }
         }
       }
-    }
+    },
+    ...args
   }, { models, lnd, boss })
 }
 
 // when the pending forward fails, we need to cancel the incoming invoice
-export async function paidActionFailedForward ({ data: { invoiceId }, models, lnd, boss }) {
+export async function paidActionFailedForward ({ data: { invoiceId, withdrawal: pWithdrawal, ...args }, models, lnd, boss }) {
   return await transitionInvoice('paidActionFailedForward', {
     invoiceId,
     fromState: 'FORWARDING',
@@ -289,7 +292,7 @@ export async function paidActionFailedForward ({ data: { invoiceId }, models, ln
       let withdrawal
       let notSent = false
       try {
-        withdrawal = await getPayment({ id: dbInvoice.invoiceForward.withdrawl.hash, lnd })
+        withdrawal = pWithdrawal ?? await getPayment({ id: dbInvoice.invoiceForward.withdrawl.hash, lnd })
       } catch (err) {
         if (err[1] === 'SentPaymentNotFound' &&
           dbInvoice.invoiceForward.withdrawl.createdAt < datePivot(new Date(), { milliseconds: -LND_PATHFINDING_TIMEOUT_MS * 2 })) {
@@ -319,11 +322,12 @@ export async function paidActionFailedForward ({ data: { invoiceId }, models, ln
           }
         }
       }
-    }
+    },
+    ...args
   }, { models, lnd, boss })
 }
 
-export async function paidActionHeld ({ data: { invoiceId }, models, lnd, boss }) {
+export async function paidActionHeld ({ data: { invoiceId, ...args }, models, lnd, boss }) {
   return await transitionInvoice('paidActionHeld', {
     invoiceId,
     fromState: 'PENDING_HELD',
@@ -355,11 +359,12 @@ export async function paidActionHeld ({ data: { invoiceId }, models, lnd, boss }
         isHeld: true,
         msatsReceived: BigInt(lndInvoice.received_mtokens)
       }
-    }
+    },
+    ...args
   }, { models, lnd, boss })
 }
 
-export async function paidActionCanceling ({ data: { invoiceId }, models, lnd, boss }) {
+export async function paidActionCanceling ({ data: { invoiceId, ...args }, models, lnd, boss }) {
   return await transitionInvoice('paidActionCanceling', {
     invoiceId,
     fromState: ['HELD', 'PENDING', 'PENDING_HELD', 'FAILED_FORWARD'],
@@ -370,11 +375,12 @@ export async function paidActionCanceling ({ data: { invoiceId }, models, lnd, b
       }
 
       await cancelHodlInvoice({ id: dbInvoice.hash, lnd })
-    }
+    },
+    ...args
   }, { models, lnd, boss })
 }
 
-export async function paidActionFailed ({ data: { invoiceId }, models, lnd, boss }) {
+export async function paidActionFailed ({ data: { invoiceId, ...args }, models, lnd, boss }) {
   return await transitionInvoice('paidActionFailed', {
     invoiceId,
     // any of these states can transition to FAILED
@@ -390,6 +396,7 @@ export async function paidActionFailed ({ data: { invoiceId }, models, lnd, boss
       return {
         cancelled: true
       }
-    }
+    },
+    ...args
   }, { models, lnd, boss })
 }

--- a/worker/paidAction.js
+++ b/worker/paidAction.js
@@ -317,7 +317,7 @@ export async function paidActionFailedForward ({ data: { invoiceId, withdrawal: 
           update: {
             withdrawl: {
               update: {
-                status: getPaymentFailureStatus(withdrawal)
+                status: getPaymentFailureStatus(withdrawal).status
               }
             }
           }

--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -291,16 +291,15 @@ export async function checkWithdrawal ({ data: { hash, withdrawal, invoice }, bo
 
     const fee = Number(wdrwl.payment.fee_mtokens)
     const paid = Number(wdrwl.payment.mtokens) - fee
-    const [{ confirm_withdrawl: code }] = await serialize(
+    const [{ confirm_withdrawl: code }] = await serialize([
       models.$queryRaw`SELECT confirm_withdrawl(${dbWdrwl.id}::INTEGER, ${paid}, ${fee})`,
       models.withdrawl.update({
         where: { id: dbWdrwl.id },
         data: {
           preimage: wdrwl.payment.secret
         }
-      }),
-      { models }
-    )
+      })
+    ], { models })
     if (code === 0) {
       notifyWithdrawal(dbWdrwl.userId, wdrwl)
       if (dbWdrwl.wallet) {


### PR DESCRIPTION
Currently, we beat the crap out of lnd with super frequent, redundant, or unnecessary grpc calls.

So far:
- replace use of `decodePaymentRequest` with `parsePaymentRequest`
- cache blockheight
- cache our node's pubkey
- cache node info
- bonus: reuse cache abstraction for price fetching and fee rate fetching

Planned:

- [x] store preimage when invoice is confirmed - so we don't have to ask lnd errytime
- [x] store preimage on successful withdrawal - so we don't have to ask lnd errytime
- [x] avoid redundant `getInvoice` and `getPayment` calls in the `paidAction` state machine - in the happy case we've already requested these
     - this was worse than I thought - it's was two calls per state machine transition when we could've gotten away with 0 using the subscription event object

Test todo:
- [x] optimistic paid actions
    - [x] failures
    - [x] retries
- [x] pessimistic paid actions
    - [x] failures
- [x] p2p zaps
    - [x] outbound failures
- [x] lnurl-verify
- [x] funding account
- [x] withdrawaling
- [x] autowithdrawaling