### PR TITLE
feat: carousel back action integrated into browser history

### DIFF
--- a/components/carousel.js
+++ b/components/carousel.js
@@ -5,6 +5,7 @@ import ArrowRight from '@/svgs/arrow-right-line.svg'
 import styles from './carousel.module.css'
 import { useShowModal } from './modal'
 import { Dropdown } from 'react-bootstrap'
+import { usePathname } from 'next/navigation'
 
 function useSwiping ({ moveLeft, moveRight }) {
   const [touchStartX, setTouchStartX] = useState(null)
@@ -104,12 +105,19 @@ function CarouselOverflow ({ originalSrc, rel }) {
 }
 
 export function CarouselProvider ({ children }) {
+  const pathname = usePathname()
+
   const media = useRef(new Map())
   const showModal = useShowModal()
 
   const showCarousel = useCallback(({ src }) => {
+    window.history.pushState(null, '', pathname)
+
     showModal((close, setOptions) => {
-      return <Carousel close={close} mediaArr={Array.from(media.current.entries())} src={src} setOptions={setOptions} />
+      const closeAction = () => {
+        window.history.back()
+      }
+      return <Carousel close={closeAction} mediaArr={Array.from(media.current.entries())} src={src} setOptions={setOptions} />
     }, {
       fullScreen: true,
       overflow: <CarouselOverflow {...media.current.get(src)} />


### PR DESCRIPTION
## Description

*This is a cleaner version of [this PR](https://github.com/stackernews/stacker.news/issues/1508) as that branch contained a lot of commits and was diverging from master.*

Carousel's modal now closes when navigating backward through the browser's history, going back to the post instead of returning to the main page. Fixes #1508.

## Screenshots

I have committed a version of the fix which works in case of multiple carousel shows as well:

https://github.com/user-attachments/assets/fa6c8908-54c5-4293-86f1-0e03021154cd

## Additional Context
I wasn't able to use  `router.push` as suggested in the original issue and had to stick to the native APIs, [which is documented by NextJS as an alternative to router methods as well](https://nextjs.org/docs/app/building-your-application/routing/linking-and-navigating#using-the-native-history-api).

The code overrides the `close` function of the carousel, triggering a 'back' navigation when the carousel is closed. It is still relying on native history APIs, unfortunately a router's shallow navigation immediately closes the carousel, presumably due to the listener I have highlighted in the previous comments.

**Before marking this PR ready for review I would like to know if it's fine for your to use window's native APIs, then maybe explore a solution which relies on router in the future.**

## Checklist

**Are your changes backwards compatible? Please answer below:** Yes


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:** 8, I tested the changes manually and with various content.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:** Yes


**Did you introduce any new environment variables? If so, call them out explicitly here:** No
