### PR TITLE
November 5th

### DIFF
--- a/api/paidAction/README.md
+++ b/api/paidAction/README.md
@@ -139,8 +139,15 @@ Each paid action is implemented in its own file in the `paidAction` directory. E
 
 ### Boolean flags
 - `anonable`: can be performed anonymously
-- `supportsPessimism`: supports a pessimistic payment flow
-- `supportsOptimism`: supports an optimistic payment flow
+
+### Payment methods
+- `paymentMethods`: an array of payment methods that the action supports ordered from most preferred to least preferred
+    - P2P: a p2p payment made directly from the client to the recipient
+        - after wrapping the invoice, anonymous users will follow a PESSIMISTIC flow to pay the invoice and logged in users will follow an OPTIMISTIC flow
+    - FEE_CREDIT: a payment made from the user's fee credit balance
+    - REWARD_SATS: a payment made from the user's reward sats balance
+    - OPTIMISTIC: an optimistic payment flow
+    - PESSIMISTIC: a pessimistic payment flow
 
 ### Functions
 

--- a/api/paidAction/boost.js
+++ b/api/paidAction/boost.js
@@ -1,8 +1,13 @@
+import { PAID_ACTION_PAYMENT_METHODS } from '@/lib/constants'
 import { msatsToSats, satsToMsats } from '@/lib/format'
 
 export const anonable = false
