### PR TITLE
Wallet wizard poc (wip)

### DIFF
--- a/components/wallet-fields.js
+++ b/components/wallet-fields.js
@@ -1,0 +1,52 @@
+import { ClientInput, PasswordInput, Checkbox, Select } from '@/components/form'
+import Info from '@/components/info'
+import { useIsClient } from '@/components/use-client'
+import Text from '@/components/text'
+
+export default function WalletFields ({ wallet: { config, fields, isConfigured } }) {
+  const isClient = useIsClient()
+
+  return fields
+    .map(({ name, label = '', type, help, optional, editable, clientOnly, serverOnly, ...props }, i) => {
+      const rawProps = {
+        ...props,
+        name,
+        initialValue: config?.[name],
+        readOnly: isClient && isConfigured && editable === false && !!config?.[name],
+        groupClassName: props.hidden ? 'd-none' : undefined,
+        label: label
+          ? (
+            <div className='d-flex align-items-center'>
+              {label}
+              {/* help can be a string or object to customize the label */}
+              {help && (
+                <Info label={help.label}>
+                  <Text>{help.text || help}</Text>
+                </Info>
+              )}
+              {optional && (
+                <small className='text-muted ms-2'>
+                  {typeof optional === 'boolean' ? 'optional' : <Text>{optional}</Text>}
+                </small>
+              )}
+            </div>
+            )
+          : undefined,
+        required: !optional,
+        autoFocus: i === 0
+      }
+      if (type === 'text') {
+        return <ClientInput key={i} {...rawProps} />
+      }
+      if (type === 'password') {
+        return <PasswordInput key={i} {...rawProps} newPass />
+      }
+      if (type === 'checkbox') {
+        return <Checkbox key={i} {...rawProps} />
+      }
+      if (type === 'select') {
+        return <Select key={i} {...rawProps} />
+      }
+      return null
+    })
+}

--- a/pages/settings/wallets/[wallet].js
+++ b/pages/settings/wallets/[wallet].js
@@ -1,16 +1,15 @@
 import { getGetServerSideProps } from '@/api/ssrApollo'
-import { Form, ClientInput, PasswordInput, CheckboxGroup, Checkbox } from '@/components/form'
+import { Form, CheckboxGroup, Checkbox } from '@/components/form'
 import { CenterLayout } from '@/components/layout'
 import { WalletSecurityBanner } from '@/components/banners'
 import { WalletLogs } from '@/components/wallet-logger'
 import { useToast } from '@/components/toast'
 import { useRouter } from 'next/router'
 import { useWallet } from 'wallets'
-import Info from '@/components/info'
 import Text from '@/components/text'
 import { AutowithdrawSettings } from '@/components/autowithdraw-shared'
 import dynamic from 'next/dynamic'
-import { useIsClient } from '@/components/use-client'
+import WalletFields from '@/components/wallet-fields'
 
 const WalletButtonBar = dynamic(() => import('@/components/wallet-buttonbar.js'), { ssr: false })
 
@@ -99,46 +98,4 @@ export default function WalletSettings () {
       </div>
     </CenterLayout>
   )
-}
-
-function WalletFields ({ wallet: { config, fields, isConfigured } }) {
-  const isClient = useIsClient()
-
-  return fields
-    .map(({ name, label = '', type, help, optional, editable, clientOnly, serverOnly, ...props }, i) => {
-      const rawProps = {
-        ...props,
-        name,
-        initialValue: config?.[name],
-        readOnly: isClient && isConfigured && editable === false && !!config?.[name],
-        groupClassName: props.hidden ? 'd-none' : undefined,
-        label: label
-          ? (
-            <div className='d-flex align-items-center'>
-              {label}
-              {/* help can be a string or object to customize the label */}
-              {help && (
-                <Info label={help.label}>
-                  <Text>{help.text || help}</Text>
-                </Info>
-              )}
-              {optional && (
-                <small className='text-muted ms-2'>
-                  {typeof optional === 'boolean' ? 'optional' : <Text>{optional}</Text>}
-                </small>
-              )}
-            </div>
-            )
-          : undefined,
-        required: !optional,
-        autoFocus: i === 0
-      }
-      if (type === 'text') {
-        return <ClientInput key={i} {...rawProps} />
-      }
-      if (type === 'password') {
-        return <PasswordInput key={i} {...rawProps} newPass />
-      }
-      return null
-    })
 }

