### PR TITLE
Fix comment not outlined again

### DIFF
--- a/components/comment.js
+++ b/components/comment.js
@@ -130,6 +130,10 @@ export default function Comment ({
       // HACK wait for other comments to uncollapse if they're collapsed
       setTimeout(() => {
         ref.current.scrollIntoView({ behavior: 'instant', block: 'start' })
+        // make sure we can outline a comment again if it was already outlined before
+        ref.current.addEventListener('animationend', () => {
+          ref.current.classList.remove('outline-it')
+        }, { once: true })
         ref.current.classList.add('outline-it')
       }, 100)
     }


### PR DESCRIPTION
## Description

To outline a comment again, we add the class `outline-it`. However, if the comment was already outlined before, this doesn't work.

This PR fixes it by removing the class after the animation ended so we can add it again.

## Video

https://github.com/user-attachments/assets/e5932cc7-8237-4077-84e0-fc639835f45d

## Additional Context

There is another bug that a comment with its id already in the query param can't be outlined again since the corresponding `useEffect` is not triggered. Will fix in another PR.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Simple change + [`once`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#browser_compatibility) and [`animationend`](https://developer.mozilla.org/en-US/docs/Web/API/Element/animationend_event) have good browser support since a while

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
