### PR TITLE
Use same naming scheme between ln containers and env vars

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -127,26 +127,26 @@ P2P_PORT=18444
 ZMQ_BLOCK_PORT=28334
 ZMQ_TX_PORT=28335
 
-# sn lnd container stuff
-LND_REST_PORT=8080
-LND_GRPC_PORT=10009
-LND_P2P_PORT=9735
+# sn_lnd container stuff
+SN_LND_REST_PORT=8080
+SN_LND_GRPC_PORT=10009
+SN_LND_P2P_PORT=9735
 # docker exec -u lnd sn_lnd lncli newaddress p2wkh --unused
-LND_ADDR=bcrt1q7q06n5st4vqq3lssn0rtkrn2qqypghv9xg2xnl
-LND_PUBKEY=02cb2e2d5a6c5b17fa67b1a883e2973c82e328fb9bd08b2b156a9e23820c87a490
+SN_LND_ADDR=bcrt1q7q06n5st4vqq3lssn0rtkrn2qqypghv9xg2xnl
+SN_LND_PUBKEY=02cb2e2d5a6c5b17fa67b1a883e2973c82e328fb9bd08b2b156a9e23820c87a490
 
-# stacker lnd container stuff
-STACKER_LND_REST_PORT=8081
-STACKER_LND_GRPC_PORT=10010
+# lnd container stuff
+LND_REST_PORT=8081
+LND_GRPC_PORT=10010
 # docker exec -u lnd lnd lncli newaddress p2wkh --unused
-STACKER_LND_ADDR=bcrt1qfqau4ug9e6rtrvxrgclg58e0r93wshucumm9vu
-STACKER_LND_PUBKEY=028093ae52e011d45b3e67f2e0f2cb6c3a1d7f88d2920d408f3ac6db3a56dc4b35
+LND_ADDR=bcrt1qfqau4ug9e6rtrvxrgclg58e0r93wshucumm9vu
+LND_PUBKEY=028093ae52e011d45b3e67f2e0f2cb6c3a1d7f88d2920d408f3ac6db3a56dc4b35
 
-# stacker cln container stuff
-STACKER_CLN_REST_PORT=9092
+# cln container stuff
+CLN_REST_PORT=9092
 # docker exec -u clightning cln lightning-cli newaddr bech32
-STACKER_CLN_ADDR=bcrt1q02sqd74l4pxedy24fg0qtjz4y2jq7x4lxlgzrx
-STACKER_CLN_PUBKEY=03ca7acec181dbf5e427c682c4261a46a0dd9ea5f35d97acb094e399f727835b90
+CLN_ADDR=bcrt1q02sqd74l4pxedy24fg0qtjz4y2jq7x4lxlgzrx
+CLN_PUBKEY=03ca7acec181dbf5e427c682c4261a46a0dd9ea5f35d97acb094e399f727835b90
 
 LNCLI_NETWORK=regtest
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -270,7 +270,7 @@ services:
             command bitcoin-cli -chain=regtest -rpcport=${RPC_PORT} -rpcuser=${RPC_USER} -rpcpassword=${RPC_PASS} "$$@"
           }
           blockcount=$$(bitcoin-cli getblockcount 2>/dev/null)
-          nodes=(${LND_ADDR} ${STACKER_LND_ADDR} ${STACKER_CLN_ADDR})
+          nodes=(${SN_LND_ADDR} ${LND_ADDR} ${CLN_ADDR})
           if (( blockcount <= 0 )); then
             echo "Creating wallet and address..."
             bitcoin-cli createwallet ""
@@ -344,8 +344,8 @@ services:
     expose:
       - "9735"
     ports:
-      - "${LND_REST_PORT}:8080"
-      - "${LND_GRPC_PORT}:10009"
+      - "${SN_LND_REST_PORT}:8080"
+      - "${SN_LND_GRPC_PORT}:10009"
     volumes:
       - sn_lnd:/home/lnd/.lnd
     labels:
