### PR TITLE
Fix edit timer stuck at 0000

### DIFF
--- a/components/use-can-edit.js
+++ b/components/use-can-edit.js
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react'
+import { datePivot } from '@/lib/time'
+import { useMe } from '@/components/me'
+import { USER_ID } from '@/lib/constants'
+
+export default function useCanEdit (item) {
+  const editThreshold = datePivot(new Date(item.invoice?.confirmedAt ?? item.createdAt), { minutes: 10 })
+  const { me } = useMe()
+
+  // deleted items can never be edited and every item has a 10 minute edit window
+  // except bios, they can always be edited but they should never show the countdown
+  const noEdit = !!item.deletedAt || (Date.now() >= editThreshold) || item.bio
+  const authorEdit = me && item.mine
+  const [canEdit, setCanEdit] = useState(!noEdit && authorEdit)
+
+  useEffect(() => {
+    // allow anon edits if they have the correct hmac for the item invoice
+    // (the server will verify the hmac)
+    const invParams = window.localStorage.getItem(`item:${item.id}:hash:hmac`)
+    const anonEdit = !!invParams && !me && Number(item.user.id) === USER_ID.anon
+    // anonEdit should not override canEdit, but only allow edits if they aren't already allowed
+    setCanEdit(canEdit => canEdit || anonEdit)
+  }, [])
+
+  return [canEdit, setCanEdit, editThreshold]
+}

--- a/pages/items/[id]/edit.js
+++ b/pages/items/[id]/edit.js
@@ -12,6 +12,7 @@ import { useRouter } from 'next/router'
 import PageLoading from '@/components/page-loading'
 import { FeeButtonProvider } from '@/components/fee-button'
 import SubSelect from '@/components/sub-select'
+import useCanEdit from '@/components/use-can-edit'
 
 export const getServerSideProps = getGetServerSideProps({
   query: ITEM,
@@ -26,7 +27,7 @@ export default function PostEdit ({ ssrData }) {
   const { item } = data || ssrData
   const [sub, setSub] = useState(item.subName)
 
-  const editThreshold = new Date(item?.invoice?.confirmedAt ?? item.createdAt).getTime() + 10 * 60000
+  const [,, editThreshold] = useCanEdit(item)
 
   let FormType = DiscussionForm
   let itemType = 'DISCUSSION'


### PR DESCRIPTION
## Description

Fix #1671 

## Video

https://github.com/user-attachments/assets/9372ba07-40b1-432c-bd10-a777ffef22f2

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested as can be seen in the video and made sure post edits also still show the correct edit timer.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no