### PR TITLE
Show Progress Bar on Back

### DIFF
--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -55,15 +55,7 @@ export function Back () {
   if (!back) return null
 
   return (
-    <a
-      role='button' tabIndex='0' className='nav-link p-0 me-2' onClick={() => {
-        if (back) {
-          router.back()
-        } else {
-          router.push('/')
-        }
-      }}
-    >
+    <a role='button' tabIndex='0' className='nav-link p-0 me-2' onClick={() => router.back()}>
       <BackArrow className='theme me-1 me-md-2' width={24} height={24} />
     </a>
   )

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -46,8 +46,8 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
   const router = useRouter()
 
   useEffect(() => {
-    const nprogressStart = (_, { shallow }) => !shallow && NProgress.start()
-    const nprogressDone = (_, { shallow }) => !shallow && NProgress.done()
+    const nprogressStart = (_, { shallow }) => NProgress.start()
+    const nprogressDone = (_, { shallow }) => NProgress.done()
 
     router.events.on('routeChangeStart', nprogressStart)
     router.events.on('routeChangeComplete', nprogressDone)
@@ -58,15 +58,14 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
     // So every page load, we modify the route in browser history
     // to point to the same page but without SSR, ie ?nodata=true
     // this nodata var will get passed to the server on back/foward and
-    // 1. prevent data from reloading and 2. perserve scroll
+    // 1. prevent data from reloading and 2. preserve scroll
     // (2) is not possible while intercepting nav with beforePopState
     router.replace({
       pathname: router.pathname,
       query: { ...router.query, nodata: true }
-    }, router.asPath, { ...router.options, shallow: true }).catch((e) => {
+    }, router.asPath, { ...router.options, shallow: false }).catch((e) => {
       // workaround for https://github.com/vercel/next.js/issues/37362
       if (!e.cancelled) {
-        console.log(e)
         throw e
       }
     })

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -46,8 +46,8 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
   const router = useRouter()
 
   useEffect(() => {
-    const nprogressStart = (_, { shallow }) => NProgress.start()
-    const nprogressDone = (_, { shallow }) => NProgress.done()
+    const nprogressStart = (_, { shallow }) => !shallow && NProgress.start()
+    const nprogressDone = (_, { shallow }) => !shallow && NProgress.done()
 
     router.events.on('routeChangeStart', nprogressStart)
     router.events.on('routeChangeComplete', nprogressDone)


### PR DESCRIPTION
Fixes #1471 

**Observations before fixing**
- If a user clicks on a post from the homepage and then clicks back then the progress bar is now shown
- If a user click on a post and then clicks to somewhere else and then uses back then the progress bar is shown on every page

**Attempted Solution**
The issue lies with the passing of `shallow: true` in `_app.js`.

This PR offers the quick fix of `shallow: false` but I would assume this has implications elsewhere in the app?