--- a/pages/settings/wallets/wizards/[wizard].js
+++ b/pages/settings/wallets/wizards/[wizard].js
@@ -1,0 +1,172 @@
+import { getGetServerSideProps } from '@/api/ssrApollo'
+import Layout from '@/components/layout'
+import { useToast } from '@/components/toast'
+import { useRouter } from 'next/router'
+import Text from '@/components/text'
+import WalletFields from '@/components/wallet-fields'
+import wizards from '@/wallets/wizards'
+import { useState, useEffect, useRef } from 'react'
+import { Form, SubmitButton } from '@/components/form'
+import styles from '@/components/comment.module.css'
+import { Button } from 'react-bootstrap'
+import { useWallets } from 'wallets'
+
+export const getServerSideProps = getGetServerSideProps({ query: null })
+
+const StepComponent = ({ index, title, name, completed }) => {
+  return (
+    <div className='fw-bold d-flex align-items-center ml-8'>
+      <div
+        className={`rounded-circle text-black ${completed ? 'bg-secondary' : 'bg-light'}
+           align-items-center justify-content-center d-flex
+           `} style={{ width: '1.4rem', height: '1.4rem' }}
+      >
+        <span>{index + 1}</span>
+      </div>
+      <div className='ps-2 pe-4'>{title ?? name ?? 'Step ' + (index + 1)}</div>
+    </div>
+  )
+}
+
+export default function WalletWizard () {
+  const router = useRouter()
+  const { wizard: name } = router.query
+  const wizard = wizards[name]
+  const stepsData = useRef({})
+
+  const { wallets } = useWallets()
+  wallets.connect = async (name, values, label) => {
+    values.enabled = true
+    console.log(values)
+    const wallet = wallets.find(w => w.name === name)
+    if (!wallet) {
+      throw new Error(`Wallet ${name} not found`)
+    }
+    await wallet.save(values)
+  }
+
+  const [currentStep, setCurrentStep] = useState(null)
+  const [currentStepData, setCurrentStepData] = useState({})
+  const [currentStepIndex, setCurrentStepIndex] = useState(0)
+  const [completedSteps, setCompletedSteps] = useState([])
+
+  const [isLastStep, setIsLastStep] = useState(false)
+  const stepTitle = currentStep?.title ?? currentStep?.name ?? 'Step ' + (currentStepIndex + 1)
+
+  const setStep = async (index) => {
+    let step = wizard.getStep ? await wizard.getStep(index, stepsData.current, wallets) : wizard.steps[index]
+    if (typeof step === 'function') {
+      step = await step(stepsData.current, wallets)
+    }
+    setCurrentStep(step)
+    let currentStepData = stepsData.current[step.name]
+    if (!currentStepData) {
+      currentStepData = {}
+      stepsData.current[step.name] = currentStepData
+    }
+    setCurrentStepData(currentStepData)
+    return step
+  }
+
+  const nextStep = async () => {
+    if (isLastStep) throw new Error('Cannot go forward from last step')
+    const index = currentStepIndex + 1
+    setCompletedSteps([...completedSteps, stepTitle])
+    setCurrentStepIndex(index)
+    const step = await setStep(index)
+    if (step.last != null) {
+      setIsLastStep(step.last)
+    } else if (wizard.isLastStep) {
+      setIsLastStep(await wizard.isLastStep(index, stepsData.current, wallets))
+    } else {
+      setIsLastStep(wizard.steps && index === wizard.steps.length - 1)
+    }
+  }
+
+  const prevStep = async () => {
+    if (currentStepIndex === 0) throw new Error('Cannot go back from first step')
+    setIsLastStep(false)
+    setCompletedSteps(completedSteps.slice(0, -1))
+    const index = currentStepIndex - 1
+    setCurrentStepIndex(index)
+    await setStep(index)
+  }
+
+  useEffect(() => {
+    setCompletedSteps([])
+    setIsLastStep(false)
+    setCurrentStepIndex(0)
+    setStep(0)
+  }, [])
+
+  const validateProps = currentStep && currentStep.fieldValidation
+    ? (typeof currentStep.fieldValidation === 'function'
+        ? { validate: currentStep.fieldValidation }
+        : { schema: currentStep.fieldValidation })
+    : {}
+
+  if (!currentStep) return <></>
+  return (
+    <Layout>
+      <div className='py-5 w-100'>
+
+        <h2 className='mb-2 text-center'>configure {wizard.title}</h2>
+
+        <h6 className='text-muted text-center mb-4'><Text>{wizard.description}</Text></h6>
+        <div className='pt-4  d-flex align-items-center text-muted small'>
+          {completedSteps.map((step, i) => (
+            <StepComponent key={i} index={i} name={step} completed />
+          )
+          )}
+
+          <StepComponent index={currentStepIndex} name={stepTitle} />
+        </div>
+        <Form
+          className='mt-4'
+          initial={currentStepData}
+          // {...validateProps}
+          onSubmit={async (values) => {
+            Object.assign(currentStepData, values)
+            nextStep()
+            console.log(stepsData.current)
+            window.scrollTo({ top: 0 })
+          }}
+        >
+          <div className={styles.text}>
+            <Text>{currentStep.description}</Text>
+          </div>
+          <div className='mt-4 mb-4'>
+            <WalletFields wallet={{
+              config: currentStepData,
+              fields: currentStep.fields.map(f => {
+                f.key = f.name ?? f.title
+                return f
+              })
+            }}
+            />
+          </div>
+          <div className='mt-4 d-flex align-items-center ms-auto justify-content-end'>
+
+            {
+            !isLastStep && currentStepIndex > 0 && (
+              <Button className='me-4 text-muted nav-link fw-bold' variant='link' onClick={prevStep}>back</Button>
+
+            )
+          }
+            {
+            !isLastStep
+              ? (
+
+                <SubmitButton variant='primary' className='mt-1 px-4'>next</SubmitButton>
+                )
+              : (
+                <Button className='btn btn-primary' onClick={(() => router.back())}>Ok</Button>
+                )
+
+          }
+          </div>
+        </Form>
+      </div>
+    </Layout>
+  )
+}

