### PR TITLE
Fix job edits

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1434,7 +1434,7 @@ export const updateItem = async (parent, { sub: subName, forward, hash, hmac, ..
   // but forever if an admin is editing an "admin item", it's their bio or a job
   const myBio = user.bioId === old.id
   const timer = Date.now() < datePivot(new Date(old.invoicePaidAt ?? old.createdAt), { seconds: ITEM_EDIT_SECONDS })
-  const canEdit = (timer && ownerEdit) || adminEdit || myBio || isJob(item)
+  const canEdit = (timer && ownerEdit) || adminEdit || myBio || isJob(old)
   if (!canEdit) {
     throw new GqlInputError('item can no longer be edited')
   }


### PR DESCRIPTION
## Description

Fix #1807 

Issue was that we destructured `subName` from `item` so `item.subName` was undefined.

Decided to simply pass `old` as the item to `isJob`.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. Made sure `isJob` now returns `true` for job edits.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no