### PR TITLE
Use invoice.cancelledAt to determine if invoice expired or was canceled by user

### DIFF
--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -108,6 +108,7 @@ const typeDefs = `
     bolt11: String!
     expiresAt: Date!
     cancelled: Boolean!
+    cancelledAt: Date
     confirmedAt: Date
     satsReceived: Int
     satsRequested: Int!

--- a/components/countdown.js
+++ b/components/countdown.js
@@ -43,7 +43,7 @@ export function CompactLongCountdown (props) {
                 ? ` ${props.formatted.hours}:${props.formatted.minutes}:${props.formatted.seconds}`
                 : Number(props.formatted.minutes) > 0
                   ? ` ${props.formatted.minutes}:${props.formatted.seconds}`
-                  : Number(props.formatted.seconds) > 0
+                  : Number(props.formatted.seconds) >= 0
                     ? ` ${props.formatted.seconds}s`
                     : ' '}
           </>

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -11,6 +11,7 @@ export const INVOICE_FIELDS = gql`
     satsRequested
     satsReceived
     cancelled
+    cancelledAt
     confirmedAt
     expiresAt
     nostr

--- a/prisma/migrations/20241122041724_invoice_cancelled_at/migration.sql
+++ b/prisma/migrations/20241122041724_invoice_cancelled_at/migration.sql
@@ -1,0 +1,4 @@
+-- AlterTable
+ALTER TABLE "Invoice" ADD COLUMN     "cancelledAt" TIMESTAMP(3);
+
+UPDATE "Invoice" SET "cancelledAt" = "expiresAt" WHERE "cancelled" = true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -909,6 +909,7 @@ model Invoice {
   confirmedAt    DateTime?
   confirmedIndex BigInt?
   cancelled      Boolean         @default(false)
+  cancelledAt    DateTime?
   msatsRequested BigInt
   msatsReceived  BigInt?
   desc           String?

--- a/worker/paidAction.js
+++ b/worker/paidAction.js
@@ -456,7 +456,8 @@ export async function paidActionFailed ({ data: { invoiceId, ...args }, models, 
       await paidActions[dbInvoice.actionType].onFail?.({ invoice: dbInvoice }, { models, tx, lnd })
 
       return {
-        cancelled: true
+        cancelled: true,
+        cancelledAt: new Date()
       }
     },
     ...args

--- a/worker/wallet.js
+++ b/worker/wallet.js
@@ -182,7 +182,8 @@ export async function checkInvoice ({ data: { hash, invoice }, boss, models, lnd
           hash: inv.id
         },
         data: {
-          cancelled: true
+          cancelled: true,
+          cancelledAt: new Date()
         }
       }), { models }
     )


### PR DESCRIPTION
## Description

If an invoice expires, LND emits a new invoice update event with `is_canceled` set. We use that event in `checkInvoice` to mark the invoice as cancelled in our database.

However, this means that we can't really tell if an invoice was canceled because it expired or because it was actually canceled by the user. For LND, this makes no difference, but imo, this makes a difference in our UI because QR codes change their state from "expired" to "cancelled".

I think this state change is bad UX. If the user didn't cancel the invoice themselves (by closing the modal), the status should stay at expired and the modal should not close.

I fixed this by adding a new column `Invoice.cancelledAt` so we can now check `invoice.expiresAt < invoice.cancelledAt`. If this is true, we know the invoice was canceled because it expired.

## Video

<details>
<summary>existing behavior on master</summary>

https://github.com/user-attachments/assets/f84649d1-9628-414c-b1d9-0e4f41e23b2f

</details>

<details>
<summary>new (fixed) behavior (this PR)</summary>

https://github.com/user-attachments/assets/14dd3241-85da-45dc-b60c-ecb5c8e1cfea

</details>

## Additional checklist

I have seen sometimes on master how the invoice expired but it was never cancelled in the database. However, I wasn't able to properly debug using `console.trace` etc. since it never seemed to happen when I was ready to debug it. LND might not always emit an event if an invoice expired or we're missing events.

I have also seen this rare bug in this PR.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes, I only added a new column but didn't drop `invoice.cancelled`. We can drop it in a future migration if we want.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. QR codes that expire stay open and continue to show `expired`.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no