### PR TITLE
run noncritical side effects outside critical path of paid action

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ GITHUB_SECRET=<Client secret>
 
 ## Enabling web push notifications
 
-To enable Web Push locally, you will need to set the `VAPID_*` env vars. `VAPID_MAILTO` needs to be an email address using the `mailto:` scheme. For `NEXT_PUBLIC_VAPID_KEY` and `VAPID_PRIVKEY`, you can run `npx web-push generate-vapid-keys`.
+To enable Web Push locally, you will need to set the `VAPID_*` env vars. `VAPID_MAILTO` needs to be an email address using the `mailto:` scheme. For `NEXT_PUBLIC_VAPID_PUBKEY` and `VAPID_PRIVKEY`, you can run `npx web-push generate-vapid-keys`.
 
 <br>
 

--- a/api/paidAction/README.md
+++ b/api/paidAction/README.md
@@ -154,7 +154,11 @@ All functions have the following signature: `function(args: Object, context: Obj
        - it can optionally store in the invoice with the `invoiceId` the `actionId` to be able to link the action with the invoice regardless of retries
 - `onPaid`: called when the action is paid
     - if the action does not support optimism, this function is optional
-    - this function should be used to mark the rows created in `perform` as `PAID` and perform any other side effects of the action (like notifications or denormalizations)
+    - this function should be used to mark the rows created in `perform` as `PAID` and perform critical side effects of the action (like denormalizations)
+- `nonCriticalSideEffects`: called after the action is paid to run any side effects whose failure does not affect the action's execution
+    - this function is always optional
+    - it's passed the result of the action (or the action's paid invoice) and the current context
+    - this is where things like push notifications should be handled
 - `onFail`: called when the action fails
     - if the action does not support optimism, this function is optional
     - this function should be used to mark the rows created in `perform` as `FAILED`

--- a/api/paidAction/boost.js
+++ b/api/paidAction/boost.js
@@ -38,7 +38,7 @@ export async function retry ({ invoiceId, newInvoiceId }, { tx, cost }) {
   return { id, sats: msatsToSats(cost), act: 'BOOST', path }
 }
 
-export async function onPaid ({ invoice, actId }, { models, tx }) {
+export async function onPaid ({ invoice, actId }, { tx }) {
   let itemAct
   if (invoice) {
     await tx.itemAct.updateMany({

--- a/api/paidAction/zap.js
+++ b/api/paidAction/zap.js
@@ -165,11 +165,12 @@ export async function onPaid ({ invoice, actIds }, { tx }) {
       WHERE "Item".path @> zapped.path AND "Item".id <> zapped.id`
 }
 
-export async function nonCriticalSideEffects ({ invoice, id }, { models }) {
-  const item = await models.item.findFirst({
-    where: invoice ? { invoiceId: invoice.id } : { id: parseInt(id) }
+export async function nonCriticalSideEffects ({ invoice, actIds }, { models }) {
+  const itemAct = await models.itemAct.findFirst({
+    where: invoice ? { invoiceId: invoice.id } : { id: { in: actIds } },
+    include: { item: true }
   })
-  notifyZapped({ models, item }).catch(console.error)
+  notifyZapped({ models, item: itemAct.item }).catch(console.error)
 }
 
 export async function onFail ({ invoice }, { tx }) {


### PR DESCRIPTION
fixes #1461

These were failing in prod regularly because some of them were done in the paid action's interactive tx, but because they were async the tx was already closed when they ran.

This moves these noncritical side effects outside of the tx.

QA: `8`. I've tested that the modified paid actions still run (fee credits, optimistic, pessimistic), and that noncriticalSideEffects don't error. I tested that all modified paid actions send notifications, but I didn't test all possible notifications they can send.
