### PR TITLE
Fix sub?.removeAllListeners is not a function

### DIFF
--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -34,7 +34,10 @@ function subscribeForever (subscribe) {
         }
         if (sub.then) {
           // sub is promise
-          sub.then(sub => sub.on('error', reject))
+          sub.then(resolved => {
+            sub = resolved
+            sub.on('error', reject)
+          })
         } else {
           sub.on('error', reject)
         }


### PR DESCRIPTION
## Description

I noticed that in `subscribeForever`, `sub` could still be a promise when we reach the finally block since we never assign the event emitter to it when `subscribe` returned a promise.

I am not sure if this lead to any leaks but if so, they should be fixed now.

You can reproduce the error by giving the worker bad LND credentials.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. Looked at logs w/o change -> found `sub?.removeAllListeners is not a function` in worker logs. Looked at logs with change -> no more such error

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
