### PR TITLE
Add createrune info for v24.11

### DIFF
--- a/wallets/cln/index.js
+++ b/wallets/cln/index.js
@@ -21,7 +21,12 @@ export const fields = [
     name: 'rune',
     label: 'invoice only rune',
     help: {
-      text: 'We only accept runes that *only* allow `method=invoice`.\nRun this to generate one:\n\n```lightning-cli createrune restrictions=\'["method=invoice"]\'```'
+      text: 'We only accept runes that *only* allow `method=invoice`.\n\n' +
+      'Run this if you are on v23.08 to generate one:\n\n' +
+      '```lightning-cli createrune restrictions=\'["method=invoice"]\'```\n\n' +
+      'Or this if you are on v24.11 or later:\n\n' +
+      '```lightning-cli createrune restrictions=\'[["method=invoice"]]\'```\n\n' +
+      '[see `createrune` documentation](https://docs.corelightning.org/reference/lightning-createrune#restriction-format)'
     },
     type: 'text',
     placeholder: 'S34KtUW-6gqS_hD_9cc_PNhfF-NinZyBOCgr1aIrark9NCZtZXRob2Q9aW52b2ljZQ==',


### PR DESCRIPTION
## Description

Fix #1846 

## Screenshots

![2025-01-25-230018_1918x1177_scrot](https://github.com/user-attachments/assets/518a3965-e7b7-4ba9-864f-61d1d58ea475)

## Additional Context

the line break for the v24.11+ command looks bad

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested both commands myself.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

![2025-01-25-225718_1920x1200_scrot](https://github.com/user-attachments/assets/b4883eda-c1f1-4c44-ab65-fd43403ec3cc)

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no