### PR TITLE
enhance: show an error when uploads are expired

### DIFF
--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -38,6 +38,16 @@ export async function perform (args, context) {
   const { tx, me, cost } = context
   const boostMsats = satsToMsats(boost)
 
+  const deletedUploads = []
+  for (const uploadId of uploadIds) {
+    if (!await tx.upload.findUnique({ where: { id: uploadId }})) {
+      deletedUploads.push(uploadId)
+    }
+  }
+  if (deletedUploads.length > 0) {
+    throw new Error(`upload(s) ${deletedUploads.join(', ')} are expired, consider reuploading.`)
+  }
+
   let invoiceData = {}
   if (invoiceId) {
     invoiceData = { invoiceId, invoiceActionState: 'PENDING' }

--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -40,7 +40,7 @@ export async function perform (args, context) {
 
   const deletedUploads = []
   for (const uploadId of uploadIds) {
-    if (!await tx.upload.findUnique({ where: { id: uploadId }})) {
+    if (!await tx.upload.findUnique({ where: { id: uploadId } })) {
       deletedUploads.push(uploadId)
     }
   }


### PR DESCRIPTION
## Description

Completes #1505 
Shows an error that informs the users that their uploads have been expired (24 hours)

## Screenshots
before:
![image_2024-12-05_12-51-36](https://github.com/user-attachments/assets/7f5d883e-e16d-4585-becb-a3f4b4237a8d)

after:
![image_2024-12-05_12-52-19](https://github.com/user-attachments/assets/094a8916-a3fc-49ff-b043-8e5a8514dad0)



## Additional Context

All is good! 
maybe we should disclose to users that their uploads will last 24 hours if not used.

## Checklist

**Are your changes backwards compatible? Please answer below:** Yes


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
9. Multiple file uploads, some of them deleted and some not, error is consistently correct about affected IDs.


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:** n/a


**Did you introduce any new environment variables? If so, call them out explicitly here:** No
