### PR TITLE
Require invite limit

### DIFF
--- a/api/paidAction/inviteGift.js
+++ b/api/paidAction/inviteGift.js
@@ -21,7 +21,7 @@ export async function perform ({ id, userId }, { me, cost, tx }) {
     where: { id, userId: me.id, revoked: false }
   })
 
-  if (invite.giftedCount >= invite.limit) {
+  if (invite.limit && invite.giftedCount >= invite.limit) {
     throw new Error('invite limit reached')
   }
 
@@ -45,7 +45,7 @@ export async function perform ({ id, userId }, { me, cost, tx }) {
   })
 
   return await tx.invite.update({
-    where: { id, userId: me.id, giftedCount: { lt: invite.limit }, revoked: false },
+    where: { id, userId: me.id, revoked: false, ...(invite.limit ? { giftedCount: { lt: invite.limit } } : {}) },
     data: {
       giftedCount: {
         increment: 1

--- a/api/typeDefs/invite.js
+++ b/api/typeDefs/invite.js
@@ -7,7 +7,7 @@ export default gql`
   }
 
   extend type Mutation {
-    createInvite(id: String, gift: Int!, limit: Int, description: String): Invite
+    createInvite(id: String, gift: Int!, limit: Int!, description: String): Invite
     revokeInvite(id: ID!): Invite
   }
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -478,7 +478,7 @@ export const bioSchema = object({
 
 export const inviteSchema = object({
   gift: intValidator.positive('must be greater than 0').required('required'),
-  limit: intValidator.positive('must be positive').nullable(),
+  limit: intValidator.positive('must be positive'),
   description: string().trim().max(40, 'must be at most 40 characters'),
   id: string().matches(/^[\w-_]+$/, 'only letters, numbers, underscores, and hyphens').min(8, 'must be at least 8 characters').max(32, 'must be at most 32 characters')
 })

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -478,7 +478,7 @@ export const bioSchema = object({
 
 export const inviteSchema = object({
   gift: intValidator.positive('must be greater than 0').required('required'),
-  limit: intValidator.positive('must be positive'),
+  limit: intValidator.positive('must be positive').nullable(),
   description: string().trim().max(40, 'must be at most 40 characters'),
   id: string().matches(/^[\w-_]+$/, 'only letters, numbers, underscores, and hyphens').min(8, 'must be at least 8 characters').max(32, 'must be at most 32 characters')
 })

--- a/pages/invites/index.js
+++ b/pages/invites/index.js
@@ -57,7 +57,7 @@ function InviteForm () {
           variables: {
             id: id || undefined,
             gift: Number(gift),
-            limit: limit ? Number(limit) : limit,
+            limit: limit ? Number(limit) : null,
             description: description || undefined
           }
         })

--- a/pages/invites/index.js
+++ b/pages/invites/index.js
@@ -19,7 +19,7 @@ function InviteForm () {
   const [createInvite] = useMutation(
     gql`
       ${INVITE_FIELDS}
-      mutation createInvite($id: String, $gift: Int!, $limit: Int, $description: String) {
+      mutation createInvite($id: String, $gift: Int!, $limit: Int!, $description: String) {
         createInvite(id: $id, gift: $gift, limit: $limit, description: $description) {
           ...InviteFields
         }
@@ -57,7 +57,7 @@ function InviteForm () {
           variables: {
             id: id || undefined,
             gift: Number(gift),
-            limit: limit ? Number(limit) : null,
+            limit: Number(limit),
             description: description || undefined
           }
         })
@@ -72,7 +72,7 @@ function InviteForm () {
         required
       />
       <Input
-        label={<>invitee limit <small className='text-muted ms-2'>optional</small></>}
+        label='invitee limit'
         name='limit'
       />
       <AccordianItem


### PR DESCRIPTION
## Description

The frontend says `invite limit` is optional but if you don't enter anything and submit, we throw 

> Variable "$limit" got invalid value ""; Int cannot represent non-integer value: ""

I believe this has been an issue even before #1649 since the validation schema was not changed in #1649 and I had to update it to use `.nullable()`.

Additionally, our code checked if `invite.limit` was defined everywhere except in the most critical part where it gets redeemed, lol.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. Testing creating and redeeming limited and unlimited invite links.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no