### PR TITLE
Fix pending forwards considered paid by client

### DIFF
--- a/components/use-invoice.js
+++ b/components/use-invoice.js
@@ -4,8 +4,6 @@ import { InvoiceCanceledError, InvoiceExpiredError, WalletReceiverError } from '
 import { RETRY_PAID_ACTION } from '@/fragments/paidAction'
 import { INVOICE, CANCEL_INVOICE } from '@/fragments/wallet'
 
-const PENDING_FORWARD_STATES = ['PENDING_HELD', 'FORWARDING']
-
 export default function useInvoice () {
   const client = useApolloClient()
   const [retryPaidAction] = useMutation(RETRY_PAID_ACTION)
@@ -18,7 +16,7 @@ export default function useInvoice () {
       throw error
     }
 
-    const { cancelled, cancelledAt, actionState, actionError, expiresAt, forwardStatus } = data.invoice
+    const { cancelled, cancelledAt, actionError, expiresAt, forwardStatus } = data.invoice
 
     const expired = cancelledAt && new Date(expiresAt) < new Date(cancelledAt)
     if (expired) {
@@ -35,12 +33,7 @@ export default function useInvoice () {
       throw new InvoiceCanceledError(data.invoice, actionError)
     }
 
-    // never let check pass if a forward is pending
-    // see https://github.com/stackernews/stacker.news/issues/1707
-    const pendingForward = PENDING_FORWARD_STATES.includes(actionState)
-    const check = that(data.invoice) && !pendingForward
-
-    return { invoice: data.invoice, check }
+    return { invoice: data.invoice, check: that(data.invoice) }
   }, [client])
 
   const cancel = useCallback(async ({ hash, hmac }) => {


### PR DESCRIPTION
## Description

Fix #1707 

This excludes pending forwards from ever being considered for something by the client.

I think this is a change that should really only affect the bug regarding failed forwards and doesn't cause any regression during other payments.

## Additional Context

Maybe the server should set a `pending` field in the invoice which the client can use to know that it shouldn't use this state to determine something about the invoice? I don't like how the client becomes more aware of individual transitions because it _might_ see them just so it can ignore them. 

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`.  Tested with failed forwards, successful forwards and no forwards. The bug is easy to trigger without these changes and this patch:

```diff
diff --git a/wallets/payment.js b/wallets/payment.js
index 33baa717..db8c9883 100644
--- a/wallets/payment.js
+++ b/wallets/payment.js
@@ -123,7 +123,7 @@ function invoiceController (inv, isInvoice) {
           clearInterval(interval)
           signal.removeEventListener('abort', abort)
         }
-      }, FAST_POLL_INTERVAL)
+      }, 100)

       const abort = () => {
         console.info(`invoice #${inv.id}: stopped waiting`)
diff --git a/worker/paidAction.js b/worker/paidAction.js
index 70396ddb..9d711b0f 100644
--- a/worker/paidAction.js
+++ b/worker/paidAction.js
@@ -268,7 +268,7 @@ export async function paidActionForwarding ({ data: { invoiceId, ...args }, mode
     payViaPaymentRequest({
       lnd,
       request: bolt11,
-      max_fee_mtokens: String(maxFeeMsats),
+      max_fee_mtokens: String(0),
       pathfinding_timeout: LND_PATHFINDING_TIMEOUT_MS,
       max_timeout_height: maxTimeoutHeight
     }).catch(console.error)
```

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no