### PR TITLE
Fix forever edits

### DIFF
--- a/components/use-can-edit.js
+++ b/components/use-can-edit.js
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react'
 import { datePivot } from '@/lib/time'
 import { useMe } from '@/components/me'
-import { USER_ID } from '@/lib/constants'
+import { ITEM_EDIT_SECONDS, USER_ID } from '@/lib/constants'
 
 export default function useCanEdit (item) {
-  const editThreshold = datePivot(new Date(item.invoice?.confirmedAt ?? item.createdAt), { minutes: 10 })
+  const editThreshold = datePivot(new Date(item.invoice?.confirmedAt ?? item.createdAt), { seconds: ITEM_EDIT_SECONDS })
   const { me } = useMe()
 
   // deleted items can never be edited and every item has a 10 minute edit window

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -46,6 +46,7 @@ export const MAX_POST_TEXT_LENGTH = 100000 // 100k
 export const MAX_COMMENT_TEXT_LENGTH = 10000 // 10k
 export const MAX_TERRITORY_DESC_LENGTH = 1000 // 1k
 export const MAX_POLL_CHOICE_LENGTH = 40
+export const ITEM_EDIT_SECONDS = 600
 export const ITEM_SPAM_INTERVAL = '10m'
 export const ANON_ITEM_SPAM_INTERVAL = '0'
 export const INV_PENDING_LIMIT = 100

--- a/lib/item.js
+++ b/lib/item.js
@@ -10,7 +10,7 @@ export const defaultCommentSort = (pinned, bio, createdAt) => {
   return 'hot'
 }
 
-export const isJob = item => item.subName !== 'jobs'
+export const isJob = item => item.subName === 'jobs'
 
 // a delete directive preceded by a non word character that isn't a backtick
 const deletePattern = /\B@delete\s+in\s+(\d+)\s+(second|minute|hour|day|week|month|year)s?/gi


### PR DESCRIPTION
## Description

Regular items were considered jobs which meant that regular items could be edited forever.

TODO:

- [x] refactor this logic since I initially thought something else is wrong from just reading the code

## Screenshots

## Additional Context

This was reported multiple times by 0xbitcoiner already (last report [here](https://stacker.news/items/804740)) but I must have always forgotten to look into it.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`. Regular items are no longer editable forever because no condition to bypass the edit check is true anymore.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no