### PR TITLE
Refactor Blink function signatures

### DIFF
--- a/wallets/blink/server.js
+++ b/wallets/blink/server.js
@@ -4,7 +4,7 @@ import { msatsToSats } from '@/lib/format'
 export * from '@/wallets/blink'
 
 export async function testCreateInvoice ({ apiKeyRecv, currencyRecv }) {
-  const scopes = await getScopes(apiKeyRecv)
+  const scopes = await getScopes({ apiKey: apiKeyRecv })
   if (!scopes.includes(SCOPE_READ)) {
     throw new Error('missing READ scope')
   }
@@ -22,40 +22,43 @@ export async function testCreateInvoice ({ apiKeyRecv, currencyRecv }) {
 
 export async function createInvoice (
   { msats, description, expiry },
-  { apiKeyRecv, currencyRecv }) {
-  currencyRecv = currencyRecv ? currencyRecv.toUpperCase() : 'BTC'
+  { apiKeyRecv: apiKey, currencyRecv: currency }) {
+  currency = currency ? currency.toUpperCase() : 'BTC'
 
-  const wallet = await getWallet(apiKeyRecv, currencyRecv)
+  const wallet = await getWallet({ apiKey, currency })
 
-  if (currencyRecv !== 'BTC') {
-    throw new Error('unsupported currency ' + currencyRecv)
+  if (currency !== 'BTC') {
+    throw new Error('unsupported currency ' + currency)
   }
-  const mutation = `
-        mutation LnInvoiceCreate($input: LnInvoiceCreateInput!) {
-            lnInvoiceCreate(input: $input) {
-                invoice {
-                    paymentRequest
-                }
-                errors {
-                    message
-                }
-            }
-        }
-    `
 
-  const out = await request(apiKeyRecv, mutation, {
-    input: {
-      amount: msatsToSats(msats),
-      expiresIn: Math.floor(expiry / 60) || 1,
-      memo: description,
-      walletId: wallet.id
+  const out = await request({
+    apiKey,
+    query: `
+      mutation LnInvoiceCreate($input: LnInvoiceCreateInput!) {
+        lnInvoiceCreate(input: $input) {
+          invoice {
+            paymentRequest
+          }
+          errors {
+            message
+          }
+        }
+      }`,
+    variables: {
+      input: {
+        amount: msatsToSats(msats),
+        expiresIn: Math.floor(expiry / 60) || 1,
+        memo: description,
+        walletId: wallet.id
+      }
     }
   })
+
   const res = out.data.lnInvoiceCreate
   const errors = res.errors
   if (errors && errors.length > 0) {
     throw new Error(errors.map(e => e.code + ' ' + e.message).join(', '))
   }
-  const invoice = res.invoice.paymentRequest
-  return invoice
+
+  return res.invoice.paymentRequest
 }


### PR DESCRIPTION
## Description

For #1722, I need to pass `signal` as a context to the Blink wallet functions. To make this easier and consistent with how other wallets are implemented, I changed the function signatures to match the common `[bolt11, ] config, context` signature. 

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested by attaching Blink send+recv:

https://github.com/user-attachments/assets/57e6f7dd-838b-43ab-a998-2a212e1146fd

I also attempted a zap and got the expected error (insufficient balance).

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no