### PR TITLE
Fix ignored cancel error

### DIFF
--- a/components/use-qr-payment.js
+++ b/components/use-qr-payment.js
@@ -20,7 +20,7 @@ export default function useQrPayment () {
       let paid
       const cancelAndReject = async (onClose) => {
         if (!paid && cancelOnClose) {
-          const updatedInv = await invoice.cancel(inv).catch(console.error)
+          const updatedInv = await invoice.cancel(inv)
           reject(new InvoiceCanceledError(updatedInv))
         }
         resolve(inv)


### PR DESCRIPTION
## Description

If an invoice cancel fails, we currently only log the error and return `undefined` and then throw in the constructor of `InvoiceCanceledError` because `invoice` is undefined. This results in an uncaught `Unhandled Runtime Error`.

This change doesn't change that cancel errors result in an unhandled runtime error, but it will at least show the proper error.

[According to NextJS docs](https://nextjs.org/docs/pages/building-your-application/configuring/error-handling#handling-errors-in-development), these unhandled runtime errors don't show up in prod. I assume they just get logged to console but don't crash the app? Not sure though.

But anyway, so far we never had an invoice cancel fail and this is just about throwing the actual error.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`. Works on successful cancel. If I throw `new Error("test")` in the backend, it actually shows me that error in the overlay.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no