### PR TITLE
Feat: PDF support via Imgproxy

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -28,7 +28,8 @@ export const UPLOAD_TYPES_ALLOW = [
   'image/webp',
   'video/mp4',
   'video/mpeg',
-  'video/webm'
+  'video/webm',
+  'application/pdf'
 ]
 export const AVATAR_TYPES_ALLOW = UPLOAD_TYPES_ALLOW.filter(t => t.startsWith('image/'))
 export const INVOICE_ACTION_NOTIFICATION_TYPES = ['ITEM_CREATE', 'ZAP', 'DOWN_ZAP', 'POLL_VOTE', 'BOOST']


### PR DESCRIPTION
## Description

Completes #853.
These changes allows for PDFs to be uploaded and processed by Imgproxy. At the moment it retrieves the first page of an uploaded PDF to be displayed as a thumbnail, sets the quality, the color background and DPI per [Imgproxy options](https://docs.imgproxy.net/usage/processing#page).

## Screenshots

n/a

## Additional Context

This is an exclusive Imgproxy PRO feature, other than following the documentation, AFAIK there's no way for me to test this functionality. Therefore i'll draft this PR until we're sure it works.

## Checklist

**Are your changes backwards compatible? Please answer below:**
Being an addition with processing and detection happening only after image/video, it shouldn't affect existing uploads

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
2. 
- PDFs do upload and can be accessed
- Images and videos completely work as before
- Functionality cannot be tested as this is an imgproxy pro only feature and I don't have access to it atm.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Color background for PDF is set to be white

**Did you introduce any new environment variables? If so, call them out explicitly here:** No