### PR TITLE
Fix nwc timeout not increased

### DIFF
--- a/wallets/nwc/index.js
+++ b/wallets/nwc/index.js
@@ -3,8 +3,9 @@ import { string } from '@/lib/yup'
 import { parseNwcUrl } from '@/lib/url'
 import { NDKNwc } from '@nostr-dev-kit/ndk'
 import { TimeoutError } from '@/lib/time'
+import { WALLET_CREATE_INVOICE_TIMEOUT_MS, WALLET_SEND_PAYMENT_TIMEOUT_MS } from '@/lib/constants'
 
-const NWC_CONNECT_TIMEOUT_MS = 15_000
+const NWC_CONNECT_TIMEOUT_MS = Math.max(WALLET_SEND_PAYMENT_TIMEOUT_MS, WALLET_CREATE_INVOICE_TIMEOUT_MS)
 
 export const name = 'nwc'
 export const walletType = 'NWC'


### PR DESCRIPTION
## Description

We intended to increase the wallet timeouts in https://github.com/stackernews/stacker.news/commit/faeefdc498cec342deb65dfc864f161fce26b9f9 and https://github.com/stackernews/stacker.news/commit/16b7160d3611c8f181b2babb9b3e68550f496d77 but NWC has its own timeout for the initial relay connection.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. This will now use whatever timeout is bigger for the initial relay connection.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no