### PR TITLE
Fix description of wrapped invoices don't respect privacy setting

### DIFF
--- a/api/paidAction/index.js
+++ b/api/paidAction/index.js
@@ -258,8 +258,10 @@ export async function createLightningInvoice (actionType, args, context) {
         expiry: INVOICE_EXPIRE_SECS
       }, { models })
 
+      // the sender (me) decides if the wrapped invoice has a description
+      // whereas the recipient decides if their invoice has a description
       const { invoice: wrappedInvoice, maxFee } = await wrapInvoice(
-        bolt11, { msats: cost, description }, { lnd })
+        bolt11, { msats: cost, description }, { me, lnd })
 
       return {
         bolt11,

--- a/wallets/wrap.js
+++ b/wallets/wrap.js
@@ -22,7 +22,7 @@ const ZAP_SYBIL_FEE_MULT = 10 / 7 // the fee for the zap sybil service
     maxFee: number
   }
 */
-export default async function wrapInvoice (bolt11, { msats, description, descriptionHash }, { lnd }) {
+export default async function wrapInvoice (bolt11, { msats, description, descriptionHash }, { me, lnd }) {
   try {
     console.group('wrapInvoice', description)
 
@@ -110,6 +110,11 @@ export default async function wrapInvoice (bolt11, { msats, description, descrip
     } else {
       // use the invoice description
       wrapped.description = inv.description
+    }
+
+    if (me?.hideInvoiceDesc) {
+      wrapped.description = undefined
+      wrapped.description_hash = undefined
     }
 
     // validate the expiration


### PR DESCRIPTION
fix https://stacker.news/items/738313

Invoices from attached wallets already respected the privacy setting of the recipient.

However, the description of wrapped invoices was determined by the setting of the recipient.

This PR fixes that. Wrapped invoices now respect the sender's privacy setting.

QA: `8`. I tested all combinations of sender+receiver privacy settings. This respects them in all cases.

