### PR TITLE
Fix upvote button shown for deleted items

### DIFF
--- a/components/boost-button.js
+++ b/components/boost-button.js
@@ -26,7 +26,7 @@ export default function Boost ({ item, className, ...props }) {
       item={item} As={oprops =>
         <div className='upvoteParent'>
           <div
-            className={styles.upvoteWrapper}
+            className={classNames(styles.upvoteWrapper, item.deletedAt && styles.noSelfTips)}
           >
             <BoostIcon
               {...props}

--- a/components/upvote.module.css
+++ b/components/upvote.module.css
@@ -37,7 +37,7 @@
 }
 
 .noSelfTips {
-    transform: scaleX(-1);
+    visibility: hidden;
 }
 
 .upvoteWrapper:not(.noSelfTips):hover {


### PR DESCRIPTION
## Description

I tried to find the changes that broke this to have full context and see if I am missing something but I can't tell.

Using `git blame` on components/upvote.module.css (because that's where I fixed it) shows 5f0494de3 but I don't think this was broken since we shipped #1408.

Using `git log -G "deletedAt"` I find following commits but from looking into them, I also can't tell which one broke it:

```
$ git log --oneline --no-decorate -G "deletedAt" -10
6d9db696 Fix upvote button shown for deleted items
b8061a63 don't double factor trust
6d4dfdda improve rewards (#1731)
01d51770 Fix edit timer stuck at 00:00 (#1673)
8a2bd84f fix: upvote widget not rendered when comment is collapsed (#1583)
fdd34b2e Fix edit countdown on deleted items (#1571)
9f06fd65 UX latency enhancements for paid actions (#1434)
5f0494de rethinking boost (#1408)
e63609a7 don't show deleted items in main sorts
5e771062 Undelete bio items (#1346)
```

So I am not sure if I am missing something but looks good to me. Boost and upvote icon disappears now for deleted items.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. Tested deleted items of self and deleted items of others. Upbolt and boost icon disappeared on delete.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no