### PR TITLE
Fix NostrAuth link text

### DIFF
--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -707,7 +707,7 @@ function NostrLinkButton ({ unlink, status }) {
     ? unlink
     : () => showModal(onClose =>
       <div className='d-flex flex-column align-items-center'>
-        <NostrAuth text='Unlink' />
+        <NostrAuth text='Link' />
       </div>)
 
   return (


### PR DESCRIPTION
## Description

The modal that is opened when one wants to link a nostr key always showed `Unlink`

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no