### PR TITLE
Fix scroll after modal close

### DIFF
--- a/components/modal.js
+++ b/components/modal.js
@@ -109,6 +109,7 @@ export default function useModal () {
 
   const showModal = useCallback(
     (getContent, options) => {
+      document.activeElement?.blur()
       const ref = { node: getContent(onClose, setOptions), options }
       if (options?.replaceModal) {
         modalStack.current = [ref]


### PR DESCRIPTION
## Description

This fixes this:

https://github.com/user-attachments/assets/c49513c1-6091-4708-87d4-de778d076353

I identified that the issue is that the text input does not lose focus by opening a modal, at least on Safari iOS.

## Video

https://github.com/user-attachments/assets/50ec907a-8966-41ec-b9b5-68ba987c7ab6

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. See video.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no