### PR TITLE
Fix fee added to received amount

### DIFF
--- a/worker/paidAction.js
+++ b/worker/paidAction.js
@@ -281,9 +281,12 @@ export async function paidActionForwarded ({ data: { invoiceId, withdrawal, ...a
       // settle the invoice, allowing us to transition to PAID
       await settleHodlInvoice({ secret: payment.secret, lnd })
 
+      // the amount we paid includes the fee so we need to subtract it to get the amount received
+      const received = Number(payment.mtokens) - Number(payment.fee_mtokens)
+
       const logger = walletLogger({ wallet: dbInvoice.invoiceForward.wallet, models })
       logger.ok(
-        `↙ payment received: ${formatSats(msatsToSats(payment.mtokens))}`,
+        `↙ payment received: ${formatSats(msatsToSats(received))}`,
         {
           bolt11,
           preimage: payment.secret

--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -309,8 +309,9 @@ export async function checkWithdrawal ({ data: { hash, withdrawal, invoice }, bo
       notifyWithdrawal(dbWdrwl.userId, wdrwl)
 
       const { request: bolt11, secret: preimage } = wdrwl.payment
+
       logger?.ok(
-        `↙ payment received: ${formatSats(msatsToSats(Number(wdrwl.payment.mtokens)))}`,
+        `↙ payment received: ${formatSats(msatsToSats(paid))}`,
         {
           bolt11,
           preimage,


### PR DESCRIPTION
## Description

I am pretty sure that fixes https://stacker.news/items/760734?commentId=760753 but couldn't test without fees.

## Additional Context

I personally would be interested in seeing how much SN had to pay for the forwarding but I can see how that can conflict with UX. It probably isn't interesting to most and would just cause confusion and lead to questions, even if I rename `fee` to `sn_fee`. However, what do you think?

```diff
diff --git a/worker/paidAction.js b/worker/paidAction.js
index 60aac122..5d505963 100644
--- a/worker/paidAction.js
+++ b/worker/paidAction.js
@@ -289,10 +289,10 @@ export async function paidActionForwarded ({ data: { invoiceId, withdrawal, ...a
         `↙ payment received: ${formatSats(msatsToSats(received))}`,
         {
           bolt11,
-          preimage: payment.secret
+          preimage: payment.secret,
           // we could show the outgoing fee that we paid from the incoming amount to the receiver
           // but we don't since it might look like the receiver paid the fee but that's not the case.
-          // fee: formatMsats(Number(payment.fee_mtokens))
+          sn_fee: formatMsats(Number(payment.fee_mtokens))
         })

       return {
```

We could also use `SN_ADMIN_IDS` to only include it for us.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes but old logs will still be wrong ... if I used relations, that wouldn't be the case :upside_down_face: 

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested p2p zap and autowithdrawal. I also made sure that `payment.request === bolt11` as a sanity check.

**For frontend changes: Tested on mobile? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
