### PR TITLE
fix #1648: increases navbar height when scrolling on mobile

### DIFF
--- a/components/header.module.css
+++ b/components/header.module.css
@@ -72,7 +72,7 @@
 .navbarNav {
     width: 100%;
     align-items: center;
-    height: 39px;
+    height: 50px;
     align-content: center;
 }
 


### PR DESCRIPTION
## Description

A simple CSS change to address issue #1648 by increasing the height of the navbar on mobile devices.

## Screenshots

![image](https://github.com/user-attachments/assets/e9c7da66-5c35-4686-b86f-914ef71a5ed2)

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No