### PR TITLE
Remove unused wallet context args

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -65,7 +65,7 @@ function injectResolvers (resolvers) {
         wallet,
         testCreateInvoice:
           walletDef.testCreateInvoice && validateLightning && canReceive({ def: walletDef, config: data })
-            ? (data) => walletDef.testCreateInvoice(data, { logger, me, models })
+            ? (data) => walletDef.testCreateInvoice(data, { logger })
             : null
       }, {
         settings,

--- a/wallets/config.js
+++ b/wallets/config.js
@@ -43,7 +43,7 @@ export function useWalletConfigurator (wallet) {
           clientConfig = Object.assign(clientConfig, transformedConfig)
         }
         if (wallet.def.testSendPayment && validateLightning) {
-          transformedConfig = await wallet.def.testSendPayment(clientConfig, { me, logger })
+          transformedConfig = await wallet.def.testSendPayment(clientConfig, { logger })
           if (transformedConfig) {
             clientConfig = Object.assign(clientConfig, transformedConfig)
           }

--- a/wallets/nwc/client.js
+++ b/wallets/nwc/client.js
@@ -1,16 +1,16 @@
 import { getNwc, supportedMethods, nwcTryRun } from '@/wallets/nwc'
 export * from '@/wallets/nwc'
 
-export async function testSendPayment ({ nwcUrl }, { logger }) {
+export async function testSendPayment ({ nwcUrl }) {
   const timeout = 15_000
 
-  const supported = await supportedMethods(nwcUrl, { logger, timeout })
+  const supported = await supportedMethods(nwcUrl, { timeout })
   if (!supported.includes('pay_invoice')) {
     throw new Error('pay_invoice not supported')
   }
 }
 
-export async function sendPayment (bolt11, { nwcUrl }, { logger }) {
+export async function sendPayment (bolt11, { nwcUrl }) {
   const nwc = await getNwc(nwcUrl)
   const result = await nwcTryRun(() => nwc.payInvoice(bolt11))
   return result.preimage

--- a/wallets/nwc/index.js
+++ b/wallets/nwc/index.js
@@ -63,7 +63,7 @@ export async function nwcTryRun (fun) {
   }
 }
 
-export async function supportedMethods (nwcUrl, { logger, timeout } = {}) {
+export async function supportedMethods (nwcUrl, { timeout } = {}) {
   const nwc = await getNwc(nwcUrl, { timeout })
   const result = await nwcTryRun(() => nwc.getInfo())
   return result.methods

--- a/wallets/nwc/server.js
+++ b/wallets/nwc/server.js
@@ -2,10 +2,10 @@ import { withTimeout } from '@/lib/time'
 import { getNwc, supportedMethods, nwcTryRun } from '@/wallets/nwc'
 export * from '@/wallets/nwc'
 
-export async function testCreateInvoice ({ nwcUrlRecv }, { logger }) {
+export async function testCreateInvoice ({ nwcUrlRecv }) {
   const timeout = 15_000
 
-  const supported = await supportedMethods(nwcUrlRecv, { logger, timeout })
+  const supported = await supportedMethods(nwcUrlRecv, { timeout })
 
   const supports = (method) => supported.includes(method)
 
@@ -20,10 +20,10 @@ export async function testCreateInvoice ({ nwcUrlRecv }, { logger }) {
     }
   }
 
-  return await withTimeout(createInvoice({ msats: 1000, expiry: 1 }, { nwcUrlRecv }, { logger }), timeout)
+  return await withTimeout(createInvoice({ msats: 1000, expiry: 1 }, { nwcUrlRecv }), timeout)
 }
 
-export async function createInvoice ({ msats, description, expiry }, { nwcUrlRecv }, { logger }) {
+export async function createInvoice ({ msats, description, expiry }, { nwcUrlRecv }) {
   const nwc = await getNwc(nwcUrlRecv)
   const result = await nwcTryRun(() => nwc.sendReq('make_invoice', { amount: msats, description, expiry }))
   return result.invoice


### PR DESCRIPTION
## Description

We were passing `models` and `me` into the wallet test functions. I think they were used in the past for logging but we no longer need them. 

I also removed `logger` from the NWC functions since they don't use it.

## Additional Context

Maybe I am overdoing it with small PRs but it's nice to get small changes out of the way so I can focus on the relevant stuff in #1558.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. I looked at all `testSendPayment` and `testCreateInvoice` function signatures and saw none of them use these arguments.

Regarding removal of `logger`: removing an unused argument doesn't break any function calls in JS since you can always call a function with as many arguments as you want, any arguments that aren't defined as parameters are simply not used.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no