### PR TITLE
fix LNC attachment and docs

### DIFF
--- a/wallets/lnc/ATTACH.md
+++ b/wallets/lnc/ATTACH.md
@@ -7,12 +7,12 @@ This can be done one of two ways:
 We only need permissions for the uri `/lnrpc.Lightning/SendPaymentSync`
 
 ```bash
-$ sndev stacker_litcli accounts create --balance <budget>
+$ sndev cli litd accounts create --balance <budget>
 ```
 
 Grab the `account.id` from the output and use it here:
 ```bash
-$ sndev stacker_litcli sessions add --type custom --label <your label> --account_id <account_id> --uri /lnrpc.Lightning/SendPaymentSync
+$ sndev cli litd sessions add --type custom --label <your label> --account_id <account_id> --uri /lnrpc.Lightning/SendPaymentSync
 ```
 
 Grab the `pairing_secret_mnemonic` from the output and that's your pairing phrase.

--- a/wallets/lnc/client.js
+++ b/wallets/lnc/client.js
@@ -95,7 +95,7 @@ async function getLNC (credentials = {}) {
     }
     return window.lnc
   }
-  const { default: { default: LNC } } = await import('@lightninglabs/lnc-web')
+  const { default: LNC } = await import('@lightninglabs/lnc-web')
   window.lnc = new LNC({
     credentialStore: new LncCredentialStore({
       ...credentials,


### PR DESCRIPTION
It seems the import broke at some point. This PR makes the LNC attachment  """"work"""" again.

Also, the doc needed a refresh after the sndev refactoring.
