### PR TITLE
fix: clicking on iOS notification sends to wrong url

### DIFF
--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -135,7 +135,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
     if (SUM_SATS_TAGS.includes(compareTag)) {
       newSats = acc.sats + data.sats
     }
-    const newPayload = { ...data, amount: newAmount, sats: newSats }
+    const newPayload = { ...data, url: acc.url, itemId: acc.itemId, amount: newAmount, sats: newSats }
     return newPayload
   }, { ...incomingData, amount: initialAmount })
 


### PR DESCRIPTION
## Description

Partial fix of #756, 3: (clicking on notification replies sends you to really old threads)

Updates the value of `url` and `itemId` by including incoming payload's `url` and `itemId` in the merged payload.

## Screenshots
before:
```
  // incoming payload options: {"url":"/items/52742?commentId=459565","itemId":459565}
  // merged payload: {"url":"/items/458388?commentId=459556","itemId":459556,"amount":9}
```
after:
```
  // incoming payload.options.data: {"url":"/items/52742?commentId=459570","itemId":459570}
  // merged payload: {"url":"/items/52742?commentId=459570","itemId":459570,"amount":14}
```

## Additional Context

This is part of a series of fixes tracked on #1794 

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6, incoming payload is received correctly, this just updates the url inside the merged payload. Clicking on a merged notification links to the correct `Item`

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No
