### PR TITLE
Fix the check for misleading links

### DIFF
--- a/lib/rehype-sn.js
+++ b/lib/rehype-sn.js
@@ -253,15 +253,22 @@ export default function rehypeSN (options = {}) {
   function isMisleadingLink (text, href) {
     let misleading = false
 
-    if (/^\s*(\w+\.)+\w+/.test(text)) {
-      try {
-        const hrefUrl = new URL(href)
-
-        if (new URL(hrefUrl.protocol + text).origin !== hrefUrl.origin) {
-          misleading = true
-        }
-      } catch {}
-    }
+		try {
+			const hrefUrl = new URL(href)
+	
+			try {
+				const textUrl = new URL(text)
+				if (textUrl.origin !== hrefUrl.origin) {
+					misleading = true
+				}         
+			} catch {}
+	
+			if (/^\s*(\w+\.)+\w+/.test(text)) {
+				if (new URL(hrefUrl.protocol + text).origin !== hrefUrl.origin) {
+					misleading = true
+				}
+			}
+		} catch {}
 
     return misleading
   }

--- a/lib/rehype-sn.js
+++ b/lib/rehype-sn.js
@@ -253,23 +253,23 @@ export default function rehypeSN (options = {}) {
   function isMisleadingLink (text, href) {
     let misleading = false
 
-		try {
-			const hrefUrl = new URL(href)
-	
-			try {
-				const textUrl = new URL(text)
-				if (textUrl.origin !== hrefUrl.origin) {
-					misleading = true
-				}         
-			} catch {}
-	
-			if (/^\s*(\w+\.)+\w+/.test(text)) {
-				if (new URL(hrefUrl.protocol + text).origin !== hrefUrl.origin) {
-					misleading = true
-				}
-			}
-		} catch {}
-
+    try {
+      const hrefUrl = new URL(href)
+      
+      try {
+        const textUrl = new URL(text)
+        if (textUrl.origin !== hrefUrl.origin) {
+          misleading = true
+        }         
+      } catch {}
+      
+      if (/^\s*(\w+\.)+\w+/.test(text)) {
+        if (new URL(hrefUrl.protocol + text).origin !== hrefUrl.origin) {
+          misleading = true
+        }
+      }
+    } catch {}
+    
     return misleading
   }
 

--- a/lib/rehype-sn.js
+++ b/lib/rehype-sn.js
@@ -255,21 +255,21 @@ export default function rehypeSN (options = {}) {
 
     try {
       const hrefUrl = new URL(href)
-      
+
       try {
         const textUrl = new URL(text)
         if (textUrl.origin !== hrefUrl.origin) {
           misleading = true
-        }         
+        }
       } catch {}
-      
+
       if (/^\s*(\w+\.)+\w+/.test(text)) {
         if (new URL(hrefUrl.protocol + text).origin !== hrefUrl.origin) {
           misleading = true
         }
       }
     } catch {}
-    
+
     return misleading
   }
 

--- a/lib/rehype-sn.js
+++ b/lib/rehype-sn.js
@@ -1,5 +1,5 @@
 import { SKIP, visit } from 'unist-util-visit'
-import { parseEmbedUrl, parseInternalLinks } from './url'
+import { parseEmbedUrl, parseInternalLinks, isMisleadingLink } from './url'
 import { slug } from 'github-slugger'
 import { toString } from 'mdast-util-to-string'
 
@@ -248,29 +248,6 @@ export default function rehypeSN (options = {}) {
       properties: { href: '/~' + sub, name: sub },
       children: [{ type: 'text', value }]
     }
-  }
-
-  function isMisleadingLink (text, href) {
-    let misleading = false
-
-    try {
-      const hrefUrl = new URL(href)
-
-      try {
-        const textUrl = new URL(text)
-        if (textUrl.origin !== hrefUrl.origin) {
-          misleading = true
-        }
-      } catch {}
-
-      if (/^\s*(\w+\.)+\w+/.test(text)) {
-        if (new URL(hrefUrl.protocol + text).origin !== hrefUrl.origin) {
-          misleading = true
-        }
-      }
-    } catch {}
-
-    return misleading
   }
 
   function replaceNostrId (value, id) {

--- a/lib/url.js
+++ b/lib/url.js
@@ -254,7 +254,7 @@ export function isMisleadingLink (text, href) {
       }
     } catch {}
 
