### PR TITLE
Fix send-only wallet save after device sync enabled

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -810,9 +810,9 @@ async function upsertWallet (
           ...(Object.keys(recvConfig).length > 0
             ? {
                 [wallet.field]: {
-                  update: {
-                    where: { walletId: Number(id) },
-                    data: recvConfig
+                  upsert: {
+                    create: recvConfig,
+                    update: recvConfig
                   }
                 }
               }

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -786,7 +786,7 @@ async function upsertWallet (
     }
   }
 
-  const { id, enabled, priority, ...walletData } = data
+  const { id, enabled, priority, ...recvConfig } = data
 
   const txs = []
 
@@ -806,13 +806,13 @@ async function upsertWallet (
         data: {
           enabled,
           priority,
-          // client only wallets has no walletData
-          ...(Object.keys(walletData).length > 0
+          // client only wallets have no receive config and thus don't have their own table
+          ...(Object.keys(recvConfig).length > 0
             ? {
                 [wallet.field]: {
                   update: {
                     where: { walletId: Number(id) },
-                    data: walletData
+                    data: recvConfig
                   }
                 }
               }
@@ -851,8 +851,8 @@ async function upsertWallet (
           priority,
           userId: me.id,
           type: wallet.type,
-          // client only wallets has no walletData
-          ...(Object.keys(walletData).length > 0 ? { [wallet.field]: { create: walletData } } : {}),
+          // client only wallets have no receive config and thus don't have their own table
+          ...(Object.keys(recvConfig).length > 0 ? { [wallet.field]: { create: recvConfig } } : {}),
           ...(vaultEntries
             ? {
                 vaultEntries: {
@@ -876,7 +876,7 @@ async function upsertWallet (
     )
   }
 
-  if (canReceive({ def: walletDef, config: walletData })) {
+  if (canReceive({ def: walletDef, config: recvConfig })) {
     txs.push(
       models.walletLog.createMany({
         data: {


### PR DESCRIPTION
## Description

_Using NWC as the example wallet here._

If you have a NWC send-only config for a wallet and then enable device sync, the mutation in `syncLocalWallets` only creates a row in `Wallet` and `VaultEntry` but not in `WalletNWC`.

If you then try to save again, the backend will see that there is a row for the wallet in `Wallet` and will try to update `WalletNWC`. This fails because there was no such row created during sync to server. 

This PR fixes this by always creating a row in `WalletNWC` if `Wallet` was created.

---

update: Okay, this breaks WebLN though as the comment `// client only wallets has no walletData` indicated why there was this check for existing wallet data. Added as TODO.

Maybe the fix is to also pass an empty receive config during local sync since that's what we also do on regular saves.

---

update: decided to use a [nested upsert](https://www.prisma.io/docs/orm/reference/prisma-client-reference#upsert-1) during `wallet.update` 

## Video of bug

https://github.com/user-attachments/assets/50eb45d8-81b5-4ff9-8aa7-c7625b240ee2

## Additional Context

- There is still a bug where if you now disconnect from the user vault, the row in `VaultEntry` is deleted but the row in `Wallet` isn't so you now have an enabled wallet with an empty config. Added as TODO.

## TODO

- [ ] ~fix empty enabled wallet after vault disconnect with send-only wallet~ _will fix in different PR because unrelated_

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. I am not entirely sure if I tested every combination of send-only, send+recv, recv-only and device sync enabled/disabled with NWC but I tried and I saw no issues. That these changes fix the issue without breaking anything else also make sense to me.

Also tested enabling/disabling WebLN with and without device sync since a previous attempt broke it.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no