### PR TITLE
THREAD notifications to distinguish direct replies from follow-ups

### DIFF
--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -250,7 +250,7 @@ export const notifyItemParents = async ({ models, item }) => {
     Promise.allSettled(
       parents.map(({ userId, isDirect }) => {
         return sendUserNotification(userId, {
-          title: `@${user.name} ${isDirect ? 'replied to you' : 'replied to someone that'}`,
+          title: `@${user.name} ${isDirect ? 'replied to you' : 'replied to someone that replied to you'}`,
           body: item.text,
           item,
           tag: isDirect ? 'REPLY' : 'THREAD'

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -37,7 +37,7 @@ const createPayload = (notification) => {
 const createUserFilter = (tag) => {
   // filter users by notification settings
   const tagMap = {
-    REPLY: 'noteAllDescendants',
+    THREAD: 'noteAllDescendants',
     MENTION: 'noteMentions',
     ITEM_MENTION: 'noteItemMentions',
     TIP: 'noteItemSats',
@@ -244,16 +244,18 @@ export const notifyItemParents = async ({ models, item }) => {
   try {
     const user = await models.user.findUnique({ where: { id: item.userId } })
     const parents = await models.$queryRawUnsafe(
-      'SELECT DISTINCT p."userId" FROM "Item" i JOIN "Item" p ON p.path @> i.path WHERE i.id = $1 and p."userId" <> $2 ' +
+      'SELECT DISTINCT p."userId", (SELECT "userId" FROM "Item" WHERE id = $1) = p."userId" as "isDirect" FROM "Item" i JOIN "Item" p ON p.path @> i.path WHERE i.id = $1 and p."userId" <> $2 ' +
       'AND NOT EXISTS (SELECT 1 FROM "Mute" m WHERE m."muterId" = p."userId" AND m."mutedId" = $2)',
       Number(item.parentId), Number(user.id))
     Promise.allSettled(
-      parents.map(({ userId }) => sendUserNotification(userId, {
-        title: `@${user.name} replied to you`,
-        body: item.text,
-        item,
-        tag: 'REPLY'
-      }))
+      parents.map(({ userId, isDirect }) => {
+        return sendUserNotification(userId, {
+          title: `@${user.name} ${isDirect ? 'replied to you' : 'replied to someone that'}`,
+          body: item.text,
+          item,
+          tag: isDirect ? 'REPLY' : 'THREAD'
+        })
+      })
     )
   } catch (err) {
     console.error(err)

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -91,7 +91,7 @@ const mergeNotification = (event, sw, payload, currentNotifications, tag, nid) =
   // merge notifications into single notification payload
   // ---
   // tags that need to know the amount of notifications with same tag for merging
-  const AMOUNT_TAGS = ['REPLY', 'MENTION', 'ITEM_MENTION', 'REFERRAL', 'INVITE', 'FOLLOW', 'TERRITORY_POST']
+  const AMOUNT_TAGS = ['REPLY', 'THREAD', 'MENTION', 'ITEM_MENTION', 'REFERRAL', 'INVITE', 'FOLLOW', 'TERRITORY_POST']
   // tags that need to know the sum of sats of notifications with same tag for merging
   const SUM_SATS_TAGS = ['DEPOSIT', 'WITHDRAWAL']
   // this should reflect the amount of notifications that were already merged before
@@ -116,6 +116,8 @@ const mergeNotification = (event, sw, payload, currentNotifications, tag, nid) =
   if (AMOUNT_TAGS.includes(compareTag)) {
     if (compareTag === 'REPLY') {
       title = `you have ${amount} new replies`
+    } else if (compareTag === 'THREAD') {
+      title = `you have ${amount} new follow-up replies`
     } else if (compareTag === 'MENTION') {
       title = `you were mentioned ${amount} times`
     } else if (compareTag === 'ITEM_MENTION') {


### PR DESCRIPTION
## Description
Fixes #1844
Introduces THREAD notification type, it gets sent instead of REPLY whenever the item's parentId doesn't match the recipient's userId

## Screenshots
<img width="400px" src="https://github.com/user-attachments/assets/3ea2fb04-0588-4ec2-98e3-d018e5378b3c">

## Additional Context

n/a

## Checklist

**Are your changes backwards compatible? Please answer below:**
it checks for isDirect which can only be true if there are follow-up replies, otherwise it will send the usual REPLY notification

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, will edit once I tested on more scenarios

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a