### PR TITLE
Distinguish invoices cancelled by user

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -489,7 +489,7 @@ const resolvers = {
     },
     createWithdrawl: createWithdrawal,
     sendToLnAddr,
-    cancelInvoice: async (parent, { hash, hmac }, { me, models, lnd, boss }) => {
+    cancelInvoice: async (parent, { hash, hmac, userCancel }, { me, models, lnd, boss }) => {
       // stackers can cancel their own invoices without hmac
       if (me && !hmac) {
         const inv = await models.invoice.findUnique({ where: { hash } })
@@ -499,7 +499,7 @@ const resolvers = {
         verifyHmac(hash, hmac)
       }
       await finalizeHodlInvoice({ data: { hash }, lnd, models, boss })
-      return await models.invoice.findFirst({ where: { hash } })
+      return await models.invoice.update({ where: { hash }, data: { userCancel: !!userCancel } })
     },
     dropBolt11: async (parent, { hash }, { me, models, lnd }) => {
       if (!me) {

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -78,7 +78,7 @@ const typeDefs = `
     createInvoice(amount: Int!): InvoiceOrDirect!
     createWithdrawl(invoice: String!, maxFee: Int!): Withdrawl!
     sendToLnAddr(addr: String!, amount: Int!, maxFee: Int!, comment: String, identifier: Boolean, name: String, email: String): Withdrawl!
-    cancelInvoice(hash: String!, hmac: String): Invoice!
+    cancelInvoice(hash: String!, hmac: String, userCancel: Boolean): Invoice!
     dropBolt11(hash: String!): Boolean
     removeWallet(id: ID!): Boolean
     deleteWalletLogs(wallet: String): Boolean

--- a/components/use-invoice.js
+++ b/components/use-invoice.js
@@ -36,9 +36,9 @@ export default function useInvoice () {
     return { invoice: data.invoice, check: that(data.invoice) }
   }, [client])
 
-  const cancel = useCallback(async ({ hash, hmac }) => {
+  const cancel = useCallback(async ({ hash, hmac }, { userCancel = false } = {}) => {
     console.log('canceling invoice:', hash)
-    const { data } = await cancelInvoice({ variables: { hash, hmac } })
+    const { data } = await cancelInvoice({ variables: { hash, hmac, userCancel } })
     return data.cancelInvoice
   }, [cancelInvoice])
 

--- a/components/use-qr-payment.js
+++ b/components/use-qr-payment.js
@@ -20,7 +20,7 @@ export default function useQrPayment () {
       let paid
       const cancelAndReject = async (onClose) => {
         if (!paid && cancelOnClose) {
-          const updatedInv = await invoice.cancel(inv)
+          const updatedInv = await invoice.cancel(inv, { userCancel: true })
           reject(new InvoiceCanceledError(updatedInv))
         }
         resolve(inv)

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -225,8 +225,8 @@ export const SET_WALLET_PRIORITY = gql`
 
 export const CANCEL_INVOICE = gql`
   ${INVOICE_FIELDS}
-  mutation cancelInvoice($hash: String!, $hmac: String) {
-    cancelInvoice(hash: $hash, hmac: $hmac) {
+  mutation cancelInvoice($hash: String!, $hmac: String, $userCancel: Boolean) {
+    cancelInvoice(hash: $hash, hmac: $hmac, userCancel: $userCancel) {
       ...InvoiceFields
     }
   }

--- a/prisma/migrations/20241231223214_invoice_user_cancel/migration.sql
+++ b/prisma/migrations/20241231223214_invoice_user_cancel/migration.sql
@@ -1,0 +1,28 @@
+-- AlterTable
+ALTER TABLE "Invoice" ADD COLUMN "userCancel" BOOLEAN;
+
+-- Migrate existing rows
+UPDATE "Invoice" SET "userCancel" = false;
+
+-- Add constraint to ensure consistent cancel state
+ALTER TABLE "Invoice" ADD CONSTRAINT "Invoice_cancel" CHECK (
+  ("cancelled" = true AND "cancelledAt" IS NOT NULL AND "userCancel" IS NOT NULL) OR
+  ("cancelled" = false AND "cancelledAt" IS NULL AND "userCancel" IS NULL)
+);
+
+-- Add trigger to set userCancel to false by default when cancelled updated and userCancel not specified
+CREATE OR REPLACE FUNCTION invoice_set_user_cancel_default()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.cancelled AND NEW."userCancel" IS NULL THEN
+    NEW."userCancel" := false;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER invoice_user_cancel_trigger
+  BEFORE UPDATE ON "Invoice"
+  FOR EACH ROW
+  EXECUTE FUNCTION invoice_set_user_cancel_default();
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -917,6 +917,7 @@ model Invoice {
   confirmedIndex     BigInt?
   cancelled          Boolean             @default(false)
   cancelledAt        DateTime?
+  userCancel         Boolean?
   msatsRequested     BigInt
   msatsReceived      BigInt?
   desc               String?


### PR DESCRIPTION
## Description

Requirement for #1776 

This adds a boolean column `Invoice.userCancel`. It is set if the invoice was cancelled by the user, i.e. the invoice was shown to the user via a QR code and they closed it. In any other case, it is not set.

I also added a constraint so cancelled invoices cannot be in a weird state where it's not clear if it has been cancelled and how.

## Video

https://github.com/user-attachments/assets/37de1f5b-db26-4dd0-9225-f281f9ad2932

## Additional Context

I decided to use a trigger to set `userCancel` to false by default if it was not specified in the same call as `cancelled` and `cancelledAt` are set.

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes, old rows are migrated by setting `userCancel` to false. I also checked that there are no existing rows that would fail the new constraint:

```
> SELECT COUNT(1) FROM "Invoice" WHERE cancelled AND "cancelledAt" IS NULL;
0
> SELECT COUNT(1) FROM "Invoice" WHERE NOT cancelled AND "cancelledAt" IS NOT NULL;
0
```

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. See video

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no