### PR TITLE
fix precedence of op for not full hot sort

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -115,11 +115,11 @@ const orderByClause = (by, me, models, type) => {
 }
 
 export function orderByNumerator ({ models, commentScaler = 0.5, considerBoost = false }) {
-  return `(CASE WHEN "Item"."weightedVotes" - "Item"."weightedDownVotes" > 0 THEN
+  return `((CASE WHEN "Item"."weightedVotes" - "Item"."weightedDownVotes" > 0 THEN
               GREATEST("Item"."weightedVotes" - "Item"."weightedDownVotes", POWER("Item"."weightedVotes" - "Item"."weightedDownVotes", 1.2))
             ELSE
               "Item"."weightedVotes" - "Item"."weightedDownVotes"
-            END + "Item"."weightedComments"*${commentScaler}) + ${considerBoost ? `("Item".boost / ${BOOST_MULT})` : 0}`
+            END + "Item"."weightedComments"*${commentScaler}) + ${considerBoost ? `("Item".boost / ${BOOST_MULT})` : 0})`
 }
 
 export function joinZapRankPersonalView (me, models) {


### PR DESCRIPTION
I noticed during SNL yesterday that inactive territories have `hot` sorts that look more like `top` ... it turns out they were `top`.

This happened sometime ago when I changed the equation for sorting to have a boost term in the numerator. What I missed is that this effectively made the equation `numerator + boost / decay` rather than `(numerator + boost) / decay`. Lame.
