### PR TITLE
Fix adding an account doesn't automatically switch to it  #1779

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -98,9 +98,12 @@ function getCallbacks (req, res) {
         const secret = process.env.NEXTAUTH_SECRET
         const jwt = await encodeJWT({ token, secret })
         const me = await prisma.user.findUnique({ where: { id: token.id } })
-        // we set multi_auth cookies on login/signup with only one user so the rest of the code doesn't
-        // have to consider the case where they aren't set yet because account switching wasn't used yet
-        setMultiAuthCookies(req, res, { ...me, jwt })
+        const hasMultiAuth = !!req.cookies['multi_auth.user-id']
+        if (!hasMultiAuth) {
+          // we set multi_auth cookies on login/signup with only one user so the rest of the code doesn't
+          // have to consider the case where they aren't set yet because account switching wasn't used yet
+          setMultiAuthCookies(req, res, { ...me, jwt })
+        }
       }
 
       return token


### PR DESCRIPTION
Fixes https://github.com/stackernews/stacker.news/issues/1779 

The issue was that the code responsible for setting the default multi-auth cookie for the user on their first login was being called on every authentication, including when adding a new account. This caused the authentication cookies to be set but then immediately overwritten by the default cookie, reverting to the previous user.


## Screenshots

before the patch
![image](https://github.com/user-attachments/assets/43dfb2b7-3ee1-49ca-98a0-a11e0302c076)


after the patch
![image](https://github.com/user-attachments/assets/698e30fa-cc3b-424c-9e1f-a57f885bb5fb)


## Checklist

**Are your changes backwards compatible? Please answer below:**
yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
Tested with sndev login and nostr nip05
- [x] the default multi_auth cookie is set on first login
- [x] switching happens automatically when a new account is added
- [x] switching to anon works
- [x] switching to another account works