### PR TITLE
refactor: Check darkmode in useWallets

### DIFF
--- a/components/wallet-card.js
+++ b/components/wallet-card.js
@@ -7,8 +7,6 @@ import { Status, isConfigured } from '@/wallets/common'
 import DraggableIcon from '@/svgs/draggable.svg'
 import RecvIcon from '@/svgs/arrow-left-down-line.svg'
 import SendIcon from '@/svgs/arrow-right-up-line.svg'
-import useDarkMode from './dark-mode'
-import { useEffect, useState } from 'react'
 
 const statusToClass = status => {
   switch (status) {
@@ -20,15 +18,7 @@ const statusToClass = status => {
 }
 
 export default function WalletCard ({ wallet, draggable, onDragStart, onDragEnter, onDragEnd, onTouchStart, sourceIndex, targetIndex, index }) {
-  const [dark] = useDarkMode()
   const { card: { title, image } } = wallet.def
-  const [imgSrc, setImgSrc] = useState(image?.src)
-
-  useEffect(() => {
-    if (!imgSrc) return
-    // wallet.png <-> wallet-dark.png
-    setImgSrc(dark ? image?.src.replace(/\.([a-z]{3})$/, '-dark.$1') : image?.src)
-  }, [dark])
 
   return (
     <Card
@@ -56,7 +46,7 @@ export default function WalletCard ({ wallet, draggable, onDragStart, onDragEnte
       >
         <div className='d-flex text-center align-items-center h-100'>
           {image
-            ? <img alt={title} width='100%' {...image} src={imgSrc} />
+            ? <img alt={title} width='100%' {...image} />
             : <Card.Title className='w-100 justify-content-center align-items-center'>{title}</Card.Title>}
         </div>
       </Card.Body>

--- a/components/wallet-card.js
+++ b/components/wallet-card.js
@@ -7,6 +7,7 @@ import { Status, isConfigured } from '@/wallets/common'
 import DraggableIcon from '@/svgs/draggable.svg'
 import RecvIcon from '@/svgs/arrow-left-down-line.svg'
 import SendIcon from '@/svgs/arrow-right-up-line.svg'
+import { useWalletImage } from '@/components/wallet-image'
 
 const statusToClass = status => {
   switch (status) {
@@ -18,7 +19,7 @@ const statusToClass = status => {
 }
 
 export default function WalletCard ({ wallet, draggable, onDragStart, onDragEnter, onDragEnd, onTouchStart, sourceIndex, targetIndex, index }) {
-  const { card: { title, image } } = wallet.def
+  const image = useWalletImage(wallet)
 
   return (
     <Card
@@ -46,8 +47,8 @@ export default function WalletCard ({ wallet, draggable, onDragStart, onDragEnte
       >
         <div className='d-flex text-center align-items-center h-100'>
           {image
-            ? <img alt={title} width='100%' {...image} />
-            : <Card.Title className='w-100 justify-content-center align-items-center'>{title}</Card.Title>}
+            ? <img width='100%' {...image} />
+            : <Card.Title className='w-100 justify-content-center align-items-center'>{wallet.def.card.title}</Card.Title>}
         </div>
       </Card.Body>
       <Link href={`/settings/wallets/${wallet.def.name}`}>

--- a/components/wallet-image.js
+++ b/components/wallet-image.js
@@ -1,0 +1,14 @@
+import useDarkMode from '@/components/dark-mode'
+
+export function useWalletImage (wallet) {
+  const [darkMode] = useDarkMode()
+
+  const { title, image } = wallet.def.card
+
+  if (!image) return null
+
+  // wallet.png <-> wallet-dark.png
+  const src = darkMode ? image?.src.replace(/\.([a-z]{3})$/, '-dark.$1') : image?.src
+
+  return { ...image, alt: title, src }
+}

--- a/pages/settings/wallets/[wallet].js
+++ b/pages/settings/wallets/[wallet].js
@@ -13,12 +13,11 @@ import { canReceive, canSend, isConfigured } from '@/wallets/common'
 import { SSR } from '@/lib/constants'
 import WalletButtonBar from '@/components/wallet-buttonbar'
 import { useWalletConfigurator } from '@/wallets/config'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useMe } from '@/components/me'
 import validateWallet from '@/wallets/validate'
 import { ValidationError } from 'yup'
 import { useFormikContext } from 'formik'
-import useDarkMode from '@/components/dark-mode'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
@@ -29,8 +28,6 @@ export default function WalletSettings () {
   const wallet = useWallet(name)
   const { me } = useMe()
   const { save, detach } = useWalletConfigurator(wallet)
-  const [dark] = useDarkMode()
-  const [imgSrc, setImgSrc] = useState(wallet?.def.card?.image?.src)
 
   const initial = useMemo(() => {
     const initial = wallet?.def.fields.reduce((acc, field) => {
@@ -72,16 +69,10 @@ export default function WalletSettings () {
 
   const { card: { image, title, subtitle } } = wallet?.def || { card: {} }
 
-  useEffect(() => {
-    if (!imgSrc) return
-    // wallet.png <-> wallet-dark.png
-    setImgSrc(dark ? image?.src.replace(/\.([a-z]{3})$/, '-dark.$1') : image?.src)
-  }, [dark])
-
   return (
     <CenterLayout>
       {image
-        ? <img alt={title} {...image} src={imgSrc} className='pb-3 px-2 mw-100' />
+        ? <img alt={title} {...image} className='pb-3 px-2 mw-100' />
         : <h2 className='pb-2'>{title}</h2>}
       <h6 className='text-muted text-center pb-3'><Text>{subtitle}</Text></h6>
       <Form

--- a/pages/settings/wallets/[wallet].js
+++ b/pages/settings/wallets/[wallet].js
@@ -18,6 +18,7 @@ import { useMe } from '@/components/me'
 import validateWallet from '@/wallets/validate'
 import { ValidationError } from 'yup'
 import { useFormikContext } from 'formik'
+import { useWalletImage } from '@/components/wallet-image'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
@@ -28,6 +29,7 @@ export default function WalletSettings () {
   const wallet = useWallet(name)
   const { me } = useMe()
   const { save, detach } = useWalletConfigurator(wallet)
+  const image = useWalletImage(wallet)
 
   const initial = useMemo(() => {
     const initial = wallet?.def.fields.reduce((acc, field) => {
@@ -67,14 +69,12 @@ export default function WalletSettings () {
     }
   }, [wallet.def])
 
-  const { card: { image, title, subtitle } } = wallet?.def || { card: {} }
-
   return (
     <CenterLayout>
       {image
-        ? <img alt={title} {...image} className='pb-3 px-2 mw-100' />
-        : <h2 className='pb-2'>{title}</h2>}
-      <h6 className='text-muted text-center pb-3'><Text>{subtitle}</Text></h6>
+        ? <img {...image} className='pb-3 px-2 mw-100' />
+        : <h2 className='pb-2'>{wallet.def.card.title}</h2>}
+      <h6 className='text-muted text-center pb-3'><Text>{wallet.def.card.subtitle}</Text></h6>
       <Form
         initial={initial}
         enableReinitialize

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -10,6 +10,7 @@ import { decode as bolt11Decode } from 'bolt11'
 import walletDefs from '@/wallets/client'
 import { generateMutation } from './graphql'
 import { formatSats } from '@/lib/format'
+import useDarkMode from '@/components/dark-mode'
 
 const WalletsContext = createContext({
   wallets: []
@@ -68,6 +69,7 @@ export function WalletsProvider ({ children }) {
   const [serverWallets, setServerWallets] = useState([])
   const client = useApolloClient()
   const { logs } = useWalletLogs()
+  const [darkMode] = useDarkMode()
 
   const { data, refetch } = useQuery(WALLETS,
     SSR ? {} : { nextFetchPolicy: 'cache-and-network' })
@@ -133,6 +135,12 @@ export function WalletsProvider ({ children }) {
     return Object.values(merged)
       .sort(walletPrioritySort)
       .map(w => {
+        const { card: { image } } = w.def
+        let imgSrc = image?.src
+        if (imgSrc && darkMode) {
+          // wallet.png <-> wallet-dark.png
+          imgSrc = image.src.replace(/\.([a-z]{3})$/, '-dark.$1')
+        }
         return {
           ...w,
           support: {
@@ -143,10 +151,17 @@ export function WalletsProvider ({ children }) {
             any: w.config?.enabled && isConfigured(w) ? Status.Enabled : Status.Disabled,
             send: w.config?.enabled && canSend(w) ? Status.Enabled : Status.Disabled,
             recv: w.config?.enabled && canReceive(w) ? Status.Enabled : Status.Disabled
+          },
+          def: {
+            ...w.def,
+            card: {
+              ...w.def.card,
+              image: imgSrc ? { src: imgSrc } : undefined
+            }
           }
         }
       }).map(w => statusFromLog(w, logs))
-  }, [serverWallets, localWallets, logs])
+  }, [serverWallets, localWallets, logs, darkMode])
 
   const settings = useMemo(() => {
     return {

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -10,7 +10,6 @@ import { decode as bolt11Decode } from 'bolt11'
 import walletDefs from '@/wallets/client'
 import { generateMutation } from './graphql'
 import { formatSats } from '@/lib/format'
-import useDarkMode from '@/components/dark-mode'
 
 const WalletsContext = createContext({
   wallets: []
@@ -69,7 +68,6 @@ export function WalletsProvider ({ children }) {
   const [serverWallets, setServerWallets] = useState([])
   const client = useApolloClient()
   const { logs } = useWalletLogs()
-  const [darkMode] = useDarkMode()
 
   const { data, refetch } = useQuery(WALLETS,
     SSR ? {} : { nextFetchPolicy: 'cache-and-network' })
@@ -135,12 +133,6 @@ export function WalletsProvider ({ children }) {
     return Object.values(merged)
       .sort(walletPrioritySort)
       .map(w => {
-        const { card: { image } } = w.def
-        let imgSrc = image?.src
-        if (imgSrc && darkMode) {
-          // wallet.png <-> wallet-dark.png
-          imgSrc = image.src.replace(/\.([a-z]{3})$/, '-dark.$1')
-        }
         return {
           ...w,
           support: {
@@ -151,17 +143,10 @@ export function WalletsProvider ({ children }) {
             any: w.config?.enabled && isConfigured(w) ? Status.Enabled : Status.Disabled,
             send: w.config?.enabled && canSend(w) ? Status.Enabled : Status.Disabled,
             recv: w.config?.enabled && canReceive(w) ? Status.Enabled : Status.Disabled
-          },
-          def: {
-            ...w.def,
-            card: {
-              ...w.def.card,
-              image: imgSrc ? { src: imgSrc } : undefined
-            }
           }
         }
       }).map(w => statusFromLog(w, logs))
-  }, [serverWallets, localWallets, logs, darkMode])
+  }, [serverWallets, localWallets, logs])
 
   const settings = useMemo(() => {
     return {


### PR DESCRIPTION
## Description

`useWallets` is a more appropriate location to check which image we should use.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. The correct image is still used in light and dark mode.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**
