### PR TITLE
listen for local storage wallet changes

### DIFF
--- a/wallets/index.js
+++ b/wallets/index.js
@@ -41,7 +41,17 @@ function useLocalWallets () {
   }, [wallets, setWallets, me?.id])
 
   useEffect(() => {
+    // listen for changes to any wallet config in local storage
+    // from any window with the same origin
+    const handleStorage = (event) => {
+      if (event.key.startsWith(getStorageKey(''))) {
+        loadWallets()
+      }
+    }
+    window.addEventListener('storage', handleStorage)
+
     loadWallets()
+    return () => window.removeEventListener('storage', handleStorage)
   }, [loadWallets])
 
   return { wallets, reloadLocalWallets: loadWallets, removeLocalWallets: removeWallets }


### PR DESCRIPTION
## Description

Add a `storage` even listener to pickup wallet updates in other tabs. fix #1550

QA: `8`. Opened two tabs to nwc wallet, modified config and watched it change. Detached one, watched the other go blank. Reattached one and was able to zap in the other without reload.