### PR TITLE
Use same view about failed forwards on server and client

### DIFF
--- a/wallets/server.js
+++ b/wallets/server.js
@@ -148,7 +148,8 @@ export async function getInvoiceableWallets (userId, { predecessorId, models }) 
           "InvoiceForward"."walletId"
         FROM "Retries"
         JOIN "InvoiceForward" ON "InvoiceForward"."invoiceId" = "Retries"."id"
-        WHERE "InvoiceForward"."withdrawlId" IS NOT NULL
+        JOIN "Withdrawl" ON "Withdrawl".id = "InvoiceForward"."withdrawlId"
+        WHERE "Withdrawl"."status" IS DISTINCT FROM 'CONFIRMED'
       )
     ORDER BY "Wallet"."priority" ASC, "Wallet"."id" ASC`
 


### PR DESCRIPTION
## Description

This changes the condition for failed forwards on the server such that client and server share the same view. 

## Additional Context

Related to https://github.com/stackernews/stacker.news/pull/1688#issuecomment-2532805496

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. I tested failed forwards with this change and without this change and receiver fallbacks still work.
 
**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no