-    if (/^\s*(\w+\.)+\w+/.test(text)) {
+    if (/^\s*([\w-]+\.)+\w+/.test(text)) {
       if (new URL(hrefUrl.protocol + text).origin !== hrefUrl.origin) {
         misleading = true
       }

--- a/lib/url.js
+++ b/lib/url.js
@@ -241,6 +241,29 @@ export function decodeProxyUrl (imgproxyUrl) {
   return originalUrl
 }
 
+export function isMisleadingLink (text, href) {
+  let misleading = false
+
+  try {
+    const hrefUrl = new URL(href)
+
+    try {
+      const textUrl = new URL(text)
+      if (textUrl.origin !== hrefUrl.origin) {
+        misleading = true
+      }
+    } catch {}
+
+    if (/^\s*(\w+\.)+\w+/.test(text)) {
+      if (new URL(hrefUrl.protocol + text).origin !== hrefUrl.origin) {
+        misleading = true
+      }
+    }
+  } catch {}
+
+  return misleading
+}
+
 // eslint-disable-next-line
 export const URL_REGEXP = /^((https?|ftp):\/\/)?(www.)?(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i
 

--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -31,15 +31,19 @@ describe('internal links', () => {
 })
 
 const misleadingLinkCases = [
+  // if text is the same as the link, it's not misleading
   ['https://stacker.news/items/1234', 'https://stacker.news/items/1234', false],
+  // same origin is not misleading
+  ['https://stacker.news/items/1235', 'https://stacker.news/items/1234', false],
+  ['www.google.com', 'https://www.google.com', false],
+  ['stacker.news', 'https://stacker.news', false],
+  // if text is obviously not a link, it's not misleading
   ['innocent text', 'https://stacker.news/items/1234', false],
   ['innocenttext', 'https://stacker.news/items/1234', false],
+  // if text might be a link to a different origin, it's misleading
   ['innocent.text', 'https://stacker.news/items/1234', true],
-  ['https://stacker.news/items/1235', 'https://stacker.news/items/1234', false],
   ['https://google.com', 'https://bing.com', true],
-  ['www.google.com', 'https://bing.com', true],
-  ['www.google.com', 'https://www.google.com', false],
-  ['stacker.news', 'https://stacker.news', false]
+  ['www.google.com', 'https://bing.com', true]
 ]
 
 describe('misleading links', () => {

--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -1,8 +1,8 @@
 /* eslint-env jest */
 
-import { parseInternalLinks } from './url.js'
+import { parseInternalLinks, isMisleadingLink } from './url.js'
 
-const cases = [
+const internalLinkCases = [
   ['https://stacker.news/items/123', '#123'],
   ['https://stacker.news/items/123/related', '#123/related'],
   // invalid links should not be parsed so user can spot error
@@ -20,11 +20,33 @@ const cases = [
 ]
 
 describe('internal links', () => {
-  test.each(cases)(
+  test.each(internalLinkCases)(
     'parses %p as %p',
     (href, expected) => {
       process.env.NEXT_PUBLIC_URL = 'https://stacker.news'
       const { linkText: actual } = parseInternalLinks(href)
+      expect(actual).toBe(expected)
+    }
+  )
+})
+
+const misleadingLinkCases = [
+  ['https://stacker.news/items/1234', 'https://stacker.news/items/1234', false],
+  ['innocent text', 'https://stacker.news/items/1234', false],
+  ['innocenttext', 'https://stacker.news/items/1234', false],
+  ['innocent.text', 'https://stacker.news/items/1234', true],
+  ['https://stacker.news/items/1235', 'https://stacker.news/items/1234', false],
+  ['https://google.com', 'https://bing.com', true],
+  ['www.google.com', 'https://bing.com', true],
+  ['www.google.com', 'https://www.google.com', false],
+  ['stacker.news', 'https://stacker.news', false]
+]
+
+describe('misleading links', () => {
+  test.each(misleadingLinkCases)(
+    'identifies [%p](%p) as misleading: %p',
+    (text, href, expected) => {
+      const actual = isMisleadingLink(text, href)
       expect(actual).toBe(expected)
     }
   )

--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -43,7 +43,8 @@ const misleadingLinkCases = [
   // if text might be a link to a different origin, it's misleading
   ['innocent.text', 'https://stacker.news/items/1234', true],
   ['https://google.com', 'https://bing.com', true],
-  ['www.google.com', 'https://bing.com', true]
+  ['www.google.com', 'https://bing.com', true],
+  ['s-tacker.news', 'https://snacker.news', true]
 ]
 
 describe('misleading links', () => {


### PR DESCRIPTION
## Description

Fix/address issue https://github.com/stackernews/stacker.news/issues/323

Currently, `isMisleadingLink` in `lib/rehype-sn.js` checks whether links are misleading by comparing the link text to the href. If the link text is URL-like (contains letters, numbers, underscores, and dots), the function adds `http://` to the link-text and then checks whether the URL's origin has the same origin as href.

The issue is that if the link text contains other characters, like `:` or `/`, which are common in URLs, `isMisleadingLink` will return false (doesn't identify the link as misleading). This PR fixes the issue by checking if the link text is any valid URL. If it is, it compares the origin of the link text to that of the href, and if the two are different, `isMisleadingLink` will return true (is misleading).

Before:
- `[https://bing.com](https://google.com)` renders the text as https://bing.com and the href as https://google.com
- `[bing.com](https://google.com)` renders both the text and href as https://google.com 

After:
- `[https://bing.com](https://google.com)` renders both the text and href as https://google.com
- `[bing.com](https://google.com)` renders both the text and href as https://google.com 


## Additional Context

This patch does not fix (potentially) misleading links where the domain of the link text and the href are the same. For example, `[https://stacker.news/items/123](https://stacker.news/items/321)` will render the link text as https://stacker.,news/items/123 while linking to https://stacker.news/items/321. It was considered that there may be legitimate use cases of having a link text and the href be different while sharing the same origin, while not being able to do phishing attacks by this vector. See https://github.com/stackernews/stacker.news/issues/323


## Checklist

**Are your changes backwards compatible? Please answer below:**

Some link texts that weren't caught and replaced by `isMisleadingLink` before will now be caught and replaced. However, I've never observed such a link while using stacker news

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7:  I've tested it on local instance with various posts. I'm not sure how to test effects on performance / impact on existing SN posts.

Also, here is a small unit test of `isMisleadingLink` that I did manually:

```
function isMisleadingLink (text, href) {
  let misleading = false

  try {
    const hrefUrl = new URL(href)

    try {
      const textUrl = new URL(text)
      if (textUrl.origin !== hrefUrl.origin) {
        misleading = true
      }         
    } catch {}

    if (/^\s*(\w+\.)+\w+/.test(text)) {
      if (new URL(hrefUrl.protocol + text).origin !== hrefUrl.origin) {
        misleading = true
      }
    }
  } catch {}
  return misleading
}

let tests = [
  ["https://stacker.news/items/1234", "https://stacker.news/items/1234"],
  ["innocent text", "https://stacker.news/items/1234"],
  ["innocenttext", "https://stacker.news/items/1234"],
  ["innocent.text", "https://stacker.news/items/1234"],
  ["https://stacker.news/items/1235", "https://stacker.news/items/1234"],
  ["https://google.com", "https://bing.com"],
  ["www.google.com", "https://bing.com"],
  ["www.google.com", "https://www.google.com"],
  ["stacker.news", "https://stacker.news"]
];

for (let [text, href] of tests) {
  console.log(`text: ${text}`);
  console.log(`href: ${href}`);
  console.log(`misleading: ${isMisleadingLink(text, href)}`);
}
```

Output:
```
text: https://stacker.news/items/1234
href: https://stacker.news/items/1234
misleading: false
text: innocent text
href: https://stacker.news/items/1234
misleading: false
text: innocenttext
href: https://stacker.news/items/1234
misleading: false
text: innocent.text
href: https://stacker.news/items/1234
misleading: true
text: https://stacker.news/items/1235
href: https://stacker.news/items/1234
misleading: false
text: https://google.com
href: https://bing.com
misleading: true
text: www.google.com
href: https://bing.com
misleading: true
text: www.google.com
href: https://www.google.com
misleading: false
text: stacker.news
href: https://stacker.news
misleading: false
```



**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

not frontend change

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no