@@ -358,7 +358,7 @@ services:
           if [ $$(lncli getinfo | jq '.num_active_channels + .num_pending_channels') -ge 3 ]; then
             exit 0
           else
-            lncli openchannel --node_key=$STACKER_LND_PUBKEY --connect lnd:9735 --sat_per_vbyte 1 \\
+            lncli openchannel --node_key=$LND_PUBKEY --connect lnd:9735 --sat_per_vbyte 1 \\
               --min_confs 0 --local_amt=1000000000 --push_amt=500000000
           fi
         "
@@ -412,8 +412,8 @@ services:
       - "9735"
       - "10009"
     ports:
-      - "${STACKER_LND_REST_PORT}:8080"
-      - "${STACKER_LND_GRPC_PORT}:10009"
+      - "${LND_REST_PORT}:8080"
+      - "${LND_GRPC_PORT}:10009"
     volumes:
       - lnd:/home/lnd/.lnd
       - tordata:/home/lnd/.tor
@@ -429,7 +429,7 @@ services:
           if [ $$(lncli getinfo | jq '.num_active_channels + .num_pending_channels') -ge 3 ]; then
             exit 0
           else
-            lncli openchannel --node_key=$LND_PUBKEY --connect sn_lnd:9735 --sat_per_vbyte 1 \\
+            lncli openchannel --node_key=$SN_LND_PUBKEY --connect sn_lnd:9735 --sat_per_vbyte 1 \\
               --min_confs 0 --local_amt=1000000000 --push_amt=500000000
           fi
         "
@@ -501,7 +501,7 @@ services:
     expose:
       - "9735"
     ports:
-      - "${STACKER_CLN_REST_PORT}:3010"
+      - "${CLN_REST_PORT}:3010"
     volumes:
       - cln:/home/clightning/.lightning
       - tordata:/home/clightning/.tor
@@ -517,8 +517,8 @@ services:
           if [ $$(lightning-cli --regtest getinfo | jq '.num_active_channels + .num_pending_channels') -ge 3 ]; then
             exit 0
           else
-            lightning-cli --regtest connect $LND_PUBKEY@sn_lnd:9735
-            lightning-cli --regtest fundchannel id=$LND_PUBKEY feerate=1000perkb \\
+            lightning-cli --regtest connect $SN_LND_PUBKEY@sn_lnd:9735
+            lightning-cli --regtest fundchannel id=$SN_LND_PUBKEY feerate=1000perkb \\
               amount=1000000000 push_msat=500000000000 minconf=0
           fi
         "


### PR DESCRIPTION
## Description

This renames `LND` to `SN_LND` and `STACKER_LND` to `LND` to match `sn_lnd` and `lnd` as the respective container names.

## Additional Context

This already annoyed me during #1679 since "lnd" can mean the SN node or the stacker node depending on context.

I also considered to keep the `STACKER_LND` for the env vars so it's clear which node we're referring to if we ever add more nodes but then we'll have to also change the container name anyway, so I decided it's better to keep env vars simply consistent with how our containers are currently named.  

## Checklist

**Are your changes backwards compatible? Please answer below:**

basically

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested by making sure nodes can still pay each other's invoices:

```
sndev cli lnd payinvoice -f $(sndev cli sn_lnd addinvoice --amt 1000 | jq -r .payment_request)
sndev cli sn_lnd payinvoice -f $(sndev cli lnd addinvoice --amt 1000 | jq -r .payment_request)
```

CLN requires a unique label for each invoice so I used [`$RANDOM`](https://www.cyberciti.biz/faq/bash-shell-script-generating-random-numbers/): 

```
sndev cli cln pay $(sndev cli sn_lnd addinvoice --amt 1000 | jq -r .payment_request)
sndev cli sn_lnd payinvoice -f $(sndev cli cln invoice 1000 $RANDOM "test" | jq -r .bolt11)
```

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

only renamed env vars for local dev