### PR TITLE
Fix territory unarchive schema validation

### DIFF
--- a/api/resolvers/sub.js
+++ b/api/resolvers/sub.js
@@ -260,7 +260,7 @@ export default {
 
       const { name } = data
 
-      await ssValidate(territorySchema, data, { models, me, sub: { name } })
+      await ssValidate(territorySchema, data, { models, me })
 
       const oldSub = await models.sub.findUnique({ where: { name } })
       if (!oldSub) {


### PR DESCRIPTION
## Description

Fix https://stacker.news/items/731783?commentId=731806

The validation on the server to unarchive territories included the sub name which meant it was in "edit mode" an dthus failed for achived territories.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. I reproduced the bug and noticed the divergence of validation on client vs server. Fixing it also fixed the bug.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
