### PR TITLE
normalized wallet logs

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -767,9 +767,8 @@ const resolvers = {
         }
       }
 
-      if (invoice) {
-        return await logContextFromBolt11(invoice.bolt11)
-      }
+      // XXX never return invoice as context because it might leak sensitive sender details
+      // if (invoice) { ... }
 
       return context
     }

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -745,10 +745,44 @@ const resolvers = {
       return item
     },
     sats: fact => msatsToSatsDecimal(fact.msats)
+  },
+
+  WalletLogEntry: {
+    context: async ({ level, context, invoiceId, withdrawalId }, args, { models }) => {
+      const isError = ['error', 'warn'].includes(level.toLowerCase())
+
+      if (withdrawalId) {
+        const wdrwl = await models.withdrawl.findUnique({ where: { id: withdrawalId } })
+        return {
+          ...await logContextFromBolt11(wdrwl.bolt11),
+          ...(wdrwl.preimage ? { preimage: wdrwl.preimage } : {}),
+          ...(isError ? { max_fee: formatMsats(wdrwl.msatsFeePaying) } : {})
+        }
+      }
+
+      if (invoiceId) {
+        const inv = await models.invoice.findUnique({ where: { id: invoiceId } })
+        return await logContextFromBolt11(inv.bolt11)
+      }
+
+      return context
+    }
   }
 }
 
 export default injectResolvers(resolvers)
