### PR TITLE
Remove unused useWallet from QR code component

### DIFF
--- a/components/invoice.js
+++ b/components/invoice.js
@@ -19,7 +19,7 @@ import styles from './invoice.module.css'
 
 export default function Invoice ({
   id, query = INVOICE, modal, onPayment, onExpired, onCanceled, info, successVerb = 'deposited',
-  heldVerb = 'settling', useWallet = true, walletError, poll, waitFor, ...props
+  heldVerb = 'settling', walletError, poll, waitFor, ...props
 }) {
   const { data, error } = useQuery(query, SSR
     ? {}
@@ -79,15 +79,12 @@ export default function Invoice ({
         {invoice.forwardedSats && <Badge className={styles.badge} bg={null}>p2p</Badge>}
       </>
     )
-    useWallet = false
   } else if (expired) {
     variant = 'failed'
     status = 'expired'
-    useWallet = false
   } else if (invoice.cancelled) {
     variant = 'failed'
     status = 'cancelled'
-    useWallet = false
   } else if (invoice.isHeld) {
     variant = 'pending'
     status = (
@@ -95,7 +92,6 @@ export default function Invoice ({
         <Moon className='spin fill-grey me-2' /> {heldVerb}
       </div>
     )
-    useWallet = false
   } else {
     variant = 'pending'
     status = (
@@ -113,7 +109,7 @@ export default function Invoice ({
           <code> {walletError.message}</code>
         </div>}
       <Qr
-        useWallet={useWallet} value={invoice.bolt11}
+        value={invoice.bolt11}
         description={numWithUnits(invoice.satsRequested, { abbreviate: false })}
         statusVariant={variant} status={status}
       />

--- a/components/payment.js
+++ b/components/payment.js
@@ -150,7 +150,6 @@ export const useQrPayment = () => {
           description
           status='loading'
           successVerb='received'
-          useWallet={false}
           walletError={walletError}
           waitFor={waitFor}
           onExpired={inv => reject(new InvoiceExpiredError(inv?.hash))}

--- a/components/qr.js
+++ b/components/qr.js
@@ -1,8 +1,6 @@
 import { QRCodeSVG } from 'qrcode.react'
 import { CopyInput, InputSkeleton } from './form'
 import InvoiceStatus from './invoice-status'
-import { useEffect } from 'react'
-import { useWallet } from '@/wallets/index'
 import Bolt11Info from './bolt11-info'
 
 export const qrImageSettings = {
@@ -14,22 +12,8 @@ export const qrImageSettings = {
   excavate: true
 }
 
-export default function Qr ({ asIs, value, useWallet: automated, statusVariant, description, status }) {
+export default function Qr ({ asIs, value, statusVariant, description, status }) {
   const qrValue = asIs ? value : 'lightning:' + value.toUpperCase()
-  const wallet = useWallet()
-
-  useEffect(() => {
-    async function effect () {
-      if (automated && wallet) {
-        try {
-          await wallet.sendPayment(value)
-        } catch (e) {
-          console.log(e?.message)
-        }
-      }
-    }
-    effect()
-  }, [wallet])
 
   return (
     <>

--- a/pages/invoices/[id].js
+++ b/pages/invoices/[id].js
@@ -12,7 +12,7 @@ export default function FullInvoice () {
 
   return (
     <CenterLayout>
-      <Invoice id={router.query.id} query={INVOICE_FULL} poll description status='loading' bolt11Info useWallet={false} />
+      <Invoice id={router.query.id} query={INVOICE_FULL} poll description status='loading' bolt11Info />
     </CenterLayout>
   )
 }


### PR DESCRIPTION
## Description

We no longer ever try to pay QR codes with attached wallets. We only show QR codes if attached wallets are unavailable or all failed.

That's why we always pass `useWallet={false}` to every `Invoice` component so we can completely remove it now.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`3`. Only tested with single failed zap from LNbits and the QR code showed up. From reading the code, I am pretty sure that this doesn't break anything and simply removes dead code.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no