### PR TITLE
fix: allow downzapping of pinned posts

### DIFF
--- a/components/item-info.js
+++ b/components/item-info.js
@@ -193,8 +193,7 @@ export default function ItemInfo ({
               )}
               {item && item.mine && !item.noteId && !item.isJob && !item.parentId &&
                 <CrosspostDropdownItem item={item} />}
-              {me && !item.position &&
-            !item.mine && !item.deletedAt &&
+              {me && !item.mine && !item.deletedAt &&
             (item.meDontLikeSats > meSats
               ? <DropdownItemUpVote item={item} />
               : <DontLikeThisDropdownItem item={item} />)}


### PR DESCRIPTION
## Description

Fixes #1692
Removes `!item.position` from downzap condition allowing downzapping on pinned posts

## Screenshots
Downzappable
<img width="496" alt="image" src="https://github.com/user-attachments/assets/13189d3a-aa5f-444a-b4de-bdd77c2c8ff0" />

After downzapping
<img width="494" alt="image" src="https://github.com/user-attachments/assets/c825ff8d-5730-4372-8d65-9999d6eb2ecc" />

## Additional Context

n/a

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, tested on pinned posts without sub and with sub

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No