### PR TITLE
reduce territory price with prorated refund for actives

### DIFF
--- a/components/territory-form.js
+++ b/components/territory-form.js
@@ -197,7 +197,7 @@ export default function TerritoryForm ({ sub }) {
             >
               <Checkbox
                 type='radio'
-                label='100k sats/month'
+                label={`${abbrNum(TERRITORY_PERIOD_COST('MONTHLY'))} sats/month`}
                 value='MONTHLY'
                 name='billingType'
                 id='monthly-checkbox'
@@ -206,7 +206,7 @@ export default function TerritoryForm ({ sub }) {
               />
               <Checkbox
                 type='radio'
-                label='1m sats/year'
+                label={`${abbrNum(TERRITORY_PERIOD_COST('YEARLY'))} sats/year`}
                 value='YEARLY'
                 name='billingType'
                 id='yearly-checkbox'
@@ -215,7 +215,7 @@ export default function TerritoryForm ({ sub }) {
               />
               <Checkbox
                 type='radio'
-                label='3m sats once'
+                label={`${abbrNum(TERRITORY_PERIOD_COST('ONCE'))} sats once`}
                 value='ONCE'
                 name='billingType'
                 id='once-checkbox'

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -92,19 +92,19 @@ export const FREEBIE_BASE_COST_THRESHOLD = 10
 // From lawyers: north korea, cuba, iran, ukraine, syria
 export const SANCTIONED_COUNTRY_CODES = ['KP', 'CU', 'IR', 'UA', 'SY']
 
-export const TERRITORY_COST_MONTHLY = 100000
-export const TERRITORY_COST_YEARLY = 1000000
+export const TERRITORY_COST_MONTHLY = 50000
+export const TERRITORY_COST_YEARLY = 500000
 export const TERRITORY_COST_ONCE = 3000000
 
 export const TERRITORY_BILLING_OPTIONS = (labelPrefix) => ({
   monthly: {
-    term: '+ 100k',
+    term: '+ 50k',
     label: `${labelPrefix} month`,
     op: '+',
     modifier: cost => cost + TERRITORY_COST_MONTHLY
   },
   yearly: {
-    term: '+ 1m',
+    term: '+ 500k',
     label: `${labelPrefix} year`,
     op: '+',
     modifier: cost => cost + TERRITORY_COST_YEARLY

--- a/prisma/migrations/20241223204948_territory_refund/migration.sql
+++ b/prisma/migrations/20241223204948_territory_refund/migration.sql
@@ -1,0 +1,16 @@
+-- refund users who have active territories and paid the old, higher price
+-- for the rest of their billing period once the switchover is complete
+
+WITH active_territories AS (
+    SELECT *,
+        "billingCost" *
+            EXTRACT(epoch FROM "billPaidUntil" - now()) / EXTRACT(epoch FROM "billPaidUntil" - "billedLastAt") *
+                0.5 AS refund_sats
+    FROM "Sub"
+    WHERE "status" = 'ACTIVE'
+    AND "billingType" IN ('MONTHLY', 'YEARLY')
+)
+UPDATE users
+SET msats = msats + refund_sats*1000
+FROM active_territories
+WHERE users.id = active_territories."userId";


### PR DESCRIPTION
This reduces monthly and yearly territory prices by half. It also refunds active territory owners for what they "overpaid" for what remains of their billing period.

QA: `8`. I ran the CTE in prod to verify it produces the right values. Locally, I created a new territory with monthly billing, upgraded to yearly, and manually made it enter into grace period - verifying new prices are used. I also manually made the territory 6 months into a yearly billing cycle with a `billingCost = 1m` then ran the migration, verifying I received a refund of ~250k sats.


