### PR TITLE
Only send push notification if referrer was updated

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -77,8 +77,8 @@ function getCallbacks (req, res) {
         if (req.cookies.sn_referrer && user?.id) {
           const referrerId = await getReferrerId(req.cookies.sn_referrer)
           if (referrerId && referrerId !== parseInt(user?.id)) {
-            await prisma.user.updateMany({ where: { id: user.id, referrerId: null }, data: { referrerId } })
-            notifyReferral(referrerId)
+            const { count } = await prisma.user.updateMany({ where: { id: user.id, referrerId: null }, data: { referrerId } })
+            if (count > 0) notifyReferral(referrerId)
           }
         }
       }


### PR DESCRIPTION
## Description

Fix #1560 

## Additional Context

- Prisma Client API documentation for [`updateMany`](https://www.prisma.io/docs/orm/reference/prisma-client-reference#updatemany)

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. Confirmed no push notification is sent when I do the same I did in https://github.com/stackernews/stacker.news/issues/1560#issuecomment-2466410003

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no