### PR TITLE
Allow cancel of own invoices without hmac

### DIFF
--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -78,7 +78,7 @@ const typeDefs = `
     createInvoice(amount: Int!): InvoiceOrDirect!
     createWithdrawl(invoice: String!, maxFee: Int!): Withdrawl!
     sendToLnAddr(addr: String!, amount: Int!, maxFee: Int!, comment: String, identifier: Boolean, name: String, email: String): Withdrawl!
-    cancelInvoice(hash: String!, hmac: String!): Invoice!
+    cancelInvoice(hash: String!, hmac: String): Invoice!
     dropBolt11(hash: String!): Boolean
     removeWallet(id: ID!): Boolean
     deleteWalletLogs(wallet: String): Boolean

--- a/components/use-invoice.js
+++ b/components/use-invoice.js
@@ -37,10 +37,6 @@ export default function useInvoice () {
   }, [client])
 
   const cancel = useCallback(async ({ hash, hmac }) => {
-    if (!hash || !hmac) {
-      throw new Error('missing hash or hmac')
-    }
-
     console.log('canceling invoice:', hash)
     const { data } = await cancelInvoice({ variables: { hash, hmac } })
     return data.cancelInvoice

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -225,7 +225,7 @@ export const SET_WALLET_PRIORITY = gql`
 
 export const CANCEL_INVOICE = gql`
   ${INVOICE_FIELDS}
-  mutation cancelInvoice($hash: String!, $hmac: String!) {
+  mutation cancelInvoice($hash: String!, $hmac: String) {
     cancelInvoice(hash: $hash, hmac: $hmac) {
       ...InvoiceFields
     }


### PR DESCRIPTION
## Description

Required for #1776.

Since we only return hmacs when the invoice is created, stackers need to be able to cancel their invoices even if they don't contain an hmac anymore for #1776.

TODO:

- [x] sleep over this

## Video

https://github.com/user-attachments/assets/7377757f-634b-4eed-99c1-d7ac190362c7

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested anon cancels via hmac and stacker cancel without hmac, see video.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no