### PR TITLE
Add exclusion constraint to prevent duplicate items within 10m

### DIFF
--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -142,7 +142,8 @@ export async function perform (args, context) {
       item = await tx.item.create({ data: itemData })
     } catch (err) {
       if (err.message.includes('violates exclusion constraint \\"Item_unique_time_constraint\\"')) {
-        throw new GqlInputError('duplicate item within 10 minutes')
+        const message = `you already submitted this ${itemData.title ? 'post' : 'comment'}`
+        throw new GqlInputError(message)
       }
       throw err
     }

--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -2,6 +2,7 @@ import { ANON_ITEM_SPAM_INTERVAL, ITEM_SPAM_INTERVAL, PAID_ACTION_PAYMENT_METHOD
 import { notifyItemMention, notifyItemParents, notifyMention, notifyTerritorySubscribers, notifyUserSubscribers } from '@/lib/webPush'
 import { getItemMentions, getMentions, performBotBehavior } from './lib/item'
 import { msatsToSats, satsToMsats } from '@/lib/format'
+import { GqlInputError } from '@/lib/error'
 
 export const anonable = true
 
@@ -137,7 +138,14 @@ export async function perform (args, context) {
       }
     })).bio
   } else {
-    item = await tx.item.create({ data: itemData })
+    try {
+      item = await tx.item.create({ data: itemData })
+    } catch (err) {
+      if (err.message.includes('violates exclusion constraint \\"Item_unique_time_constraint\\"')) {
+        throw new GqlInputError('duplicate item within 10 minutes')
+      }
+      throw err
+    }
   }
 
   // store a reference to the item in the invoice

--- a/prisma/migrations/20241220000308_fix_duplicate_comments/migration.sql
+++ b/prisma/migrations/20241220000308_fix_duplicate_comments/migration.sql
@@ -3,13 +3,12 @@ CREATE EXTENSION IF NOT EXISTS btree_gist;
 ALTER TABLE "Item" ADD CONSTRAINT "Item_unique_time_constraint"
   EXCLUDE USING gist (
     "userId" WITH =,
-    -- we use COALESCE so NULL is considered equal to itself
+    -- we use COALESCE so NULL is considered equal to itself. we also use md5 hashes because columns
+    -- of type TEXT can make index row too large and columns of type CITEXT are not supported by GiST.
     COALESCE("parentId", -1) WITH =,
-    COALESCE("title", '') WITH =,
-    -- GiST does not support citext so we use md5 hash
+    md5(COALESCE("title", '')) WITH =,
     md5(COALESCE("subName", '')) WITH =,
-    -- including text column directly can make index row too large so we use md5 hash
-    md5("text") WITH =,
+    md5(COALESCE("text", '')) WITH =,
     tsrange(created_at, created_at + INTERVAL '10 minutes') WITH &&
   )
   -- enforce constraint after this date

--- a/prisma/migrations/20241220000308_fix_duplicate_comments/migration.sql
+++ b/prisma/migrations/20241220000308_fix_duplicate_comments/migration.sql
@@ -6,10 +6,10 @@ ALTER TABLE "Item" ADD CONSTRAINT "Item_unique_time_constraint"
     -- we use COALESCE so NULL is considered equal to itself
     COALESCE("parentId", -1) WITH =,
     COALESCE("title", '') WITH =,
-    -- GiST does not support citext so we cast to bytea
-    digest(COALESCE("subName", ''), 'sha256') WITH =,
-    -- including text column directly can make index row too large so we use the hash
-    digest("text", 'sha256') WITH =,
+    -- GiST does not support citext so we use md5 hash
+    md5(COALESCE("subName", '')) WITH =,
+    -- including text column directly can make index row too large so we use md5 hash
+    md5("text") WITH =,
     tsrange(created_at, created_at + INTERVAL '10 minutes') WITH &&
   )
   -- enforce constraint after this date

