### PR TITLE
Login 2fa (totp)

### DIFF
--- a/api/resolvers/index.js
+++ b/api/resolvers/index.js
@@ -20,6 +20,7 @@ import { GraphQLScalarType, Kind } from 'graphql'
 import { createIntScalar } from 'graphql-scalar'
 import paidAction from './paidAction'
 import vault from './vault'
+import verify2fa from './verify2fa'
 
 const date = new GraphQLScalarType({
   name: 'Date',
@@ -56,4 +57,4 @@ const limit = createIntScalar({
 
 export default [user, item, message, wallet, lnurl, notifications, invite, sub,
   upload, search, growth, rewards, referrals, price, admin, blockHeight, chainFee,
-  { JSONObject }, { Date: date }, { Limit: limit }, paidAction, vault]
+  { JSONObject }, { Date: date }, { Limit: limit }, paidAction, vault, verify2fa]

--- a/api/resolvers/verify2fa.js
+++ b/api/resolvers/verify2fa.js
@@ -1,0 +1,26 @@
+import * as Auth2fa from '@/lib/auth2fa'
+
+export default {
+  Mutation: {
+    verify2fa: async (parent, { method, callbackUrl, ...args }, { models, unverifiedSession }) => {
+      const session = unverifiedSession
+      if (!session) throw new Error('Not authenticated')
+
+      const userId = session.user.id
+      const user = await models.user.findUnique({ where: { id: userId } })
+      if (!user) throw new Error('User not found')
+
+      const valid = Auth2fa.validate2fa(method, args, { me: user })
+      if (!valid) throw new Error('Invalid 2FA token')
+
+      const token = await Auth2fa.getEncodedLogin2faToken({ result: valid, userId, jti2fa: session.jti2fa, callbackUrl })
+      return {
+        result: valid,
+        tokens: [
+          token
+        ],
+        callbackUrl
+      }
+    }
+  }
+}

--- a/api/typeDefs/index.js
+++ b/api/typeDefs/index.js
@@ -19,6 +19,7 @@ import blockHeight from './blockHeight'
 import chainFee from './chainFee'
 import paidAction from './paidAction'
 import vault from './vault'
+import verify2fa from './verify2fa'
 
 const common = gql`
   type Query {
@@ -39,4 +40,4 @@ const common = gql`
 `
 
 export default [common, user, item, itemForward, message, wallet, lnurl, notifications, invite,
-  sub, upload, growth, rewards, referrals, price, admin, blockHeight, chainFee, paidAction, vault]
+  sub, upload, growth, rewards, referrals, price, admin, blockHeight, chainFee, paidAction, vault, verify2fa]

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -44,6 +44,8 @@ export default gql`
     generateApiKey(id: ID!): String
     deleteApiKey(id: ID!): User
     disableFreebies: Boolean
+    setTotpSecret(secret: String!, token: String!): Boolean
+    unsetTotpSecret: Boolean
   }
 
   type User {
@@ -189,6 +191,7 @@ export default gql`
     walletsUpdatedAt: Date
     proxyReceive: Boolean
     directReceive: Boolean
+    isTotpEnabled: Boolean
   }
 
   type UserOptional {

--- a/api/typeDefs/verify2fa.js
+++ b/api/typeDefs/verify2fa.js
@@ -1,0 +1,18 @@
+import { gql } from 'graphql-tag'
+
+export default gql`
+  type Tokens2fa {
+    key: String
+    value: String
+  }
+
+  type Verify2faResponse {
+    result: Boolean!
+    tokens: [Tokens2fa]
+    callbackUrl: String
+  }
+
+  extend type Mutation {
+    verify2fa(method: String!, token: String!, callbackUrl: String): Verify2faResponse
+  }
+`

--- a/components/account.js
+++ b/components/account.js
@@ -14,7 +14,7 @@ const AccountContext = createContext()
 const b64Decode = str => Buffer.from(str, 'base64').toString('utf-8')
 const b64Encode = obj => Buffer.from(JSON.stringify(obj)).toString('base64')
 
-const maybeSecureCookie = cookie => {
+export const maybeSecureCookie = cookie => {
   return window.location.protocol === 'https:' ? cookie + '; Secure' : cookie
 }
 

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -261,7 +261,7 @@ export default function LoginButton () {
   )
 }
 
-function LogoutObstacle ({ onClose }) {
+export function LogoutObstacle ({ onClose }) {
   const { registration: swRegistration, togglePushSubscription } = useServiceWorker()
   const { removeLocalWallets } = useWallets()
   const { multiAuthSignout } = useAccounts()

--- a/components/totp.js
+++ b/components/totp.js
@@ -1,0 +1,88 @@
+import { useCallback } from 'react'
+import { useShowModal } from '@/components/modal'
+import { validateTotp } from '@/lib/auth2fa'
+import { qrImageSettings } from '@/components/qr'
+import { QRCodeSVG } from 'qrcode.react'
+import BootstrapForm from 'react-bootstrap/Form'
+import { totpSchema, totpTokenSchema } from '@/lib/validate'
+import { Form, SubmitButton, PasswordInput } from '@/components/form'
+import { useToast } from '@/components/toast'
+import CancelButton from './cancel-button'
+
+export const useTOTPEnableDialog = () => {
+  const showModal = useShowModal()
+  const toaster = useToast()
+  const showTOTPDialog = useCallback(({ secret, otpUri }, onToken) => {
+    showModal((close) => {
+      return (
+        <Form
+          initial={{
+            secret: secret.base32,
+            token: ''
+          }}
+          schema={totpSchema}
+          onSubmit={async ({ token }) => {
+            try {
+              const verified = validateTotp({ secret: secret.base32, token })
+              if (!verified) {
+                toaster.danger('invalid code')
+                return
+              }
+              await onToken(token)
+              close()
+            } catch (err) {
+              console.error(err)
+              toaster.danger('failed to enable ' + err.message)
+            }
+          }}
+        >
+          <div className='mb-4 text-center'>
+            <BootstrapForm.Label>use a two-factor authenticator (TOTP) app to scan this qr code</BootstrapForm.Label>
+            <div className='d-block p-3 mb-2 mx-auto' style={{ background: 'white', maxWidth: '300px' }}>
+              <QRCodeSVG
+                className='h-auto mw-100' value={otpUri} size={300} imageSettings={qrImageSettings}
+              />
+            </div>
+            <PasswordInput name='secret' label='or use this setup key' as='textarea' readOnly copy />
+          </div>
+          <PasswordInput name='token' required label='input the one-time authentication code to confirm' />
+          <div className='d-flex'>
+            <CancelButton onClick={close} />
+            <SubmitButton variant='primary' className='ms-auto mt-1 px-4'>enable</SubmitButton>
+          </div>
+        </Form>
+      )
+    })
+  }, [])
+  return showTOTPDialog
+}
+
+export const TOTPInputForm = ({ onSubmit, onCancel }) => {
+  const toaster = useToast()
+  return (
+    <Form
+      initial={{
+        token: ''
+      }}
+      schema={totpTokenSchema}
+      onSubmit={async ({ token }) => {
+        try {
+          await onSubmit(token)
+        } catch (err) {
+          console.error(err)
+          toaster.danger(err.message)
+        }
+      }}
+    >
+      <h3>Two-factor Authentication</h3>
+      <PasswordInput name='token' required label='input the one-time authentication code to continue' />
+      <small className='text-muted'>
+        open your two-factor authenticator (TOTP) app or browser extension to view your authentication code
+      </small>
+      <div className='d-flex mt-4'>
+        <CancelButton onClick={onCancel} />
+        <SubmitButton variant='primary' className='ms-auto mt-1 px-4'>submit</SubmitButton>
+      </div>
+    </Form>
+  )
+}

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -52,6 +52,7 @@ ${STREAK_FIELDS}
       walletsUpdatedAt
       proxyReceive
       directReceive
+      isTotpEnabled
     }
     optional {
       isContributor

--- a/lib/auth2fa.js
+++ b/lib/auth2fa.js
@@ -1,0 +1,177 @@
+import { TOTP } from 'otpauth'
+import { NextResponse } from 'next/server'
+import { getToken, encode } from 'next-auth/jwt'
+
+/**
+ * Get totp provider
+ */
+function getTotp ({ label, secret } = {}) {
+  return new TOTP({
+    issuer: 'stacker.news',
+    label,
+    digits: 6,
+    period: 30,
+    secret
+  })
+}
+
+/**
+ * Check if the given token is valid within the window
+ * @param {Object} param0
+ * @param {string} param0.secret - the totp secret
+ * @param {string} param0.token - the totp token
+ * @returns {boolean} - true if the token is valid
+ */
+export function validateTotp ({ secret, token }) {
+  const totp = getTotp({ secret })
+  const delta = totp.validate({ token, window: 1 })
+  return delta !== null
+}
+
+/**
+ * Generate a totp secret
+ * @param {args} param0
+ * @param {string} param0.label - the totp label (eg. usernames)
+ * @returns {Object} - the totp secret
+ * @returns {string} base32 - the base32 secret
+ * @returns {string} uri - the totp uri
+ */
+export function generateTotpSecret ({ label = 'stacker.news - login' }) {
+  const totp = getTotp({ label })
+  return {
+    base32: totp.secret.base32,
+    uri: totp.toString()
+  }
+}
+
+/**
+ * Return all the 2fa methods supported by the user
+ * @param {Object} context
+ * @param {Object} context.me - the user object
+ * @returns {Array<String>} - the 2fa methods supported by the user eg ['totp']
+ */
+export function getRequired2faMethods ({ me }) {
+  if (me?.isTotpEnabled || me?.totpSecret) {
+    return ['totp']
+  }
+  return null
+}
+
+/**
+ * Validate 2fa
+ * @param {string} method - the 2fa method (eg totp)
+ * @param {Object} args - the 2fa tokens required for the method
+ * @param {Object} context
+ * @param {Object} context.me - the user object
+ * @returns {boolean} - true if the 2fa is valid
+ */
+export function validate2fa (method, args, { me }) {
+  switch (method) {
+    case 'totp': {
+      const { token } = args
+      const totpSecret = me.totpSecret
+      if (!totpSecret) throw new Error('2FA not enabled')
+      return validateTotp({ secret: totpSecret, token })
+    }
+    default:
+      throw new Error('Unsupported 2FA method ' + method)
+  }
+}
+
+/**
+ * Get the 2fa jwt token for the user session
+ * @param {Object} context
+ * @param {Object} context.req - the request object
+ * @param {string} context.userId - the user id
+ * @returns {Object} - the decoded 2fa token
+ */
+export async function getLogin2faToken ({ req, userId }) {
+  const cookieName = `sn2fa_${userId}`
+  const secret = process.env.NEXTAUTH_SECRET
+  const token = await getToken({ req, secret, cookieName })
+  return token
+}
+
+/**
+ * Check if the user session requires 2fa
+ * @param {args} param0
+ * @param {Object} param0.session - the user session
+ * @param {Object} param0.req - the request object
+ * @returns {Object}
+ * @returns {Object} session - the verified session or null if 2fa is required
+ * @returns {Object} unverifiedSession - the unverified session or null if 2fa is not required
+ */
+export async function sessionGuard ({ session, req }) {
+  // if anon or 2fa is not set, user doesn't need 2fa
+  if (!session?.requires2faMethods) return { session }
+  const token2fa = await getLogin2faToken({ req, userId: session.user.id })
+  let unverifiedSession = null
+
+  // if 2fa was not passed or the jti2fa is different (replay attack), user needs 2fa
+  const needLogin2fa = token2fa?.jti2fa !== session?.jti2fa
+  if (needLogin2fa) {
+    unverifiedSession = session
+    session = null
+  }
+
+  return { session, unverifiedSession }
+}
+
+/**
+ * Check if the user session requires 2fa and if so redirect to the 2fa prompt page
+ * @param {Object} param0
+ * @param {Object} param0.req - the request object
+ * @returns {Object|null} - the nextjs redirect response or null if no redirect is needed
+ */
+export async function pageGuard ({ req }) {
+  const secret = process.env.NEXTAUTH_SECRET
+  const token = await getToken({ req, secret })
+  const userId = token?.id
+
+  // anons don't need 2fa
+  if (!userId) return null
+
+  // if not 2fa method is required, user doesn't need 2fa
+  if (!token?.requires2faMethods?.length) return null
+
+  // select one 2fa method from the available ones
+  const method2fa = token.requires2faMethods[0] // there is a single 2fa method for now
+
+  // if we are already on the right 2fa prompt page, we don't need to redirect
+  const pathname = req.nextUrl.pathname
+  const searchParams = new URLSearchParams(req.nextUrl.search)
+  if (pathname === '/auth/prompt2fa' && searchParams.get('method') === method2fa) return null
+
+  // redirect only if the 2fa was not passed or the jti2fa is different (replay attack)
+  const token2fa = await getLogin2faToken({ req, userId })
+  const needLogin2fa = token2fa?.jti2fa !== token?.jti2fa
+  if (needLogin2fa) {
+    const redirectTo = new URL('/auth/prompt2fa', req.url)
+    redirectTo.searchParams.set('callbackUrl', req.url)
+    redirectTo.searchParams.set('method', method2fa)
+    return NextResponse.redirect(redirectTo)
+  }
+}
+
+/**
+ * Get the 2fa encoded token to be stored in the user session
+ * @param {Object} param0
+ * @param {boolean} param0.result - the 2fa result
+ * @param {string} param0.userId - the user id
+ * @param {string} param0.jti2fa - the 2fa jwt id
+ * @returns {Object} - the cookie key and value
+ */
+export async function getEncodedLogin2faToken ({ result, userId, jti2fa }) {
+  const cookieName = `sn2fa_${userId}`
+  const secret = process.env.NEXTAUTH_SECRET
+  const encodedToken = await encode({
+    token: {
+      jti2fa
+    },
+    secret
+  })
+  return {
+    key: cookieName,
+    value: encodedToken
+  }
+}

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -513,3 +513,12 @@ export const deviceSyncSchema = object().shape({
       return true
     })
 })
+
+export const totpSchema = object({
+  secret: string().required('required').trim().max(64, 'secret too long').matches(/^[A-Z2-7]+$/, 'invalid secret'),
+  token: string().required('required').trim().matches(/^[0-9]{6}$/, 'otp code must be 6 digits')
+})
+
+export const totpTokenSchema = object({
+  token: string().required('required').trim().matches(/^[0-9]{6}$/, 'otp code must be 6 digits')
+})

--- a/middleware.js
+++ b/middleware.js
@@ -1,4 +1,5 @@
 import { NextResponse, URLPattern } from 'next/server'
+import * as Auth2fa from '@/lib/auth2fa'
 
 const referrerPattern = new URLPattern({ pathname: ':pathname(*)/r/:referrer([\\w_]+)' })
 const itemPattern = new URLPattern({ pathname: '/items/:id(\\d+){/:other(\\w+)}?' })
@@ -69,7 +70,11 @@ function referrerMiddleware (request) {
   return response
 }
 
-export function middleware (request) {
+export async function middleware (request) {
+  // 2fa check
+  const redirect = await Auth2fa.pageGuard({ req: request })
+  if (redirect) return redirect
+
   const resp = referrerMiddleware(request)
 
   const isDev = process.env.NODE_ENV === 'development'

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "nostr-tools": "^2.8.0",
         "nprogress": "^0.2.0",
         "opentimestamps": "^0.4.9",
+        "otpauth": "^9.3.5",
         "page-metadata-parser": "^1.1.4",
         "pg-boss": "^9.0.3",
         "piexifjs": "^1.0.6",
@@ -16022,6 +16023,30 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/otpauth": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.3.5.tgz",
+      "integrity": "sha512-jQyqOuQExeIl4YIiOUz4TdEcamgAgPX6UYeeS9Iit4lkvs7bwHb0JNDqchGRccbRfvWHV6oRwH36tOsVmc+7hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/hectorm/otpauth?sponsor=1"
+      }
+    },
+    "node_modules/otpauth/node_modules/@noble/hashes": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/p-cancelable": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "nostr-tools": "^2.8.0",
     "nprogress": "^0.2.0",
     "opentimestamps": "^0.4.9",
+    "otpauth": "^9.3.5",
     "page-metadata-parser": "^1.1.4",
     "pg-boss": "^9.0.3",
     "piexifjs": "^1.0.6",

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -7,6 +7,8 @@ import typeDefs from '@/api/typeDefs'
 import { getServerSession } from 'next-auth/next'
 import { getAuthOptions } from './auth/[...nextauth]'
 import search from '@/api/search'
+import * as Auth2fa from '@/lib/auth2fa'
+
 import {
   ApolloServerPluginLandingPageLocalDefault,
   ApolloServerPluginLandingPageProductionDefault
@@ -70,6 +72,11 @@ export default startServerAndCreateNextHandler(apolloServer, {
       req = multiAuthMiddleware(req)
       session = await getServerSession(req, res, getAuthOptions(req))
     }
+
+    // 2fa check
+    let unverifiedSession = null
+    ;({ session, unverifiedSession } = await Auth2fa.sessionGuard({ session, req }))
+
     return {
       models,
       headers: req.headers,
@@ -77,7 +84,8 @@ export default startServerAndCreateNextHandler(apolloServer, {
       me: session
         ? session.user
         : null,
-      search
+      search,
+      unverifiedSession
     }
   }
 })

--- a/pages/auth/prompt2fa.js
+++ b/pages/auth/prompt2fa.js
@@ -1,0 +1,75 @@
+import { useRouter } from 'next/router'
+import { useMutation } from '@apollo/client'
+import gql from 'graphql-tag'
+import { TOTPInputForm } from '@/components/totp'
+import { useToast } from '@/components/toast'
+import { getGetServerSideProps } from '@/api/ssrApollo'
+import { maybeSecureCookie } from '@/components/account'
+import { StaticLayout } from '@/components/layout'
+import { LogoutObstacle } from '@/components/nav/common'
+import { useShowModal } from '@/components/modal'
+import CancelButton from '@/components/cancel-button'
+import { useCallback } from 'react'
+export const getServerSideProps = getGetServerSideProps({ })
+
+export default function Prompt2fa () {
+  const router = useRouter()
+  const toaster = useToast()
+  const { callbackUrl, method } = router.query
+
+  const [verify2fa] = useMutation(gql`
+   mutation Verify2fa($method: String!, $token: String!, $callbackUrl: String) {
+      verify2fa(method:$method, token: $token, callbackUrl: $callbackUrl) {
+        result
+        tokens {
+          key
+          value
+        }
+        callbackUrl
+      }
+    }
+  `)
+  const showModal = useShowModal()
+
+  const logout = useCallback(() => {
+    showModal((close) => {
+      return (
+        <LogoutObstacle onClose={close} />
+      )
+    })
+  }, [])
+
+  switch (method) {
+    case 'totp':{
+      return (
+        <StaticLayout>
+          <TOTPInputForm
+            onCancel={logout}
+            onSubmit={async (token) => {
+              try {
+                let res = await verify2fa({ variables: { method: 'totp', token, callbackUrl } })
+                res = res.data.verify2fa
+                console.log(res)
+                if (!res.result) throw new Error('Invalid token')
+                for (const { key, value } of res.tokens) {
+                  document.cookie = maybeSecureCookie(`${key}=${value}; Path=/`)
+                }
+                router.push(res.callbackUrl)
+              } catch (e) {
+                console.error(e)
+                toaster.danger(e.message)
+              }
+            }}
+          />
+        </StaticLayout>
+      )
+    }
+    default:
+      return (
+        <StaticLayout>
+          <h3>Unsupported 2fa method</h3>
+          <CancelButton onClick={logout} />
+        </StaticLayout>
+      )
+  }
+}

--- a/prisma/migrations/20241127205631_totp/migration.sql
+++ b/prisma/migrations/20241127205631_totp/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "totpSecret" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -119,6 +119,7 @@ model User {
   autoWithdrawMaxFeePercent Float?
   autoWithdrawThreshold     Int?
   autoWithdrawMaxFeeTotal   Int?
+  totpSecret                String?
   muters                    Mute[]               @relation("muter")
   muteds                    Mute[]               @relation("muted")
   ArcOut                    Arc[]                @relation("fromUser")


### PR DESCRIPTION
## Description

Add optional TOTP 2fa for login.
Partially solves: https://github.com/stackernews/stacker.news/issues/1439

## Screenshots
![Screenshot_20241204_155305](https://github.com/user-attachments/assets/9fc703b8-f888-4264-be6e-036a350f73c0)
![Screenshot_20241204_153539](https://github.com/user-attachments/assets/1d7ee861-d311-4304-8977-dc10528103a9)

## Additional Context

next-auth does not support 2fa natively. 
There are several ways to implement it, but i've come up with this custom solution that is tailored to sn.

The goals of this implementation are:
- don't make it feel like an hack
     - don't ask for TOTP before the login (eg. enter the totp code if you have one)
     - don't ask the user to login twice
- make it work for every present and future credential provider 
- use graphql apis like the rest of the site
- don't mess with next-auth internals
- make it extensible for other 2fa methods

To achieve this i've implemented 2fa as two middlewares:
-  pageGuard: that redirects the user to the 2fa prompt 
-  sessionGuard: that forces the session to 'anon'  until 2fa is resolved

Most of the logic is contained in `/lib/auth2fa`

As reference i've used the github 2fa flow.


## Checklist

**Are your changes backwards compatible? Please answer below:**
yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
not yet

**Did you introduce any new environment variables? If so, call them out explicitly here:**
no