### PR TITLE
Always check res.ok and content-type header

### DIFF
--- a/lib/cln.js
+++ b/lib/cln.js
@@ -1,7 +1,7 @@
 import fetch from 'cross-fetch'
 import crypto from 'crypto'
 import { getAgent } from '@/lib/proxy'
-import { assertContentTypeJson } from './url'
+import { assertContentTypeJson, assertResponseOk } from './url'
 
 export const createInvoice = async ({ socket, rune, cert, label, description, msats, expiry }) => {
   const agent = getAgent({ hostname: socket, cert })
@@ -27,9 +27,8 @@ export const createInvoice = async ({ socket, rune, cert, label, description, ms
     })
   })
 
-  if (!res.ok) {
-    assertContentTypeJson(res)
-  }
+  assertResponseOk(res)
+  assertContentTypeJson(res)
 
   const inv = await res.json()
   if (inv.error) {

--- a/lib/url.js
+++ b/lib/url.js
@@ -213,6 +213,12 @@ export function parseNwcUrl (walletConnectUrl) {
   return params
 }
 
+export function assertResponseOk (res) {
+  if (!res.ok) {
+    throw new Error(`POST ${res.url}: ${res.status} ${res.statusText}`)
+  }
+}
+
 export function assertContentTypeJson (res) {
   const contentType = res.headers.get('content-type')
   if (!contentType || !contentType.includes('application/json')) {

--- a/wallets/blink/common.js
+++ b/wallets/blink/common.js
@@ -1,3 +1,5 @@
+import { assertContentTypeJson, assertResponseOk } from '@/lib/url'
+
 export const galoyBlinkUrl = 'https://api.blink.sv/graphql'
 export const galoyBlinkDashboardUrl = 'https://dashboard.blink.sv/'
 
@@ -37,15 +39,14 @@ export async function request (authToken, query, variables = {}) {
     body: JSON.stringify({ query, variables })
   }
   const res = await fetch(galoyBlinkUrl, options)
-  if (res.status >= 400 && res.status <= 599) {
-    // consume res
-    res.text().catch(() => {})
-    if (res.status === 401) {
-      throw new Error('unauthorized')
-    } else {
-      throw new Error('API responded with HTTP ' + res.status)
-    }
-  }
+
+  // consume response body to avoid memory leaks
+  // see https://github.com/nodejs/node/issues/51162
+  res.text().catch(() => {})
+
+  assertResponseOk(res)
+  assertContentTypeJson(res)
+
   return res.json()
 }
 

--- a/wallets/lightning-address/server.js
+++ b/wallets/lightning-address/server.js
@@ -1,5 +1,6 @@
 import { msatsSatsFloor } from '@/lib/format'
 import { lnAddrOptions } from '@/lib/lnurl'
+import { assertContentTypeJson, assertResponseOk } from '@/lib/url'
 
 export * from '@/wallets/lightning-address'
 
@@ -24,8 +25,13 @@ export const createInvoice = async (
   }
 
   // call callback with amount and conditionally comment
-  const res = await (await fetch(callbackUrl.toString())).json()
-  if (res.status === 'ERROR') {
+  const res = await fetch(callbackUrl.toString())
+
+  assertResponseOk(res)
+  assertContentTypeJson(res)
+
+  const body = await res.json()
+  if (body.status === 'ERROR') {
     throw new Error(res.reason)
   }
 

--- a/wallets/lnbits/client.js
+++ b/wallets/lnbits/client.js
@@ -33,8 +33,9 @@ async function getWallet ({ url, adminKey, invoiceKey }) {
   headers.append('X-Api-Key', adminKey || invoiceKey)
 
   const res = await fetch(url + path, { method: 'GET', headers })
+
+  assertContentTypeJson(res)
   if (!res.ok) {
-    assertContentTypeJson(res)
     const errBody = await res.json()
     throw new Error(errBody.detail)
   }
@@ -54,8 +55,9 @@ async function postPayment (bolt11, { url, adminKey }) {
   const body = JSON.stringify({ bolt11, out: true })
 
   const res = await fetch(url + path, { method: 'POST', headers, body })
+
+  assertContentTypeJson(res)
   if (!res.ok) {
-    assertContentTypeJson(res)
     const errBody = await res.json()
     throw new Error(errBody.detail)
   }
@@ -73,8 +75,9 @@ async function getPayment (paymentHash, { url, adminKey }) {
   headers.append('X-Api-Key', adminKey)
 
   const res = await fetch(url + path, { method: 'GET', headers })
+
+  assertContentTypeJson(res)
   if (!res.ok) {
-    assertContentTypeJson(res)
     const errBody = await res.json()
     throw new Error(errBody.detail)
   }

--- a/wallets/lnbits/server.js
+++ b/wallets/lnbits/server.js
@@ -44,8 +44,9 @@ export async function createInvoice (
     agent,
     body
   })
+
+  assertContentTypeJson(res)
   if (!res.ok) {
-    assertContentTypeJson(res)
     const errBody = await res.json()
     throw new Error(errBody.detail)
   }

--- a/wallets/phoenixd/client.js
+++ b/wallets/phoenixd/client.js
@@ -1,3 +1,5 @@
+import { assertContentTypeJson, assertResponseOk } from '@/lib/url'
+
 export * from '@/wallets/phoenixd'
 
 export async function testSendPayment (config, { logger }) {
@@ -24,9 +26,9 @@ export async function sendPayment (bolt11, { url, primaryPassword }) {
     headers,
     body
   })
-  if (!res.ok) {
-    throw new Error(`POST ${res.url}: ${res.status} ${res.statusText}`)
-  }
+
+  assertResponseOk(res)
+  assertContentTypeJson(res)
 
   const payment = await res.json()
   const preimage = payment.paymentPreimage

--- a/wallets/phoenixd/server.js
+++ b/wallets/phoenixd/server.js
@@ -1,4 +1,5 @@
 import { msatsToSats } from '@/lib/format'
+import { assertContentTypeJson, assertResponseOk } from '@/lib/url'
 
 export * from '@/wallets/phoenixd'
 
@@ -28,9 +29,9 @@ export async function createInvoice (
     headers,
     body
   })
-  if (!res.ok) {
-    throw new Error(`POST ${res.url}: ${res.status} ${res.statusText}`)
-  }
+
+  assertResponseOk(res)
+  assertContentTypeJson(res)
 
   const payment = await res.json()
   return payment.serialized


### PR DESCRIPTION
## Description

I have noticed that I forgot some response assertions in #1516.

I also noticed that it makes more sense to _always_ check the content-type header if we're going to call `res.json()`.

Therefore, if we know the response might include error details in JSON, we first check the header. If we know this isn't the case, we first check if the response was ok before we check the header. If we would always check first if the response is ok, we might miss error details.

## Additional Context

https://stacker.news/items/773703

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. I tested successful withdrawals with:

- LNbits
- NWC
- ~CLN~ _local certificate needs an update_

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no