--- a/wallets/wizards/coinos.js
+++ b/wallets/wizards/coinos.js
@@ -1,0 +1,112 @@
+import { nwcSchema, lnAddrSchema } from '@/lib/validate'
+
+export const title = 'coinos'
+export const authors = ['supratic']
+export const icon = 'https://coinos.io/icons/logo.svg'
+export const description = '[Coinos](https://coinos.io/) wallet'
+
+const step1 = async (stepsData, wallets) => {
+  return {
+    name: 'SignUp',
+    title: 'Sign Up',
+    description: `
+Create a Coinos account on https://Coinos.io/register, fyi... it's KYC free, 
+so no question asked on signup apart username and password. 
+You can have it fully anonymous, clicking on the 🎲 and it will generate a random username for you. 
+Make sure your password is secure.
+    `,
+    fields: []
+  }
+}
+
+const step2 = async (stepsData, wallets) => {
+  return {
+    name: 'NWC',
+    title: 'Get NWC',
+    description: `
+Once you have your whateverusername@coinos.os account...
+![image](https://imgprxy.stacker.news/R1tVUU8XIXA5s0rqoL6d3x4syJDnq4r_BXgdqvDGfyM/rs:fit:1920:1080/aHR0cHM6Ly9tLnN0YWNrZXIubmV3cy81MzMxMQ)
+... expand the details.
+![image](https://imgprxy.stacker.news/G9oqobqhSGEt37-sq7LStJqtJ880QSEYCEX8aD-sdig/rs:fit:1920:1080/aHR0cHM6Ly9tLnN0YWNrZXIubmV3cy81MzMxMw)
+Then copy the Nostr Wallet Connect url and paste it below
+    `,
+    fields: [
+      {
+        name: 'nwcAddr',
+        label: 'Input the NWC url',
+        type: 'password',
+        placeholder: 'nostr+walletconnect://...',
+        autoComplete: 'off'
+      }
+    ],
+    fieldValidation: nwcSchema
+  }
+}
+
+const step3 = async (stepsData, wallets) => {
+  return {
+    name: 'lnAddress',
+    title: 'Get LN Address',
+    description: `
+Once you have your whateverusername@coinos.os account...
+![image](https://imgprxy.stacker.news/R1tVUU8XIXA5s0rqoL6d3x4syJDnq4r_BXgdqvDGfyM/rs:fit:1920:1080/aHR0cHM6Ly9tLnN0YWNrZXIubmV3cy81MzMxMQ)
+... expand the details.
+![image](hhttps://imgprxy.stacker.news/jnrYBUi4dmYkO4SpDuJcc6Ww9D7GfIHTN_o8nuKvCn0/rs:fit:1600:900/aHR0cHM6Ly9tLnN0YWNrZXIubmV3cy81MzMxMg)
+Then copy that lightning address and paste it below.
+    `,
+    fields: [
+      {
+        name: 'lnAddr',
+        label: 'Input the Lightning Address',
+        type: 'text',
+        placeholder: '...@coinos.io',
+        autoComplete: 'off'
+      }
+    ],
+    fieldValidation: lnAddrSchema
+  }
+}
+
+const step4 = async (stepsData, wallets) => {
+  try {
+    console.log(stepsData)
+    const nwcUrl = stepsData.NWC.nwcAddr
+    const lnAddress = stepsData.lnAddress.lnAddr
+
+    await wallets.connect(
+      'nwc', // connector
+      { // fields
+        nwcUrl
+      },
+      'coinos' // label
+    )
+    await wallets.connect(
+      'lightning-address', // connector
+      { // fields
+        address: lnAddress
+      },
+      'coinos' // label
+    )
+    return {
+      name: 'final',
+      title: 'Connected!',
+      description: `
+You have successfully connected your Coinos wallet!
+      `,
+      fields: []
+    }
+  } catch (e) {
+    return {
+      name: 'error',
+      title: 'Error',
+      description: `
+There was an error connecting your Coinos wallet. Please try again.
+
+Error: ${e.message}
+      `,
+      fields: []
+    }
+  }
+}
+
+export const steps = [step1, step2, step3, step4]

