### PR TITLE
Update price button accessibility in header

### DIFF
--- a/components/header.module.css
+++ b/components/header.module.css
@@ -110,3 +110,14 @@
     background-color: var(--bs-body-bg);
     z-index: 1000;
 }
+
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}

--- a/components/header.module.css
+++ b/components/header.module.css
@@ -110,14 +110,3 @@
     background-color: var(--bs-body-bg);
     z-index: 1000;
 }
-
-.visually-hidden {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    border: 0;
-}

--- a/components/price.js
+++ b/components/price.js
@@ -44,6 +44,15 @@ export function PriceProvider ({ price, children }) {
   )
 }
 
+function AccessibleButton ({ id, description, children, ...props }) {
+  return (
+    <div>
+      <button {...props} aria-describedby={id}>{children}</button>
+      <div id={id} className='visually-hidden'>{description}</div>
+    </div>
+  )
+}
+
 export default function Price ({ className }) {
   const [selection, handleClick] = usePriceCarousel()
 
@@ -56,71 +65,53 @@ export default function Price ({ className }) {
   if (selection === 'yep') {
     if (!price || price < 0) return null
     return (
-      <div>
-        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='yep-hint'>
-          {fixedDecimal(100000000 / price, 0) + ` sats/${fiatSymbol}`}
-        </button>
-        <div id='yep-hint' className='visually-hidden'>Show 1 satoshi equals 1 satoshi</div>
-      </div>
+      <AccessibleButton id='yep-hint' description='Show 1 satoshi equals 1 satoshi' className={compClassName} onClick={handleClick} variant='link'>
+        {fixedDecimal(100000000 / price, 0) + ` sats/${fiatSymbol}`}
+      </AccessibleButton>
     )
   }
 
   if (selection === '1btc') {
     return (
-      <div>
-        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='1btc-hint'>
-          1sat=1sat
-        </button>
-        <div id='1btc-hint' className='visually-hidden'>Show blockheight</div>
-      </div>
+      <AccessibleButton id='1btc-hint' description='Show blockheight' className={compClassName} onClick={handleClick} variant='link'>
+        1sat=1sat
+      </AccessibleButton>
     )
   }
 
   if (selection === 'blockHeight') {
     if (blockHeight <= 0) return null
     return (
-      <div>
-        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='blockHeight-hint'>
-          {blockHeight}
-        </button>
-        <div id='blockHeight-hint' className='visually-hidden'>Show fee rate</div>
-      </div>
+      <AccessibleButton id='blockHeight-hint' description='Show fee rate' className={compClassName} onClick={handleClick} variant='link'>
+        {blockHeight}
+      </AccessibleButton>
     )
   }
 
   if (selection === 'halving') {
     if (!halving) return null
     return (
-      <div>
-        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='halving-hint'>
-          <CompactLongCountdown date={halving} />
-        </button>
-        <div id='halving-hint' className='visually-hidden'>Show fiat price</div>
-      </div>
+      <AccessibleButton id='halving-hint' description='Show fiat price' className={compClassName} onClick={handleClick} variant='link'>
+        <CompactLongCountdown date={halving} />
+      </AccessibleButton>
     )
   }
 
   if (selection === 'chainFee') {
     if (chainFee <= 0) return null
     return (
-      <div>
-        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='chainFee-hint'>
-          {chainFee} sat/vB
-        </button>
-        <div id='chainFee-hint' className='visually-hidden'>Show time until halving</div>
-      </div>
+      <AccessibleButton id='chainFee-hint' description='Show time until halving' className={compClassName} onClick={handleClick} variant='link'>
+        {chainFee} sat/vB
+      </AccessibleButton>
     )
   }
 
   if (selection === 'fiat') {
     if (!price || price < 0) return null
     return (
-      <div>
-        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='fiat-hint'>
-          {fiatSymbol + fixedDecimal(price, 0)}
-        </button>
-        <div id='fiat-hint' className='visually-hidden'>Show price in satoshis per fiat unit</div>
-      </div>
+      <AccessibleButton id='fiat-hint' description='Show price in satoshis per fiat unit' className={compClassName} onClick={handleClick} variant='link'>
+        {fiatSymbol + fixedDecimal(price, 0)}
+      </AccessibleButton>
     )
   }
 }

--- a/components/price.js
+++ b/components/price.js
@@ -56,53 +56,53 @@ export default function Price ({ className }) {
   if (selection === 'yep') {
     if (!price || price < 0) return null
     return (
-      <div className={compClassName} onClick={handleClick} variant='link'>
+      <button className={compClassName} onClick={handleClick} variant='link' aria-label='Show 1 satoshi equals 1 satoshi'>
         {fixedDecimal(100000000 / price, 0) + ` sats/${fiatSymbol}`}
-      </div>
+      </button>
     )
   }
 
   if (selection === '1btc') {
     return (
-      <div className={compClassName} onClick={handleClick} variant='link'>
+      <button className={compClassName} onClick={handleClick} variant='link' aria-label='Show blockheight'>
         1sat=1sat
-      </div>
+      </button>
     )
   }
 
   if (selection === 'blockHeight') {
     if (blockHeight <= 0) return null
     return (
-      <div className={compClassName} onClick={handleClick} variant='link'>
+      <button className={compClassName} onClick={handleClick} variant='link' aria-label='Show fee rate'>
         {blockHeight}
-      </div>
+      </button>
     )
   }
 
   if (selection === 'halving') {
     if (!halving) return null
     return (
-      <div className={compClassName} onClick={handleClick} variant='link'>
+      <button className={compClassName} onClick={handleClick} variant='link' aria-label='Show fiat price'>
         <CompactLongCountdown date={halving} />
-      </div>
+      </button>
     )
   }
 
   if (selection === 'chainFee') {
     if (chainFee <= 0) return null
     return (
-      <div className={compClassName} onClick={handleClick} variant='link'>
+      <button className={compClassName} onClick={handleClick} variant='link' aria-label='Show time until halving'>
         {chainFee} sat/vB
-      </div>
+      </button>
     )
   }
 
   if (selection === 'fiat') {
     if (!price || price < 0) return null
     return (
-      <div className={compClassName} onClick={handleClick} variant='link'>
+      <button className={compClassName} onClick={handleClick} variant='link' aria-label='Show price in satoshis per fiat unit'>
         {fiatSymbol + fixedDecimal(price, 0)}
-      </div>
+      </button>
     )
   }
 }

--- a/components/price.js
+++ b/components/price.js
@@ -57,7 +57,7 @@ export default function Price ({ className }) {
     if (!price || price < 0) return null
     return (
       <div>
-        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby="yep-hint">
+        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='yep-hint'>
           {fixedDecimal(100000000 / price, 0) + ` sats/${fiatSymbol}`}
         </button>
         <div id='yep-hint' class='visually-hidden'>Show 1 satoshi equals 1 satoshi</div>

--- a/components/price.js
+++ b/components/price.js
@@ -56,53 +56,71 @@ export default function Price ({ className }) {
   if (selection === 'yep') {
     if (!price || price < 0) return null
     return (
-      <button className={compClassName} onClick={handleClick} variant='link' aria-label='Show 1 satoshi equals 1 satoshi'>
-        {fixedDecimal(100000000 / price, 0) + ` sats/${fiatSymbol}`}
-      </button>
+      <div>
+        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby="yep-hint">
+          {fixedDecimal(100000000 / price, 0) + ` sats/${fiatSymbol}`}
+        </button>
+        <div id='yep-hint' class='visually-hidden'>Show 1 satoshi equals 1 satoshi</div>
+      </div> 
     )
   }
 
   if (selection === '1btc') {
     return (
-      <button className={compClassName} onClick={handleClick} variant='link' aria-label='Show blockheight'>
-        1sat=1sat
-      </button>
+      <div>
+        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='1btc-hint'>
+          1sat=1sat
+        </button>
+        <div id='1btc-hint' class='visually-hidden'>Show blockheight</div>
+      </div>
     )
   }
 
   if (selection === 'blockHeight') {
     if (blockHeight <= 0) return null
     return (
-      <button className={compClassName} onClick={handleClick} variant='link' aria-label='Show fee rate'>
-        {blockHeight}
-      </button>
+      <div>
+        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='blockHeight-hint'>
+          {blockHeight}
+        </button>
+        <div id='blockHeight-hint' class='visually-hidden'>Show fee rate</div>
+      </div>
     )
   }
 
   if (selection === 'halving') {
     if (!halving) return null
     return (
-      <button className={compClassName} onClick={handleClick} variant='link' aria-label='Show fiat price'>
-        <CompactLongCountdown date={halving} />
-      </button>
+      <div>
+        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='halving-hint'>
+          <CompactLongCountdown date={halving} />
+        </button>
+        <div id='halving-hint' class='visually-hidden'>Show fiat price</div>
+      </div>
     )
   }
 
   if (selection === 'chainFee') {
     if (chainFee <= 0) return null
     return (
-      <button className={compClassName} onClick={handleClick} variant='link' aria-label='Show time until halving'>
-        {chainFee} sat/vB
-      </button>
+      <div>
+        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='chainFee-hint'>
+          {chainFee} sat/vB
+        </button>
+        <div id='chainFee-hint' class='visually-hidden'>Show time until halving</div>
+      </div>
     )
   }
 
   if (selection === 'fiat') {
     if (!price || price < 0) return null
     return (
-      <button className={compClassName} onClick={handleClick} variant='link' aria-label='Show price in satoshis per fiat unit'>
-        {fiatSymbol + fixedDecimal(price, 0)}
-      </button>
+      <div>
+        <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='fiat-hint'>
+          {fiatSymbol + fixedDecimal(price, 0)}
+        </button>
+        <div id='fiat-hint' class='visually-hidden'>Show price in satoshis per fiat unit</div> 
+      </div>
     )
   }
 }

--- a/components/price.js
+++ b/components/price.js
@@ -60,7 +60,7 @@ export default function Price ({ className }) {
         <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='yep-hint'>
           {fixedDecimal(100000000 / price, 0) + ` sats/${fiatSymbol}`}
         </button>
-        <div id='yep-hint' class='visually-hidden'>Show 1 satoshi equals 1 satoshi</div>
+        <div id='yep-hint' className='visually-hidden'>Show 1 satoshi equals 1 satoshi</div>
       </div>
     )
   }
@@ -71,7 +71,7 @@ export default function Price ({ className }) {
         <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='1btc-hint'>
           1sat=1sat
         </button>
-        <div id='1btc-hint' class='visually-hidden'>Show blockheight</div>
+        <div id='1btc-hint' className='visually-hidden'>Show blockheight</div>
       </div>
     )
   }
@@ -83,7 +83,7 @@ export default function Price ({ className }) {
         <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='blockHeight-hint'>
           {blockHeight}
         </button>
-        <div id='blockHeight-hint' class='visually-hidden'>Show fee rate</div>
+        <div id='blockHeight-hint' className='visually-hidden'>Show fee rate</div>
       </div>
     )
   }
