### PR TITLE
Don't hide cancel if edit timer runs out

### DIFF
--- a/components/comment.js
+++ b/components/comment.js
@@ -180,6 +180,7 @@ export default function Comment ({
                         </ActionTooltip>}
                     </>
                   }
+                  edit={edit}
                   onEdit={e => { setEdit(!edit) }}
                   editText={edit ? 'cancel' : 'edit'}
                 />}

--- a/components/comment.js
+++ b/components/comment.js
@@ -181,7 +181,7 @@ export default function Comment ({
                     </>
                   }
                   edit={edit}
-                  onEdit={e => { setEdit(!edit) }}
+                  toggleEdit={e => { setEdit(!edit) }}
                   editText={edit ? 'cancel' : 'edit'}
                 />}
 

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -30,7 +30,7 @@ import classNames from 'classnames'
 
 export default function ItemInfo ({
   item, full, commentsText = 'comments',
-  commentTextSingular = 'comment', className, embellishUser, extraInfo, onEdit, editText,
+  commentTextSingular = 'comment', className, embellishUser, extraInfo, edit, onEdit, editText,
   onQuoteReply, extraBadges, nested, pinnable, showActionDropdown = true, showUser = true,
   setDisableRetry, disableRetry
 }) {
@@ -151,7 +151,7 @@ export default function ItemInfo ({
         showActionDropdown &&
           <>
             <EditInfo
-              item={item} canEdit={canEdit}
+              item={item} edit={edit} canEdit={canEdit}
               setCanEdit={setCanEdit} onEdit={onEdit} editText={editText} editThreshold={editThreshold}
             />
             <PaymentInfo item={item} disableRetry={disableRetry} setDisableRetry={setDisableRetry} />
@@ -311,7 +311,7 @@ function PaymentInfo ({ item, disableRetry, setDisableRetry }) {
   )
 }
 
-function EditInfo ({ item, canEdit, setCanEdit, onEdit, editText, editThreshold }) {
+function EditInfo ({ item, edit, canEdit, setCanEdit, onEdit, editText, editThreshold }) {
   const router = useRouter()
 
   if (canEdit) {
@@ -329,6 +329,22 @@ function EditInfo ({ item, canEdit, setCanEdit, onEdit, editText, editThreshold 
                 onComplete={() => { setCanEdit(false) }}
               />
             : <span>10:00</span>}
+        </span>
+      </>
+    )
+  }
+
+  if (edit && !canEdit) {
+    // if we're still editing after timer ran out
+    return (
+      <>
+        <span> \ </span>
+        <span
+          className='text-reset pointer fw-bold'
+          onClick={() => setEdit(false)}
+        >
+          <span>cancel </span>
+          <span>00:00</span>
         </span>
       </>
     )

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -30,7 +30,7 @@ import classNames from 'classnames'
 
 export default function ItemInfo ({
   item, full, commentsText = 'comments',
-  commentTextSingular = 'comment', className, embellishUser, extraInfo, edit, onEdit, editText,
+  commentTextSingular = 'comment', className, embellishUser, extraInfo, edit, toggleEdit, editText,
   onQuoteReply, extraBadges, nested, pinnable, showActionDropdown = true, showUser = true,
   setDisableRetry, disableRetry
 }) {
@@ -152,7 +152,7 @@ export default function ItemInfo ({
           <>
             <EditInfo
               item={item} edit={edit} canEdit={canEdit}
-              setCanEdit={setCanEdit} onEdit={onEdit} editText={editText} editThreshold={editThreshold}
+              setCanEdit={setCanEdit} toggleEdit={toggleEdit} editText={editText} editThreshold={editThreshold}
             />
             <PaymentInfo item={item} disableRetry={disableRetry} setDisableRetry={setDisableRetry} />
             <ActionDropdown>
@@ -311,7 +311,7 @@ function PaymentInfo ({ item, disableRetry, setDisableRetry }) {
   )
 }
 
-function EditInfo ({ item, edit, canEdit, setCanEdit, onEdit, editText, editThreshold }) {
+function EditInfo ({ item, edit, canEdit, setCanEdit, toggleEdit, editText, editThreshold }) {
   const router = useRouter()
 
   if (canEdit) {
@@ -320,7 +320,7 @@ function EditInfo ({ item, edit, canEdit, setCanEdit, onEdit, editText, editThre
         <span> \ </span>
         <span
           className='text-reset pointer fw-bold'
-          onClick={() => onEdit ? onEdit() : router.push(`/items/${item.id}/edit`)}
+          onClick={() => toggleEdit ? toggleEdit() : router.push(`/items/${item.id}/edit`)}
         >
           <span>{editText || 'edit'} </span>
           {(!item.invoice?.actionState || item.invoice?.actionState === 'PAID')
@@ -341,7 +341,7 @@ function EditInfo ({ item, edit, canEdit, setCanEdit, onEdit, editText, editThre
         <span> \ </span>
         <span
           className='text-reset pointer fw-bold'
-          onClick={() => setEdit(false)}
+          onClick={() => toggleEdit ? toggleEdit() : router.push(`/items/${item.id}`)}
         >
           <span>cancel </span>
           <span>00:00</span>


### PR DESCRIPTION
## Description

This often happens to me: I am editing something and then the timer runs out. Now I am stuck with a comment in edit mode that I can't exit 

This PR fixes that by showing `cancel 00:00` when the timer runs out so one can still exit edit mode.

## Additional context

an edgy amount of props drilling was required here

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. I edited a comment and waited until the timer runs out. It still showed the option to cancel.

**For frontend changes: Tested on mobile? Please answer below:**

yes, no changes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no