### PR TITLE
feat: back to wallet link

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 unsafe-perm=true
 legacy-peer-deps=true
+proxy=socks5://127.0.0.1:9050

--- a/pages/invoices/[id].js
+++ b/pages/invoices/[id].js
@@ -3,6 +3,7 @@ import { CenterLayout } from '@/components/layout'
 import { useRouter } from 'next/router'
 import { INVOICE_FULL } from '@/fragments/wallet'
 import { getGetServerSideProps } from '@/api/ssrApollo'
+import { LinkToWallet } from '../wallet'
 
 // force SSR to include CSP nonces
 export const getServerSideProps = getGetServerSideProps({ query: null })
@@ -13,6 +14,7 @@ export default function FullInvoice () {
   return (
     <CenterLayout>
       <Invoice id={router.query.id} query={INVOICE_FULL} poll description status='loading' bolt11Info useWallet={false} />
+      <LinkToWallet />
     </CenterLayout>
   )
 }

--- a/pages/wallet/index.js
+++ b/pages/wallet/index.js
@@ -88,10 +88,10 @@ function WalletHistory () {
   )
 }
 
-function LinkBackToWallet () {
+export function LinkToWallet () {
   return (
     <Link href='/wallet' className='text-muted fw-bold text-underline mt-3'>
-      <medium className='ms-3'>go back to wallet</medium>
+      <medium className='ms-3'>go to wallet</medium>
     </Link>
   )
 }
@@ -168,7 +168,7 @@ export function FundForm () {
           <SubmitButton variant='success' className='mt-2'>generate invoice</SubmitButton>
         </Form>
       </div>
-      <LinkBackToWallet />
+      <LinkToWallet />
     </>
   )
 }
@@ -200,7 +200,7 @@ export function WithdrawalForm () {
         </Nav.Item>
       </Nav>
       <SelectedWithdrawalForm />
-      <LinkBackToWallet />
+      <LinkToWallet />
     </div>
   )
 }

--- a/pages/wallet/index.js
+++ b/pages/wallet/index.js
@@ -88,6 +88,14 @@ function WalletHistory () {
   )
 }
 
+function LinkBackToWallet () {
+  return (
+    <Link href='/wallet' className='text-muted fw-bold text-underline mt-3'>
+      <medium className='ms-3'>go back to wallet</medium>
+    </Link>
+  )
+}
+
 export function WalletForm () {
   return (
     <div className='align-items-center text-center pt-5 pb-4'>
@@ -160,7 +168,7 @@ export function FundForm () {
           <SubmitButton variant='success' className='mt-2'>generate invoice</SubmitButton>
         </Form>
       </div>
-      <WalletHistory />
+      <LinkBackToWallet />
     </>
   )
 }
@@ -192,6 +200,7 @@ export function WithdrawalForm () {
         </Nav.Item>
       </Nav>
       <SelectedWithdrawalForm />
+      <LinkBackToWallet />
     </div>
   )
 }

--- a/pages/withdrawals/[id].js
+++ b/pages/withdrawals/[id].js
@@ -16,6 +16,7 @@ import { gql } from 'graphql-tag'
 import { useShowModal } from '@/components/modal'
 import { DeleteConfirm } from '@/components/delete'
 import { getGetServerSideProps } from '@/api/ssrApollo'
+import { LinkToWallet } from '../wallet'
 
 // force SSR to include CSP nonces
 export const getServerSideProps = getGetServerSideProps({ query: null })
@@ -24,6 +25,7 @@ export default function Withdrawl () {
   return (
     <CenterLayout>
       <LoadWithdrawl />
+      <LinkToWallet />
     </CenterLayout>
   )
 }


### PR DESCRIPTION

## Description
Addresses #1369.
I have implemented it a bit different than described solution in issue. The link is seen after you go to 'fund' or 'withdraw' on wallet page. It also shown on 'invoices' and 'withdrawals' pages. I have removed the 'wallet history' link that was previously show on `FundForm`


<!--
A clear and concise description of what you changed and why.
Don't forget to mention which tickets this closes (if any).
Use following syntax to close them automatically on merge: closes #<number>
-->

## Screenshots
![Screenshot from 2024-10-03 15-02-07](https://github.com/user-attachments/assets/039e6dba-6739-4ce4-a304-3ff49d28f1c5)
![screen](https://github.com/user-attachments/assets/b314edb1-2dd4-4bf4-baba-39a850ef8429)


<!--
If your changes are user facing, please add screenshots of the new UI.
You can also create a video to showcase your changes (useful to show UX).
-->

## Additional Context

<!--
You can mention here anything that you think is relevant for this PR. Some examples:
* You encountered something that you didn't understand while working on this PR
* You were not sure about something you did but did not find a better way
* You initially had a different approach but went with a different approach for some reason
-->

## Checklist

**Are your changes backwards compatible? Please answer below:**

<!-- put your answer about backwards compatibility here -->

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

<!-- put your answer about QA here -->

**For frontend changes: Tested on mobile? Please answer below:**

<!-- put your answer about mobile QA here -->

**Did you introduce any new environment variables? If so, call them out explicitly here:**

<!-- put your answer about env vars here -->
