### PR TITLE
Highrisk mutations 2fa (totp)

### DIFF
--- a/api/resolvers/index.js
+++ b/api/resolvers/index.js
@@ -20,6 +20,7 @@ import { GraphQLScalarType, Kind } from 'graphql'
 import { createIntScalar } from 'graphql-scalar'
 import paidAction from './paidAction'
 import vault from './vault'
+import verify2fa from './verify2fa'
 
 const date = new GraphQLScalarType({
   name: 'Date',
@@ -56,4 +57,4 @@ const limit = createIntScalar({
 
 export default [user, item, message, wallet, lnurl, notifications, invite, sub,
   upload, search, growth, rewards, referrals, price, admin, blockHeight, chainFee,
-  { JSONObject }, { Date: date }, { Limit: limit }, paidAction, vault]
+  { JSONObject }, { Date: date }, { Limit: limit }, paidAction, vault, verify2fa]

--- a/api/resolvers/verify2fa.js
+++ b/api/resolvers/verify2fa.js
@@ -1,0 +1,26 @@
+import * as Auth2fa from '@/lib/auth2fa'
+
+export default {
+  Mutation: {
+    verify2fa: async (parent, { method, callbackUrl, ...args }, { models, unverifiedSession }) => {
+      const session = unverifiedSession
+      if (!session) throw new Error('Not authenticated')
+
+      const userId = session.user.id
+      const user = await models.user.findUnique({ where: { id: userId } })
+      if (!user) throw new Error('User not found')
+
+      const valid = Auth2fa.validate2fa(method, args, { me: user })
+      if (!valid) throw new Error('Invalid 2FA token')
+
+      const token = await Auth2fa.getEncodedLogin2faToken({ result: valid, userId, jti2fa: session.jti2fa, callbackUrl })
+      return {
+        result: valid,
+        tokens: [
+          token
+        ],
+        callbackUrl
+      }
+    }
+  }
+}

--- a/api/typeDefs/index.js
+++ b/api/typeDefs/index.js
@@ -19,6 +19,7 @@ import blockHeight from './blockHeight'
 import chainFee from './chainFee'
 import paidAction from './paidAction'
 import vault from './vault'
+import verify2fa from './verify2fa'
 
 const common = gql`
   type Query {
@@ -39,4 +40,4 @@ const common = gql`
 `
 
 export default [common, user, item, itemForward, message, wallet, lnurl, notifications, invite,
-  sub, upload, growth, rewards, referrals, price, admin, blockHeight, chainFee, paidAction, vault]
+  sub, upload, growth, rewards, referrals, price, admin, blockHeight, chainFee, paidAction, vault, verify2fa]

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -44,6 +44,8 @@ export default gql`
     generateApiKey(id: ID!): String
     deleteApiKey(id: ID!): User
     disableFreebies: Boolean
+    setTotpSecret(secret: String!, token: String!): Boolean
+    unsetTotpSecret: Boolean
   }
 
   type User {
@@ -189,6 +191,7 @@ export default gql`
     walletsUpdatedAt: Date
     proxyReceive: Boolean
     directReceive: Boolean
+    isTotpEnabled: Boolean
   }
 
   type UserOptional {

--- a/api/typeDefs/verify2fa.js
+++ b/api/typeDefs/verify2fa.js
@@ -1,0 +1,18 @@
+import { gql } from 'graphql-tag'
+
+export default gql`
+  type Tokens2fa {
+    key: String
+    value: String
+  }
+
+  type Verify2faResponse {
+    result: Boolean!
+    tokens: [Tokens2fa]
+    callbackUrl: String
+  }
+
+  extend type Mutation {
+    verify2fa(method: String!, token: String!, callbackUrl: String): Verify2faResponse
+  }
+`

--- a/components/account.js
+++ b/components/account.js
@@ -14,7 +14,7 @@ const AccountContext = createContext()
 const b64Decode = str => Buffer.from(str, 'base64').toString('utf-8')
 const b64Encode = obj => Buffer.from(JSON.stringify(obj)).toString('base64')
 
-const maybeSecureCookie = cookie => {
+export const maybeSecureCookie = cookie => {
   return window.location.protocol === 'https:' ? cookie + '; Secure' : cookie
 }
 

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -261,7 +261,7 @@ export default function LoginButton () {
   )
 }
 
-function LogoutObstacle ({ onClose }) {
+export function LogoutObstacle ({ onClose }) {
   const { registration: swRegistration, togglePushSubscription } = useServiceWorker()
   const { removeLocalWallets } = useWallets()
   const { multiAuthSignout } = useAccounts()

--- a/components/totp.js
+++ b/components/totp.js
@@ -1,0 +1,88 @@
+import { useCallback } from 'react'
+import { useShowModal } from '@/components/modal'
+import { validateTotp } from '@/lib/auth2fa'
+import { qrImageSettings } from '@/components/qr'
+import { QRCodeSVG } from 'qrcode.react'
+import BootstrapForm from 'react-bootstrap/Form'
+import { totpSchema, totpTokenSchema } from '@/lib/validate'
+import { Form, SubmitButton, PasswordInput } from '@/components/form'
+import { useToast } from '@/components/toast'
+import CancelButton from './cancel-button'
+
+export const useTOTPEnableDialog = () => {
+  const showModal = useShowModal()
+  const toaster = useToast()
+  const showTOTPDialog = useCallback(({ secret, otpUri }, onToken) => {
+    showModal((close) => {
+      return (
+        <Form
+          initial={{
+            secret: secret.base32,
+            token: ''
+          }}
+          schema={totpSchema}
+          onSubmit={async ({ token }) => {
+            try {
+              const verified = validateTotp({ secret: secret.base32, token })
+              if (!verified) {
+                toaster.danger('invalid code')
+                return
+              }
+              await onToken(token)
+              close()
+            } catch (err) {
+              console.error(err)
+              toaster.danger('failed to enable ' + err.message)
+            }
+          }}
+        >
+          <div className='mb-4 text-center'>
+            <BootstrapForm.Label>use a two-factor authenticator (TOTP) app to scan this qr code</BootstrapForm.Label>
+            <div className='d-block p-3 mb-2 mx-auto' style={{ background: 'white', maxWidth: '300px' }}>
+              <QRCodeSVG
+                className='h-auto mw-100' value={otpUri} size={300} imageSettings={qrImageSettings}
+              />
+            </div>
+            <PasswordInput name='secret' label='or use this setup key' as='textarea' readOnly copy />
+          </div>
+          <PasswordInput name='token' required label='input the one-time authentication code to confirm' />
+          <div className='d-flex'>
+            <CancelButton onClick={close} />
+            <SubmitButton variant='primary' className='ms-auto mt-1 px-4'>enable</SubmitButton>
+          </div>
+        </Form>
+      )
+    })
+  }, [])
+  return showTOTPDialog
+}
+
+export const TOTPInputForm = ({ onSubmit, onCancel }) => {
+  const toaster = useToast()
+  return (
+    <Form
+      initial={{
+        token: ''
+      }}
+      schema={totpTokenSchema}
+      onSubmit={async ({ token }) => {
+        try {
+          await onSubmit(token)
+        } catch (err) {
+          console.error(err)
+          toaster.danger(err.message)
+        }
+      }}
+    >
+      <h3>Two-factor Authentication</h3>
+      <PasswordInput name='token' required label='input the one-time authentication code to continue' />
+      <small className='text-muted'>
+        open your two-factor authenticator (TOTP) app or browser extension to view your authentication code
+      </small>
+      <div className='d-flex mt-4'>
+        <CancelButton onClick={onCancel} />
+        <SubmitButton variant='primary' className='ms-auto mt-1 px-4'>submit</SubmitButton>
+      </div>
+    </Form>
+  )
+}

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -52,6 +52,7 @@ ${STREAK_FIELDS}
       walletsUpdatedAt
       proxyReceive
       directReceive
+      isTotpEnabled
     }
     optional {
       isContributor

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -2,6 +2,7 @@ import { ApolloClient, InMemoryCache, HttpLink, makeVar, split } from '@apollo/c
 import { BatchHttpLink } from '@apollo/client/link/batch-http'
 import { decodeCursor, LIMIT } from './cursor'
 import { SSR } from './constants'
+import { newApolloClient2faLink } from '@/lib/auth2fa'
 
 function isFirstPage (cursor, existingThings, limit = LIMIT) {
   if (cursor) {
@@ -29,12 +30,14 @@ export default function getApolloClient () {
 export const meAnonSats = {}
 
 function getClient (uri) {
-  const link = split(
+  let link = split(
     // batch zaps if wallet is enabled so they can be executed serially in a single request
     operation => operation.operationName === 'act' && operation.variables.act === 'TIP' && operation.getContext().batch,
     new BatchHttpLink({ uri, batchInterval: 1000, batchDebounce: true, batchMax: 0, batchKey: op => op.variables.id }),
     new HttpLink({ uri })
   )
+
+  link = newApolloClient2faLink(link)
 
   return new ApolloClient({
     link,

--- a/lib/auth2fa.js
+++ b/lib/auth2fa.js
@@ -1,6 +1,38 @@
 import { TOTP } from 'otpauth'
 import { NextResponse } from 'next/server'
 import { getToken, encode } from 'next-auth/jwt'
+import { TwoFactorAuthenticationError } from '@/lib/error'
+import { ApolloLink } from '@apollo/client/core'
+import Observable from 'zen-observable'
+import { SSR } from '@/lib/constants'
+
+const HighRiskMutationFields = [
+  'transferTerritory',
+  'deleteWalletLogs',
+  'setSettings',
+  'removeWallet',
+  'updateVaultKey',
+  'unlinkAuth',
+  'generateApiKey',
+  'deleteApiKey',
+  'setTotpSecret',
+  'unsetTotpSecret',
+  ({ name, variables }) => { // high cost actions
+    if (!['donateToRewards', 'act'].includes(name)) return false
+    if (variables.sats && BigInt(variables.sats) >= 100_000n) {
+      return true
+    }
+    return false
+  }
+]
+
+export function isHighRiskMutation ({ name, variables }) {
+  for (const p of HighRiskMutationFields) {
+    const isHighRisk = typeof p === 'function' ? p({ name, variables }) : p === name
+    if (isHighRisk) return true
+  }
+  return false
+}
 
 /**
  * Get totp provider
@@ -68,9 +100,10 @@ export function getRequired2faMethods ({ me }) {
 export function validate2fa (method, args, { me }) {
   switch (method) {
     case 'totp': {
-      const { token } = args
-      const totpSecret = me.totpSecret
-      if (!totpSecret) throw new Error('2FA not enabled')
+      const token = args?.token ?? args?.get?.('X-TOTP')
+      const totpSecret = me?.totpSecret
+      if (!totpSecret) throw new Error('totp not enabled')
+      if (!token) throw new Error('no totp token')
       return validateTotp({ secret: totpSecret, token })
     }
     default:
@@ -173,5 +206,145 @@ export async function getEncodedLogin2faToken ({ result, userId, jti2fa }) {
   return {
     key: cookieName,
     value: encodedToken
+  }
+}
+
+export function get2faHeaders (method, args) {
+  switch (method) {
+    case 'totp': {
+      const token = args?.token
+      if (!token) throw new Error('TOTP required')
+      const headers = {
+        'X-TOTP': token
+      }
+      return headers
+    }
+    default: {
+      throw new Error('Unsupported 2FA method ' + method)
+    }
+  }
+}
+
+export function newApolloServer2faPlugin () {
+  return {
+    async requestDidStart () {
+      return {
+        async didResolveOperation ({ request, document, contextValue: context }) {
+          // api keys don't have 2fa
+          const isApiKey = request.http.headers.get('x-api-key')
+          if (isApiKey) return
+
+          // only logged in users have 2fa
+          const { me, models } = context
+          if (!me) return
+
+          // only mutations have 2fa
+          const defs = document.definitions.filter((definition) => definition.kind === 'OperationDefinition')
+          const mutationDefs = defs.filter((definition) => definition.operation === 'mutation')
+          if (!mutationDefs.length) return
+
+          // only high risk mutations need 2fa
+          const fieldNames = mutationDefs.flatMap((definition) => {
+            return definition.selectionSet.selections.filter((selection) => selection.kind === 'Field').map((selection) => selection.name.value)
+          })
+          const isHighRisk = fieldNames.some((field) => isHighRiskMutation({
+            name: field,
+            variables: request.variables
+          }))
+          if (!isHighRisk) return
+
+          // mark high risk context
+          context.highRisk = {
+            confirmed: false
+          }
+
+          const userId = me.id
+          const user = await models.user.findUnique({ where: { id: userId } })
+
+          const available2faMethods = getRequired2faMethods({ me: user })
+          // only users with 2fa have 2fa
+          if (!available2faMethods?.length) {
+            context.highRisk.confirmed = true
+            context.highRisk.confirmedWithMethod = null
+            return
+          }
+
+          // select best 2fa method
+          const method2fa = available2faMethods[0] // there is a single 2fa method for now
+
+          // finally validate totp
+          try {
+            const valid = validate2fa(method2fa, request.http.headers, { me: user })
+            if (!valid) {
+              throw new Error('failed 2fa validation')
+            }
+            context.highRisk.confirmed = true
+            context.highRisk.confirmedWithMethod = method2fa
+          } catch (error) {
+            throw new TwoFactorAuthenticationError(error)
+          }
+        }
+      }
+    }
+  }
+}
+
+export function newApolloClient2faLink (link) {
+  const link2fa = new ApolloLink((operation, forward) => {
+    if (!SSR) {
+      // only mutations need 2fa
+      const defs = operation.query.definitions.filter(def => def.kind === 'OperationDefinition')
+      const mutations = defs.filter(def => def.operation === 'mutation')
+
+      // only high risk mutations need 2fa
+      const fieldNames = mutations.flatMap(def => {
+        return def.selectionSet.selections.filter(selection => selection.kind === 'Field').map(selection => selection.name.value)
+      })
+      const isHighRisk = fieldNames.some(field => isHighRiskMutation({ name: field, variables: operation.variables }))
+      if (isHighRisk) {
+        return new Observable(observer => {
+          (async () => {
+            try {
+              const availablePrompts = window.prompts2fa ? Object.values(window.prompts2fa) : []
+              if (availablePrompts.length) {
+                for (const prompt of availablePrompts) {
+                  const res = await prompt()
+                  if (res === null) continue
+                  const { method, ...args } = res
+                  operation.setContext(({ headers = {} }) => {
+                    const headers2fa = get2faHeaders(method, args)
+                    return {
+                      headers: {
+                        ...headers,
+                        ...headers2fa
+                      }
+                    }
+                  })
+                }
+              } else {
+                console.warn('no 2fa prompt registered')
+              }
+            } catch (error) {
+              console.error(error)
+            }
+            forward(operation).subscribe({
+              next: observer.next.bind(observer),
+              error: observer.error.bind(observer),
+              complete: observer.complete.bind(observer)
+            })
+          })()
+        })
+      }
+    }
+    return forward(operation)
+  })
+
+  if (link) {
+    return ApolloLink.from([
+      link2fa,
+      link
+    ])
+  } else {
+    return link2fa
   }
 }

--- a/lib/auth2fa.js
+++ b/lib/auth2fa.js
@@ -1,0 +1,177 @@
+import { TOTP } from 'otpauth'
+import { NextResponse } from 'next/server'
+import { getToken, encode } from 'next-auth/jwt'
+
+/**
+ * Get totp provider
+ */
+function getTotp ({ label, secret } = {}) {
+  return new TOTP({
+    issuer: 'stacker.news',
+    label,
+    digits: 6,
+    period: 30,
+    secret
+  })
+}
+
+/**
+ * Check if the given token is valid within the window
+ * @param {Object} param0
+ * @param {string} param0.secret - the totp secret
+ * @param {string} param0.token - the totp token
+ * @returns {boolean} - true if the token is valid
+ */
+export function validateTotp ({ secret, token }) {
+  const totp = getTotp({ secret })
+  const delta = totp.validate({ token, window: 1 })
+  return delta !== null
+}
+
+/**
+ * Generate a totp secret
+ * @param {args} param0
+ * @param {string} param0.label - the totp label (eg. usernames)
+ * @returns {Object} - the totp secret
+ * @returns {string} base32 - the base32 secret
+ * @returns {string} uri - the totp uri
+ */
+export function generateTotpSecret ({ label = 'stacker.news - login' }) {
+  const totp = getTotp({ label })
+  return {
+    base32: totp.secret.base32,
+    uri: totp.toString()
+  }
+}
+
+/**
+ * Return all the 2fa methods supported by the user
+ * @param {Object} context
+ * @param {Object} context.me - the user object
+ * @returns {Array<String>} - the 2fa methods supported by the user eg ['totp']
+ */
+export function getRequired2faMethods ({ me }) {
+  if (me?.isTotpEnabled || me?.totpSecret) {
+    return ['totp']
+  }
+  return null
+}
+
+/**
+ * Validate 2fa
+ * @param {string} method - the 2fa method (eg totp)
+ * @param {Object} args - the 2fa tokens required for the method
+ * @param {Object} context
+ * @param {Object} context.me - the user object
+ * @returns {boolean} - true if the 2fa is valid
+ */
+export function validate2fa (method, args, { me }) {
+  switch (method) {
+    case 'totp': {
+      const { token } = args
+      const totpSecret = me.totpSecret
+      if (!totpSecret) throw new Error('2FA not enabled')
+      return validateTotp({ secret: totpSecret, token })
+    }
+    default:
+      throw new Error('Unsupported 2FA method ' + method)
+  }
+}
+
+/**
+ * Get the 2fa jwt token for the user session
+ * @param {Object} context
+ * @param {Object} context.req - the request object
+ * @param {string} context.userId - the user id
+ * @returns {Object} - the decoded 2fa token
+ */
+export async function getLogin2faToken ({ req, userId }) {
+  const cookieName = `sn2fa_${userId}`
+  const secret = process.env.NEXTAUTH_SECRET
+  const token = await getToken({ req, secret, cookieName })
+  return token
+}
+
+/**
+ * Check if the user session requires 2fa
+ * @param {args} param0
+ * @param {Object} param0.session - the user session
+ * @param {Object} param0.req - the request object
+ * @returns {Object}
+ * @returns {Object} session - the verified session or null if 2fa is required
+ * @returns {Object} unverifiedSession - the unverified session or null if 2fa is not required
+ */
+export async function sessionGuard ({ session, req }) {
+  // if anon or 2fa is not set, user doesn't need 2fa
+  if (!session?.requires2faMethods) return { session }
+  const token2fa = await getLogin2faToken({ req, userId: session.user.id })
+  let unverifiedSession = null
+
+  // if 2fa was not passed or the jti2fa is different (replay attack), user needs 2fa
+  const needLogin2fa = token2fa?.jti2fa !== session?.jti2fa
+  if (needLogin2fa) {
+    unverifiedSession = session
+    session = null
+  }
+
+  return { session, unverifiedSession }
+}
+
+/**
+ * Check if the user session requires 2fa and if so redirect to the 2fa prompt page
+ * @param {Object} param0
+ * @param {Object} param0.req - the request object
+ * @returns {Object|null} - the nextjs redirect response or null if no redirect is needed
+ */
+export async function pageGuard ({ req }) {
+  const secret = process.env.NEXTAUTH_SECRET
+  const token = await getToken({ req, secret })
+  const userId = token?.id
+
+  // anons don't need 2fa
+  if (!userId) return null
+
+  // if not 2fa method is required, user doesn't need 2fa
+  if (!token?.requires2faMethods?.length) return null
+
+  // select one 2fa method from the available ones
+  const method2fa = token.requires2faMethods[0] // there is a single 2fa method for now
+
+  // if we are already on the right 2fa prompt page, we don't need to redirect
+  const pathname = req.nextUrl.pathname
+  const searchParams = new URLSearchParams(req.nextUrl.search)
+  if (pathname === '/auth/prompt2fa' && searchParams.get('method') === method2fa) return null
+
+  // redirect only if the 2fa was not passed or the jti2fa is different (replay attack)
+  const token2fa = await getLogin2faToken({ req, userId })
+  const needLogin2fa = token2fa?.jti2fa !== token?.jti2fa
+  if (needLogin2fa) {
+    const redirectTo = new URL('/auth/prompt2fa', req.url)
+    redirectTo.searchParams.set('callbackUrl', req.url)
+    redirectTo.searchParams.set('method', method2fa)
+    return NextResponse.redirect(redirectTo)
+  }
+}
+
+/**
+ * Get the 2fa encoded token to be stored in the user session
+ * @param {Object} param0
+ * @param {boolean} param0.result - the 2fa result
+ * @param {string} param0.userId - the user id
+ * @param {string} param0.jti2fa - the 2fa jwt id
+ * @returns {Object} - the cookie key and value
+ */
+export async function getEncodedLogin2faToken ({ result, userId, jti2fa }) {
+  const cookieName = `sn2fa_${userId}`
+  const secret = process.env.NEXTAUTH_SECRET
+  const encodedToken = await encode({
+    token: {
+      jti2fa
+    },
+    secret
+  })
+  return {
+    key: cookieName,
+    value: encodedToken
+  }
+}

--- a/lib/error.js
+++ b/lib/error.js
@@ -22,3 +22,16 @@ export class GqlInputError extends GraphQLError {
     super(message, { extensions: { code: code || E_BAD_INPUT } })
   }
 }
+
+export class TwoFactorAuthenticationError extends GraphQLError {
+  constructor (error) {
+    super('2fa verification failed ' + (error?.message || error.toString()), {
+      extensions: {
+        code: E_UNAUTHENTICATED,
+        http: {
+          status: 401
+        }
+      }
+    })
+  }
+}

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -513,3 +513,12 @@ export const deviceSyncSchema = object().shape({
       return true
     })
 })
+
+export const totpSchema = object({
+  secret: string().required('required').trim().max(64, 'secret too long').matches(/^[A-Z2-7]+$/, 'invalid secret'),
+  token: string().required('required').trim().matches(/^[0-9]{6}$/, 'otp code must be 6 digits')
+})
+
+export const totpTokenSchema = object({
+  token: string().required('required').trim().matches(/^[0-9]{6}$/, 'otp code must be 6 digits')
+})

--- a/middleware.js
+++ b/middleware.js
@@ -1,4 +1,5 @@
 import { NextResponse, URLPattern } from 'next/server'
+import * as Auth2fa from '@/lib/auth2fa'
 
 const referrerPattern = new URLPattern({ pathname: ':pathname(*)/r/:referrer([\\w_]+)' })
 const itemPattern = new URLPattern({ pathname: '/items/:id(\\d+){/:other(\\w+)}?' })
@@ -69,7 +70,11 @@ function referrerMiddleware (request) {
   return response
 }
 
-export function middleware (request) {
+export async function middleware (request) {
+  // 2fa check
+  const redirect = await Auth2fa.pageGuard({ req: request })
+  if (redirect) return redirect
+
   const resp = referrerMiddleware(request)
 
   const isDev = process.env.NODE_ENV === 'development'

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "nostr-tools": "^2.8.0",
         "nprogress": "^0.2.0",
         "opentimestamps": "^0.4.9",
+        "otpauth": "^9.3.5",
         "page-metadata-parser": "^1.1.4",
         "pg-boss": "^9.0.3",
         "piexifjs": "^1.0.6",
@@ -16022,6 +16023,30 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/otpauth": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/otpauth/-/otpauth-9.3.5.tgz",
+      "integrity": "sha512-jQyqOuQExeIl4YIiOUz4TdEcamgAgPX6UYeeS9Iit4lkvs7bwHb0JNDqchGRccbRfvWHV6oRwH36tOsVmc+7hQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/hectorm/otpauth?sponsor=1"
+      }
+    },
+    "node_modules/otpauth/node_modules/@noble/hashes": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/p-cancelable": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "nostr-tools": "^2.8.0",
     "nprogress": "^0.2.0",
     "opentimestamps": "^0.4.9",
+    "otpauth": "^9.3.5",
     "page-metadata-parser": "^1.1.4",
     "pg-boss": "^9.0.3",
     "piexifjs": "^1.0.6",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -23,6 +23,7 @@ import { HasNewNotesProvider } from '@/components/use-has-new-notes'
 import { WebLnProvider } from '@/wallets/webln/client'
 import { AccountProvider } from '@/components/account'
 import { WalletsProvider } from '@/wallets/index'
+import { TOTPDialogProvider } from '@/components/totp'
 
 const PWAPrompt = dynamic(() => import('react-ios-pwa-prompt'), { ssr: false })
 
@@ -115,14 +116,16 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
                             <LightningProvider>
                               <ToastProvider>
                                 <ShowModalProvider>
-                                  <BlockHeightProvider blockHeight={blockHeight}>
-                                    <ChainFeeProvider chainFee={chainFee}>
-                                      <ErrorBoundary>
-                                        <Component ssrData={ssrData} {...otherProps} />
-                                        {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
-                                      </ErrorBoundary>
-                                    </ChainFeeProvider>
-                                  </BlockHeightProvider>
+                                  <TOTPDialogProvider>
+                                    <BlockHeightProvider blockHeight={blockHeight}>
+                                      <ChainFeeProvider chainFee={chainFee}>
+                                        <ErrorBoundary>
+                                          <Component ssrData={ssrData} {...otherProps} />
+                                          {!router?.query?.disablePrompt && <PWAPrompt copyBody='This website has app functionality. Add it to your home screen to use it in fullscreen and receive notifications. In Safari:' promptOnVisit={2} />}
+                                        </ErrorBoundary>
+                                      </ChainFeeProvider>
+                                    </BlockHeightProvider>
+                                  </TOTPDialogProvider>
                                 </ShowModalProvider>
                               </ToastProvider>
                             </LightningProvider>

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -7,6 +7,8 @@ import typeDefs from '@/api/typeDefs'
 import { getServerSession } from 'next-auth/next'
 import { getAuthOptions } from './auth/[...nextauth]'
 import search from '@/api/search'
+import * as Auth2fa from '@/lib/auth2fa'
+
 import {
   ApolloServerPluginLandingPageLocalDefault,
   ApolloServerPluginLandingPageProductionDefault
@@ -70,6 +72,11 @@ export default startServerAndCreateNextHandler(apolloServer, {
       req = multiAuthMiddleware(req)
       session = await getServerSession(req, res, getAuthOptions(req))
     }
+
+    // 2fa check
+    let unverifiedSession = null
+    ;({ session, unverifiedSession } = await Auth2fa.sessionGuard({ session, req }))
+
     return {
       models,
       headers: req.headers,
@@ -77,7 +84,8 @@ export default startServerAndCreateNextHandler(apolloServer, {
       me: session
         ? session.user
         : null,
-      search
+      search,
+      unverifiedSession
     }
   }
 })

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -47,6 +47,7 @@ const apolloServer = new ApolloServer({
       }
     }
   },
+  Auth2fa.newApolloServer2faPlugin(),
   process.env.NODE_ENV === 'production'
     ? ApolloServerPluginLandingPageProductionDefault(
       { embed: { endpointIsEditable: false, persistExplorerState: true, displayOptions: { theme: 'dark' } }, footer: false })

--- a/pages/auth/prompt2fa.js
+++ b/pages/auth/prompt2fa.js
@@ -1,0 +1,75 @@
+import { useRouter } from 'next/router'
+import { useMutation } from '@apollo/client'
+import gql from 'graphql-tag'
+import { TOTPInputForm } from '@/components/totp'
+import { useToast } from '@/components/toast'
+import { getGetServerSideProps } from '@/api/ssrApollo'
+import { maybeSecureCookie } from '@/components/account'
+import { StaticLayout } from '@/components/layout'
+import { LogoutObstacle } from '@/components/nav/common'
+import { useShowModal } from '@/components/modal'
+import CancelButton from '@/components/cancel-button'
+import { useCallback } from 'react'
+export const getServerSideProps = getGetServerSideProps({ })
+
+export default function Prompt2fa () {
+  const router = useRouter()
+  const toaster = useToast()
+  const { callbackUrl, method } = router.query
+
+  const [verify2fa] = useMutation(gql`
+   mutation Verify2fa($method: String!, $token: String!, $callbackUrl: String) {
+      verify2fa(method:$method, token: $token, callbackUrl: $callbackUrl) {
+        result
+        tokens {
+          key
+          value
+        }
+        callbackUrl
+      }
+    }
+  `)
+  const showModal = useShowModal()
+
+  const logout = useCallback(() => {
+    showModal((close) => {
+      return (
+        <LogoutObstacle onClose={close} />
+      )
+    })
+  }, [])
+
+  switch (method) {
+    case 'totp':{
+      return (
+        <StaticLayout>
+          <TOTPInputForm
+            onCancel={logout}
+            onSubmit={async (token) => {
+              try {
+                let res = await verify2fa({ variables: { method: 'totp', token, callbackUrl } })
+                res = res.data.verify2fa
+                console.log(res)
+                if (!res.result) throw new Error('Invalid token')
+                for (const { key, value } of res.tokens) {
+                  document.cookie = maybeSecureCookie(`${key}=${value}; Path=/`)
+                }
+                router.push(res.callbackUrl)
+              } catch (e) {
+                console.error(e)
+                toaster.danger(e.message)
+              }
+            }}
+          />
+        </StaticLayout>
+      )
+    }
+    default:
+      return (
+        <StaticLayout>
+          <h3>Unsupported 2fa method</h3>
+          <CancelButton onClick={logout} />
+        </StaticLayout>
+      )
+  }
+}

--- a/prisma/migrations/20241127205631_totp/migration.sql
+++ b/prisma/migrations/20241127205631_totp/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "totpSecret" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -119,6 +119,7 @@ model User {
   autoWithdrawMaxFeePercent Float?
   autoWithdrawThreshold     Int?
   autoWithdrawMaxFeeTotal   Int?
+  totpSecret                String?
   muters                    Mute[]               @relation("muter")
   muteds                    Mute[]               @relation("muted")
   ArcOut                    Arc[]                @relation("fromUser")


### PR DESCRIPTION
## Description

Depends on https://github.com/stackernews/stacker.news/pull/1680
Together with https://github.com/stackernews/stacker.news/pull/1680 closes https://github.com/stackernews/stacker.news/issues/1439 .

This PR adds 2fa for high risk mutations. 
Whenever the user triggers a mutation that we deem high risk (eg. big zap, territory transfer...) a 2fa prompt shows.
The mutation gets rejected if the user doesn't complete the 2fa.

## Screenshots

https://github.com/user-attachments/assets/bd79891c-ad5c-4e40-9bf9-62e942517b85


## Additional Context

I've implemented this as an `Apollo Server plugin` and `Apollo Client link`.
- On one side the apollo server plugin intercept the mutation and checks if it is marked as high risk, if it is, it checks if the request has a valid 2fa header (eg. a totp token).
- On the other side, the Apollo Client link intercepts the mutation before it triggers and if it is marked as high risk it shows a prompt requesting the 2fa to the user, then it insert the 2fa token in the request headers and continues the flow.

To mark a mutation as high risk (both for server and client) it needs to be included in the `HighRiskMutationFields` array in  `lib/auth2fa`. The `HighRiskMutationFields` array can contain also functions that are used to do some more advanced filtering
eg.
```js
 ({ name, variables }) => { // high cost actions
    if (!['donateToRewards', 'act'].includes(name)) return false
    if (variables.sats && BigInt(variables.sats) >= 100_000n) {
      return true
    }
    return false
  }
````

Once the mutation is marked as high risk, everything is handled automatically by the plugin, there is no need to make the resolver aware it is running an high risk mutation.

However as debug and hardening resource, resolvers triggered by a request that contains an highrisk mutation, will receive an `highRisk` field in their `context`, this field is an object defined as:
```js
{
    confirmed: boolean  // true if the user provided a valid 2fa
    confirmedWithMethod: string // the method used by the 2fa (eg. totp)
}
```

that can be used to do additional checks or assertions 



## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

8

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
no