### PR TITLE
Update forward limits

### DIFF
--- a/wallets/wrap.js
+++ b/wallets/wrap.js
@@ -2,8 +2,8 @@ import { createHodlInvoice, parsePaymentRequest } from 'ln-service'
 import { estimateRouteFee, getBlockHeight } from '../api/lnd'
 import { toBigInt, toPositiveBigInt, toPositiveNumber } from '@/lib/format'
 
-const MIN_OUTGOING_MSATS = BigInt(900) // the minimum msats we'll allow for the outgoing invoice
-const MAX_OUTGOING_MSATS = BigInt(900_000_000) // the maximum msats we'll allow for the outgoing invoice
+const MIN_OUTGOING_MSATS = BigInt(700) // the minimum msats we'll allow for the outgoing invoice
+const MAX_OUTGOING_MSATS = BigInt(700_000_000) // the maximum msats we'll allow for the outgoing invoice
 const MAX_EXPIRATION_INCOMING_MSECS = 900_000 // the maximum expiration time we'll allow for the incoming invoice
 const INCOMING_EXPIRATION_BUFFER_MSECS = 300_000 // the buffer enforce for the incoming invoice expiration
 const MAX_OUTGOING_CLTV_DELTA = 1000 // the maximum cltv delta we'll allow for the outgoing invoice


### PR DESCRIPTION
## Description

Node runners with a private channel to SN can not receive 1 sat payments because the forward limit is set to 900 msats but we deduct 30% instead of 10% from each zap since a while.

## Screenshots

![2025-01-18-095033_719x801_scrot](https://github.com/user-attachments/assets/4fc99ccc-0404-4b82-82a3-995873d06fc8)

## Additional context

it should probably say "incoming payment: 700 msats" instead of rounding to 0 sats for amounts < 1 sat.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`0`. Did not test but change looks good to me

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no