### PR TITLE
Fix user since if first item wasn't paid

### DIFF
--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -935,7 +935,8 @@ export default {
       // get the user's first item
       const item = await models.item.findFirst({
         where: {
-          userId: user.id
+          userId: user.id,
+          OR: [{ invoiceActionState: 'PAID' }, { invoiceActionState: null }]
         },
         orderBy: {
           createdAt: 'asc'


### PR DESCRIPTION
## Description

Noticed [here](https://stacker.news/bitcoin_wallets) that if the first item wasn't paid, we still show it next to `stacking since`.

This changes the query for `user.since` to use the same filter we use elsewhere to filter out unpaid items.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`3`. Tested with unpaid first item.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no