### PR TITLE
fix: uncaught promise on getOS causes event to end early

### DIFF
--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -236,7 +236,7 @@ export function onMessage (sw) {
       messageChannelPort = event.ports[0]
     }
     log('[sw:message] received message', 'info', { action: event.data.action })
-    const currentOS = await getOS()
+    const currentOS = event.waitUntil(getOS())
     log('[sw:message] stored os: ' + currentOS, 'info', { action: event.data.action })
     if (event.data.action === STORE_SUBSCRIPTION) {
       log('[sw:message] storing subscription in IndexedDB', 'info', { endpoint: event.data.subscription.endpoint })
@@ -253,8 +253,8 @@ export function onMessage (sw) {
       promises.push(sw.registration.getNotifications().then((notifications) => {
         notifications.forEach(notification => notification.close())
       }))
-      activeCount = 0
       promises.push(clearAppBadge(sw))
+      activeCount = 0
       event.waitUntil(Promise.all(promises))
     }
   }


### PR DESCRIPTION
## Description

Fixes #1822 
By forgetting that getOS was asynchronous, I was causing the event to end earlier than expected, creating an InvalidStateError.
Extending the event's lifetime with event.waitUntil on getOS fixed this behavior.

## Screenshots
n/a

## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_
n/a

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8, no errors show up on console anymore, notifications works as usual

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No