### PR TITLE
Refine #1739 and fix regression causing nostr crossposts and login to not work

### DIFF
--- a/components/nostr-auth.js
+++ b/components/nostr-auth.js
@@ -124,8 +124,9 @@ export function NostrAuth ({ text, callbackUrl, multiAuth }) {
       const k1 = data?.createAuth.k1
       if (!k1) throw new Error('Error generating challenge') // should never happen
 
+      const nostr = Nostr.get()
       const useExtension = !nip46token
-      const signer = Nostr.getSigner({ nip46token, supportNip07: useExtension })
+      const signer = nostr.getSigner({ nip46token, supportNip07: useExtension })
       if (!signer && useExtension) throw new Error('No extension found')
 
       if (signer instanceof NDKNip46Signer) {
@@ -142,7 +143,7 @@ export function NostrAuth ({ text, callbackUrl, multiAuth }) {
         loading: true
       })
 
-      const signedEvent = await Nostr.sign({
+      const signedEvent = await nostr.sign({
         kind: 27235,
         created_at: Math.floor(Date.now() / 1000),
         tags: [

--- a/components/nostr-auth.js
+++ b/components/nostr-auth.js
@@ -117,6 +117,8 @@ export function NostrAuth ({ text, callbackUrl, multiAuth }) {
       error: false,
       loading: true
     })
+
+    const nostr = new Nostr()
     try {
       const { data, error } = await createAuth()
       if (error) throw error
@@ -124,7 +126,6 @@ export function NostrAuth ({ text, callbackUrl, multiAuth }) {
       const k1 = data?.createAuth.k1
       if (!k1) throw new Error('Error generating challenge') // should never happen
 
-      const nostr = Nostr.get()
       const useExtension = !nip46token
       const signer = nostr.getSigner({ nip46token, supportNip07: useExtension })
       if (!signer && useExtension) throw new Error('No extension found')
@@ -162,6 +163,7 @@ export function NostrAuth ({ text, callbackUrl, multiAuth }) {
     } catch (e) {
       setError(e)
     } finally {
+      nostr.close()
       clearSuggestionTimer()
     }
   }, [])

--- a/components/use-crossposter.js
+++ b/components/use-crossposter.js
@@ -202,8 +202,9 @@ export default function useCrossposter () {
     if (!event) return { allSuccessful, noteId }
 
     do {
+      const nostr = new Nostr()
       try {
-        const result = await Nostr.crosspost(event, { relays: failedRelays || relays })
+        const result = await nostr.crosspost(event, { relays: failedRelays || relays })
 
         if (result.error) {
           failedRelays = []
@@ -231,6 +232,8 @@ export default function useCrossposter () {
         // wait 2 seconds to show error then break
         await new Promise(resolve => setTimeout(resolve, 2000))
         return { allSuccessful, noteId }
+      } finally {
+        nostr.close()
       }
     } while (failedRelays.length > 0)
 

--- a/lib/nostr.js
+++ b/lib/nostr.js
@@ -34,7 +34,7 @@ export default class Nostr {
    * @type {NDK}
    */
   _ndk = null
-
+  static globalInstance = null
   constructor ({ privKey, defaultSigner, relays, nip46token, supportNip07 = false, ...ndkOptions } = {}) {
     this._ndk = new NDK({
       explicitRelayUrls: relays,
@@ -45,6 +45,16 @@ export default class Nostr {
       signer: defaultSigner ?? this.getSigner({ privKey, supportNip07, nip46token }),
       ...ndkOptions
     })
+  }
+
+  /**
+   * @type {NDK}
+   */
+  static get () {
+    if (!Nostr.globalInstance) {
+      Nostr.globalInstance = new Nostr()
+    }
+    return Nostr.globalInstance
   }
 
   /**
@@ -149,6 +159,16 @@ export default class Nostr {
     } catch (error) {
       console.error('Crosspost error:', error)
       return { error }
+    }
+  }
+
+  /**
+   * Close all relay connections
+   */
+  close () {
+    const pool = this.ndk.pool
+    for (const relay of pool.urls()) {
+      pool.removeRelay(relay)
     }
   }
 }

--- a/wallets/nwc/index.js
+++ b/wallets/nwc/index.js
@@ -36,8 +36,8 @@ export const card = {
   subtitle: 'use Nostr Wallet Connect for payments'
 }
 
-async function getNwc (nwcUrl, { signal }) {
-  const ndk = new Nostr().ndk
+async function getNwc (nostr, nwcUrl, { signal }) {
+  const ndk = nostr.ndk
   const { walletPubkey, secret, relayUrls } = parseNwcUrl(nwcUrl)
   const nwc = new NDKNwc({
     ndk,
@@ -66,9 +66,9 @@ async function getNwc (nwcUrl, { signal }) {
  * @returns - the result of the nwc function
  */
 export async function nwcTryRun (fun, { nwcUrl }, { signal }) {
-  let nwc
+  const nostr = new Nostr()
   try {
-    nwc = await getNwc(nwcUrl, { signal })
+    const nwc = await getNwc(nostr, nwcUrl, { signal })
     const { error, result } = await fun(nwc)
     if (error) throw new Error(error.message || error.code)
     return result
@@ -76,17 +76,7 @@ export async function nwcTryRun (fun, { nwcUrl }, { signal }) {
     if (e.error) throw new Error(e.error.message || e.error.code)
     throw e
   } finally {
-    if (nwc) close(nwc)
-  }
-}
-
-/**
- * Close all relay connections of the NDKNwc instance
- * @param {NDKNwc} nwc
- */
-async function close (nwc) {
-  for (const relay of nwc.relaySet.relays) {
-    nwc.ndk.pool.removeRelay(relay.url)
+    nostr.close()
   }
 }
 

--- a/worker/nostr.js
+++ b/worker/nostr.js
@@ -45,8 +45,9 @@ export async function nip57 ({ data: { hash }, boss, lnd, models }) {
     }
 
     console.log('zap note', e, relays)
-    const signer = Nostr.getSigner({ privKey: process.env.NOSTR_PRIVATE_KEY })
-    await Nostr.publish(e, {
+    const nostr = Nostr.get()
+    const signer = nostr.getSigner({ privKey: process.env.NOSTR_PRIVATE_KEY })
+    await nostr.publish(e, {
       relays,
       signer,
       timeout: 1000


### PR DESCRIPTION
This PR 
 -  fixes nostr logins and crossposts: Closes #1741 
 - and refines  #1739 by:
    - moving the close method inside the nostr class
    - adding static method to return the ndk singleton
    - disconnecting from the relay after crosspost on the client

