### PR TITLE
Fix missing autowithdraw settings validation

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -726,7 +726,8 @@ export const lnbitsSchema = object().shape({
         test: invoiceKey => adminKey !== invoiceKey,
         message: 'invoice key cannot be the same as admin key'
       })
-    })
+    }),
+  ...autowithdrawSchemaMembers
   // need to set order to avoid cyclic dependencies in Yup schema
   // see https://github.com/jquense/yup/issues/176#issuecomment-367352042
 }, ['adminKey', 'invoiceKey'])
@@ -745,7 +746,8 @@ export const nwcSchema = object().shape({
       test: nwcUrlRecv => nwcUrlRecv !== nwcUrl,
       message: 'connection for receiving cannot be the same as for sending'
     })
-  })
+  }),
+  ...autowithdrawSchemaMembers
 }, ['nwcUrl', 'nwcUrlRecv'])
 
 export const blinkSchema = object({
@@ -796,7 +798,8 @@ export const phoenixdSchema = object().shape({
         test: secondary => primary !== secondary,
         message: 'secondary password cannot be the same as primary password'
       })
-    })
+    }),
+  ...autowithdrawSchemaMembers
 }, ['primaryPassword', 'secondaryPassword'])
 
 export const bioSchema = object({


### PR DESCRIPTION
## Description

The wallets which weren't the original receive wallets didn't validate autowithdraw settings (NWC, LNbits, phoenixd).

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. I saved NWC, others should work too then

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
