### PR TITLE
Fix wallet validation blocking saves

### DIFF
--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -17,7 +17,7 @@ function mutationTypeDefs () {
     args += w.fields
       .filter(isServerField)
       .map(fieldToGqlArg).join(', ')
-    args += ', settings: AutowithdrawSettings!, priorityOnly: Boolean'
+    args += ', settings: AutowithdrawSettings!, skipValidation: Boolean'
     const resolverName = generateResolverName(w.walletField)
     const typeDef = `${resolverName}(${args}): Boolean`
     console.log(typeDef)

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -182,6 +182,9 @@ function useConfig (wallet) {
   }
 
   const saveConfig = useCallback(async (newConfig, { logger, skipValidation }) => {
+    // always skip validation if wallet was disabled
+    skipValidation ||= (newConfig.enabled === false)
+
     // NOTE:
     //   verifying the client/server configuration before saving it
     //   prevents unsetting just one configuration if both are set.

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -207,7 +207,7 @@ function useConfig (wallet) {
         valid = false
       }
 
-      if (valid) {
+      if (valid || priorityOnly) {
         if (priorityOnly) {
           setClientConfig(newClientConfig)
         } else {

--- a/wallets/webln/index.js
+++ b/wallets/webln/index.js
@@ -35,6 +35,11 @@ export default function WebLnProvider ({ children }) {
       wallet.disablePayments()
     }
 
+    if (wallet.enabled && typeof window.webln === 'undefined') {
+      // automatically disable WebLN if extension no longer found
+      onDisable()
+    }
+
     window.addEventListener('webln:enabled', onEnable)
     // event is not fired by Alby browser extension but added here for sake of completeness
     window.addEventListener('webln:disabled', onDisable)


### PR DESCRIPTION
## Description

This fixes #1501 and the following unreported issue:

If you had WebLN enabled and then disabled the extension but kept it enabled as a wallet on SN, priority changes to that wallet were blocked because client validation via schema (silently) failed.

This was fixed by 355feb61 which makes the behavior of priority changes consistent for wallets stored on the server and client.

Other changes:

- 5a09b2b2 disables the WebLN wallet if `window.webln` is no longer available. I think that's a good idea.

- I replaced the local storage call to disable/enable wallets on triggers (like on `webln:enabled`) with a regular `saveConfig` call like we do for priority changes. Validation is also unnecessary in that case, so I renamed `priorityOnly` to `skipValidation` in cee7cbb2.

Since cee7cbb2 still runs validation on regular save so didn't fix #1501, I updated `saveConfig` to always skip validation if the wallet is about to get disabled in 5d0fc923.

## Additional Context

- The unreported issue will probably not exist in #1507 so feel free to close this if we can wait for the fix in it
- I believe #1501 is also fixed in #1460

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

<!--
If your PR is not ready for review yet, please mark your PR as a draft.
If changes were requested, request a new review when you incorporated the feedback.
-->
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. I was able to change WebLN wallet priority even though WebLN extension was disabled. I was still able to attach send+recv wallets. When I now disable a wallet, validation on client and server is skipped.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
