### PR TITLE
make possibly conflicting optimistic cache updates write to each other

### DIFF
--- a/components/bookmark.js
+++ b/components/bookmark.js
@@ -17,7 +17,8 @@ export default function BookmarkDropdownItem ({ item: { id, meBookmark } }) {
           id: `Item:${id}`,
           fields: {
             meBookmark: () => bookmarkItem.meBookmark
-          }
+          },
+          optimistic: true
         })
       }
     }

--- a/components/comment-edit.js
+++ b/components/comment-edit.js
@@ -18,7 +18,8 @@ export default function CommentEdit ({ comment, editThreshold, onSuccess, onCanc
             text () {
               return result.text
             }
-          }
+          },
+          optimistic: true
         })
       }
     },

--- a/components/delete.js
+++ b/components/delete.js
@@ -30,7 +30,8 @@ export default function Delete ({ itemId, children, onDelete, type = 'post' }) {
             url: () => deleteItem.url,
             pollCost: () => deleteItem.pollCost,
             deletedAt: () => deleteItem.deletedAt
-          }
+          },
+          optimistic: true
         })
       }
     }

--- a/components/dont-link-this.js
+++ b/components/dont-link-this.js
@@ -84,7 +84,8 @@ export function OutlawDropdownItem ({ item }) {
           id: `Item:${item.id}`,
           fields: {
             outlawed: () => true
-          }
+          },
+          optimistic: true
         })
       }
     }

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -209,7 +209,8 @@ function modifyActCache (cache, { result, invoice }) {
         }
         return existingBoost
       }
-    }
+    },
+    optimistic: true
   })
 }
 
@@ -228,7 +229,8 @@ function updateAncestors (cache, { result, invoice }) {
           commentSats (existingCommentSats = 0) {
             return existingCommentSats + sats
           }
-        }
+        },
+        optimistic: true
       })
     })
   }

--- a/components/pay-bounty.js
+++ b/components/pay-bounty.js
@@ -22,7 +22,8 @@ export const payBountyCacheMods = {
         bountyPaidTo (existingPaidTo = []) {
           return [...(existingPaidTo || []), Number(id)]
         }
-      }
+      },
+      optimistic: true
     })
   },
   onPayError: (e, cache, { data }) => {
@@ -36,7 +37,8 @@ export const payBountyCacheMods = {
         bountyPaidTo (existingPaidTo = []) {
           return (existingPaidTo || []).filter(i => i !== Number(id))
         }
-      }
+      },
+      optimistic: true
     })
   }
 }

--- a/components/poll.js
+++ b/components/poll.js
@@ -123,7 +123,8 @@ export function usePollVote ({ query = POLL_VOTE, itemId }) {
           poll.count += 1
           return poll
         }
-      }
+      },
+      optimistic: true
     })
     cache.modify({
       id: `PollOption:${id}`,
@@ -131,7 +132,8 @@ export function usePollVote ({ query = POLL_VOTE, itemId }) {
         count (existingCount) {
           return existingCount + 1
         }
-      }
+      },
+      optimistic: true
     })
   }
 
@@ -154,7 +156,8 @@ export function usePollVote ({ query = POLL_VOTE, itemId }) {
           poll.count -= 1
           return poll
         }
-      }
+      },
+      optimistic: true
     })
     cache.modify({
       id: `PollOption:${id}`,
@@ -162,7 +165,8 @@ export function usePollVote ({ query = POLL_VOTE, itemId }) {
         count (existingCount) {
           return existingCount - 1
         }
-      }
+      },
+      optimistic: true
     })
   }
 

--- a/components/reply.js
+++ b/components/reply.js
@@ -78,7 +78,8 @@ export default forwardRef(function Reply ({
               })
               return [newCommentRef, ...existingCommentRefs]
             }
-          }
+          },
+          optimistic: true
         })
 
         // no lag for itemRepetition
@@ -102,7 +103,8 @@ export default forwardRef(function Reply ({
               ncomments (existingNComments = 0) {
                 return existingNComments + 1
               }
-            }
+            },
+            optimistic: true
           })
         })
 

--- a/components/subscribe.js
+++ b/components/subscribe.js
@@ -17,7 +17,8 @@ export default function SubscribeDropdownItem ({ item: { id, meSubscription } })
           id: `Item:${id}`,
           fields: {
             meSubscription: () => subscribeItem.meSubscription
-          }
+          },
+          optimistic: true
         })
       }
     }

--- a/components/use-item-submit.js
+++ b/components/use-item-submit.js
@@ -118,7 +118,8 @@ export function useRetryCreateItem ({ id }) {
               `,
               data: { bolt11: response.invoice.bolt11 }
             })
-          }
+          },
+          optimistic: true
         })
         paidActionCacheMods?.update?.(cache, { data })
       }


### PR DESCRIPTION
My theory as to why #1655 and #1669 occur is that an earlier and conflicting optimistic mutation fails while another optimistic mutation is in progress. When the optimistic mutation fails, it rolls back the cache to its initial state which causes the in-progress optimistic mutation to have its cache updates overwritten.

In the case of #1655, I believe that this occurs when an earlier zap (in a succession of zaps) fails. In the case of #1669, I believe this occurs when a poll is zapped, then voted on.

I've made the relevant cache updates write to each other. It's very hard to reproduce so I'm not sure I got all the relevant `cache.modify` calls, but I'll continue looking for any cache updates on the optimistic response path in the few places we do it (zaps/boosts/polls) ... it's unclear if there are consequences to doing it on every `cache.modify` call. 

--------------

Update: I've made all the `cache.modify` calls on items update optimistic caches. This might be unnecessary overhead but afaict it shouldn't cause anything bad to happen, and should prevent optimistic rollbacks from affecting these cache updates.
