### PR TITLE
Fix receiver fallbacks depend on fast polls

### DIFF
--- a/wallets/payment.js
+++ b/wallets/payment.js
@@ -58,10 +58,9 @@ export function useWalletPayment () {
         // we just need to distinguish between receiver and sender errors
 
         try {
-          // we always await the poll promise here to check for failed forwards since sender wallet errors
+          // we need to poll one more time to check for failed forwards since sender wallet errors
           // can be caused by them which we want to handle as receiver errors, not sender errors.
-          // but we don't wait forever because real sender errors will cause the poll promise to never settle.
-          await withTimeout(pollPromise, FAST_POLL_INTERVAL * 2.5)
+          await invoiceHelper.isInvoice(latestInvoice, waitFor)
         } catch (err) {
           if (err instanceof WalletError) {
             paymentError = err


### PR DESCRIPTION
## Description

As mentioned in the chat, I noticed the usage of `withTimeout` to check for receiver fallbacks depends on how fast the server responds.

If the server is too slow, we will timeout before we get an invoice update which would tell us about receiver errors.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested with the patch from #1688.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no