### PR TITLE
Always return new user token for JWT callback to use

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -91,15 +91,14 @@ function getCallbacks (req, res) {
         token.sub = Number(token.id)
       }
 
-      // response is only defined during signup/login
+      // this only runs during a signup/login because response is only defined during signup/login
+      // and will add the multi_auth cookies for the user we just logged in as
       if (req && res) {
         req = new NodeNextRequest(req)
         res = new NodeNextResponse(res)
         const secret = process.env.NEXTAUTH_SECRET
         const jwt = await encodeJWT({ token, secret })
         const me = await prisma.user.findUnique({ where: { id: token.id } })
-        // we set multi_auth cookies on login/signup with only one user so the rest of the code doesn't
-        // have to consider the case where they aren't set yet because account switching wasn't used yet
         setMultiAuthCookies(req, res, { ...me, jwt })
       }
 
@@ -165,30 +164,21 @@ async function pubkeyAuth (credentials, req, res, pubkeyColumnName) {
       // does the pubkey already exist in our db?
       let user = await prisma.user.findUnique({ where: { [pubkeyColumnName]: pubkey } })
 
-      // get token if it exists
+      // make following code aware of cookie pointer for account switching
       req = multiAuthMiddleware(req)
+      // token will be undefined if we're not logged in at all or if we switched to anon
       const token = await getToken({ req })
       if (!user) {
         // we have not seen this pubkey before
 
-        // only update our pubkey if we're not currently trying to add a new account
+        // only update our pubkey if we're logged in (token exists)
+        // and we're not currently trying to add a new account
         if (token?.id && !multiAuth) {
           user = await prisma.user.update({ where: { id: token.id }, data: { [pubkeyColumnName]: pubkey } })
         } else {
           // we're not logged in: create new user with that pubkey
           user = await prisma.user.create({ data: { name: pubkey.slice(0, 10), [pubkeyColumnName]: pubkey } })
         }
-      }
-
-      if (token && token?.id !== user.id && multiAuth) {
-        // we're logged in as a different user than the one we're authenticating as
-        // and we want to add a new account. this means we want to add this account
-        // to our list of accounts for switching between so we issue a new JWT and
-        // update the cookies for multi-authentication.
-        const secret = process.env.NEXTAUTH_SECRET
-        const userJWT = await encodeJWT({ token: { id: user.id, name: user.name, email: user.email }, secret })
-        setMultiAuthCookies(req, res, { ...user, jwt: userJWT })
-        return token
       }
 
       return user


### PR DESCRIPTION
## Description

As @riccardobl mentioned in #1781, #1779 is caused by the cookie pointer update in `pubkeyAuth` getting overridden back to the initial cookie pointer in the JWT callback.

As I mentioned in https://github.com/stackernews/stacker.news/issues/1779#issuecomment-2565585659, I thought I fixed  this in #1618 but it appears that I didn't really test all cases, but only the case when we switched to anon and then try to add a new account. Then we automatically get switched because the JWT callback will run with the token set to the new user since we return the new user token (the variable that is called `user`) in `pubkeyAuth`, not the old user token (the variable that is called `token`).

However, as noticed in #1779, this does not work if you're logged in as some account and then add an account because we then return `token` (the old user). This is what I must have broken in #1618 and @riccardobl fixed in #1781. However, #1781 then breaks switching from anon to a new account because `setMultiAuthCookies` will not be called in `pubkeyAuth` and in the JWT callback.

Since the token that the JWT callback receives is the token we returned in `pubkeyAuth`, returning the token of the user we want to switch to in `pubkeyAuth` makes sure that the JWT callback will call `setMultiAuthCookies` with the token we want. So afaict, we don't actually need to set the cookie pointer in `pubkeyAuth` but can rely on the JWT callback to do this for us. This is what this PR does.

fix #1779 supersedes #1781

## Videos

switching around to new accounts:

https://github.com/user-attachments/assets/9b7fb5d1-44fa-4322-8389-2fbac3fbc43d

switching around to existing accounts:

https://github.com/user-attachments/assets/833b1154-e3dc-44ae-88bd-b3571ce225c1

unlinking + linking new nostr key:

https://github.com/user-attachments/assets/1e67f9b4-65f7-421b-8408-f097d4761fc8

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. It was a little tricky to consider all cases and make sense of them but I've tested all cases afaict now as can be seen in the videos and all make sense to me now. Simply return token we want to switch to and let JWT callback set the cookies. We only need to consider account switching in `pubkeyAuth` to not accidentally update pubkeys when we instead wanted to switch accounts.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no