### PR TITLE
collapse childless deleted comments

### DIFF
--- a/components/comment.js
+++ b/components/comment.js
@@ -100,8 +100,9 @@ export default function Comment ({
   const [edit, setEdit] = useState()
   const { me } = useMe()
   const isHiddenFreebie = me?.privates?.satsFilter !== 0 && !item.mine && item.freebie && !item.freedFreebie
+  const isDeletedChildless = item?.ncomments === 0 && item?.deletedAt
   const [collapse, setCollapse] = useState(
-    (isHiddenFreebie || item?.user?.meMute || (item?.outlawed && !me?.privates?.wildWestMode)) && !includeParent
+    (isHiddenFreebie || isDeletedChildless || item?.user?.meMute || (item?.outlawed && !me?.privates?.wildWestMode)) && !includeParent
       ? 'yep'
       : 'nope')
   const ref = useRef(null)


### PR DESCRIPTION
## Description

Collapses the comment if it has `deletedAt` and no child comments, closes #363 

## Screenshots
<img width="931" alt="image" src="https://github.com/user-attachments/assets/0ebb1841-5e3e-40a4-abc9-deabd0035354" />

## Additional Context
n/a

## Checklist

**Are your changes backwards compatible? Please answer below:** 
Yes, it's an addition to default collapse conditions


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8, found correct behavior: if no childs, collapse.


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:** n/a


**Did you introduce any new environment variables? If so, call them out explicitly here:** No
