### PR TITLE
Fix expirein used instead of keepuntil

### DIFF
--- a/api/paidAction/boost.js
+++ b/api/paidAction/boost.js
@@ -67,9 +67,9 @@ export async function onPaid ({ invoice, actId }, { tx }) {
   })
 
   await tx.$executeRaw`
-    INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter, expirein)
+    INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter, keepuntil)
     VALUES ('expireBoost', jsonb_build_object('id', ${itemAct.itemId}::INTEGER), 21, true,
-              now() + interval '30 days', interval '40 days')`
+              now() + interval '30 days', now() + interval '40 days')`
 }
 
 export async function onFail ({ invoice }, { tx }) {

--- a/api/paidAction/index.js
+++ b/api/paidAction/index.js
@@ -461,11 +461,11 @@ async function createDbInvoice (actionType, args, context) {
 
   // insert a job to check the invoice after it's set to expire
   await db.$executeRaw`
-      INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter, expirein, priority)
+      INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter, keepuntil, priority)
       VALUES ('checkInvoice',
         jsonb_build_object('hash', ${invoice.hash}::TEXT), 21, true,
           ${expiresAt}::TIMESTAMP WITH TIME ZONE,
-          ${expiresAt}::TIMESTAMP WITH TIME ZONE - now() + interval '10m', 100)`
+          ${expiresAt}::TIMESTAMP WITH TIME ZONE + interval '10m', 100)`
 
   // the HMAC is only returned during invoice creation
   // this makes sure that only the person who created this invoice

--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -216,9 +216,9 @@ export async function onPaid ({ invoice, id }, context) {
 
   if (item.boost > 0) {
     await tx.$executeRaw`
-    INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter, expirein)
+    INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter, keepuntil)
     VALUES ('expireBoost', jsonb_build_object('id', ${item.id}::INTEGER), 21, true,
-              now() + interval '30 days', interval '40 days')`
+              now() + interval '30 days', now() + interval '40 days')`
   }
 
   if (item.parentId) {

--- a/api/paidAction/itemUpdate.js
+++ b/api/paidAction/itemUpdate.js
@@ -137,15 +137,15 @@ export async function perform (args, context) {
   })
 
   await tx.$executeRaw`
-    INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter, expirein)
+    INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter, keepuntil)
     VALUES ('imgproxy', jsonb_build_object('id', ${id}::INTEGER), 21, true,
-              now() + interval '5 seconds', interval '1 day')`
+              now() + interval '5 seconds', now() + interval '1 day')`
 
   if (newBoost > 0) {
     await tx.$executeRaw`
-      INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter, expirein)
+      INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter, keepuntil)
       VALUES ('expireBoost', jsonb_build_object('id', ${id}::INTEGER), 21, true,
-                now() + interval '30 days', interval '40 days')`
+                now() + interval '30 days', now() + interval '40 days')`
   }
 
   await performBotBehavior(args, context)

--- a/api/paidAction/lib/item.js
+++ b/api/paidAction/lib/item.js
@@ -60,23 +60,23 @@ export async function performBotBehavior ({ text, id }, { me, tx }) {
     const deleteAt = getDeleteAt(text)
     if (deleteAt) {
       await tx.$queryRaw`
-        INSERT INTO pgboss.job (name, data, startafter, expirein)
+        INSERT INTO pgboss.job (name, data, startafter, keepuntil)
         VALUES (
           'deleteItem',
           jsonb_build_object('id', ${id}::INTEGER),
           ${deleteAt}::TIMESTAMP WITH TIME ZONE,
-          ${deleteAt}::TIMESTAMP WITH TIME ZONE - now() + interval '1 minute')`
+          ${deleteAt}::TIMESTAMP WITH TIME ZONE + interval '1 minute')`
     }
 
     const remindAt = getRemindAt(text)
     if (remindAt) {
       await tx.$queryRaw`
-        INSERT INTO pgboss.job (name, data, startafter, expirein)
+        INSERT INTO pgboss.job (name, data, startafter, keepuntil)
         VALUES (
           'reminder',
           jsonb_build_object('itemId', ${id}::INTEGER, 'userId', ${userId}::INTEGER),
           ${remindAt}::TIMESTAMP WITH TIME ZONE,
-          ${remindAt}::TIMESTAMP WITH TIME ZONE - now() + interval '1 minute')`
+          ${remindAt}::TIMESTAMP WITH TIME ZONE + interval '1 minute')`
       await tx.reminder.create({
         data: {
           userId,

--- a/prisma/migrations/20250103011357_fix_expireboost_keepuntil/migration.sql
+++ b/prisma/migrations/20250103011357_fix_expireboost_keepuntil/migration.sql
@@ -1,0 +1,4 @@
+-- fix existing boost jobs
+UPDATE pgboss.job
+SET keepuntil = startafter + interval '10 days'
+WHERE name = 'expireBoost' AND state = 'created';


### PR DESCRIPTION
## Description

We've been using `expirein` for reminder, delete and boost jobs far into the future. We thought `expirein > startafter` would make sure they don't disappear before they get run. However, `expirein` is for how long a job can stay in the **active state**:

> **Expiration options**
>
> - expireInSeconds, number
>  How many seconds a job may be in active state before it is failed because of expiration. Must be >=1

-- https://timgit.github.io/pg-boss/#/./api/jobs

The docs aren't clear, but I assume `keepuntil` is called "Retention options" in the docs and they state this:

> **Retention options**
>
> - retentionSeconds, number
>  How many seconds a job may be in created or retry state before it's archived. Must be >=1

So we want to use `keepuntil` instead of `expirein` for reminder, delete and boost jobs.

Our defaults via `\d pgboss.job`:

- `expirein`: 15 minutes
- `keepuntil`: 14 days

TODO:

- [ ] ~reschedule reminders~ 

since the jobs are just for the push notifications, I decided to not reschedule them to avoid duplicate push notifications for past or future reminders

- [ ] ~reschedule deletes~ 

won't do in this PR because I need an up-to-date db dump from prod after this was deployed

- [x] fix existing active boost jobs by updating `keepuntil`

added migration

## Additional Context

We could add a constraint on `pgboss.job` to make sure that `keepuntil` > `startafter` since I think any such case is a bug.

## Checklist

**Are your changes backwards compatible? Please answer below:**

- some delete jobs have been lost (see TODO)
- some reminders might not send push notifications but that's not a big deal
- fixed existing `expireBoost` via update query in migrations

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. tested that reminders, deletes, expire boost, `checkInvoice` jobs are inserted without error.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no