### PR TITLE
Fix mentions for pessimistic actions

### DIFF
--- a/api/paidAction/lib/item.js
+++ b/api/paidAction/lib/item.js
@@ -2,11 +2,11 @@ import { USER_ID } from '@/lib/constants'
 import { deleteReminders, getDeleteAt, getRemindAt } from '@/lib/item'
 import { parseInternalLinks } from '@/lib/url'
 
-export async function getMentions ({ text }, { me, models }) {
+export async function getMentions ({ text }, { me, tx }) {
   const mentionPattern = /\B@[\w_]+/gi
   const names = text.match(mentionPattern)?.map(m => m.slice(1))
   if (names?.length > 0) {
-    const users = await models.user.findMany({
+    const users = await tx.user.findMany({
       where: {
         name: {
           in: names
@@ -21,7 +21,7 @@ export async function getMentions ({ text }, { me, models }) {
   return []
 }
 
-export const getItemMentions = async ({ text }, { me, models }) => {
+export const getItemMentions = async ({ text }, { me, tx }) => {
   const linkPattern = new RegExp(`${process.env.NEXT_PUBLIC_URL}/items/\\d+[a-zA-Z0-9/?=]*`, 'gi')
   const refs = text.match(linkPattern)?.map(m => {
     try {
@@ -33,7 +33,7 @@ export const getItemMentions = async ({ text }, { me, models }) => {
   }).filter(r => !!r)
 
   if (refs?.length > 0) {
-    const referee = await models.item.findMany({
+    const referee = await tx.item.findMany({
       where: {
         id: { in: refs },
         userId: { not: me?.id || USER_ID.anon }

--- a/worker/paidAction.js
+++ b/worker/paidAction.js
@@ -120,7 +120,8 @@ async function performPessimisticAction ({ lndInvoice, dbInvoice, tx, models, ln
     tx,
     cost: BigInt(lndInvoice.received_mtokens),
     me: dbInvoice.user,
-    sybilFeePercent: await paidActions[dbInvoice.actionType].getSybilFeePercent?.()
+    sybilFeePercent: await paidActions[dbInvoice.actionType].getSybilFeePercent?.(),
+    models
   }
 
   const result = await paidActions[dbInvoice.actionType].perform(args, context)

--- a/worker/paidAction.js
+++ b/worker/paidAction.js
@@ -119,12 +119,12 @@ async function performPessimisticAction ({ lndInvoice, dbInvoice, tx, models, ln
   const context = {
     tx,
     cost: BigInt(lndInvoice.received_mtokens),
-    me: dbInvoice.user,
-    sybilFeePercent: await paidActions[dbInvoice.actionType].getSybilFeePercent?.(),
-    models
+    me: dbInvoice.user
   }
 
-  const result = await paidActions[dbInvoice.actionType].perform(args, context)
+  const sybilFeePercent = await paidActions[dbInvoice.actionType].getSybilFeePercent?.(args, context)
+
+  const result = await paidActions[dbInvoice.actionType].perform(args, { ...context, sybilFeePercent })
   await tx.invoice.update({
     where: { id: dbInvoice.id },
     data: {


### PR DESCRIPTION
## Description

If we're running an item creation pessimistically, the worker didn't include `models` in the context when calling `performPessimisticAction`. If the text included a mention, the query to fetch the mentioned users would then fail.

## Video

https://github.com/user-attachments/assets/480ae087-8868-4c2f-b74b-b77e3ed852d6

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. Anon can now mention stackers.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no