### PR TITLE
Fix lightning address logs deletion

### DIFF
--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -133,7 +133,7 @@ export function useWalletLogManager (setLogs) {
     `,
     {
       onCompleted: (_, { variables: { wallet: walletType } }) => {
-        setLogs?.(logs => logs.filter(l => walletType ? l.wallet !== getWalletByType(walletType).name : false))
+        setLogs?.(logs => logs.filter(l => walletType ? l.wallet !== walletTag(getWalletByType(walletType)) : false))
       }
     }
   )


### PR DESCRIPTION
## Description

The lightning address wallet has `shortName` set so we need to use `walletTag` to filter the wallet out of logs since that we use `walletTag` inside logs.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Simple change

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no