### PR TITLE
Fix missing toast padding

### DIFF
--- a/components/toast.js
+++ b/components/toast.js
@@ -118,7 +118,7 @@ export const ToastProvider = ({ children }) => {
 
   return (
     <ToastContext.Provider value={toaster}>
-      <ToastContainer className={`pb-3 pe-3 ${styles.toastContainer}`} position='bottom-end' containerPosition='fixed'>
+      <ToastContainer className={`pb-3 px-3 ${styles.toastContainer}`} position='bottom-end' containerPosition='fixed'>
         {visibleToasts.map(toast => {
           const textStyle = toast.variant === 'warning' ? 'text-dark' : ''
           const onClose = () => {


### PR DESCRIPTION
## Description

For big toasts, there was padding on the left missing.

## Screenshots

before:

![localhost_3000_settings_wallets_lnbits(iPhone SE)](https://github.com/user-attachments/assets/de9d3081-100d-46be-8937-21c09a715de9)

after:

![localhost_3000_settings_wallets_lnbits(iPhone SE) (1)](https://github.com/user-attachments/assets/e5afceaf-3f80-4ec4-88b6-d0cd08e24347)

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. See screenshots.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no