### PR TITLE
Fix infinite loop of loading wallet logs + center more button

### DIFF
--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -12,10 +12,7 @@ import useIndexedDB from './use-indexeddb'
 import { SSR } from '@/lib/constants'
 
 export function WalletLogs ({ wallet, embedded }) {
-  const { logs, setLogs, hasMore, loadMore, loadLogs, loading } = useWalletLogs(wallet)
-  useEffect(() => {
-    loadLogs()
-  }, [loadLogs])
+  const { logs, setLogs, hasMore, loadMore, loading } = useWalletLogs(wallet)
 
   const showModal = useShowModal()
 
@@ -246,6 +243,10 @@ export function useWalletLogs (wallet, initialPage = 1, logsPerPage = 10) {
     setPage(1)
     setLoading(false)
   }, [wallet, loadLogsPage])
+
+  useEffect(() => {
+    loadLogs()
+  }, [wallet])
 
   return { logs, hasMore, total, loadMore, loadLogs, setLogs, loading }
 }

--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -43,7 +43,7 @@ export function WalletLogs ({ wallet, embedded }) {
           ? <div className='w-100 text-center'>loading...</div>
           : logs.length === 0 && <div className='w-100 text-center'>empty</div>}
         {hasMore
-          ? <Button onClick={loadMore} size='sm' className='mt-3'>Load More</Button>
+          ? <div className='w-100 text-center'><Button onClick={loadMore} size='sm' className='mt-3'>more</Button></div>
           : <div className='w-100 text-center'>------ start of logs ------</div>}
       </div>
     </>


### PR DESCRIPTION
## Description

This fixes an infinite loop of reloading wallet logs.

Also moved `more` button from this

![localhost_3000_settings_wallets_nwc(iPhone SE) (1)](https://github.com/user-attachments/assets/0e8a7699-52f9-4e03-8877-09214d5a0741)

to center like this:

![localhost_3000_settings_wallets_nwc(iPhone SE)](https://github.com/user-attachments/assets/ef17b554-7ed3-4670-9454-ead6abba2f31)

I think this is more consistent with the logs layout and how other buttons for more look.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. Made sure logs for every wallet still load correctly.

**For frontend changes: Tested on mobile? Please answer below:**

yes, see screenshots

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
