### PR TITLE
remove unused fields from me fragment

### DIFF
--- a/fragments/users.js
+++ b/fragments/users.js
@@ -15,31 +15,16 @@ export const ME = gql`
         diagnostics
         noReferralLinks
         fiatCurrency
+        autoWithdrawMaxFeePercent
+        autoWithdrawThreshold
+        withdrawMaxFeeDefault
         satsFilter
-        hideCowboyHat
         hideFromTopUsers
-        hideGithub
-        hideNostr
-        hideTwitter
-        hideInvoiceDesc
-        hideIsContributor
         hideWalletBalance
         hideWelcomeBanner
         imgproxyOnly
         showImagesAndVideos
-        lastCheckedJobs
         nostrCrossposting
-        noteAllDescendants
-        noteCowboyHat
-        noteDeposits
-        noteWithdrawals
-        noteEarning
-        noteForwardedSats
-        noteInvites
-        noteItemSats
-        noteJobIndicator
-        noteMentions
-        noteItemMentions
         sats
         tipDefault
         tipRandom
@@ -50,19 +35,12 @@ export const ME = gql`
         zapUndos
         upvotePopover
         wildWestMode
-        withdrawMaxFeeDefault
-        lnAddr
-        autoWithdrawMaxFeePercent
-        autoWithdrawThreshold
         disableFreebies
       }
       optional {
         isContributor
         stacked
         streak
-        githubId
-        nostrAuthPubkey
-        twitterId
       }
     }
   }`

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -385,14 +385,14 @@ export default function Settings ({ ssrData }) {
             groupClassName='mb-0'
           />
           <Checkbox
-            disabled={me.optional.githubId === null}
+            disabled={!settings?.authMethods?.github}
             label={
               <div className='d-flex align-items-center'>hide my linked github profile
                 <Info>
                   <ul>
                     <li>Linked accounts are hidden from your profile by default</li>
                     <li>uncheck this to display your github on your profile</li>
-                    {me.optional.githubId === null &&
+                    {!settings?.authMethods?.github &&
                       <div className='my-2'>
                         <li><i>You don't seem to have a linked github account</i></li>
                         <ul><li>If this is wrong, try unlinking/relinking</li></ul>
@@ -405,14 +405,14 @@ export default function Settings ({ ssrData }) {
             groupClassName='mb-0'
           />
           <Checkbox
-            disabled={me.optional.nostrAuthPubkey === null}
+            disabled={!settings?.authMethods?.nostr}
             label={
               <div className='d-flex align-items-center'>hide my linked nostr profile
                 <Info>
                   <ul>
                     <li>Linked accounts are hidden from your profile by default</li>
                     <li>Uncheck this to display your npub on your profile</li>
-                    {me.optional.nostrAuthPubkey === null &&
+                    {!settings?.authMethods?.nostr &&
                       <div className='my-2'>
                         <li>You don't seem to have a linked nostr account</li>
                         <ul><li>If this is wrong, try unlinking/relinking</li></ul>
@@ -425,14 +425,14 @@ export default function Settings ({ ssrData }) {
             groupClassName='mb-0'
           />
           <Checkbox
-            disabled={me.optional.twitterId === null}
+            disabled={!settings?.authMethods?.twitter}
             label={
               <div className='d-flex align-items-center'>hide my linked twitter profile
                 <Info>
                   <ul>
                     <li>Linked accounts are hidden from your profile by default</li>
                     <li>Uncheck this to display your twitter on your profile</li>
-                    {me.optional.twitterId === null &&
+                    {!settings?.authMethods?.twitter &&
                       <div className='my-2'>
                         <i>You don't seem to have a linked twitter account</i>
                         <ul><li>If this is wrong, try unlinking/relinking</li></ul>


### PR DESCRIPTION
## Description

These are no longer used and considering we fetch `me` a lot, probably best to remove.

QA: `5`. I searched around for all uses of `\b(user|me)\??\.(optional|privates)\??\.` and looked for any unexpected/unnecessary `me` usage.