@@ -95,7 +95,7 @@ export default function Price ({ className }) {
         <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='halving-hint'>
           <CompactLongCountdown date={halving} />
         </button>
-        <div id='halving-hint' class='visually-hidden'>Show fiat price</div>
+        <div id='halving-hint' className='visually-hidden'>Show fiat price</div>
       </div>
     )
   }
@@ -107,7 +107,7 @@ export default function Price ({ className }) {
         <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='chainFee-hint'>
           {chainFee} sat/vB
         </button>
-        <div id='chainFee-hint' class='visually-hidden'>Show time until halving</div>
+        <div id='chainFee-hint' className='visually-hidden'>Show time until halving</div>
       </div>
     )
   }
@@ -119,7 +119,7 @@ export default function Price ({ className }) {
         <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='fiat-hint'>
           {fiatSymbol + fixedDecimal(price, 0)}
         </button>
-        <div id='fiat-hint' class='visually-hidden'>Show price in satoshis per fiat unit</div>
+        <div id='fiat-hint' className='visually-hidden'>Show price in satoshis per fiat unit</div>
       </div>
     )
   }

--- a/components/price.js
+++ b/components/price.js
@@ -61,7 +61,7 @@ export default function Price ({ className }) {
           {fixedDecimal(100000000 / price, 0) + ` sats/${fiatSymbol}`}
         </button>
         <div id='yep-hint' class='visually-hidden'>Show 1 satoshi equals 1 satoshi</div>
-      </div> 
+      </div>
     )
   }
 
