### PR TITLE
Fix muted parents not uncollapsed

### DIFF
--- a/components/comment.js
+++ b/components/comment.js
@@ -26,6 +26,7 @@ import { commentSubTreeRootId } from '@/lib/item'
 import Pin from '@/svgs/pushpin-fill.svg'
 import LinkToContext from './link-to-context'
 import Boost from './boost-button'
+import { gql, useApolloClient } from '@apollo/client'
 
 function Parent ({ item, rootText }) {
   const root = useRoot()
@@ -108,7 +109,19 @@ export default function Comment ({
   const root = useRoot()
   const { ref: textRef, quote, quoteReply, cancelQuote } = useQuoteReply({ text: item.text })
 
+  const { cache } = useApolloClient()
+
   useEffect(() => {
+    const comment = cache.readFragment({
+      id: `Item:${router.query.commentId}`,
+      fragment: gql`
+        fragment _ on Item {
+          path
+        }`
+    })
+    if (comment?.path.split('.').includes(item.id)) {
+      window.localStorage.setItem(`commentCollapse:${item.id}`, 'nope')
+    }
     setCollapse(window.localStorage.getItem(`commentCollapse:${item.id}`) || collapse)
     if (Number(router.query.commentId) === Number(item.id)) {
       // HACK wait for other comments to collapse if they're collapsed

--- a/components/comment.js
+++ b/components/comment.js
@@ -130,7 +130,7 @@ export default function Comment ({
         ref.current.classList.add('outline-it')
       }, 100)
     }
-  }, [item.id, router.query.commentId])
+  }, [item.id, cache, router.query.commentId])
 
   useEffect(() => {
     if (router.query.commentsViewedAt &&

--- a/components/comment.js
+++ b/components/comment.js
@@ -115,7 +115,7 @@ export default function Comment ({
     const comment = cache.readFragment({
       id: `Item:${router.query.commentId}`,
       fragment: gql`
-        fragment _ on Item {
+        fragment CommentPath on Item {
           path
         }`
     })

--- a/components/comment.js
+++ b/components/comment.js
@@ -124,7 +124,7 @@ export default function Comment ({
     }
     setCollapse(window.localStorage.getItem(`commentCollapse:${item.id}`) || collapse)
     if (Number(router.query.commentId) === Number(item.id)) {
-      // HACK wait for other comments to collapse if they're collapsed
+      // HACK wait for other comments to uncollapse if they're collapsed
       setTimeout(() => {
         ref.current.scrollIntoView({ behavior: 'instant', block: 'start' })
         ref.current.classList.add('outline-it')


### PR DESCRIPTION
## Description

This fixes #1706 by populating a new context for query params with the full comment so we can use `comment.path` to uncollapse all parents.

## Video

https://github.com/user-attachments/assets/1097e4e9-729d-4d3b-8abf-0031aa2d1e89

## Additional Context

I named this new context `QueryParamsContext` since I struggled with a better name and we might want to use this for other stuff at some point even though I currently lack the imagination for what. Open for better naming ideas.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. See video. Also made sure in 91645e1e that if one navigates back and then forward again, the thread is still uncollapsed by storing the state in local storage.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no