### PR TITLE
fix: iOS push subscription gets lost

### DIFF
--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -67,7 +67,7 @@ export function onPush (sw) {
           notifications.filter(({ tag: nTag }) => nTag === tag).forEach(n => n.close())
         }
         log(`[sw:push] ${nid} - show notification with title "${payload.title}"`)
-        return await sw.registration.showNotification(payload.title, payload.options)
+        return event.waitUntil(sw.registration.showNotification(payload.title, payload.options))
       }
 
       // according to the spec, there should only be zero or one notification since we used a tag filter
@@ -77,7 +77,7 @@ export function onPush (sw) {
         log(`[sw:push] ${nid} - no existing ${tag} notifications found`)
         setAppBadge(sw, ++activeCount)
         log(`[sw:push] ${nid} - show notification with title "${payload.title}"`)
-        return await sw.registration.showNotification(payload.title, payload.options)
+        return event.waitUntil(sw.registration.showNotification(payload.title, payload.options))
       }
 
       // handle unexpected case here
@@ -90,7 +90,7 @@ export function onPush (sw) {
         // return null
       }
 
-      return await mergeAndShowNotification(sw, payload, notifications, tag, nid, iOS)
+      return event.waitUntil(mergeAndShowNotification(event, sw, payload, notifications, tag, nid, iOS))
     })())
   }
 }
@@ -100,7 +100,7 @@ export function onPush (sw) {
 const immediatelyShowNotification = (tag) =>
   !tag || ['TIP', 'FORWARDEDTIP', 'EARN', 'STREAK', 'TERRITORY_TRANSFER'].includes(tag.split('-')[0])
 
-const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, nid, iOS) => {
+const mergeAndShowNotification = async (event, sw, payload, currentNotifications, tag, nid, iOS) => {
   // sanity check
   const otherTagNotifications = currentNotifications.filter(({ tag: nTag }) => nTag !== tag)
   if (otherTagNotifications.length > 0) {
@@ -178,7 +178,7 @@ const mergeAndShowNotification = async (sw, payload, currentNotifications, tag, 
 
   const options = { icon: payload.options?.icon, tag, data: { url: '/notifications', ...mergedPayload } }
   log(`[sw:push] ${nid} - show notification with title "${title}"`)
-  return await sw.registration.showNotification(title, options)
+  return event.waitUntil(sw.registration.showNotification(title, options))
 }
 
 export function onNotificationClick (sw) {


### PR DESCRIPTION
## Description

Partial (final) fix of #756, 1: (push notifications continue to be lost #411)

Sometimes an `await showNotification` can be considered as an **hidden push notification** (like those spam websites), when 3 of those gets recognized as 'hidden' consecutively, Apple revokes the subscription.

We need to tell the service worker that the work is finished (sending a notification) and we could do this by using `event.waitUntil`[^1] instead of `await`

This PR aligns showNotification calls with Apple's recommended way, which is `event.waitUntil(showNotification)`.

## Screenshots
n/a

## Additional Context

This measure aligns our service worker with Apple's vision of how push notifications should work and it should be cross-platform. Not having Android I would need some test on it to see if notifications get sent correctly (Chrome didn't have problems)

This is part of a series of fixes tracked on #1794 

Edit: I just found this [comment](https://github.com/stackernews/stacker.news/issues/411#issuecomment-1871399648), which is correct but weirdly enough `return await showNotification` sometimes creates a notification without telling the service worker that it happened, causing a 'silent notification'. 
`event.waitUntil` tells the service worker that work is happening and doesn't return a Promise[^1]
I can be incorrect in evaluating what is happening here

Passing `event` from `onPush` to `mergeAndShowNotification` should ensure that `showNotification` gets done within the same context not violating Apple's requirement

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yesnt, I need to test with Android

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6, tested only on iOS, so far no lost push subscription in a 2-day test environment.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No

[^1]: The ExtendableEvent.waitUntil() method tells the event dispatcher that work is ongoing. It can also be used to detect whether that work was successful. In service workers, waitUntil() tells the browser that work is ongoing until the promise settles, and it shouldn't terminate the service worker if it wants that work to complete.
[waitUntil specification](https://developer.mozilla.org/en-US/docs/Web/API/ExtendableEvent/waitUntil)
