### PR TITLE
fix 1695 by not updating ancestors on zap

### DIFF
--- a/components/item-act.js
+++ b/components/item-act.js
@@ -181,7 +181,7 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
 
 function modifyActCache (cache, { result, invoice }) {
   if (!result) return
-  const { id, sats, path, act } = result
+  const { id, sats, act } = result
   cache.modify({
     id: `Item:${id}`,
     fields: {
@@ -212,20 +212,22 @@ function modifyActCache (cache, { result, invoice }) {
     }
   })
 
-  if (act === 'TIP') {
-    // update all ancestors
-    path.split('.').forEach(aId => {
-      if (Number(aId) === Number(id)) return
-      cache.modify({
-        id: `Item:${aId}`,
-        fields: {
-          commentSats (existingCommentSats = 0) {
-            return existingCommentSats + sats
-          }
-        }
-      })
-    })
-  }
+  // removing this fixes issue #1695 because optimistically updating all ancestors
+  // conflicts with the writeQuery on navigation from SSR
+  // if (act === 'TIP') {
+  //   // update all ancestors
+  //   path.split('.').forEach(aId => {
+  //     if (Number(aId) === Number(id)) return
+  //     cache.modify({
+  //       id: `Item:${aId}`,
+  //       fields: {
+  //         commentSats (existingCommentSats = 0) {
+  //           return existingCommentSats + sats
+  //         }
+  //       }
+  //     })
+  //   })
+  // }
 }
 
 export function useAct ({ query = ACT_MUTATION, ...options } = {}) {


### PR DESCRIPTION
I'm running out of less severe changes to fix this bug. I describe the problem in #1695 some, but the gist is:

1. a thread is cached on the client
2. someone replies to us in that thread and we get a notification 
3. we zap the item in notifications and the optimistic response updates all of an item's ancestors in the cache
4. on navigation, we use `writeQuery` to merge SSR data with the cache
5. `writeQuery` does not support merging into optimistic caches, so until the real response returns, the stale optimistic cache (which does not yet have the item in the thread) is shown 

(I should note this happens in more places than just notifications, so doing a hack checking the pathname is especially not worth it.)

This fixes the problem by avoiding a need to merge the ancestors in the thread. BUT it means the `commentSats` which displays at the top of comment threads never updates in response to zaps. The tradeoff is worth it, but I'd prefer to not have to make it.

I'll try a few more fixes, but there aren't many things left to try.

I wound up updating ancestors `onPaid` ... we still can update `commentSats` (with some delay) and this write conflict doesn't happen.