-export const supportsPessimism = false
-export const supportsOptimism = true
+
+export const paymentMethods = [
+  PAID_ACTION_PAYMENT_METHODS.FEE_CREDIT,
+  PAID_ACTION_PAYMENT_METHODS.REWARD_SATS,
+  PAID_ACTION_PAYMENT_METHODS.OPTIMISTIC
+]
 
 export async function getCost ({ sats }) {
   return satsToMsats(sats)

--- a/api/paidAction/buyCredits.js
+++ b/api/paidAction/buyCredits.js
@@ -1,13 +1,12 @@
-// XXX we don't use this yet ...
-// it's just showing that even buying credits
-// can eventually be a paid action
-
-import { USER_ID } from '@/lib/constants'
+import { PAID_ACTION_PAYMENT_METHODS, USER_ID } from '@/lib/constants'
 import { satsToMsats } from '@/lib/format'
 
 export const anonable = false
-export const supportsPessimism = false
-export const supportsOptimism = true
+
+export const paymentMethods = [
+  PAID_ACTION_PAYMENT_METHODS.REWARD_SATS,
+  PAID_ACTION_PAYMENT_METHODS.PESSIMISTIC
+]
 
 export async function getCost ({ amount }) {
   return satsToMsats(amount)

--- a/api/paidAction/donate.js
+++ b/api/paidAction/donate.js
@@ -1,9 +1,13 @@
-import { USER_ID } from '@/lib/constants'
+import { PAID_ACTION_PAYMENT_METHODS, USER_ID } from '@/lib/constants'
 import { satsToMsats } from '@/lib/format'
 
 export const anonable = true
-export const supportsPessimism = true
-export const supportsOptimism = false
+
+export const paymentMethods = [
+  PAID_ACTION_PAYMENT_METHODS.FEE_CREDIT,
+  PAID_ACTION_PAYMENT_METHODS.REWARD_SATS,
+  PAID_ACTION_PAYMENT_METHODS.PESSIMISTIC
+]
 
 export async function getCost ({ sats }) {
   return satsToMsats(sats)

--- a/api/paidAction/downZap.js
+++ b/api/paidAction/downZap.js
@@ -1,8 +1,13 @@
+import { PAID_ACTION_PAYMENT_METHODS } from '@/lib/constants'
 import { msatsToSats, satsToMsats } from '@/lib/format'
 
 export const anonable = false
-export const supportsPessimism = false
-export const supportsOptimism = true
+
+export const paymentMethods = [
+  PAID_ACTION_PAYMENT_METHODS.FEE_CREDIT,
+  PAID_ACTION_PAYMENT_METHODS.REWARD_SATS,
+  PAID_ACTION_PAYMENT_METHODS.OPTIMISTIC
+]
 
 export async function getCost ({ sats }) {
   return satsToMsats(sats)

--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -1,11 +1,16 @@
-import { ANON_ITEM_SPAM_INTERVAL, ITEM_SPAM_INTERVAL, USER_ID } from '@/lib/constants'
+import { ANON_ITEM_SPAM_INTERVAL, ITEM_SPAM_INTERVAL, PAID_ACTION_PAYMENT_METHODS, USER_ID } from '@/lib/constants'
 import { notifyItemMention, notifyItemParents, notifyMention, notifyTerritorySubscribers, notifyUserSubscribers } from '@/lib/webPush'
 import { getItemMentions, getMentions, performBotBehavior } from './lib/item'
 import { msatsToSats, satsToMsats } from '@/lib/format'
 
 export const anonable = true
-export const supportsPessimism = true
-export const supportsOptimism = true
+
+export const paymentMethods = [
+  PAID_ACTION_PAYMENT_METHODS.FEE_CREDIT,
+  PAID_ACTION_PAYMENT_METHODS.REWARD_SATS,
+  PAID_ACTION_PAYMENT_METHODS.OPTIMISTIC,
+  PAID_ACTION_PAYMENT_METHODS.PESSIMISTIC
+]
 
 export async function getCost ({ subName, parentId, uploadIds, boost = 0, bio }, { models, me }) {
   const sub = (parentId || bio) ? null : await models.sub.findUnique({ where: { name: subName } })

--- a/api/paidAction/itemUpdate.js
+++ b/api/paidAction/itemUpdate.js
@@ -1,12 +1,16 @@
-import { USER_ID } from '@/lib/constants'
+import { PAID_ACTION_PAYMENT_METHODS, USER_ID } from '@/lib/constants'
 import { uploadFees } from '../resolvers/upload'
 import { getItemMentions, getMentions, performBotBehavior } from './lib/item'
 import { notifyItemMention, notifyMention } from '@/lib/webPush'
 import { satsToMsats } from '@/lib/format'
 
 export const anonable = true
-export const supportsPessimism = true
-export const supportsOptimism = false
+
+export const paymentMethods = [
+  PAID_ACTION_PAYMENT_METHODS.FEE_CREDIT,
+  PAID_ACTION_PAYMENT_METHODS.REWARD_SATS,
+  PAID_ACTION_PAYMENT_METHODS.PESSIMISTIC
+]
 
 export async function getCost ({ id, boost = 0, uploadIds, bio }, { me, models }) {
   // the only reason updating items costs anything is when it has new uploads

--- a/api/paidAction/pollVote.js
+++ b/api/paidAction/pollVote.js
@@ -1,8 +1,13 @@
+import { PAID_ACTION_PAYMENT_METHODS } from '@/lib/constants'
 import { satsToMsats } from '@/lib/format'
 
 export const anonable = false
-export const supportsPessimism = true
-export const supportsOptimism = true
+
+export const paymentMethods = [
+  PAID_ACTION_PAYMENT_METHODS.FEE_CREDIT,
+  PAID_ACTION_PAYMENT_METHODS.REWARD_SATS,
+  PAID_ACTION_PAYMENT_METHODS.OPTIMISTIC
+]
 
 export async function getCost ({ id }, { me, models }) {
   const pollOption = await models.pollOption.findUnique({

--- a/api/paidAction/territoryBilling.js
+++ b/api/paidAction/territoryBilling.js
@@ -1,10 +1,14 @@
-import { TERRITORY_PERIOD_COST } from '@/lib/constants'
+import { PAID_ACTION_PAYMENT_METHODS, TERRITORY_PERIOD_COST } from '@/lib/constants'
 import { satsToMsats } from '@/lib/format'
 import { nextBilling } from '@/lib/territory'
 
 export const anonable = false
-export const supportsPessimism = true
-export const supportsOptimism = false
+
+export const paymentMethods = [
+  PAID_ACTION_PAYMENT_METHODS.FEE_CREDIT,
+  PAID_ACTION_PAYMENT_METHODS.REWARD_SATS,
+  PAID_ACTION_PAYMENT_METHODS.PESSIMISTIC
+]
 
 export async function getCost ({ name }, { models }) {
   const sub = await models.sub.findUnique({

--- a/api/paidAction/territoryCreate.js
+++ b/api/paidAction/territoryCreate.js
@@ -1,9 +1,14 @@
-import { TERRITORY_PERIOD_COST } from '@/lib/constants'
+import { PAID_ACTION_PAYMENT_METHODS, TERRITORY_PERIOD_COST } from '@/lib/constants'
 import { satsToMsats } from '@/lib/format'
 import { nextBilling } from '@/lib/territory'
+
 export const anonable = false
-export const supportsPessimism = true
-export const supportsOptimism = false
+
+export const paymentMethods = [
+  PAID_ACTION_PAYMENT_METHODS.FEE_CREDIT,
+  PAID_ACTION_PAYMENT_METHODS.REWARD_SATS,
+  PAID_ACTION_PAYMENT_METHODS.PESSIMISTIC
+]
 
 export async function getCost ({ billingType }) {
   return satsToMsats(TERRITORY_PERIOD_COST(billingType))

--- a/api/paidAction/territoryUnarchive.js
+++ b/api/paidAction/territoryUnarchive.js
@@ -1,10 +1,14 @@
-import { TERRITORY_PERIOD_COST } from '@/lib/constants'
+import { PAID_ACTION_PAYMENT_METHODS, TERRITORY_PERIOD_COST } from '@/lib/constants'
 import { satsToMsats } from '@/lib/format'
 import { nextBilling } from '@/lib/territory'
 
 export const anonable = false
-export const supportsPessimism = true
-export const supportsOptimism = false
+
+export const paymentMethods = [
+  PAID_ACTION_PAYMENT_METHODS.FEE_CREDIT,
+  PAID_ACTION_PAYMENT_METHODS.REWARD_SATS,
+  PAID_ACTION_PAYMENT_METHODS.PESSIMISTIC
+]
 
 export async function getCost ({ billingType }) {
   return satsToMsats(TERRITORY_PERIOD_COST(billingType))

--- a/api/paidAction/territoryUpdate.js
+++ b/api/paidAction/territoryUpdate.js
@@ -1,11 +1,15 @@
-import { TERRITORY_PERIOD_COST } from '@/lib/constants'
+import { PAID_ACTION_PAYMENT_METHODS, TERRITORY_PERIOD_COST } from '@/lib/constants'
 import { satsToMsats } from '@/lib/format'
 import { proratedBillingCost } from '@/lib/territory'
 import { datePivot } from '@/lib/time'
 
 export const anonable = false
-export const supportsPessimism = true
-export const supportsOptimism = false
+
+export const paymentMethods = [
+  PAID_ACTION_PAYMENT_METHODS.FEE_CREDIT,
+  PAID_ACTION_PAYMENT_METHODS.REWARD_SATS,
+  PAID_ACTION_PAYMENT_METHODS.PESSIMISTIC
+]
 
 export async function getCost ({ oldName, billingType }, { models }) {
   const oldSub = await models.sub.findUnique({

--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -989,6 +989,12 @@ export default {
       }
       return msatsToSats(user.msats)
     },
+    credits: async (user, args, { models, me }) => {
+      if (!me || me.id !== user.id) {
+        return 0
+      }
+      return msatsToSats(user.mcredits)
+    },
     authMethods,
     hasInvites: async (user, args, { models }) => {
       const invites = await models.user.findUnique({

--- a/api/typeDefs/paidAction.js
+++ b/api/typeDefs/paidAction.js
@@ -11,7 +11,9 @@ extend type Mutation {
 }
 
 enum PaymentMethod {
+  REWARD_SATS
   FEE_CREDIT
+  ZERO_COST
   OPTIMISTIC
   PESSIMISTIC
 }

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -123,6 +123,7 @@ export default gql`
     extremely sensitive
     """
     sats: Int!
+    credits: Int!
     authMethods: AuthMethods!
     lnAddr: String
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,6 +3,13 @@
 export const DEFAULT_SUBS = ['bitcoin', 'nostr', 'tech', 'meta', 'jobs']
 export const DEFAULT_SUBS_NO_JOBS = DEFAULT_SUBS.filter(s => s !== 'jobs')
 
+export const PAID_ACTION_PAYMENT_METHODS = {
+  REWARD_SATS: 'REWARD_SATS',
+  FEE_CREDIT: 'FEE_CREDIT',
+  PESSIMISTIC: 'PESSIMISTIC',
+  OPTIMISTIC: 'OPTIMISTIC',
+  P2P: 'P2P'
+}
 export const PAID_ACTION_TERMINAL_STATES = ['FAILED', 'PAID', 'RETRYING']
 export const NOFOLLOW_LIMIT = 1000
 export const UNKNOWN_LINK_REL = 'noreferrer nofollow noopener'

--- a/prisma/migrations/20241016213700_mcredits/migration.sql
+++ b/prisma/migrations/20241016213700_mcredits/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "mcredits" BIGINT NOT NULL DEFAULT 0;
+
+ALTER TABLE users ADD CONSTRAINT "mcredits_positive" CHECK ("mcredits" >= 0) NOT VALID;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
   emailVerified             DateTime?            @map("email_verified")
   emailHash                 String?              @unique(map: "users.email_hash_unique")
   image                     String?
+  mcredits                  BigInt               @default(0)
   msats                     BigInt               @default(0)
   freeComments              Int                  @default(5)
   freePosts                 Int                  @default(2)


### PR DESCRIPTION
So far this just introduces fee credits (aka cowboy credits) and makes it such that NON-p2p zaps increase the receiver's `mcredit` balance only.

In addition it refactors the interface of `paidAction`s to export a priority ordered list of `paymentMethods` rather than booleans of `supportsOptimism` and `supportsPessimism`. 

# TODO
- [ ] buy CCs directly (including with reward sats)
- [ ] wallet settings page for all (CC settings, dust settings, etc)
- [ ] notifications zaps when CC (shaming lack of attached wallet)
    - [ ] tbd if this will ship nov 5 as it requires denormalizing `mcredits` everywhere we do it for msats, e.g. `stackedMcredits`
- [ ] how do we display CC zaps next to sat zaps
- [ ] what to show in the navbar where sats used to go?
- [ ] rewards sats pages (this will be exactly like the withdrawal page to start probably)
- [ ] when zapper does not have a sending wallet, prioritize CC?