--- a/prisma/migrations/20241220000308_fix_duplicate_comments/migration.sql
+++ b/prisma/migrations/20241220000308_fix_duplicate_comments/migration.sql
@@ -1,0 +1,15 @@
+-- create a partial exclusion constraint that prevents insertion of duplicate items within 10 minutes
+ALTER TABLE "Item" ADD CONSTRAINT "Item_unique_time_constraint"
+  EXCLUDE USING gist (
+    "userId" WITH =,
+    -- we use COALESCE so NULL is considered equal to itself
+    COALESCE("parentId", -1) WITH =,
+    COALESCE("title", '') WITH =,
+    -- GiST does not support citext so we cast to bytea
+    digest(COALESCE("subName", ''), 'sha256') WITH =,
+    -- including text column directly can make index row too large so we use the hash
+    digest("text", 'sha256') WITH =,
+    tsrange(created_at, created_at + INTERVAL '10 minutes') WITH &&
+  )
+  -- enforce constraint after this date
+  WHERE (created_at > '2024-12-20');

--- a/prisma/migrations/20241220000308_fix_duplicate_comments/migration.sql
+++ b/prisma/migrations/20241220000308_fix_duplicate_comments/migration.sql
@@ -1,4 +1,5 @@
 -- create a partial exclusion constraint that prevents insertion of duplicate items within 10 minutes
+CREATE EXTENSION IF NOT EXISTS btree_gist;
 ALTER TABLE "Item" ADD CONSTRAINT "Item_unique_time_constraint"
   EXCLUDE USING gist (
     "userId" WITH =,

--- a/prisma/migrations/20241220000308_fix_duplicate_comments/migration.sql
+++ b/prisma/migrations/20241220000308_fix_duplicate_comments/migration.sql
@@ -12,4 +12,4 @@ ALTER TABLE "Item" ADD CONSTRAINT "Item_unique_time_constraint"
     tsrange(created_at, created_at + INTERVAL '10 minutes') WITH &&
   )
   -- enforce constraint after this date
-  WHERE (created_at > '2024-12-20');
+  WHERE (created_at > '2024-12-30');


### PR DESCRIPTION
## Description

Fix #1693 

Instead of a unique index, I used an exclusion constraint so we can specifically target duplicates within 10 minutes.

Some things I noticed during implementation:

1. A naive unique index doesn't work because the `text` column is too large for the index row so I am using `digest("text", 'sha256')`:

```sql
CREATE UNIQUE INDEX IF NOT EXISTS "Item_unique_time_constraint_idx"
ON "Item"("userId", "parentId", "title", "text", "subName");
ERROR:  index row requires 8432 bytes, maximum size is 8191
```

2. We need to make sure that NULL is considered equal via [`NULLS NOT DISTINCT`](https://www.postgresql.org/docs/16/indexes-unique.html):

```sql
CREATE UNIQUE INDEX IF NOT EXISTS "Item_unique_time_constraint_idx"
ON "Item"("userId", "parentId", "title", digest("text", 'sha256'), "subName") NULLS NOT DISTINCT;
CREATE INDEX
```

To only enforce the constraint for items within 10 minutes, I used an [exclusion constraint](https://www.postgresql.org/docs/16/sql-createtable.html#SQL-CREATETABLE-EXCLUDE):

> The EXCLUDE clause defines an exclusion constraint, which guarantees that if any two rows are compared on the specified column(s) or expression(s) using the specified operator(s), not all of these comparisons will return TRUE. If all of the specified operators test for equality, this is equivalent to a UNIQUE constraint, although an ordinary unique constraint will be faster. However, **exclusion constraints can specify constraints that are more general than simple equality**. For example, you can specify a constraint that no two rows in the table contain overlapping circles (see [Section 8.8](https://www.postgresql.org/docs/16/datatype-geometric.html)) by using the && operator.

**Since we already have cases of duplicate items, we only enforce the constraint after an "activation date". This should be a date _after_ we deployed this constraint.**

update: I decided to use md5 instead of sha256 because we only care about collisions, not about security, md5 is slightly faster and it uses 128 bits instead of 256 bits.

## Additional context

I am not entirely sure if `COALESCE` is needed since during tests, `NULL` seemed to also match `NULL` even though this is not the usual postgres behavior but to stay safe, I decided to use `COALESCE` anyway.

I am also not sure about the performance impact of this exclusion constraint in production but I think it will not be significant.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes, I added `WHERE (created_at > activation_date)` so this will only be enforced after activation date. 

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. I tested with comments and posts (with and without empty text).

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no