### PR TITLE
HOTFIX: restore missing link between lnurlp and nip57

### DIFF
--- a/api/paidAction/index.js
+++ b/api/paidAction/index.js
@@ -351,7 +351,8 @@ async function createDbInvoice (actionType, args, context) {
     actionOptimistic: optimistic,
     actionArgs: args,
     expiresAt,
-    actionId
+    actionId,
+    desc: context.internalDescription ?? servedInvoice.description
   }
 
   let invoice

--- a/api/paidAction/index.js
+++ b/api/paidAction/index.js
@@ -351,8 +351,7 @@ async function createDbInvoice (actionType, args, context) {
     actionOptimistic: optimistic,
     actionArgs: args,
     expiresAt,
-    actionId,
-    desc: context.internalDescription ?? servedInvoice.description
+    actionId
   }
 
   let invoice

--- a/api/paidAction/receive.js
+++ b/api/paidAction/receive.js
@@ -36,13 +36,15 @@ export async function getSybilFeePercent () {
 export async function perform ({
   invoiceId,
   comment,
-  lud18Data
+  lud18Data,
+  noteStr
 }, { me, tx }) {
   const invoice = await tx.invoice.update({
     where: { id: invoiceId },
     data: {
       comment,
-      lud18Data
+      lud18Data,
+      desc: noteStr
     },
     include: { invoiceForward: true }
   })

--- a/api/paidAction/receive.js
+++ b/api/paidAction/receive.js
@@ -44,7 +44,7 @@ export async function perform ({
     data: {
       comment,
       lud18Data,
-      desc: noteStr
+      ...(noteStr ? { desc: noteStr } : {})
     },
     include: { invoiceForward: true }
   })

--- a/pages/api/lnurlp/[username]/pay.js
+++ b/pages/api/lnurlp/[username]/pay.js
@@ -82,8 +82,9 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
       description,
       descriptionHash,
       comment: comment || '',
-      lud18Data: parsedPayerData
-    }, { models, lnd, me: user, internalDescription: noteStr ?? description })
+      lud18Data: parsedPayerData,
+      noteStr
+    }, { models, lnd, me: user })
 
     if (!invoice?.bolt11) throw new Error('could not generate invoice')
 

--- a/pages/api/lnurlp/[username]/pay.js
+++ b/pages/api/lnurlp/[username]/pay.js
@@ -83,7 +83,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
       descriptionHash,
       comment: comment || '',
       lud18Data: parsedPayerData
-    }, { models, lnd, me: user })
+    }, { models, lnd, me: user, internalDescription: noteStr ?? description })
 
     if (!invoice?.bolt11) throw new Error('could not generate invoice')
 


### PR DESCRIPTION
The nip57 job relies on the dbInvoice desc field to get the metadata it needs to publish the zap receipts
```js
    const desc = JSON.parse(inv.desc)
    const ptag = desc.tags.filter(t => t?.length >= 2 && t[0] === 'p')[0]
    const etag = desc.tags.filter(t => t?.length >= 2 && t[0] === 'e')[0]
    const atag = desc.tags.filter(t => t?.length >= 2 && t[0] === 'a')[0]
    const relays = desc.tags.find(t => t?.length >= 2 && t[0] === 'relays').slice(1)
```
however at some point there must have been a regression that caused this link to be broken, since this field is not being used anymore.

This PR adds an optional `internalDescription` context field that when passes is used to set the dbInvoice.desc field (that could be different than the servedInvoice.description field due to privacy settings).

This is an hotfix to restore the functionality with minimal changes, to avoid conflicts, since this code is being worked elsewhere. 