### PR TITLE
Fix account switching anon login

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -132,6 +132,9 @@ function setMultiAuthCookies (req, res, { id, jwt, name, photoId }) {
   // add JWT to **httpOnly** cookie
   res.appendHeader('Set-Cookie', cookie.serialize(`multi_auth.${id}`, jwt, cookieOptions))
 
+  // switch to user we just added
+  res.appendHeader('Set-Cookie', cookie.serialize('multi_auth.user-id', id, { ...cookieOptions, httpOnly: false }))
+
   let newMultiAuth = [{ id, name, photoId }]
   if (req.cookies.multi_auth) {
     const oldMultiAuth = b64Decode(req.cookies.multi_auth)
@@ -140,9 +143,6 @@ function setMultiAuthCookies (req, res, { id, jwt, name, photoId }) {
     newMultiAuth = [...oldMultiAuth, ...newMultiAuth]
   }
   res.appendHeader('Set-Cookie', cookie.serialize('multi_auth', b64Encode(newMultiAuth), { ...cookieOptions, httpOnly: false }))
-
-  // switch to user we just added
-  res.appendHeader('Set-Cookie', cookie.serialize('multi_auth.user-id', id, { ...cookieOptions, httpOnly: false }))
 }
 
 async function pubkeyAuth (credentials, req, res, pubkeyColumnName) {

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -14,6 +14,7 @@ import { schnorr } from '@noble/curves/secp256k1'
 import { notifyReferral } from '@/lib/webPush'
 import { hashEmail } from '@/lib/crypto'
 import * as cookie from 'cookie'
+import { multiAuthMiddleware } from '@/pages/api/graphql'
 
 /**
  * Stores userIds in user table
@@ -165,6 +166,7 @@ async function pubkeyAuth (credentials, req, res, pubkeyColumnName) {
       let user = await prisma.user.findUnique({ where: { [pubkeyColumnName]: pubkey } })
 
       // get token if it exists
+      req = multiAuthMiddleware(req)
       const token = await getToken({ req })
       if (!user) {
         // we have not seen this pubkey before

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -82,7 +82,7 @@ export default startServerAndCreateNextHandler(apolloServer, {
   }
 })
 
-function multiAuthMiddleware (request) {
+export function multiAuthMiddleware (request) {
   // switch next-auth session cookie with multi_auth cookie if cookie pointer present
 
   // is there a cookie pointer?


### PR DESCRIPTION
## Description

Fix #1613 

If we switched to anon and used credentials for an account that was already added to the `muti_auth` cookies during `login`, we didn't switch to it since we returned before we would do that after the duplicate check. This is fixed by changing the order between the user switch and duplicate check.

If we did the same but with new credentials, `getToken()` wasn't aware that we switched to anon. This is fixed by calling the middleware that updates the session cookie according to our multi_auth cookies.

## Video

Existing credentials:

https://github.com/user-attachments/assets/db1711ac-147d-42da-ac78-19488c00c749

New credentials:

https://github.com/user-attachments/assets/be2c37ae-132c-42c7-be4f-a6c382784dd8

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested as seen in the videos. Changes are minimal and should be easy to understand.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no