### PR TITLE
Fix unknown query refetch attempt on priority change

### DIFF
--- a/wallets/index.js
+++ b/wallets/index.js
@@ -294,6 +294,16 @@ function useServerConfig (wallet) {
   const autowithdrawSettings = autowithdrawInitial({ me })
   const config = { ...serverConfig, ...autowithdrawSettings }
 
+  const refetchLogs = () => {
+    // make sure to only refetch wallet logs if it's an active query
+    return client.refetchQueries({
+      include: 'active',
+      onQueryUpdated: (query) => {
+        return query.queryName === 'WalletLogs'
+      }
+    })
+  }
+
   const saveConfig = useCallback(async ({
     autoWithdrawThreshold,
     autoWithdrawMaxFeePercent,
@@ -320,7 +330,7 @@ function useServerConfig (wallet) {
         }
       })
     } finally {
-      client.refetchQueries({ include: ['WalletLogs'] })
+      refetchLogs()
       refetchConfig()
     }
   }, [client, walletId])
@@ -335,7 +345,7 @@ function useServerConfig (wallet) {
         variables: { id: walletId }
       })
     } finally {
-      client.refetchQueries({ include: ['WalletLogs'] })
+      refetchLogs()
       refetchConfig()
     }
   }, [client, walletId])


### PR DESCRIPTION
## Description

Fix #1504 

## Additional Context

> [!NOTE]
> This conflicts with #1511 because of the rename of `priorityOnly` to `skipValidation`

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. I verified that wallet logs are still refetched after save but no longer if priority is changed.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no