### PR TITLE
Don't parse content in code blocks

### DIFF
--- a/lib/rehype-sn.js
+++ b/lib/rehype-sn.js
@@ -16,6 +16,11 @@ export default function rehypeSN (options = {}) {
   return function transformer (tree) {
     try {
       visit(tree, (node, index, parent) => {
+        if (parent?.tagName === 'code') {
+          // don't process code blocks
+          return
+        }
+
         // Handle inline code property
         if (node.tagName === 'code') {
           node.properties.inline = !(parent && parent.tagName === 'pre')


### PR DESCRIPTION
## Description

Fix #1898

Currently, SN will render this:

```
# test

asdf@foobar

[](url)

![](image)

```

like this:

```
# test 

asdf
```

This is fixed by preventing any parsing inside code blocks.

## Additional Context

If you run `console.log(tree)` before `visit` is called, you still get the processed tree printed to console. I think that's because the tree is processed inline and the console will show the latest state of an object.

Therefore, I used `console.log(JSON.stringify(tree, null, 2))` to see the unprocessed tree in the console.

## Checklist

**Are your changes backwards compatible? Please answer below:**

If you mean there's no regression, I think so, yes.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

~`3`. Only tested the code block in the description but not processing anything inside a code block sounds like what we want.~

Tested some more, I give this a `7` now.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
