### PR TITLE
bounty updates and auto-rewards refill

### DIFF
--- a/components/info/cc.js
+++ b/components/info/cc.js
@@ -8,7 +8,7 @@ export default function CCInfo (props) {
       <ul className='line-height-md'>
         <li>to receive sats, you must attach an <Link href='/wallets'>external receiving wallet</Link></li>
         <li>zappers may have chosen to send you CCs instead of sats</li>
-        <li>if the zaps are split on post, recepients will receive CCs regardless of their configured receiving wallet</li>
+        <li>if the zaps are split on a post, recepients will receive CCs regardless of their configured receiving wallet</li>
         <li>there could be an issue paying your receiving wallet
           <ul>
             <li>check your <Link href='/wallets/logs'>wallet logs</Link> for clues</li>

--- a/prisma/migrations/20250113233026_weekly_posts_update/migration.sql
+++ b/prisma/migrations/20250113233026_weekly_posts_update/migration.sql
@@ -1,0 +1,37 @@
+CREATE OR REPLACE FUNCTION update_weekly_posts_job()
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+BEGIN
+    UPDATE pgboss.schedule
+    SET data = jsonb_build_object(
+        'title', 'Meme Monday - Best Bitcoin Meme Gets 5,000 CCs',
+        'text',  E'Time for another round of Meme Monday!\n\nWe have another 5,000 CCs up for grabs for this week''s winner.\n\nThe CCs will be given to the stacker with the best Bitcoin meme as voted by the "top" filter on this thread at 10am CT tomorrow.\n\nTo post an image on SN, check out our docs [here](https://stacker.news/faq#how-do-i-post-images-on-stacker-news).\n\nSend your best 👇',
+        'bounty', 5000,
+        'subName', 'memes')
+    WHERE name = 'weeklyPost-meme-mon';
+
+    UPDATE pgboss.schedule
+    SET data = jsonb_build_object(
+        'title', 'What are you working on this week?',
+        'text',  E'Calling all stackers!\n\nLeave a comment below to let the SN community know what you''re working on this week. It doesn''t matter how big or small your project is, or how much progress you''ve made.\n\nJust share what you''re up to, and let the community know if you want any feedback or help.',
+        'subName', 'meta')
+    WHERE name = 'weeklyPost-what-wed';
+
+    UPDATE pgboss.schedule
+    SET data = jsonb_build_object(
+        'title', 'Fun Fact Friday - Best Fun Fact Gets 5,000 CCs',
+        'text',  E'Let''s hear all your best fun facts, any topic counts!\n\nThe best comment as voted by the "top" filter at 10am CT tomorrow gets 5,000 CCs.\n\nBonus CCs for including a source link to your fun fact!\n\nSend your best 👇',
+        'bounty', 5000,
+        'subName', 'meta')
+    WHERE name = 'weeklyPost-fact-fri';
+
+    return 0;
+EXCEPTION WHEN OTHERS THEN
+    return 0;
+END;
+$$;
+
+SELECT update_weekly_posts_job();
+DROP FUNCTION IF EXISTS update_weekly_posts_job;

--- a/prisma/migrations/20250113235235_daily_rewards_refill_job/migration.sql
+++ b/prisma/migrations/20250113235235_daily_rewards_refill_job/migration.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE FUNCTION schedule_daily_rewards_refill_job()
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+BEGIN
+    -- 10 minutes after midnight
+    INSERT INTO pgboss.schedule (name, cron, timezone)
+    VALUES ('earnRefill', '10 0 * * *', 'America/Chicago') ON CONFLICT DO NOTHING;
+    return 0;
+EXCEPTION WHEN OTHERS THEN
+    return 0;
+END;
+$$;
+
+SELECT schedule_daily_rewards_refill_job();
+DROP FUNCTION IF EXISTS schedule_daily_rewards_refill_job;

--- a/worker/earn.js
+++ b/worker/earn.js
@@ -1,6 +1,7 @@
 import { notifyEarner } from '@/lib/webPush'
 import createPrisma from '@/lib/create-prisma'
-import { SN_NO_REWARDS_IDS } from '@/lib/constants'
+import { PAID_ACTION_PAYMENT_METHODS, SN_NO_REWARDS_IDS, USER_ID } from '@/lib/constants'
+import performPaidAction from '@/api/paidAction'
 
 const TOTAL_UPPER_BOUND_MSATS = 1_000_000_000
 
@@ -186,4 +187,16 @@ function earnStmts (data, { models }) {
         stackedMsats: { increment: msats }
       }
     })]
+}
+
+const DAILY_STIMULUS_SATS = 75_000
+export async function earnRefill ({ models, lnd }) {
+  return await performPaidAction('DONATE',
+    { sats: DAILY_STIMULUS_SATS },
+    {
+      models,
+      me: { id: USER_ID.sn },
+      lnd,
+      forcePaymentMethod: PAID_ACTION_PAYMENT_METHODS.FEE_CREDIT
+    })
 }

--- a/worker/index.js
+++ b/worker/index.js
@@ -9,7 +9,7 @@ import {
 } from './wallet'
 import { repin } from './repin'
 import { trust } from './trust'
-import { earn } from './earn'
+import { earn, earnRefill } from './earn'
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client'
 import { indexItem, indexAllItems } from './search'
 import { timestampItem } from './ots'
@@ -129,6 +129,7 @@ async function work () {
   await boss.work('trust', jobWrapper(trust))
   await boss.work('timestampItem', jobWrapper(timestampItem))
   await boss.work('earn', jobWrapper(earn))
+  await boss.work('earnRefill', jobWrapper(earnRefill))
   await boss.work('streak', jobWrapper(computeStreaks))
   await boss.work('checkStreak', jobWrapper(checkStreak))
   await boss.work('nip57', jobWrapper(nip57))

--- a/worker/weeklyPosts.js
+++ b/worker/weeklyPosts.js
@@ -5,7 +5,7 @@ import gql from 'graphql-tag'
 
 export async function autoPost ({ data: item, models, apollo, lnd, boss }) {
   return await performPaidAction('ITEM_CREATE',
-    { ...item, subName: 'meta', userId: USER_ID.sn, apiKey: true },
+    { subName: 'meta', ...item, userId: USER_ID.sn, apiKey: true },
     {
       models,
       me: { id: USER_ID.sn },


### PR DESCRIPTION
Each commit is pretty much its own change. Figure it was easier to review/merge as a package.

Changes:
- typo fix
- bot bounty changes
    - explicitly state CCs
    - reduce to 5k
    - move meme bounty to ~memes (and support `weeklyPosts` jobs being in other territories)
- automate daily rewards
    - add new job trigger every day 10 minutes after midnight to deduct and donate CCs from `@sn` 

QA: 7. I triggered all the weekly posts to confirm the changes worked and reviewed `pgboss.schedule`. For the daily rewards refill, I manually trigger it and it worked.
