### PR TITLE
Fix sybil fee for non p2p zaps

### DIFF
--- a/api/paidAction/zap.js
+++ b/api/paidAction/zap.js
@@ -33,6 +33,7 @@ export async function getSybilFeePercent () {
 }
 
 export async function perform ({ invoiceId, sats, id: itemId, ...args }, { me, cost, sybilFeePercent, tx }) {
+  sybilFeePercent ??= await getSybilFeePercent()
   const feeMsats = cost * sybilFeePercent / 100n
   const zapMsats = cost - feeMsats
   itemId = parseInt(itemId)


### PR DESCRIPTION
If the zap is not p2p, the sybil fee context value is never set in the current code.