### PR TITLE
Fix first page of wallet logs loaded twice

### DIFF
--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -225,7 +225,7 @@ export function useWalletLogs (wallet, initialPage = 1, logsPerPage = 10) {
   const loadMore = useCallback(async () => {
     if (hasMore) {
       setLoading(true)
-      const result = await loadLogsPage(page, logsPerPage, wallet)
+      const result = await loadLogsPage(page + 1, logsPerPage, wallet)
       setLogs(prevLogs => [...prevLogs, ...result.data])
       setHasMore(result.hasMore)
       setTotal(result.total)


### PR DESCRIPTION
## Description

This fixes the first page getting loaded again when clicking on `more` for wallet logs.

This also matches the behavior of `loadLogs`. It also loads the first page and then calls `setPage(1)`.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. Clicked on button once to check that second page is now loaded

**For frontend changes: Tested on mobile? Please answer below:**

yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
