### PR TITLE
fix #1538

### DIFF
--- a/wallets/blink/index.js
+++ b/wallets/blink/index.js
@@ -15,8 +15,8 @@ export const fields = [
     validate: string()
       .matches(/^blink_[A-Za-z0-9]+$/, { message: 'must match pattern blink_A-Za-z0-9' }),
     help: `you can get an API key from [Blink Dashboard](${galoyBlinkDashboardUrl}).\nPlease make sure to select ONLY the 'Read' and 'Write' scopes when generating this API key.`,
-    optional: 'for sending',
-    requiredWithout: 'apiKeyRecv'
+    requiredWithout: 'apiKeyRecv',
+    optional: 'for sending'
   },
   {
     name: 'currency',
@@ -30,33 +30,35 @@ export const fields = [
     validate: string()
       .transform(value => value ? value.toUpperCase() : 'BTC')
       .oneOf(['USD', 'BTC'], 'must be BTC or USD'),
-    optional: 'for sending'
+    optional: 'for sending',
+    requiredWithout: 'currencyRecv'
   },
   {
     name: 'apiKeyRecv',
-    label: 'api key',
+    label: 'receive api key',
     type: 'password',
     help: `you can get an API key from [Blink Dashboard](${galoyBlinkDashboardUrl}).\nPlease make sure to select ONLY the 'Read' and 'Receive' scopes when generating this API key.`,
     placeholder: 'blink_...',
-    optional: 'for receiving',
     serverOnly: true,
-    requiredWithout: 'apiKey',
     validate: string()
-      .matches(/^blink_[A-Za-z0-9]+$/, { message: 'must match pattern blink_A-Za-z0-9' })
+      .matches(/^blink_[A-Za-z0-9]+$/, { message: 'must match pattern blink_A-Za-z0-9' }),
+    optional: 'for receiving',
+    requiredWithout: 'apiKey'
   },
   {
     name: 'currencyRecv',
-    label: 'wallet type',
+    label: 'receive wallet type',
     type: 'text',
     help: 'the blink wallet to use for receiving (only BTC available)',
-    value: 'BTC',
     clear: true,
     autoComplete: 'off',
-    optional: 'for receiving',
+    placeholder: 'BTC',
     serverOnly: true,
     validate: string()
       .transform(value => value ? value.toUpperCase() : 'BTC')
-      .oneOf(['BTC'], 'must be BTC')
+      .oneOf(['BTC'], 'must be BTC'),
+    optional: 'for receiving',
+    requiredWithout: 'currency'
   }
 ]
 


### PR DESCRIPTION
fix #1538

afaict this fixes the cyclical dep issue. Breaking cyclical deps in yup requires pairs of tie breakers, e.g. `[['apiKey', 'apiKeyRecv'],['currency', 'currencyRecv']]`. Before #1479, we were coincidentally tie breaking using an array of all field names (with sometimes more than 2 members).

I did not read the issue fully before that describes this escape hatch: https://github.com/jquense/yup/issues/176#issuecomment-367352042

QA: `6`. I couldn't test blink in full, but it passes validation now if one of field pairs are set and doesn't pass if neither of them are. I also disabled validation on the client to test it on the server (it also fails if both `requiredWithout` fields aren't set, and succeeds if one is set).
