### PR TITLE
feat: PWA pull to refresh

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -6,6 +6,7 @@ import Footer from './footer'
 import Seo, { SeoSearch } from './seo'
 import Search from './search'
 import styles from './layout.module.css'
+import PullToRefresh from './pull-to-refresh'
 
 export default function Layout ({
   sub, contain = true, footer = true, footerLinks = true,
@@ -14,16 +15,18 @@ export default function Layout ({
   return (
     <>
       {seo && <Seo sub={sub} item={item} user={user} />}
-      <Navigation sub={sub} />
-      {contain
-        ? (
-          <Container as='main' className={`px-sm-0 ${styles.contain}`}>
-            {children}
-          </Container>
-          )
-        : children}
-      {footer && <Footer links={footerLinks} />}
-      <NavFooter sub={sub} />
+      <PullToRefresh>
+        <Navigation sub={sub} />
+        {contain
+          ? (
+            <Container as='main' className={`px-sm-0 ${styles.contain}`}>
+              {children}
+            </Container>
+            )
+          : children}
+        {footer && <Footer links={footerLinks} />}
+        <NavFooter sub={sub} />
+      </PullToRefresh>
     </>
   )
 }

--- a/components/layout.js
+++ b/components/layout.js
@@ -15,7 +15,7 @@ export default function Layout ({
   return (
     <>
       {seo && <Seo sub={sub} item={item} user={user} />}
-      <PullToRefresh>
+      <PullToRefresh android> {/* android prop if true disables its native PTR */}
         <Navigation sub={sub} />
         {contain
           ? (

--- a/components/pull-to-refresh.js
+++ b/components/pull-to-refresh.js
@@ -2,26 +2,34 @@ import { useRouter } from 'next/router'
 import { useState, useRef, useEffect, useCallback } from 'react'
 import styles from './pull-to-refresh.module.css'
 
-export default function PullToRefresh ({ children }) {
+const PULL_THRESHOLD = 300
+const REFRESH_TIMEOUT = 500
+
+export default function PullToRefresh ({ children, android }) {
   const router = useRouter()
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [pullDistance, setPullDistance] = useState(0)
   const [isPWA, setIsPWA] = useState(false)
+  const [isAndroid, setIsAndroid] = useState(false)
   const touchStartY = useRef(0)
   const touchEndY = useRef(0)
 
+  const checkPWA = () => {
+    const androidPWA = window.matchMedia('(display-mode: standalone)').matches
+    const iosPWA = window.navigator.standalone === true
+    setIsAndroid(androidPWA) // we need to know if the user is on Android to enable toggling its native PTR
+    setIsPWA(androidPWA || iosPWA)
+  }
+
   useEffect(() => {
-    const checkPWA = () => {
-      // android/general || ios
-      return window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true
-    }
-    setIsPWA(checkPWA())
+    checkPWA()
   }, [])
 
   const handleTouchStart = useCallback((e) => {
-    if (!isPWA || window.scrollY > 0) return // don't handle if the user is not scrolling from the top of the page
+    // don't handle if the user is not scrolling from the top of the page, is not on a PWA or if we want Android's native PTR
+    if (!isPWA || (isAndroid && !android) || window.scrollY > 0) return
     touchStartY.current = e.touches[0].clientY
-  }, [isPWA])
+  }, [isPWA, isAndroid, android])
 
   const handleTouchMove = useCallback((e) => {
     if (touchStartY.current === 0) return
@@ -31,12 +39,12 @@ export default function PullToRefresh ({ children }) {
 
   const handleTouchEnd = useCallback(() => {
     if (touchStartY.current === 0 || touchEndY.current === 0) return
-    if (touchEndY.current - touchStartY.current > 300) { // current threshold is 300, subject to change
+    if (touchEndY.current - touchStartY.current > PULL_THRESHOLD) {
       setIsRefreshing(true)
-      router.push(router.asPath)
+      router.push(router.asPath) // reload the same path
       setTimeout(() => {
         setIsRefreshing(false)
-      }, 500) // simulate loading time
+      }, REFRESH_TIMEOUT) // simulate loading time
     }
     setPullDistance(0) // using this to reset the message behavior
     touchStartY.current = 0 // avoid random refreshes by resetting touch
@@ -44,7 +52,8 @@ export default function PullToRefresh ({ children }) {
   }, [router])
 
   useEffect(() => {
-    if (!isPWA) return
+    // don't handle if the user is not on a PWA or if we want Android's native PTR
+    if (!isPWA || (isAndroid && !android)) return
     document.addEventListener('touchstart', handleTouchStart)
     document.addEventListener('touchmove', handleTouchMove)
     document.addEventListener('touchend', handleTouchEnd)
@@ -53,17 +62,17 @@ export default function PullToRefresh ({ children }) {
       document.removeEventListener('touchmove', handleTouchMove)
       document.removeEventListener('touchend', handleTouchEnd)
     }
-  }, [isPWA, handleTouchStart, handleTouchMove, handleTouchEnd])
+  }, [isPWA, isAndroid, android, handleTouchStart, handleTouchMove, handleTouchEnd])
 
   const getPullMessage = () => {
     if (isRefreshing) return 'refreshing...'
-    if (pullDistance > 300) return 'release to refresh'
+    if (pullDistance > PULL_THRESHOLD) return 'release to refresh'
     if (pullDistance > 0) return 'pull down to refresh'
     return ''
   }
 
   return (
-    <div>
+    <div className={android ? styles.pullToRefreshContainer : ''}> {/* android prop if true disables its native PTR */}
       <div
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}

--- a/components/pull-to-refresh.js
+++ b/components/pull-to-refresh.js
@@ -1,0 +1,86 @@
+import { useRouter } from 'next/router'
+import { useState, useRef, useEffect, useCallback } from 'react'
+import styles from './pull-to-refresh.module.css'
+
+export default function PullToRefresh ({ children }) {
+  const router = useRouter()
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const [pullDistance, setPullDistance] = useState(0)
+  const [isPWA, setIsPWA] = useState(false)
+  const touchStartY = useRef(0)
+  const touchEndY = useRef(0)
+
+  useEffect(() => {
+    const checkPWA = () => {
+      // android/general || ios
+      return window.matchMedia('(display-mode: standalone)').matches || window.navigator.standalone === true
+    }
+    setIsPWA(checkPWA())
+  }, [])
+
+  const handleTouchStart = useCallback((e) => {
+    if (!isPWA || window.scrollY > 0) return // don't handle if the user is not scrolling from the top of the page
+    touchStartY.current = e.touches[0].clientY
+  }, [isPWA])
+
+  const handleTouchMove = useCallback((e) => {
+    if (touchStartY.current === 0) return
+    touchEndY.current = e.touches[0].clientY
+    setPullDistance(touchEndY.current - touchStartY.current)
+  }, [])
+
+  const handleTouchEnd = useCallback(() => {
+    if (touchStartY.current === 0 || touchEndY.current === 0) return
+    if (touchEndY.current - touchStartY.current > 300) { // current threshold is 300, subject to change
+      setIsRefreshing(true)
+      router.push(router.asPath)
+      setTimeout(() => {
+        setIsRefreshing(false)
+      }, 500) // simulate loading time
+    }
+    setPullDistance(0) // using this to reset the message behavior
+    touchStartY.current = 0 // avoid random refreshes by resetting touch
+    touchEndY.current = 0
+  }, [router])
+
+  useEffect(() => {
+    if (!isPWA) return
+    document.addEventListener('touchstart', handleTouchStart)
+    document.addEventListener('touchmove', handleTouchMove)
+    document.addEventListener('touchend', handleTouchEnd)
+    return () => {
+      document.removeEventListener('touchstart', handleTouchStart)
+      document.removeEventListener('touchmove', handleTouchMove)
+      document.removeEventListener('touchend', handleTouchEnd)
+    }
+  }, [isPWA, handleTouchStart, handleTouchMove, handleTouchEnd])
+
+  const getPullMessage = () => {
+    if (isRefreshing) return 'refreshing...'
+    if (pullDistance > 300) return 'release to refresh'
+    if (pullDistance > 0) return 'pull down to refresh'
+    return ''
+  }
+
+  return (
+    <div>
+      <div
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        {pullDistance > 0 || isRefreshing
+          ? (
+            <>
+              <p className={`${styles.pullMessage} ${pullDistance > 50 || isRefreshing ? styles.fadeIn : ''}`}>
+                {getPullMessage()}
+              </p>
+              {isRefreshing && <div className={styles.spacer} />}
+            </>
+            )
+          : null}
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/components/pull-to-refresh.module.css
+++ b/components/pull-to-refresh.module.css
@@ -1,0 +1,21 @@
+.pullMessage {
+    position: fixed;
+    left: 50%;
+    top: -50px;
+    transform: translateX(-50%);
+    font-size: 18px;
+    color: #a5a5a5;
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
+    text-align: center;
+}
+
+.fadeIn {
+    opacity: 1;
+    top: 0;
+}
+
+.spacer {
+    position: relative;
+    margin-bottom: 32px;
+}

--- a/components/pull-to-refresh.module.css
+++ b/components/pull-to-refresh.module.css
@@ -1,13 +1,9 @@
-.pullToRefreshContainer {
-    overscroll-behavior: contain;
-}
-
 .pullMessage {
     position: fixed;
     left: 50%;
     top: -50px;
     transform: translateX(-50%);
-    font-size: 18px;
+    font-size: small;
     color: #a5a5a5;
     opacity: 0;
     transition: opacity 0.3s ease-in-out;
@@ -17,9 +13,4 @@
 .fadeIn {
     opacity: 1;
     top: 0;
-}
-
-.spacer {
-    position: relative;
-    margin-bottom: 32px;
 }

--- a/components/pull-to-refresh.module.css
+++ b/components/pull-to-refresh.module.css
@@ -1,16 +1,13 @@
 .pullMessage {
-    position: fixed;
+    position: absolute;
     left: 50%;
-    top: -50px;
+    top: -20px;
+    height: 15px;
     transform: translateX(-50%);
     font-size: small;
     color: #a5a5a5;
     opacity: 0;
     transition: opacity 0.3s ease-in-out;
     text-align: center;
-}
-
-.fadeIn {
-    opacity: 1;
-    top: 0;
+    opacity: 0.75;
 }

--- a/components/pull-to-refresh.module.css
+++ b/components/pull-to-refresh.module.css
@@ -1,3 +1,7 @@
+.pullToRefreshContainer {
+    overscroll-behavior: contain;
+}
+
 .pullMessage {
     position: fixed;
     left: 50%;


### PR DESCRIPTION
## Description

Pull-to-refresh for iOS, completing #1258.

As `router.reload()` is not graceful and `router.replace(...)` adds "/~" to the path breaking functionality across the app, I've decided to use `router.push()` instead, reloading the same page.
This updates the browser's history but since we're talking about a PWA there's no history to be accessed from the user.

This component wraps `<Layout />` and is present in every page that make use of it.

## Screenshots

https://github.com/user-attachments/assets/46209199-ae9d-433b-8c5f-92ae9f073c6c

## Additional Context

At the moment it's enabled also for Android, disabling its native pull-to-refresh. If we want to enable it back we can pass `android=false`

Not being a master of creativity and CSS I want to know if you'd like to see something else instead of _refreshing..._, even though I think it's geeky in its own way

## Checklist

**Are your changes backwards compatible? Please answer below:**
checkPWA prevents it from being triggered on anything that's not a PWA, also being a new component that has minimal CSS and loads only if the user is at the top of the page, I can say that it doesn't break functionality.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, I don't have an Android phone and I would like to know if there are any problems with it, as said before we can disable or enable Android's PTR.
As it should work only in a PWA context, I also tested it on browsers

**For frontend changes: Tested on mobile? Please answer below:**
Yes, being a mobile-only feature

**Did you introduce any new environment variables? If so, call them out explicitly here:** No
