### PR TITLE
Fix offcanvas not closed before showing logout prompt

### DIFF
--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -317,6 +317,7 @@ export function LogoutDropdownItem ({ handleClose }) {
       </Dropdown.Item>
       <Dropdown.Item
         onClick={async () => {
+          handleClose?.()
           showModal(onClose => (<LogoutObstacle onClose={onClose} />))
         }}
       >logout


### PR DESCRIPTION
## Description

Fix this:

https://github.com/user-attachments/assets/640a4330-3790-4b10-a575-6ed6e4bd9b9f

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. I clicked on `logout` and offcanvas closed.

**For frontend changes: Tested on mobile? Please answer below:**

yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no