### PR TITLE
fix can't upload mp4 on safari

### DIFF
--- a/components/file-upload.js
+++ b/components/file-upload.js
@@ -78,6 +78,11 @@ export const FileUpload = forwardRef(({ children, className, onSelect, onUpload,
 
       element.onerror = reject
       element.src = window.URL.createObjectURL(file)
+
+      // iOS Force the video to load metadata
+      if (element.tagName === 'VIDEO') {
+        element.load()
+      }
     })
   }, [toaster, getSignedPOST])
 


### PR DESCRIPTION
## Description

Fixes #1616 
Safari seems to need a 'bump' to load the uploaded element when it's a video
Added `element.load()` in `components/file-upload.js`

## Screenshots


https://github.com/user-attachments/assets/e9b3efa1-b389-46bf-a71d-e11aa14b61bc



## Additional Context

I don't think there's much to it, this only reminds Safari to load the element

## Checklist

**Are your changes backwards compatible? Please answer below:** It shouldn't compromise usual behavior


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, I don't have an Android but I tested it on Firefox and Safari


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:** Yes, tested mainly in Safari


**Did you introduce any new environment variables? If so, call them out explicitly here:** No