### PR TITLE
Fix insecure default id for invites

### DIFF
--- a/prisma/migrations/20250103150109_fix_invite_cuid_insecure/migration.sql
+++ b/prisma/migrations/20250103150109_fix_invite_cuid_insecure/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Invite" ALTER COLUMN "id" SET DEFAULT encode(gen_random_bytes(12), 'hex'::text);

--- a/prisma/migrations/20250103150109_fix_invite_cuid_insecure/migration.sql
+++ b/prisma/migrations/20250103150109_fix_invite_cuid_insecure/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "Invite" ALTER COLUMN "id" SET DEFAULT encode(gen_random_bytes(12), 'hex'::text);
+ALTER TABLE "Invite" ALTER COLUMN "id" SET DEFAULT encode(gen_random_bytes(16), 'hex'::text);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -467,7 +467,7 @@ model LnWith {
 }
 
 model Invite {
-  id          String   @id @default(dbgenerated("encode(gen_random_bytes(12), 'hex'::text)"))
+  id          String   @id @default(dbgenerated("encode(gen_random_bytes(16), 'hex'::text)"))
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
   userId      Int

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -467,7 +467,7 @@ model LnWith {
 }
 
 model Invite {
-  id          String   @id @default(cuid())
+  id          String   @id @default(dbgenerated("encode(gen_random_bytes(12), 'hex'::text)"))
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @default(now()) @updatedAt @map("updated_at")
   userId      Int


### PR DESCRIPTION
## Description

`cuid` has been deprecated due to security, see [README](https://github.com/paralleldrive/cuid).

`cuid2` is now recommended but when I tried to use `cuid(2)` as the default in our Prisma schema as mentioned in the [Prisma docs](https://www.prisma.io/docs/orm/reference/prisma-schema-reference#cuid), it didn't work.

```
Error: Prisma schema validation - (validate wasm)
Error code: P1012
error: Error parsing attribute "@default": The `cuid` function does not take any argument. Consider changing this default to `cuid()`.
  -->  prisma/schema.prisma:470
   |
469 | model Invite {
470 |   id          String   @id @default(cuid(2))
   |

Validation Error Count: 1
[Context: validate]

Prisma CLI Version : 5.20.0
```

Since Prisma is pretty weird anyway and I have more trust in `pgcrypto`, I decided to use [`gen_random_bytes`](https://www.postgresql.org/docs/16/pgcrypto.html#PGCRYPTO-RANDOM-DATA-FUNCS) from it.

I used hex encoding because it's url-safe, I only wanted to have alphanumeric characters and Postgres only supports base64 or hex as encodings.

TODO:

- [x] use 16 bytes

## Additional Context

- https://stacker.news/items/834962
- you not only need to migrate but also restart the app so the Prisma client is regenerated without the `cuid` default
- another annoying Prisma bug: https://github.com/prisma/prisma/issues/14917 (fixed using `db pull` as mentioned in the ticket)
- example invite link: http://localhost:3000/invites/324007289497933672459636 (24 hex chars)

## Checklist

**Are your changes backwards compatible? Please answer below:**

it doesn't fix existing invite links

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Created invite link with default id and custom id.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no