### PR TITLE
Fix missing push notifications for thread subscriptions

### DIFF
--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -1,5 +1,5 @@
 import { ANON_ITEM_SPAM_INTERVAL, ITEM_SPAM_INTERVAL, PAID_ACTION_PAYMENT_METHODS, USER_ID } from '@/lib/constants'
-import { notifyItemMention, notifyItemParents, notifyMention, notifyTerritorySubscribers, notifyUserSubscribers } from '@/lib/webPush'
+import { notifyItemMention, notifyItemParents, notifyMention, notifyTerritorySubscribers, notifyUserSubscribers, notifyThreadSubscribers } from '@/lib/webPush'
 import { getItemMentions, getMentions, performBotBehavior } from './lib/item'
 import { msatsToSats, satsToMsats } from '@/lib/format'
 import { GqlInputError } from '@/lib/error'
@@ -269,6 +269,7 @@ export async function nonCriticalSideEffects ({ invoice, id }, { models }) {
 
   notifyUserSubscribers({ models, item }).catch(console.error)
   notifyTerritorySubscribers({ models, item }).catch(console.error)
+  notifyThreadSubscribers({ models, item }).catch(console.error)
 }
 
 export async function onFail ({ invoice }, { tx }) {

--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -259,6 +259,7 @@ export async function nonCriticalSideEffects ({ invoice, id }, { models }) {
 
   if (item.parentId) {
     notifyItemParents({ item, models }).catch(console.error)
+    notifyThreadSubscribers({ models, item }).catch(console.error)
   }
   for (const { userId } of item.mentions) {
     notifyMention({ models, item, userId }).catch(console.error)
@@ -269,7 +270,6 @@ export async function nonCriticalSideEffects ({ invoice, id }, { models }) {
 
   notifyUserSubscribers({ models, item }).catch(console.error)
   notifyTerritorySubscribers({ models, item }).catch(console.error)
-  notifyThreadSubscribers({ models, item }).catch(console.error)
 }
 
 export async function onFail ({ invoice }, { tx }) {

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -202,6 +202,39 @@ export const notifyTerritorySubscribers = async ({ models, item }) => {
   }
 }
 
+export const notifyThreadSubscribers = async ({ models, item }) => {
+  try {
+    // thread subscription notifications are only sent for replies
+    if (item.title) return
+
+    const subscribers = await models.$queryRaw`
+      SELECT DISTINCT "ThreadSubscription"."userId" FROM "ThreadSubscription"
+      JOIN users ON users.id = "ThreadSubscription"."userId"
+      JOIN "Reply" r ON "ThreadSubscription"."itemId" = r."ancestorId"
+      WHERE r."itemId" = ${item.id}
+      -- don't send notifications for own items
+      AND r."userId" <> "ThreadSubscription"."userId"
+      -- send notifications for all levels?
+      AND CASE WHEN users."noteAllDescendants" THEN TRUE ELSE r.level = 1 END`
+
+    const author = await models.user.findUnique({ where: { id: item.userId } })
+
+    await Promise.allSettled(subscribers.map(({ userId }) =>
+      sendUserNotification(userId, {
+        // we reuse the same payload as for user subscriptions because they use the same title+body we want to use here
+        // so we should also merge them together (= same tag+data) to avoid confusion
+        title: `@${author.name} replied to a post`,
+        body: item.text,
+        item,
+        data: { followeeName: author.name, subType: 'COMMENT' },
+        tag: `FOLLOW-${author.id}-COMMENT`
+      })
+    ))
+  } catch (err) {
+    console.error(err)
+  }
+}
+
 export const notifyItemParents = async ({ models, item }) => {
   try {
     const user = await models.user.findUnique({ where: { id: item.userId } })

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -204,6 +204,8 @@ export const notifyTerritorySubscribers = async ({ models, item }) => {
 
 export const notifyThreadSubscribers = async ({ models, item }) => {
   try {
+    const author = await models.user.findUnique({ where: { id: item.userId } })
+
     const subscribers = await models.$queryRaw`
       SELECT DISTINCT "ThreadSubscription"."userId" FROM "ThreadSubscription"
       JOIN users ON users.id = "ThreadSubscription"."userId"
@@ -214,9 +216,13 @@ export const notifyThreadSubscribers = async ({ models, item }) => {
       -- send notifications for all levels?
       AND CASE WHEN users."noteAllDescendants" THEN TRUE ELSE r.level = 1 END
       -- muted?
-      AND NOT EXISTS (SELECT 1 FROM "Mute" m WHERE m."muterId" = users.id AND m."mutedId" = r."userId")`
-
-    const author = await models.user.findUnique({ where: { id: item.userId } })
+      AND NOT EXISTS (SELECT 1 FROM "Mute" m WHERE m."muterId" = users.id AND m."mutedId" = r."userId")
+      -- already received notification as reply to self?
+      AND NOT EXISTS (
+        SELECT 1 FROM "Item" i
+        JOIN "Item" p ON p.path @> i.path
+        WHERE i.id = ${item.parentId} AND p."userId" = "ThreadSubscription"."userId" AND users."noteAllDescendants"
+      )`
 
     await Promise.allSettled(subscribers.map(({ userId }) =>
       sendUserNotification(userId, {

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -204,9 +204,6 @@ export const notifyTerritorySubscribers = async ({ models, item }) => {
 
 export const notifyThreadSubscribers = async ({ models, item }) => {
   try {
-    // thread subscription notifications are only sent for replies
-    if (item.title) return
-
     const subscribers = await models.$queryRaw`
       SELECT DISTINCT "ThreadSubscription"."userId" FROM "ThreadSubscription"
       JOIN users ON users.id = "ThreadSubscription"."userId"

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -212,7 +212,9 @@ export const notifyThreadSubscribers = async ({ models, item }) => {
       -- don't send notifications for own items
       AND r."userId" <> "ThreadSubscription"."userId"
       -- send notifications for all levels?
-      AND CASE WHEN users."noteAllDescendants" THEN TRUE ELSE r.level = 1 END`
+      AND CASE WHEN users."noteAllDescendants" THEN TRUE ELSE r.level = 1 END
+      -- muted?
+      AND NOT EXISTS (SELECT 1 FROM "Mute" m WHERE m."muterId" = users.id AND m."mutedId" = r."userId")`
 
     const author = await models.user.findUnique({ where: { id: item.userId } })
 


### PR DESCRIPTION
## Description

I subscribed to a post and I expected to receive push notifications but I didn't because we don't send any.

Turns out we likely never had push notifications for thread subscriptions afaict. At least I couldn't find a commit where we had them using `git log -S "ThreadSubscription"`.

This PR adds push notifications for these. It sends the same push notification as if you subscribed to the user that replied to the post you subscribed to because that's the same notification format I was going for.

It also makes sure that you only receive push notifications for stuff you would also find in your notifications by considering `users."noteAllDescendants"`:

push notifications:

```sql
-- send notifications for all levels?
AND CASE WHEN users."noteAllDescendants" THEN TRUE ELSE r.level = 1 END
```

notifications page:

https://github.com/stackernews/stacker.news/blob/b28407ee99fc68db91abe2cf99983a073ccece1d/api/resolvers/notifications.js#L88

TODO:

- [x] fix mutes not considered
- [x] fix duplicate push notification (thread subscription + reply)

## Additional Context

- Seems like `Reply.ancestorId` should have been called `Reply.rootId`
- https://github.com/stackernews/stacker.news/issues/1844

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested by subscribing to a post, and then replying to it with anon on different levels, muting anon and disabling `noteAllDescendants` setting

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no