### PR TITLE
premature invoice deletion: fix interval in sql template

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -482,7 +482,7 @@ const resolvers = {
         FROM "Withdrawl"
         WHERE "userId" = ${me.id}
         AND id = ${Number(id)}
-        AND now() > created_at + interval '${retention}'
+        AND now() > created_at + ${retention}::INTERVAL
         AND hash IS NOT NULL
         AND status IS NOT NULL
       ), updated_rows AS (

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -487,7 +487,7 @@ const resolvers = {
         AND status IS NOT NULL
       ), updated_rows AS (
         UPDATE "Withdrawl"
-        SET hash = NULL, bolt11 = NULL
+        SET hash = NULL, bolt11 = NULL, preimage = NULL
         FROM to_be_updated
         WHERE "Withdrawl".id = to_be_updated.id)
       SELECT * FROM to_be_updated;`
@@ -499,7 +499,7 @@ const resolvers = {
           console.error(error)
           await models.withdrawl.update({
             where: { id: invoice.id },
-            data: { hash: invoice.hash, bolt11: invoice.bolt11 }
+            data: { hash: invoice.hash, bolt11: invoice.bolt11, preimage: invoice.preimage }
           })
           throw new GqlInputError('failed to drop bolt11 from lnd')
         }

--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -346,7 +346,7 @@ export async function autoDropBolt11s ({ models, lnd }) {
       SELECT id, hash, bolt11
       FROM "Withdrawl"
       WHERE "userId" IN (SELECT id FROM users WHERE "autoDropBolt11s")
-      AND now() > created_at + interval '${retention}'
+      AND now() > created_at + ${retention}::INTERVAL
       AND hash IS NOT NULL
       AND status IS NOT NULL
     ), updated_rows AS (

--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -351,7 +351,7 @@ export async function autoDropBolt11s ({ models, lnd }) {
       AND status IS NOT NULL
     ), updated_rows AS (
       UPDATE "Withdrawl"
-      SET hash = NULL, bolt11 = NULL
+      SET hash = NULL, bolt11 = NULL, preimage = NULL
       FROM to_be_updated
       WHERE "Withdrawl".id = to_be_updated.id)
     SELECT * FROM to_be_updated;`
@@ -364,7 +364,7 @@ export async function autoDropBolt11s ({ models, lnd }) {
         console.error(`Error removing invoice with hash ${invoice.hash}:`, error)
         await models.withdrawl.update({
           where: { id: invoice.id },
-          data: { hash: invoice.hash, bolt11: invoice.bolt11 }
+          data: { hash: invoice.hash, bolt11: invoice.bolt11, preimage: invoice.preimage }
         })
       }
     }


### PR DESCRIPTION
fixes #1485 

It looks like prisma's interpretation of intervals in templates changed at some point. I didn't find anywhere else where we use intervals this way.

QA: `6`. made invoices, reproduced bug, then made some more invoices, ran job - no deletions, made one of the invoices artificially old, ran job - only old one deleted.
