### PR TITLE
fix: duplicate push notification on subscribed user and territory

### DIFF
--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -4,6 +4,7 @@ import { COMMENT_DEPTH_LIMIT, FOUND_BLURBS, LOST_BLURBS } from './constants'
 import { msatsToSats, numWithUnits } from './format'
 import models from '@/api/models'
 import { isMuted } from '@/lib/user'
+import { Prisma } from '@prisma/client'
 
 const webPushEnabled = process.env.NODE_ENV === 'production' ||
   (process.env.VAPID_MAILTO && process.env.NEXT_PUBLIC_VAPID_PUBKEY && process.env.VAPID_PRIVKEY)
@@ -123,29 +124,36 @@ export async function replyToSubscription (subscriptionId, notification) {
 export const notifyUserSubscribers = async ({ models, item }) => {
   try {
     const isPost = !!item.title
-    const userSubsExcludingMutes = await models.$queryRawUnsafe(`
-    SELECT "UserSubscription"."followerId", "UserSubscription"."followeeId", users.name as "followeeName"
-    FROM "UserSubscription"
-    INNER JOIN users ON users.id = "UserSubscription"."followeeId"
-    WHERE "followeeId" = $1 AND ${isPost ? '"postsSubscribedAt"' : '"commentsSubscribedAt"'} IS NOT NULL
-    AND NOT EXISTS (SELECT 1 FROM "Mute" WHERE "Mute"."muterId" = "UserSubscription"."followerId" AND "Mute"."mutedId" = $1)
-    -- ignore subscription if user was already notified of item as a reply
-    AND NOT EXISTS (
-      SELECT 1 FROM "Reply"
-      INNER JOIN users follower ON follower.id = "UserSubscription"."followerId"
-      WHERE "Reply"."itemId" = $2
-      AND "Reply"."ancestorUserId" = follower.id
-      AND follower."noteAllDescendants"
-    )
-    -- ignore subscription if user has posted to a territory the recipient is subscribed to
-    AND (${isPost
-      ? `NOT EXISTS (
-        SELECT 1 FROM "SubSubscription"
-        WHERE "SubSubscription"."userId" = "UserSubscription"."followerId"
-        AND "SubSubscription"."subName" = $3
-      )`
-      : 'TRUE'})
-    `, Number(item.userId), Number(item.id), isPost && item.subName)
+
+    const userSubsExcludingMutes = await models.$queryRaw`
+      SELECT "UserSubscription"."followerId", "UserSubscription"."followeeId", users.name as "followeeName"
+      FROM "UserSubscription"
+      INNER JOIN users ON users.id = "UserSubscription"."followeeId"
+      WHERE "followeeId" = ${Number(item.userId)}::INTEGER
+        AND ${isPost ? Prisma.sql`"postsSubscribedAt"` : Prisma.sql`"commentsSubscribedAt"`} IS NOT NULL
+        -- ignore muted users
+        AND NOT EXISTS (
+          SELECT 1
+          FROM "Mute"
+          WHERE "Mute"."muterId" = "UserSubscription"."followerId"
+          AND "Mute"."mutedId" = ${Number(item.userId)}::INTEGER)
+        -- ignore subscription if user was already notified of item as a reply
+        AND NOT EXISTS (
+          SELECT 1 FROM "Reply"
+          INNER JOIN users follower ON follower.id = "UserSubscription"."followerId"
+          WHERE "Reply"."itemId" = ${Number(item.id)}::INTEGER
+          AND "Reply"."ancestorUserId" = follower.id
+          AND follower."noteAllDescendants"
+        )
+        -- ignore subscription if user has posted to a territory the recipient is subscribed to
+        ${isPost
+          ? Prisma.sql`AND NOT EXISTS (
+            SELECT 1
+            FROM "SubSubscription"
+            WHERE "SubSubscription"."userId" = "UserSubscription"."followerId"
+            AND "SubSubscription"."subName" = ${item.subName}
+          )`
+          : Prisma.empty}`
     const subType = isPost ? 'POST' : 'COMMENT'
     const tag = `FOLLOW-${item.userId}-${subType}`
     await Promise.allSettled(userSubsExcludingMutes.map(({ followerId, followeeName }) => sendUserNotification(followerId, {

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -138,13 +138,14 @@ export const notifyUserSubscribers = async ({ models, item }) => {
       AND follower."noteAllDescendants"
     )
     -- ignore subscription if user has posted to a territory the recipient is subscribed to
-    AND NOT EXISTS (
-      SELECT 1 FROM "SubSubcription"
-      INNER JOIN "Item" ON "Item"."subName" = "SubSubscription"."subName"
-      WHERE "SubSubscription"."userId" = "UserSubscription"."followerId"
-      AND "Item"."userId" = $1
-    )
-    `, Number(item.userId), Number(item.id))
+    AND (${isPost
+      ? `NOT EXISTS (
+        SELECT 1 FROM "SubSubscription"
+        WHERE "SubSubscription"."userId" = "UserSubscription"."followerId"
+        AND "SubSubscription"."subName" = $3
+      )`
+      : 'TRUE'})
+    `, Number(item.userId), Number(item.id), isPost && item.subName)
     const subType = isPost ? 'POST' : 'COMMENT'
     const tag = `FOLLOW-${item.userId}-${subType}`
     await Promise.allSettled(userSubsExcludingMutes.map(({ followerId, followeeName }) => sendUserNotification(followerId, {

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -137,6 +137,13 @@ export const notifyUserSubscribers = async ({ models, item }) => {
       AND "Reply"."ancestorUserId" = follower.id
       AND follower."noteAllDescendants"
     )
+    -- ignore subscription if user has posted to a territory the recipient is subscribed to
+    AND NOT EXISTS (
+      SELECT 1 FROM "SubSubcription"
+      INNER JOIN "Item" ON "Item"."subName" = "SubSubscription"."subName"
+      WHERE "SubSubscription"."userId" = "UserSubscription"."followerId"
+      AND "Item"."userId" = $1
+    )
     `, Number(item.userId), Number(item.id))
     const subType = isPost ? 'POST' : 'COMMENT'
     const tag = `FOLLOW-${item.userId}-${subType}`


### PR DESCRIPTION
## Description

Fixes #1819 
Adds a condition to the `notifyUserSubscribers`' query, ensuring that a push notification is not sent if the subscribed user has posted in a territory the recipient is subscribed to, avoiding duplicate notifications.

## Screenshots
before:
![Image](https://github.com/user-attachments/assets/38fc78ac-a6d5-4b3b-b59b-9eefa3e89a88)

after:
![Image](https://github.com/user-attachments/assets/a39d2807-bc3e-40a3-822d-8c9354754d65)

## Additional Context
n/a

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
9, tested with userA and userB, the latter creating an Item in a territory user A is subscribed to

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No