### PR TITLE
Fix latest timestamp not updated

### DIFF
--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -259,12 +259,12 @@ export function useWalletLogs (wallet, initialPage = 1, logsPerPage = 10) {
     if (hasMore) {
       setLoading(true)
       const result = await loadLogsPage(page + 1, logsPerPage, wallet?.def)
-      _setLogs(prevLogs => uniqueSort([...prevLogs, ...result.data]))
+      setLogs(prevLogs => uniqueSort([...prevLogs, ...result.data]))
       setHasMore(result.hasMore)
       setPage(prevPage => prevPage + 1)
       setLoading(false)
     }
-  }, [loadLogsPage, page, logsPerPage, wallet?.def, hasMore])
+  }, [setLogs, loadLogsPage, page, logsPerPage, wallet?.def, hasMore])
 
   const loadNew = useCallback(async () => {
     const latestTs = latestTimestamp.current


### PR DESCRIPTION
## Description

`loadNew` always thought it is loading the first page for the first time because `latestTimestamp` was not updated by `loadMore`. This meant it always called `setHasMore` with `true`, causing the bug that can be seen in the video.

This is fixed by calling `setLogs` in `loadMore` instead of directly setting the logs state via `_setLogs`.

## Video

https://github.com/user-attachments/assets/6fb1521a-f4e7-4950-8ea7-c41d0d3bd547

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. `loadNew` now only calls `setHasMore` during the first poll.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no