### PR TITLE
Prevent UPDATE_COMMENT from invalidating the cache of child comments (Fix #1509 )

### DIFF
--- a/fragments/paidAction.js
+++ b/fragments/paidAction.js
@@ -29,6 +29,18 @@ const ITEM_PAID_ACTION_FIELDS = gql`
     }
   }`
 
+const ITEM_PAID_ACTION_FIELDS_NO_CHILD_COMMENTS = gql`
+  ${COMMENTS}
+  fragment ItemPaidActionFieldsNoChildComments on ItemPaidAction {
+    result {
+      id
+      deleteScheduledAt
+      reminderScheduledAt
+      ...CommentFields
+    }
+  }
+`
+
 const ITEM_ACT_PAID_ACTION_FIELDS = gql`
   fragment ItemActPaidActionFields on ItemActPaidAction {
     result {
@@ -226,11 +238,11 @@ export const CREATE_COMMENT = gql`
   }`
 
 export const UPDATE_COMMENT = gql`
-  ${ITEM_PAID_ACTION_FIELDS}
+  ${ITEM_PAID_ACTION_FIELDS_NO_CHILD_COMMENTS}
   ${PAID_ACTION}
   mutation upsertComment($id: ID!, $text: String!, $boost: Int, ${HASH_HMAC_INPUT_1}) {
     upsertComment(id: $id, text: $text, boost: $boost, ${HASH_HMAC_INPUT_2}) {
-      ...ItemPaidActionFields
+      ...ItemPaidActionFieldsNoChildComments
       ...PaidActionFields
     }
   }`


### PR DESCRIPTION
## Description

The `upsertComment` mutation currently returns the list of child comments whenever a comment is edited. This behavior causes the Apollo cache to update, resulting in any new comments appearing upon the re-render triggered by the edit form. This PR modifies the `UPDATE_COMMENT` fragment to exclude the list of child comments, preventing unintended cache updates. #1509

## Checklist

**Are your changes backwards compatible? Please answer below:**
yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

9. Comments are updated as expected at different levels of depth, as expected editing doesn't cause the child comments to refresh anymore.

**For frontend changes: Tested on mobile? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**