--- a/wallets/wizards/index.js
+++ b/wallets/wizards/index.js
@@ -1,0 +1,3 @@
+import * as coinos from './coinos'
+import * as lnbits from './lnbits'
+export default { coinos, lnbits }

--- a/wallets/wizards/lnbits.js
+++ b/wallets/wizards/lnbits.js
@@ -1,0 +1,199 @@
+import { bytesToHex } from '@noble/curves/abstract/utils'
+import { getPublicKey, generateSecretKey } from 'nostr-tools'
+export const title = 'lnbits'
+export const authors = []
+export const icon = ''
+export const description = 'LNBits wallet'
+
+async function callApi ({ url, method, endpoint, adminKey, data }) {
+  let fullUrl = `${url}/${endpoint}`
+  if (method === 'GET') {
+    fullUrl = data ? `${fullUrl}?${new URLSearchParams(data)}` : fullUrl
+  } else {
+    data = JSON.stringify(data)
+  }
+  const args = {
+    method,
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-Api-Key': adminKey
+    },
+    body: method !== 'GET' ? data : undefined
+  }
+  console.log(fullUrl, JSON.stringify(args), adminKey)
+  const res = await fetch(fullUrl, args)
+  if (!res.ok) {
+    const errBody = await res.json()
+    throw new Error(errBody.detail)
+  }
+  return res.json()
+}
+
+const initial = async (stepsData, wallets) => {
+  return {
+    name: 'initial',
+    title: 'Input the url and admin key',
+    description: '',
+    fields: [
+      {
+        name: 'url',
+        label: 'Input the url',
+        type: 'text',
+        autoComplete: 'off'
+      },
+      {
+        name: 'adminKey',
+        label: 'Input the Admin Key',
+        type: 'password',
+        autoComplete: 'off'
+      }
+    ]
+  }
+}
+
+const selectMethod = async (stepsData, wallets) => {
+  const supportedMethods = [
+    'lnbits'
+  ]
+
+  try {
+    await callApi({
+      url: stepsData.initial.url,
+      method: 'GET',
+      endpoint: 'nwcprovider/api/v1/nwc',
+      adminKey: stepsData.initial.adminKey
+    })
+    supportedMethods.push('nwc')
+  } catch (e) {
+    console.warn('nwc not available')
+  }
+
+  return {
+    name: 'selectMethod',
+    title: 'Select Method',
+    description: '',
+    fields: [
+      {
+        name: 'method',
+        label: 'Select the method',
+        type: 'select',
+        items: supportedMethods
+      }
+    ]
+  }
+}
+
+const setup = async (stepsData, wallets) => {
+  const selectedMethod = stepsData.selectMethod.method
+  if (selectedMethod === 'lnbits') {
+    const lnbitsWallets = await callApi({
+      url: stepsData.initial.url,
+      method: 'GET',
+      endpoint: '/api/v1/wallets',
+      adminKey: stepsData.initial.adminKey
+    })
+    const lnbitWallet = lnbitsWallets.find(w => w.adminkey === stepsData.initial.adminKey)
+    if (!lnbitWallet) {
+      return {
+        name: 'setup',
+        title: 'Error',
+        description: 'No wallet found with the provided admin key',
+        fields: []
+      }
+    }
+    const invoiceKey = lnbitWallet.invoicekey
+    stepsData.setup = { invoiceKey, adminKey: stepsData.initial.adminKey }
+    return {
+      name: 'setup',
+      title: 'Found invoice key',
+      description: `Connecting wallet with invoice key ${invoiceKey}`,
+      fields: []
+    }
+  } else if (selectedMethod === 'nwc') {
+    stepsData.setup = {}
+    { // sender
+      const secret = generateSecretKey()
+      const publicKey = getPublicKey(secret)
+      await callApi({
+        url: stepsData.initial.url,
+        method: 'PUT',
+        endpoint: 'nwcprovider/api/v1/nwc/' + publicKey,
+        adminKey: stepsData.initial.adminKey,
+        data: {
+          permissions: [
+            'pay_invoice'
+          ],
+          description: 'StackerNews sender'
+        }
+      })
+      stepsData.setup.nwcUrl = (await callApi({
+        url: stepsData.initial.url,
+        method: 'GET',
+        endpoint: 'nwcprovider/api/v1/pairing/{SECRET}',
+        adminKey: stepsData.initial.adminKey
+      }).then(res => res.text())).replace('{SECRET}', bytesToHex(secret))
+    }
+    { // receiver
+      const secret = generateSecretKey()
+      const publicKey = getPublicKey(secret)
+      await callApi({
+        url: stepsData.initial.url,
+        method: 'PUT',
+        endpoint: 'nwcprovider/api/v1/nwc/' + publicKey,
+        adminKey: stepsData.initial.adminKey,
+        data: {
+          permissions: [
+            'make_invoice'
+          ],
+          description: 'StackerNews receiver'
+        }
+      })
+      stepsData.setup.nwcUrlRecv = (await callApi({
+        url: stepsData.initial.url,
+        method: 'GET',
+        endpoint: 'nwcprovider/api/v1/pairing/{SECRET}',
+        adminKey: stepsData.initial.adminKey
+      }).then(res => res.text())).replace('{SECRET}', bytesToHex(secret))
+    }
+
+    return {
+      name: 'setup',
+      title: 'Found NWC urls',
+      description: `Connecting wallet with NWC urls ${stepsData.setup.nwcUrl} and ${stepsData.setup.nwcUrlRecv}`,
+      fields: []
+    }
+  } else {
+    throw new Error('Unknown method')
+  }
+}
+
+const connect = async (stepsData, wallets) => {
+  const selectedMethod = stepsData.selectMethod.method
+  const url = stepsData.initial.url
+
+  if (selectedMethod === 'lnbits') {
+    const { invoiceKey, adminKey } = stepsData.setup
+    await wallets.connect(
+      'lnbits', // connector
+      { // fields
+        url,
+        invoiceKey,
+        adminKey
+      },
+      'lnbits' // label
+    )
+  } else if (selectedMethod === 'nwc') {
+    const { nwcUrl, nwcUrlRecv } = stepsData.setup
+    await wallets.connect(
+      'nwc', // connector
+      { // fields
+        nwcUrl,
+        nwcUrlRecv
+      },
+      'lnbits' // label
+    )
+  }
+}
+
+export const steps = [initial, selectMethod, setup, connect]


### PR DESCRIPTION
This is a proof of concept (still incomplete and not working) of how wallet wizards could work.
I've added two examples: 
-  the coinos guide converted to a simple wizard
- a more complex wizard for lnbits that only asks the users for the admin key and proposes multiple ways to connect:
     - **via the nwc extension** if installed: generating two nwc pairing urls
     - or **via lnbits apis**: by using the provided admin key and fetching its invoice key

The lnbits wizard is a good example of how we can build "smart" wizards to reduce the user input to a minimum.

![Screenshot from 2024-11-03 00-10-59](https://github.com/user-attachments/assets/08ee83cc-6263-40dd-904d-a5012377cc9b)
![Screenshot from 2024-11-03 00-11-09](https://github.com/user-attachments/assets/4c1bb7f0-6904-4782-9b63-cebb9d444c14)

![Screenshot from 2024-11-03 00-11-11](https://github.com/user-attachments/assets/07b393e0-209e-44e6-9bf1-892db39970e2)


