### PR TITLE
Fix actionArgs of new invoice during retry

### DIFF
--- a/api/paidAction/index.js
+++ b/api/paidAction/index.js
@@ -256,7 +256,7 @@ export async function retryPaidAction (actionType, args, incomingContext) {
     throw new Error(`retryPaidAction - missing invoice ${actionType}`)
   }
 
-  const { msatsRequested, actionId } = failedInvoice
+  const { msatsRequested, actionId, actionArgs } = failedInvoice
   const retryContext = {
     ...incomingContext,
     optimistic: true,
@@ -265,7 +265,7 @@ export async function retryPaidAction (actionType, args, incomingContext) {
     actionId
   }
 
-  const invoiceArgs = await createSNInvoice(actionType, args, retryContext)
+  const invoiceArgs = await createSNInvoice(actionType, actionArgs, retryContext)
 
   return await models.$transaction(async tx => {
     const context = { ...retryContext, tx, invoiceArgs }
@@ -282,7 +282,7 @@ export async function retryPaidAction (actionType, args, incomingContext) {
     })
 
     // create a new invoice
-    const invoice = await createDbInvoice(actionType, args, context)
+    const invoice = await createDbInvoice(actionType, actionArgs, context)
 
     return {
       result: await action.retry({ invoiceId: failedInvoice.id, newInvoiceId: invoice.id }, context),


### PR DESCRIPTION
## Description

I have noticed that when we retry an invoice, the new invoice does not include the same `actionArgs` as the old invoice but the full old invoice. See invoice with id 294087 for example.

We currently don't use these `actionArgs` of the new invoice during a retry since we only allow retrying optimistic actions so this didn't trigger any bug.

However, in #1642, pessimistic actions also should be retriable and that's where this triggers a bug like `billingType` being undefined when I pay the new invoice to create a territory.

With the changes in this PR, retries of pessimistic actions start to work in #1642.

## Checklist

**Are your changes backwards compatible? Please answer below:**

this doesn't fix it for old invoices but they aren't used anymore anyway

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. Tested inside of #1642 

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no