### PR TITLE
Close relay connections after each NWC call

### DIFF
--- a/lib/nostr.js
+++ b/lib/nostr.js
@@ -29,7 +29,7 @@ export const RELAYS_BLACKLIST = []
  * @property {function(Object, {privKey: string, signer: NDKSigner}): Promise<NDKEvent>} sign
  * @property {function(Object, {relays: Array<string>, privKey: string, signer: NDKSigner}): Promise<NDKEvent>} publish
  */
-export class Nostr {
+export default class Nostr {
   /**
    * @type {NDK}
    */
@@ -152,11 +152,6 @@ export class Nostr {
     }
   }
 }
-
-/**
- * @type {Nostr}
- */
-export default new Nostr()
 
 export function hexToBech32 (hex, prefix = 'npub') {
   return bech32.encode(prefix, bech32.toWords(Buffer.from(hex, 'hex')))

--- a/wallets/nwc/client.js
+++ b/wallets/nwc/client.js
@@ -1,4 +1,4 @@
-import { getNwc, supportedMethods, nwcTryRun } from '@/wallets/nwc'
+import { supportedMethods, nwcTryRun } from '@/wallets/nwc'
 export * from '@/wallets/nwc'
 
 export async function testSendPayment ({ nwcUrl }, { signal }) {
@@ -9,8 +9,6 @@ export async function testSendPayment ({ nwcUrl }, { signal }) {
 }
 
 export async function sendPayment (bolt11, { nwcUrl }, { signal }) {
-  const nwc = await getNwc(nwcUrl, { signal })
-  // TODO: support AbortSignal
-  const result = await nwcTryRun(() => nwc.payInvoice(bolt11))
+  const result = await nwcTryRun(nwc => nwc.payInvoice(bolt11), { nwcUrl }, { signal })
   return result.preimage
 }

--- a/wallets/nwc/server.js
+++ b/wallets/nwc/server.js
@@ -1,4 +1,4 @@
-import { getNwc, supportedMethods, nwcTryRun } from '@/wallets/nwc'
+import { supportedMethods, nwcTryRun } from '@/wallets/nwc'
 export * from '@/wallets/nwc'
 
 export async function testCreateInvoice ({ nwcUrlRecv }, { signal }) {
@@ -21,8 +21,9 @@ export async function testCreateInvoice ({ nwcUrlRecv }, { signal }) {
 }
 
 export async function createInvoice ({ msats, description, expiry }, { nwcUrlRecv }, { signal }) {
-  const nwc = await getNwc(nwcUrlRecv, { signal })
-  // TODO: support AbortSignal
-  const result = await nwcTryRun(() => nwc.sendReq('make_invoice', { amount: msats, description, expiry }))
+  const result = await nwcTryRun(
+    nwc => nwc.sendReq('make_invoice', { amount: msats, description, expiry }),
+    { nwcUrl: nwcUrlRecv }, { signal }
+  )
   return result.invoice
 }


### PR DESCRIPTION
## Description

In an attempt to fix relay issues, we're opening and closing relay connections after each nwc call. This is the same behavior as before we switched to NDK in #1590.

## Additional Context

As @riccardobl mentioned in the chat, it probably makes sense to keep the relay connections open on the server which this code doesn't do (yet). However, the previous code also didn't do that.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

tbd, will test more tomorrow

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no