### PR TITLE
fix: iOS notification counts and sums are wacky

### DIFF
--- a/components/serviceworker.js
+++ b/components/serviceworker.js
@@ -158,9 +158,10 @@ export const ServiceWorkerProvider = ({ children }) => {
     // since (a lot of) browsers don't support the pushsubscriptionchange event,
     // we sync with server manually by checking on every page reload if the push subscription changed.
     // see https://medium.com/@madridserginho/how-to-handle-webpush-api-pushsubscriptionchange-event-in-modern-browsers-6e47840d756f
+    navigator?.serviceWorker?.controller?.postMessage?.({ action: STORE_OS, os: detectOS() })
+    logger.info('sent STORE_OS to service worker: ', detectOS())
     navigator?.serviceWorker?.controller?.postMessage?.({ action: SYNC_SUBSCRIPTION })
     logger.info('sent SYNC_SUBSCRIPTION to service worker')
-    navigator?.serviceWorker?.controller?.postMessage?.({ action: STORE_OS, os: detectOS() })
   }, [registration, permission.notification])
 
   const contextValue = useMemo(() => ({


### PR DESCRIPTION
## Description

Partial fix of #756, 2: (notification counts and sums)
This PR provides immediate relief for iOS users, specifically fixes iOS check to enable ek's fix (`initialValue = 1`) giving proper counting and sums on all notifications

`os` value is not updated between events, this fix reliably saves and gets the OS value to/from `ServiceWorkerStorage`

## Screenshots
AMOUNT counts
![image](https://github.com/user-attachments/assets/f198fc1c-9b9e-4358-8abc-80defaeb79a2)

SUM_SATS sums
![IMG_1491](https://github.com/user-attachments/assets/be8500e8-df02-4d1c-9e11-99b4438b691f)


## Additional Context

This is part of a series of fixes tracked on #1794 

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
9, didn't test `FOLLOW` but it follows (heh) the same counting method as others, tested also with withdraw/deposit sums

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No
