### PR TITLE
Fix global wallet logs never fetch logs from server

### DIFF
--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -201,14 +201,14 @@ export function useWalletLogs (wallet, initialPage = 1, logsPerPage = 10) {
         const query = walletDef ? window.IDBKeyRange.bound([tag(walletDef), -Infinity], [tag(walletDef), Infinity]) : null
 
         result = await getPage(page, pageSize, indexName, query, 'prev')
-        // no walletType means we're using the local IDB
-        if (!walletDef?.walletType) {
+        // if given wallet has no walletType it means logs are only stored in local IDB
+        if (walletDef && !walletDef.walletType) {
           return result
         }
       }
       const { data } = await getWalletLogs({
         variables: {
-          type: walletDef.walletType,
+          type: walletDef?.walletType,
           // if it client logs has more, page based on it's range
           from: result?.data[result.data.length - 1]?.ts && result.hasMore ? String(result.data[result.data.length - 1].ts) : null,
           // if we have a cursor (this isn't the first page), page based on it's range


### PR DESCRIPTION
## Description

If we're on /wallet/logs, we want to show logs from all wallets. For that, we pass no wallet to `useWalletLogs` but the underlying function to fetch logs assumed there is always one set and only fetched local logs in the case of no wallet.

## Additional Context

I've seen that I basically reverted the line change in https://github.com/stackernews/stacker.news/commit/2bdbb433df8c36d848d00a6a423a5c5d2df4eb8f so I made sure that WebLN still saves. I think the previous line was correct and changing it was just an oversight.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. I made sure that NWC logs and LNbits are fetched fine individually (locally + from server) and globally.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no