### PR TITLE
fix: top boosts shows others' unpaid boosts

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -423,6 +423,7 @@ export default {
                 subClause(sub, 5, subClauseTable(type), me, showNsfw),
                 typeClause(type),
                 whenClause(when, 'Item'),
+                activeOrMine(me),
                 await filterClause(me, models, type),
                 by === 'boost' && '"Item".boost > 0',
                 muteClause(me))}


### PR DESCRIPTION
## Description

Adds `activeOrMine` to the 'top' sorting items query, effectively filtering boosts that are not created by the user and/or unpaid.
Fixes #1645 

## Screenshots
Before:
<img width="763" alt="Screenshot 2024-11-24 at 23 45 07" src="https://github.com/user-attachments/assets/6b94ecd1-ba28-42eb-a9bc-0525f2a5a7d0">
After:
<img width="763" alt="Screenshot 2024-11-24 at 23 45 25" src="https://github.com/user-attachments/assets/8b6b4ecc-fd71-4776-8bc9-8a11aae8fb68">


Boost owner context:
<img width="763" alt="Screenshot 2024-11-24 at 23 45 44" src="https://github.com/user-attachments/assets/eee2f6de-ac92-47c4-8d70-a611e5a00d1b">


## Additional Context

Nothing else!

## Checklist

**Are your changes backwards compatible? Please answer below:** I don't think so, it mimics 'recent' in filtering boosts as suggested by the issue ^^


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8. Tested as the creator pov, the stacker pov and anon pov


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:** n/a


**Did you introduce any new environment variables? If so, call them out explicitly here:** No
