### PR TITLE
filter out POST /api/graphql spam from sndev logs

### DIFF
--- a/sndev
+++ b/sndev
@@ -7,6 +7,10 @@ if [ -f .env.local ]; then
   . ./.env.local
 fi
 
+logFilter() {
+  grep -v --line-buffered --color=never -P 'POST /api/graphql \x1b\[32m200\x1b\[39m in [0-9]+ms'
+}
+
 docker__compose() {
   if [ ! -x "$(command -v docker)" ]; then
     echo "docker compose is not installed"
@@ -128,7 +132,7 @@ OPTIONS"
 sndev__logs() {
   shift
   if [ $# -eq 1 ]; then
-    docker__compose logs -t --tail=1000 -f "$@"
+    docker__compose logs -t --tail=1000 -f "$@" | logFilter
     exit 0
   fi
 

--- a/sndev
+++ b/sndev
@@ -8,7 +8,7 @@ if [ -f .env.local ]; then
 fi
 
 logFilter() {
-  grep -v --line-buffered --color=never -P 'POST /api/graphql \x1b\[32m200\x1b\[39m in [0-9]+ms'
+  grep -v --line-buffered --color=never 'POST /api/graphql .*200'
 }
 
 docker__compose() {


### PR DESCRIPTION
## Description

Since a Next.js update, the dev environment has started logging HTTP requests, which has caused the logs to become cluttered with logs of POST /api/graphql requests. This is an actual issue of  Next.js, see the related discussion here: https://github.com/vercel/next.js/discussions/65992.

This PR adds a workaround to filter out these logs by using grep in the sndev logs command.

## Screenshots
before / after

![image](https://github.com/user-attachments/assets/cb8ad566-a101-4dd0-a867-bff19104852f)
