### PR TITLE
Fix missing useDarkMode update

### DIFF
--- a/components/dark-mode.js
+++ b/components/dark-mode.js
@@ -48,6 +48,15 @@ const listenForThemeChange = (onChange) => {
       onChange({ user: true, dark })
     }
   }
+
+  const root = window.document.documentElement
+  const observer = new window.MutationObserver(() => {
+    const theme = root.getAttribute('data-bs-theme')
+    onChange(dark => ({ ...dark, dark: theme === 'dark' }))
+  })
+  observer.observe(root, { attributes: true, attributeFilter: ['data-bs-theme'] })
+
+  return () => observer.disconnect()
 }
 
 export default function useDarkMode () {


### PR DESCRIPTION
## Description

`useDarkMode` wasn't listening to the DOM updates by the icon in the footer. This caused any component that uses `useDarkMode` to not get updates about the current theme. Example bug:

https://github.com/user-attachments/assets/3ba07c47-d5b1-4e9c-bb10-81dcfd034636

## Additional Context

The footer icon does change on click correctly because it updates local state but not the state of any other component that uses `useDarkMode`.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. tested as seen in the video

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

yes, this literally fixes light and dark mode updates

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no