### PR TITLE
Remove msats warning

### DIFF
--- a/wallets/server.js
+++ b/wallets/server.js
@@ -66,8 +66,6 @@ export async function createInvoice (userId, { msats, description, descriptionHa
         if (BigInt(msats) - BigInt(bolt11.mtokens) >= 1000n) {
           throw new Error('invoice invalid: amount too small')
         }
-
-        logger.warn('wallet does not support msats')
       }
 
       return { invoice, wallet, logger }


### PR DESCRIPTION
## Description

This warning has been confusing for many stackers. I think we should remove it since there's nothing one can do and it's not very relevant.

It's nice to make them aware that they are missing out on some msats for each zap, but I think the logs aren't the place for it. Maybe in some other form in the future. 