### PR TITLE
fix: zapping too fast causes duplicate notifications

### DIFF
--- a/api/paidAction/zap.js
+++ b/api/paidAction/zap.js
@@ -206,6 +206,8 @@ export async function nonCriticalSideEffects ({ invoice, actIds }, { models }) {
     where: invoice ? { invoiceId: invoice.id } : { id: { in: actIds } },
     include: { item: true }
   })
+  // avoid duplicate notifications with the same zap amount
+  // by checking if there are any other pending acts on the item
   const pendingActs = await models.itemAct.count({
     where: {
       itemId: itemAct.itemId,

--- a/api/paidAction/zap.js
+++ b/api/paidAction/zap.js
@@ -206,7 +206,15 @@ export async function nonCriticalSideEffects ({ invoice, actIds }, { models }) {
     where: invoice ? { invoiceId: invoice.id } : { id: { in: actIds } },
     include: { item: true }
   })
-  notifyZapped({ models, item: itemAct.item }).catch(console.error)
+  const pendingActs = await models.itemAct.count({
+    where: {
+      itemId: itemAct.itemId,
+      createdAt: {
+        gt: itemAct.createdAt
+      }
+    }
+  })
+  if (pendingActs === 0) notifyZapped({ models, item: itemAct.item }).catch(console.error)
 }
 
 export async function onFail ({ invoice }, { tx }) {


### PR DESCRIPTION
## Description

Fixes #1809
Checks if there are new ItemActs before triggering notifyZapped, avoiding duplicate notifications

## Screenshots
![IMG_69E9C8279350-1](https://github.com/user-attachments/assets/162e4389-02b3-4486-8816-c52e97349fc0)


## Additional Context

n/a

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, sent a lot of zaps really really fast!

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No