+
+const logContextFromBolt11 = async (bolt11) => {
+  const decoded = await parsePaymentRequest({ request: bolt11 })
+  return {
+    bolt11,
+    amount: formatMsats(decoded.mtokens),
+    payment_hash: decoded.id,
+    created_at: decoded.created_at,
+    expires_at: decoded.expires_at,
+    description: decoded.description
+  }
+}
 
 export const walletLogger = ({ wallet, models }) => {
   // no-op logger if wallet is not provided
@@ -762,23 +796,17 @@ export const walletLogger = ({ wallet, models }) => {
   }
 
   // server implementation of wallet logger interface on client
-  const log = (level) => async (message, context = {}) => {
+  const log = (level) => async (message, ctx = {}) => {
     try {
-      if (context?.bolt11) {
+      let { invoiceId, withdrawalId, ...context } = ctx
+
+      if (context.bolt11) {
         // automatically populate context from bolt11 to avoid duplicating this code
-        const decoded = await parsePaymentRequest({ request: context.bolt11 })
         context = {
           ...context,
-          amount: formatMsats(decoded.mtokens),
-          payment_hash: decoded.id,
-          created_at: decoded.created_at,
-          expires_at: decoded.expires_at,
-          description: decoded.description,
-          // payments should affect wallet status
-          status: true
+          ...await logContextFromBolt11(context.bolt11)
         }
       }
-      context.recv = true
 
       await models.walletLog.create({
         data: {
@@ -786,7 +814,9 @@ export const walletLogger = ({ wallet, models }) => {
           wallet: wallet.type,
           level,
           message,
-          context
+          context,
+          invoiceId,
+          withdrawalId
         }
       })
     } catch (err) {

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -430,6 +430,10 @@ const resolvers = {
               lte: to ? new Date(Number(to)) : undefined
             }
           },
+          include: {
+            invoice: true,
+            withdrawal: true
+          },
           orderBy: [
             { createdAt: 'desc' },
             { id: 'desc' }
@@ -444,6 +448,10 @@ const resolvers = {
             createdAt: {
               lte: decodedCursor.time
             }
+          },
+          include: {
+            invoice: true,
+            withdrawal: true
           },
           orderBy: [
             { createdAt: 'desc' },
@@ -748,21 +756,19 @@ const resolvers = {
   },
 
   WalletLogEntry: {
-    context: async ({ level, context, invoiceId, withdrawalId }, args, { models }) => {
+    context: async ({ level, context, invoice, withdrawal }, args, { models }) => {
       const isError = ['error', 'warn'].includes(level.toLowerCase())
 
-      if (withdrawalId) {
-        const wdrwl = await models.withdrawl.findUnique({ where: { id: withdrawalId } })
+      if (withdrawal) {
         return {
-          ...await logContextFromBolt11(wdrwl.bolt11),
-          ...(wdrwl.preimage ? { preimage: wdrwl.preimage } : {}),
-          ...(isError ? { max_fee: formatMsats(wdrwl.msatsFeePaying) } : {})
+          ...await logContextFromBolt11(withdrawal.bolt11),
+          ...(withdrawal.preimage ? { preimage: withdrawal.preimage } : {}),
+          ...(isError ? { max_fee: formatMsats(withdrawal.msatsFeePaying) } : {})
         }
       }
 
-      if (invoiceId) {
-        const inv = await models.invoice.findUnique({ where: { id: invoiceId } })
-        return await logContextFromBolt11(inv.bolt11)
+      if (invoice) {
+        return await logContextFromBolt11(invoice.bolt11)
       }
 
       return context

--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -239,7 +239,13 @@ export function useWalletLogs (wallet, initialPage = 1, logsPerPage = 10) {
       const newLogs = data.walletLogs.entries.map(({ createdAt, wallet: walletType, ...log }) => ({
         ts: +new Date(createdAt),
         wallet: walletTag(getWalletByType(walletType)),
-        ...log
+        ...log,
+        // required to resolve recv status
+        context: {
+          recv: true,
+          status: !!log.context?.bolt11 && ['warn', 'error', 'success'].includes(log.level.toLowerCase()),
+          ...log.context
+        }
       }))
       const combinedLogs = uniqueSort([...result.data, ...newLogs])
 

--- a/prisma/migrations/20250118192921_normalized_wallet_logs/migration.sql
+++ b/prisma/migrations/20250118192921_normalized_wallet_logs/migration.sql
@@ -4,3 +4,5 @@ ALTER TABLE "WalletLog"
 
 ALTER TABLE "WalletLog" ADD CONSTRAINT "WalletLog_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 ALTER TABLE "WalletLog" ADD CONSTRAINT "WalletLog_withdrawalId_fkey" FOREIGN KEY ("withdrawalId") REFERENCES "Withdrawl"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+TRUNCATE "WalletLog" RESTRICT;

--- a/prisma/migrations/20250118192921_normalized_wallet_logs/migration.sql
+++ b/prisma/migrations/20250118192921_normalized_wallet_logs/migration.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "WalletLog"
+    ADD COLUMN     "invoiceId" INTEGER,
+    ADD COLUMN     "withdrawalId" INTEGER;
+
+ALTER TABLE "WalletLog" ADD CONSTRAINT "WalletLog_invoiceId_fkey" FOREIGN KEY ("invoiceId") REFERENCES "Invoice"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "WalletLog" ADD CONSTRAINT "WalletLog_withdrawalId_fkey" FOREIGN KEY ("withdrawalId") REFERENCES "Withdrawl"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -264,14 +264,18 @@ model VaultEntry {
 }
 
 model WalletLog {
-  id        Int        @id @default(autoincrement())
-  createdAt DateTime   @default(now()) @map("created_at")
-  userId    Int
-  user      User       @relation(fields: [userId], references: [id], onDelete: Cascade)
-  wallet    WalletType
-  level     LogLevel
-  message   String
-  context   Json?      @db.JsonB
+  id           Int        @id @default(autoincrement())
+  createdAt    DateTime   @default(now()) @map("created_at")
+  userId       Int
+  user         User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+  wallet       WalletType
+  level        LogLevel
+  message      String
+  invoiceId    Int?
+  invoice      Invoice?   @relation(fields: [invoiceId], references: [id])
+  withdrawalId Int?
+  withdrawal   Withdrawl? @relation(fields: [withdrawalId], references: [id])
+  context      Json?      @db.JsonB
 
   @@index([userId, createdAt])
 }
@@ -971,6 +975,7 @@ model Invoice {
   Upload             Upload[]
   PollVote           PollVote[]
   PollBlindVote      PollBlindVote[]
+  WalletLog          WalletLog[]
 
   @@index([createdAt], map: "Invoice.created_at_index")
   @@index([userId], map: "Invoice.userId_index")
@@ -1048,6 +1053,7 @@ model Withdrawl {
   user           User             @relation(fields: [userId], references: [id], onDelete: Cascade)
   wallet         Wallet?          @relation(fields: [walletId], references: [id], onDelete: SetNull)
   invoiceForward InvoiceForward?
+  WalletLog      WalletLog[]
 
   @@index([createdAt], map: "Withdrawl.created_at_index")
   @@index([userId], map: "Withdrawl.userId_index")

--- a/wallets/server.js
+++ b/wallets/server.js
@@ -39,8 +39,7 @@ export async function * createUserInvoice (userId, { msats, description, descrip
 
     try {
       logger.info(
-        `↙ incoming payment: ${formatSats(msatsToSats(msats))}`,
-        {
+        `↙ incoming payment: ${formatSats(msatsToSats(msats))}`, {
           amount: formatMsats(msats)
         })
 

--- a/worker/paidAction.js
+++ b/worker/paidAction.js
@@ -443,6 +443,7 @@ export async function paidActionCanceling ({ data: { invoiceId, ...args }, model
       const decoded = await parsePaymentRequest({ request: bolt11 })
       logger.info(
         `invoice for ${formatSats(msatsToSats(decoded.mtokens))} canceled by payer`, {
+          bolt11,
           invoiceId: transitionedInvoice.id
         })
     }

--- a/worker/payingAction.js
+++ b/worker/payingAction.js
@@ -125,11 +125,8 @@ export async function payingActionConfirmed ({ data: args, models, lnd, boss }) 
 
     const logger = walletLogger({ models, wallet: transitionedWithdrawal.wallet })
     logger?.ok(
-      `↙ payment received: ${formatSats(msatsToSats(transitionedWithdrawal.msatsPaid))}`,
-      {
-        bolt11: transitionedWithdrawal.bolt11,
-        preimage: transitionedWithdrawal.preimage,
-        fee: formatMsats(transitionedWithdrawal.msatsFeePaid)
+      `↙ payment received: ${formatSats(msatsToSats(transitionedWithdrawal.msatsPaid))}`, {
+        withdrawalId: transitionedWithdrawal.id
       })
   }
 }


### PR DESCRIPTION
## Description

We want to normalize the wallet logs. They currently don't link to invoices or withdrawals via foreign keys but store all the data in the JSON `context` column.

~However, afaict, we can't get rid of `context` entirely since either a) the data we want to show is unrelated to an invoice or b) the invoice was not created yet.~

~**update:** Decided to drop the `context` column anyway to keep it simple. If we really need some information, we can add it back or save it in a relational way.~

**update:** Realized we would lose `created invoice for X sats` log messages. We log them when we just fetched a user invoice before they get wrapped. Since wrapping can fail, this would mean we would show an error without having shown that we created an invoice.

There are and will most likely be more cases like this so I decided to keep the `context` column.

So all this PR does is to add the link to the invoice/withdrawal if we already have an invoice/withdrawal id and resolve the context from this link instead of from the JSON column.

TODO:

- [x] resolve context fields required by frontend
- [x] ~refactor context in frontend?~ _will completely remove client logs in the future and move them to server, too_

Regression tests:

- [x] test wallet status derived from logs
- [x] test log messages still show same information in frontend

## Additional Context

To not use the JSON column if not necessary, I now also resolve `context.status` and `context.recv` (needed for wallet status) from the existing information instead of saving it.

In a future PR, I will replace the logic to derive status with two status column on the `Wallet` table anyway.  

## Checklist

**Are your changes backwards compatible? Please answer below:**

maybe, but I didn't test and we don't care so we just truncate the table

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested successful/failed autowithdrawals, successful/failed p2p zaps (forward error, wrap error) and sending payments (even though sender logs were not changed at all) 

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no