### PR TITLE
Use sats / ccs format in item details

### DIFF
--- a/components/item-info.js
+++ b/components/item-info.js
@@ -252,20 +252,14 @@ function InfoDropdownItem ({ item }) {
           <div>{item.createdAt}</div>
           <div>cost</div>
           <div>{item.cost}</div>
-          <div>sats</div>
-          <div>{item.sats - item.credits}</div>
-          <div>CCs</div>
-          <div>{item.credits}</div>
-          <div>comment sats</div>
-          <div>{item.commentSats - item.commentCredits}</div>
-          <div>comment CCs</div>
-          <div>{item.commentCredits}</div>
+          <div>stacked</div>
+          <div>{item.sats - item.credits} sats / {item.credits} ccs</div>
+          <div>stacked (comments)</div>
+          <div>{item.commentSats - item.commentCredits} sats / {item.commentCredits} ccs</div>
           {me && (
             <>
-              <div>sats from me</div>
-              <div>{item.meSats - item.meCredits}</div>
-              <div>CCs from me</div>
-              <div>{item.meCredits}</div>
+              <div>from me</div>
+              <div>{item.meSats - item.meCredits} sats / {item.meCredits} ccs</div>
               <div>downsats from me</div>
               <div>{item.meDontLikeSats}</div>
             </>

--- a/components/item.module.css
+++ b/components/item.module.css
@@ -164,6 +164,8 @@ a.link:visited {
     display: grid;
     grid-template-columns: auto auto;
     column-gap: 1rem;
+    line-height: 1.25;
+    row-gap: 0.75rem;
 }
 
 /* .itemJob .hunk {


### PR DESCRIPTION
I think this:

![2025-01-05-175920_515x328_scrot](https://github.com/user-attachments/assets/7b93cdc5-7dfa-4a2a-9bae-b9cbafc7f969)

looks better than this:

![2025-01-05-175939_513x401_scrot](https://github.com/user-attachments/assets/570ff9a4-431b-4be7-a25f-66e729fa595d)

On mobile:

![localhost_3000_(iPhone SE) (1)](https://github.com/user-attachments/assets/a6570c1f-310e-4df4-867a-93df1c093436)

![stacker news_(iPhone SE) (1)](https://github.com/user-attachments/assets/57d656c6-b6c8-441c-96ad-627a6e759d92)
