### PR TITLE
fix: cannot add images above text

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -364,12 +364,18 @@ export function MarkdownInput ({ label, topLevel, groupClassName, onChange, onKe
                 let preMarker = text.slice(0, cursorPosition)
                 let postMarker = text.slice(cursorPosition)
                 // when uploading multiple files at once, we want to make sure the upload markers are separated by blank lines
-                if (preMarker && !/\n+\s*$/.test(preMarker)) {
-                  preMarker += '\n\n'
+                if (preMarker) {
+                  // Count existing newlines at the end of preMarker
+                  const existingNewlines = preMarker.match(/[\n]+$/)?.[0].length || 0
+                  // Add only the needed newlines to reach 2
+                  preMarker += '\n'.repeat(Math.max(0, 2 - existingNewlines))
                 }
                 // if there's text after the cursor, we want to make sure the upload marker is separated by a blank line
                 if (postMarker) {
-                  postMarker = '\n\n' + postMarker
+                  // Count existing newlines at the start of postMarker
+                  const existingNewlines = postMarker.match(/^[\n]*/)?.[0].length || 0
+                  // Add only the needed newlines to reach 2
+                  postMarker = '\n'.repeat(Math.max(0, 2 - existingNewlines)) + postMarker
                 }
                 const newText = preMarker + uploadMarker + postMarker
                 helpers.setValue(newText)


### PR DESCRIPTION
## Description

Fixes #1657 
Remove `text.length` as substitute for `cursorPosition: 0` since forcing it to appear at the end of the text would be worse than free placement (?)
Add blank lines after image upload if there's no text after it

## Screenshots

https://github.com/user-attachments/assets/e8f33489-8d06-473c-b029-bea294a7157c



## Additional Context

n/a

## Checklist

**Are your changes backwards compatible? Please answer below:** Yes, it doesn't interfere with pre-existing content


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8. Tested with Safari and Firefox, multiple cursorPosition values


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:** n/a


**Did you introduce any new environment variables? If so, call them out explicitly here:** No
