### PR TITLE
Fix wallet priority reorder inconsistency

### DIFF
--- a/pages/settings/wallets/index.js
+++ b/pages/settings/wallets/index.js
@@ -20,11 +20,10 @@ export default function Wallet ({ ssrData }) {
   const reorder = useCallback(async (sourceIndex, targetIndex) => {
     const newOrder = [...wallets.filter(w => w.config?.enabled)]
     const [source] = newOrder.splice(sourceIndex, 1)
-    const newTargetIndex = sourceIndex < targetIndex ? targetIndex - 1 : targetIndex
 
-    const priorities = newOrder.slice(0, newTargetIndex)
+    const priorities = newOrder.slice(0, targetIndex)
       .concat(source)
-      .concat(newOrder.slice(newTargetIndex))
+      .concat(newOrder.slice(targetIndex))
       .map((w, i) => ({ wallet: w, priority: i }))
 
     await setPriorities(priorities)


### PR DESCRIPTION
## Description

On current `master` (d6caee5b), if you want to move a wallet one to the right, you have to drag it two wallets. Dragging a wallet only one to the right does nothing which looks like a bug:

https://github.com/user-attachments/assets/d5db5e69-8699-4fab-9a12-2221efd597cc

It's also inconsistent with moving wallets to the left where you only need to drag it one slot:

https://github.com/user-attachments/assets/d6967fae-129c-419a-8a98-ac5e3e7a6e35

This PR makes dragging wallets left or right consistent with each other:

https://github.com/user-attachments/assets/8454c8ca-e15f-473a-b365-ed2deacd7bad

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. Tested as can be seen in the video.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no