@@ -119,7 +119,7 @@ export default function Price ({ className }) {
         <button className={compClassName} onClick={handleClick} variant='link' aria-describedby='fiat-hint'>
           {fiatSymbol + fixedDecimal(price, 0)}
         </button>
-        <div id='fiat-hint' class='visually-hidden'>Show price in satoshis per fiat unit</div> 
+        <div id='fiat-hint' class='visually-hidden'>Show price in satoshis per fiat unit</div>
       </div>
     )
   }

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -985,6 +985,17 @@ div[contenteditable]:focus,
   }
 }
 
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 .react-datepicker-wrapper {
   display: inline-block;
   padding: 0;


### PR DESCRIPTION
## Description

Accessibility changes to price button to ensure that the `button` role is being used and the `aria-describedby` announces the correct hint for when the user activates the button.

## Screenshots
No changes to visual UI

## Additional Context

This is my first commit. I plan on doing more accessibility work for stacker.news in the future but wanted to start small to ensure I am in sync with your contribution process. 

This PR simply changes a few lines on prices.js to ensure the price element is announced as a `button` to screen reader users with the proper `aria-describedby` which describes the next action the button will perform and that it is focusable and actionable by the keyboard. 

## Checklist

**Are your changes backwards compatible? Please answer below:**
I believe so. These are very small changes that should not impact backwards compatibility.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8 - I tested my changes on a local dev environment running only the minimal containers to view real-time changes to the UI. Some blockheight and other bitcoin data was not present in the dev environment however. 

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes, tested in an emulated mobile viewport on Chrome, also tested light mode in addition to dark

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No, only used standard `html` elements, `aria` attributes, and added a visually-hidden `css` class.