### PR TITLE
Use AbortSignal.timeout + custom timeout error message

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,14 +1,8 @@
 export async function fetchWithTimeout (resource, { timeout = 1000, ...options } = {}) {
-  const controller = new AbortController()
-  const id = setTimeout(() => controller.abort(), timeout)
-
-  const response = await fetch(resource, {
+  return await fetch(resource, {
     ...options,
-    signal: controller.signal
+    signal: AbortSignal.timeout(timeout)
   })
-  clearTimeout(id)
-
-  return response
 }
 
 class LRUCache {

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -19,6 +19,7 @@ export async function fetchWithTimeout (resource, { timeout = 1000, ...options }
       // use custom error message
       throw new FetchTimeoutError('GET', resource, timeout)
     }
+    throw err
   }
 }
 

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,5 +1,13 @@
 import { TimeoutError } from '@/lib/time'
 
+class FetchTimeoutError extends TimeoutError {
+  constructor (method, url, timeout) {
+    super(timeout)
+    this.name = 'FetchTimeoutError'
+    this.message = `${method} ${url}: timeout after ${timeout / 1000}s`
+  }
+}
+
 export async function fetchWithTimeout (resource, { timeout = 1000, ...options } = {}) {
   try {
     return await fetch(resource, {
@@ -9,7 +17,7 @@ export async function fetchWithTimeout (resource, { timeout = 1000, ...options }
   } catch (err) {
     if (err.name === 'TimeoutError') {
       // use custom error message
-      throw new TimeoutError(timeout)
+      throw new FetchTimeoutError('GET', resource, timeout)
     }
   }
 }

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,8 +1,17 @@
+import { TimeoutError } from '@/lib/time'
+
 export async function fetchWithTimeout (resource, { timeout = 1000, ...options } = {}) {
-  return await fetch(resource, {
-    ...options,
-    signal: AbortSignal.timeout(timeout)
-  })
+  try {
+    return await fetch(resource, {
+      ...options,
+      signal: AbortSignal.timeout(timeout)
+    })
+  } catch (err) {
+    if (err.name === 'TimeoutError') {
+      // use custom error message
+      throw new TimeoutError(timeout)
+    }
+  }
 }
 
 class LRUCache {

--- a/lib/time.js
+++ b/lib/time.js
@@ -128,6 +128,13 @@ function tzOffset (tz) {
   return targetOffsetHours
 }
 
+export class TimeoutError extends Error {
+  constructor (timeout) {
+    super(`timeout after ${timeout / 1000}s`)
+    this.name = 'TimeoutError'
+  }
+}
+
 function timeoutPromise (timeout) {
   return new Promise((resolve, reject) => {
     // if no timeout is specified, never settle


### PR DESCRIPTION
## Description

I am a bit ambivalent about using `AbortSignal.timeout` because it looks like an unnecessary change with some risk since [MDN](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static) can be wrong about browser support but wanted to propose it anyway to see what you think since it's not letting me go.

As mentioned, according to [MDN]([MDN](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static)), `AbortSignal.timeout` seems to have been supported pretty well for some time. Only which error is thrown (`AbortError` vs `TimeoutError`) was changed this year which isn't something we depend on.

I also added a change that makes sure that timeout errors use "timeout after X seconds" as an error message. The default is "The operation was aborted due to timeout." 

preparation for #1558

## Checklist

**Are your changes backwards compatible? Please answer below:**

should be

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. Only tested with these changes on Brave 1.66.118 and Firefox 127.0.2

```diff
diff --git a/wallets/lnbits/client.js b/wallets/lnbits/client.js
index 61abe48d..f5349db2 100644
--- a/wallets/lnbits/client.js
+++ b/wallets/lnbits/client.js
@@ -1,3 +1,4 @@
+import { fetchWithTimeout } from '@/lib/fetch'
 import { assertContentTypeJson } from '@/lib/url'
 
 export * from '@/wallets/lnbits'
@@ -32,7 +33,7 @@ async function getWallet ({ url, adminKey, invoiceKey }) {
   headers.append('Content-Type', 'application/json')
   headers.append('X-Api-Key', adminKey || invoiceKey)
 
-  const res = await fetch(url + path, { method: 'GET', headers })
+  const res = await fetchWithTimeout(url + path, { method: 'GET', headers, timeout: 1 })
 
   assertContentTypeJson(res)
   if (!res.ok) {
diff --git a/wallets/lnbits/server.js b/wallets/lnbits/server.js
index 72099055..6a2145bd 100644
--- a/wallets/lnbits/server.js
+++ b/wallets/lnbits/server.js
@@ -1,3 +1,4 @@
+import { fetchWithTimeout } from '@/lib/fetch'
 import { msatsToSats } from '@/lib/format'
 import { getAgent } from '@/lib/proxy'
 import { assertContentTypeJson } from '@/lib/url'
@@ -38,11 +39,12 @@ export async function createInvoice (
     hostname = 'lnbits:5000'
   }
 
-  const res = await fetch(`${agent.protocol}//${hostname}${path}`, {
+  const res = await fetchWithTimeout(`${agent.protocol}//${hostname}${path}`, {
     method: 'POST',
     headers,
     agent,
-    body
+    body,
+    timeout: 1
   })
 
   assertContentTypeJson(res)
```

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no