### PR TITLE
Don't expose p2p zap receivers to routing fees

### DIFF
--- a/components/notifications.js
+++ b/components/notifications.js
@@ -501,13 +501,23 @@ function Invoicification ({ n: { invoice, sortTime } }) {
 }
 
 function WithdrawlPaid ({ n }) {
-  let actionString = n.withdrawl.autoWithdraw ? 'sent to your attached wallet' : 'withdrawn from your account'
+  let amount = n.earnedSats + n.withdrawl.satsFeePaid
+  let actionString = 'withdrawn from your account'
+
+  if (n.withdrawl.autoWithdraw) {
+    actionString = 'sent to your attached wallet'
+  }
+
   if (n.withdrawl.forwardedActionType === 'ZAP') {
+    // don't expose receivers to routing fees they aren't paying
+    amount = n.earnedSats
     actionString = 'zapped directly to your attached wallet'
   }
+
   return (
     <div className='fw-bold text-info'>
-      <Check className='fill-info me-1' />{numWithUnits(n.earnedSats + n.withdrawl.satsFeePaid, { abbreviate: false, unitSingular: 'sat was ', unitPlural: 'sats were ' })}
+      <Check className='fill-info me-1' />
+      {numWithUnits(amount, { abbreviate: false, unitSingular: 'sat was ', unitPlural: 'sats were ' })}
       {actionString}
       <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.sortTime))}</small>
       {(n.withdrawl.forwardedActionType === 'ZAP' && <Badge className={styles.badge} bg={null}>p2p</Badge>) ||

--- a/worker/paidAction.js
+++ b/worker/paidAction.js
@@ -316,13 +316,11 @@ export async function paidActionForwarded ({ data: { invoiceId, withdrawal, ...a
   }, { models, lnd, boss })
 
   if (transitionedInvoice) {
-    const { bolt11, msatsPaid, msatsFeePaid } = transitionedInvoice.invoiceForward.withdrawl
-    // the amount we paid includes the fee so we need to subtract it to get the amount received
-    const received = Number(msatsPaid) - Number(msatsFeePaid)
+    const { bolt11, msatsPaid } = transitionedInvoice.invoiceForward.withdrawl
 
     const logger = walletLogger({ wallet: transitionedInvoice.invoiceForward.wallet, models })
     logger.ok(
-      `↙ payment received: ${formatSats(msatsToSats(received))}`,
+      `↙ payment received: ${formatSats(msatsToSats(Number(msatsPaid)))}`,
       {
         bolt11,
         preimage: transitionedInvoice.preimage


### PR DESCRIPTION
## Description

Fix #1704 

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested successful forwards and autowithdrawals. Expected amounts are shown in notifications and wallet logs. 


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no