### PR TITLE
Fix outlawed can show up on front page

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -535,6 +535,7 @@ export default {
                       '"Item".bio = false',
                       ad ? `"Item".id <> ${ad.id}` : '',
                       activeOrMine(me),
+                      await filterClause(me, models, type),
                       subClause(sub, 3, 'Item', me, showNsfw),
                       muteClause(me))}
                     ORDER BY rank DESC


### PR DESCRIPTION
## Description

Not tested but I believe this is what was missing.

We probably only need the outlaw clauses since the other clauses shouldn't be relevant for the front page but I think they don't hurt (except the extra user query maybe).

But we also use `filterClause` for the mostly empty subs so I guess we should apply the same filtering here.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`1`. It does not crash the server.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no