### PR TITLE
Fix edit countdown on deleted items

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1375,7 +1375,7 @@ export const updateItem = async (parent, { sub: subName, forward, hash, hmac, ..
 
   // prevent update if it's not explicitly allowed, not their bio, not their job and older than 10 minutes
   const myBio = user.bioId === old.id
-  const timer = Date.now() < new Date(old.invoicePaidAt ?? old.createdAt).getTime() + 10 * 60_000
+  const timer = Date.now() < datePivot(new Date(old.invoicePaidAt ?? old.createdAt), { minutes: 10 })
 
   // timer permission check
   if (!adminEdit && !myBio && !timer && !isJob(item)) {

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -6,7 +6,7 @@ import Dropdown from 'react-bootstrap/Dropdown'
 import Countdown from './countdown'
 import { abbrNum, numWithUnits } from '@/lib/format'
 import { newComments, commentsViewedAt } from '@/lib/new-comments'
-import { timeSince } from '@/lib/time'
+import { datePivot, timeSince } from '@/lib/time'
 import { DeleteDropdownItem } from './delete'
 import styles from './item.module.css'
 import { useMe } from './me'
@@ -34,7 +34,7 @@ export default function ItemInfo ({
   onQuoteReply, extraBadges, nested, pinnable, showActionDropdown = true, showUser = true,
   setDisableRetry, disableRetry
 }) {
-  const editThreshold = new Date(item.invoice?.confirmedAt ?? item.createdAt).getTime() + 10 * 60000
+  const editThreshold = datePivot(new Date(item.invoice?.confirmedAt ?? item.createdAt), { minutes: 10 })
   const { me } = useMe()
   const router = useRouter()
   const [hasNewComments, setHasNewComments] = useState(false)

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -37,7 +37,10 @@ export default function ItemInfo ({
   const editThreshold = new Date(item.invoice?.confirmedAt ?? item.createdAt).getTime() + 10 * 60000
   const { me } = useMe()
   const router = useRouter()
+
+  // bios are always editable, we don't want to show the countdown for them
   const [canEdit, setCanEdit] = useState(item.mine && !item.bio && (Date.now() < editThreshold))
+
   const [hasNewComments, setHasNewComments] = useState(false)
   const root = useRoot()
   const sub = item?.sub || root?.sub
@@ -48,6 +51,8 @@ export default function ItemInfo ({
     }
   }, [item])
 
+  // allow anon edits if they have the correct hmac for the item invoice
+  // (the server will verify the hmac)
   useEffect(() => {
     const authorEdit = item.mine && !item.bio
     const invParams = window.localStorage.getItem(`item:${item.id}:hash:hmac`)

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -39,7 +39,7 @@ export default function ItemInfo ({
   const router = useRouter()
 
   // bios are always editable, we don't want to show the countdown for them
-  const [canEdit, setCanEdit] = useState(item.mine && !item.bio && (Date.now() < editThreshold))
+  const [canEdit, setCanEdit] = useState(item.mine && !item.bio && !item.deletedAt && (Date.now() < editThreshold))
 
   const [hasNewComments, setHasNewComments] = useState(false)
   const root = useRoot()
@@ -54,11 +54,11 @@ export default function ItemInfo ({
   // allow anon edits if they have the correct hmac for the item invoice
   // (the server will verify the hmac)
   useEffect(() => {
-    const authorEdit = item.mine && !item.bio
+    const authorEdit = item.mine && !item.bio && !item.deletedAt
     const invParams = window.localStorage.getItem(`item:${item.id}:hash:hmac`)
     const hmacEdit = !!invParams && !me && Number(item.user.id) === USER_ID.anon
     setCanEdit((authorEdit || hmacEdit) && (Date.now() < editThreshold))
-  }, [me, item.id, item.mine, editThreshold])
+  }, [me, item.id, item.mine, editThreshold, item.deletedAt])
 
   // territory founders can pin any post in their territory
   // and OPs can pin any root reply in their post

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -37,10 +37,6 @@ export default function ItemInfo ({
   const editThreshold = new Date(item.invoice?.confirmedAt ?? item.createdAt).getTime() + 10 * 60000
   const { me } = useMe()
   const router = useRouter()
-
-  // bios are always editable, we don't want to show the countdown for them
-  const [canEdit, setCanEdit] = useState(item.mine && !item.bio && !item.deletedAt && (Date.now() < editThreshold))
-
   const [hasNewComments, setHasNewComments] = useState(false)
   const root = useRoot()
   const sub = item?.sub || root?.sub
@@ -53,12 +49,16 @@ export default function ItemInfo ({
 
   // allow anon edits if they have the correct hmac for the item invoice
   // (the server will verify the hmac)
+  const [anonEdit, setAnonEdit] = useState(false)
   useEffect(() => {
-    const authorEdit = item.mine && !item.bio && !item.deletedAt
     const invParams = window.localStorage.getItem(`item:${item.id}:hash:hmac`)
-    const hmacEdit = !!invParams && !me && Number(item.user.id) === USER_ID.anon
-    setCanEdit((authorEdit || hmacEdit) && (Date.now() < editThreshold))
-  }, [me, item.id, item.mine, editThreshold, item.deletedAt])
+    setAnonEdit(!!invParams && !me && Number(item.user.id) === USER_ID.anon)
+  }, [])
+
+  // deleted items can never be edited and every item has a 10 minute edit window
+  // except bios, they can always be edited but they should never show the countdown
+  const noEdit = !!item.deletedAt || (Date.now() >= editThreshold) || item.bio
+  const canEdit = !noEdit && ((me && item.mine) || anonEdit)
 
   // territory founders can pin any post in their territory
   // and OPs can pin any root reply in their post
@@ -157,7 +157,7 @@ export default function ItemInfo ({
           <>
             <EditInfo
               item={item} edit={edit} canEdit={canEdit}
-              setCanEdit={setCanEdit} toggleEdit={toggleEdit} editText={editText} editThreshold={editThreshold}
+              setCanEdit={setAnonEdit} toggleEdit={toggleEdit} editText={editText} editThreshold={editThreshold}
             />
             <PaymentInfo item={item} disableRetry={disableRetry} setDisableRetry={setDisableRetry} />
             <ActionDropdown>


### PR DESCRIPTION
## Description

If you delete an item while it's still editable, it still looks like it's editable.

I also refactored some code because I realized the state was only needed for anon edits (see individual commits).

## Video

The bug:

https://github.com/user-attachments/assets/188cd971-e25f-4db6-86b7-2f81dbf253ca

Proof of fix and no new regression:

https://github.com/user-attachments/assets/b7015756-4417-4e83-a5f5-daf61199ce7c

## Additional context

I considered renaming `canEdit` to `showEditCountdown` but that variable was too long and I think it's clear from the context it's only about the edit countdown and that the actual edit authorization happens on the server.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. See video.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no