### PR TITLE
Fix wallet status ignoring failed requests to create invoices

### DIFF
--- a/wallets/server.js
+++ b/wallets/server.js
@@ -73,7 +73,7 @@ export async function createInvoice (userId, { msats, description, descriptionHa
 
       return { invoice, wallet, logger }
     } catch (err) {
-      logger.error(err.message)
+      logger.error(err.message, { status: true })
     }
   }
 


### PR DESCRIPTION
## Description

If the wallet failed to create an invoice, we couldn't pass any `bolt11` to `logger.error` so `context.status` wasn't set. This meant this log message is ignored by the status indicators.

This PR fixes that by passing  `{ status: true }` manually to the call.

## Screenshots

## Additional Context

The idea behind `context.status` to control which log message should affect status is to prevent simply saving your wallet to make your wallet become green again. Only errors during sending and receiving should affect the status.

## Checklist

**Are your changes backwards compatible? Please answer below:**

kind of

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Didn't test but change is trivial so I am confident this is good to ship.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no