### PR TITLE
support generated fields on serverside wallets

### DIFF
--- a/wallets/config.js
+++ b/wallets/config.js
@@ -63,7 +63,7 @@ export function useWalletConfigurator (wallet) {
         throw err
       }
     } else if (canReceive({ def: wallet.def, config: serverConfig })) {
-      const transformedConfig = await validateWallet(wallet.def, serverConfig)
+      const transformedConfig = await validateWallet(wallet.def, serverConfig, { skipGenerated: true })
       if (transformedConfig) {
         serverConfig = Object.assign(serverConfig, transformedConfig)
       }

--- a/wallets/validate.js
+++ b/wallets/validate.js
@@ -72,7 +72,7 @@ function composeWalletSchema (walletDef, serverSide, skipGenerated) {
 
     if (clientOnly && serverSide) {
       // For server-side validation, accumulate clientOnly fields as vaultEntries
-      vaultEntrySchemas[optional ? 'optional' : 'required'].push(vaultEntrySchema(name))
+      vaultEntrySchemas[(optional || generated) ? 'optional' : 'required'].push(vaultEntrySchema(name))
     } else {
       acc[name] = createFieldSchema(name, validate)
 


### PR DESCRIPTION
## Description

Client-side wallets can transform credentials during initial configuration. Previously, this functionality was also available for server-side wallets, but a recent refactoring broke it. This PR restores it, as it is required for [stackernews/stacker.news#1763](https://github.com/stackernews/stacker.news/pull/1763).

## Checklist

**Are your changes backwards compatible? Please answer below:**
yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
tested as part of https://github.com/stackernews/stacker.news/pull/1763

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**
no