### PR TITLE
Fix more button shown after logs deleted

### DIFF
--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -248,5 +248,10 @@ export function useWalletLogs (wallet, initialPage = 1, logsPerPage = 10) {
     loadLogs()
   }, [wallet])
 
+  useEffect(() => {
+    // make sure 'more' button is removed if logs are deleted
+    if (logs.length === 0) setHasMore(false)
+  }, [logs?.length])
+
   return { logs, hasMore, total, loadMore, loadLogs, setLogs, loading }
 }


### PR DESCRIPTION
## Description

If a `more` button was shown and all wallet logs are deleted, the button was still shown.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. I deleted wallet logs and more button disappeared.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
