### PR TITLE
Fix wallet logs delete for single wallet

### DIFF
--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -142,7 +142,7 @@ export function useWalletLogManager (setLogs) {
     if ((!wallet || wallet.def.walletType) && !options?.clientOnly) {
       await deleteServerWalletLogs({ variables: { wallet: wallet?.def.walletType } })
     }
-    if (!wallet || wallet.sendPayment) {
+    if (!wallet || wallet.def.sendPayment) {
       try {
         const tag = wallet ? walletTag(wallet.def) : null
         if (notSupported) {


### PR DESCRIPTION
## Description

Deleting logs of a single wallet wasn't working because `wallet.sendPayment` was not defined.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Deleting wallet logs of only one wallet works now.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no