### PR TITLE
Fix 'Cannot mix BigInt and other types' on zaps

### DIFF
--- a/api/paidAction/index.js
+++ b/api/paidAction/index.js
@@ -56,7 +56,8 @@ export default async function performPaidAction (actionType, args, incomingConte
     }
     const context = {
       ...contextWithMe,
-      cost: await paidAction.getCost(args, contextWithMe)
+      cost: await paidAction.getCost(args, contextWithMe),
+      sybilFeePercent: await paidAction.getSybilFeePercent?.(args, contextWithMe)
     }
 
     // special case for zero cost actions
@@ -186,8 +187,7 @@ async function beginPessimisticAction (actionType, args, context) {
 async function performP2PAction (actionType, args, incomingContext) {
   // if the action has an invoiceable peer, we'll create a peer invoice
   // wrap it, and return the wrapped invoice
-  const { cost, models, lnd, me } = incomingContext
-  const sybilFeePercent = await paidActions[actionType].getSybilFeePercent?.(args, incomingContext)
+  const { cost, sybilFeePercent, models, lnd, me } = incomingContext
   if (!sybilFeePercent) {
     throw new Error('sybil fee percent is not set for an invoiceable peer action')
   }

--- a/api/paidAction/receive.js
+++ b/api/paidAction/receive.js
@@ -53,8 +53,10 @@ export async function perform ({
   }
 }
 
-export async function describe ({ description }, { me, cost, sybilFeePercent }) {
-  const fee = sybilFeePercent ? cost * BigInt(sybilFeePercent) / 100n : 0n
+export async function describe ({ description }, { me, cost, paymentMethod, sybilFeePercent }) {
+  const fee = paymentMethod === PAID_ACTION_PAYMENT_METHODS.P2P
+    ? cost * BigInt(sybilFeePercent) / 100n
+    : 0n
   return description ?? `SN: ${me?.name ?? ''} receives ${numWithUnits(msatsToSats(cost - fee))}`
 }
 

--- a/worker/paidAction.js
+++ b/worker/paidAction.js
@@ -119,11 +119,11 @@ async function performPessimisticAction ({ lndInvoice, dbInvoice, tx, models, ln
   const context = {
     tx,
     cost: BigInt(lndInvoice.received_mtokens),
-    me: dbInvoice.user
+    me: dbInvoice.user,
+    sybilFeePercent: await paidActions[dbInvoice.actionType].getSybilFeePercent?.()
   }
-  const sybilFeePercent = await paidActions[dbInvoice.actionType].getSybilFeePercent?.(args, context)
 
-  const result = await paidActions[dbInvoice.actionType].perform(args, { ...context, sybilFeePercent })
+  const result = await paidActions[dbInvoice.actionType].perform(args, context)
   await tx.invoice.update({
     where: { id: dbInvoice.id },
     data: {


### PR DESCRIPTION
## Description

In #1570, `sybilFeePercent` was removed from the context. This broke zaps with fee credits because `sybilFeePercent` was now undefined.

## Additional Context

`sybilFeePercent` is now always included in any action context. 

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. I tested zaps with fee credits and pessimistic zaps via anon.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no