### PR TITLE
Fix invoice.stopWaiting() cancels all pending invoices

### DIFF
--- a/components/payment.js
+++ b/components/payment.js
@@ -82,7 +82,8 @@ export const useInvoice = () => {
           }
         }, FAST_POLL_INTERVAL)
 
-        const abort = () => {
+        const abort = (invoiceId) => {
+          if (id !== invoiceId) return
           console.info(`invoice #${id}: stopped waiting`)
           resolve()
           clearInterval(interval)
@@ -92,7 +93,7 @@ export const useInvoice = () => {
       })
     }
 
-    controller.stop = () => controller.abort()
+    controller.stop = (id) => controller.abort(id)
 
     return controller
   }, [isInvoice])
@@ -131,7 +132,7 @@ export const useWalletPayment = () => {
       console.error('payment failed:', err)
       throw err
     } finally {
-      invoice.stopWaiting()
+      invoice.stopWaiting(id)
     }
   }, [wallet, invoice])
 


### PR DESCRIPTION
## Description

I have noticed that if you zap in quick succession and all zaps fail, only the invoice of the first zap is canceled and is shown as a QR code:

This is caused by `invoice.stopWaiting()` affecting all pending invoices.

## Videos

<details>
<summary>bug</summary>

https://github.com/user-attachments/assets/d7143d41-66ce-4a55-ac54-8b374069ca93

</details>

<details>
<summary>proof of fix</summary>

https://github.com/user-attachments/assets/b25791e4-ab2d-4cbe-aad1-6b659b913694

</details>


## Additional Context

I am not entirely sure yet why that happens since one would assume that `useInvoice` returns a controller for each call but maybe that's not actually the case? Probably related to `useMemo` even though it _does_ create a new `AbortController` for each invoice so it should return a separate `waitController` for each.

I will investigate why this fix works more.

## Checklist

**Are your changes backwards compatible? Please answer below:**


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. I don't understand the fix 100% but pretty sure that fixes it since I tried to zap as many times as possible before the first QR code pops up to trigger the bug again.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no