### PR TITLE
Fix receiver fallback on caller error

### DIFF
--- a/api/paidAction/index.js
+++ b/api/paidAction/index.js
@@ -269,7 +269,7 @@ async function performDirectAction (actionType, args, incomingContext) {
 
     const description = actionDescription ?? await paidActions[actionType].describe(args, incomingContext)
 
-    for await (const { invoice, wallet } of createUserInvoice(userId, {
+    for await (const { invoice, logger, wallet } of createUserInvoice(userId, {
       msats: cost,
       description,
       expiry: INVOICE_EXPIRE_SECS
@@ -279,6 +279,7 @@ async function performDirectAction (actionType, args, incomingContext) {
         hash = parsePaymentRequest({ request: invoice }).id
       } catch (e) {
         console.error('failed to parse invoice', e)
+        logger?.error('failed to parse invoice: ' + e.message, { bolt11: invoice })
         continue
       }
 
@@ -300,6 +301,7 @@ async function performDirectAction (actionType, args, incomingContext) {
         }
       } catch (e) {
         console.error('failed to create direct payment', e)
+        logger?.error('failed to create direct payment: ' + e.message, { bolt11: invoice })
       }
     }
   } catch (e) {

--- a/api/paidAction/index.js
+++ b/api/paidAction/index.js
@@ -3,7 +3,7 @@ import { datePivot } from '@/lib/time'
 import { PAID_ACTION_PAYMENT_METHODS, USER_ID } from '@/lib/constants'
 import { createHmac } from '@/api/resolvers/wallet'
 import { Prisma } from '@prisma/client'
-import { createWrappedInvoice, createInvoice as createUserInvoice } from '@/wallets/server'
+import { createWrappedInvoice, createUserInvoice } from '@/wallets/server'
 import { assertBelowMaxPendingInvoices, assertBelowMaxPendingDirectPayments } from './lib/assert'
 
 import * as ITEM_CREATE from './itemCreate'

--- a/wallets/server.js
+++ b/wallets/server.js
@@ -24,7 +24,7 @@ export default [lnd, cln, lnAddr, lnbits, nwc, phoenixd, blink, lnc, webln]
 
 const MAX_PENDING_INVOICES_PER_WALLET = 25
 
-export async function createUserInvoice (userId, { msats, description, descriptionHash, expiry = 360 }, { paymentAttempt, predecessorId, models }) {
+export async function * createUserInvoice (userId, { msats, description, descriptionHash, expiry = 360 }, { paymentAttempt, predecessorId, models }) {
   // get the wallets in order of priority
   const wallets = await getInvoiceableWallets(userId, {
     paymentAttempt,
@@ -72,44 +72,42 @@ export async function createUserInvoice (userId, { msats, description, descripti
         }
       }
 
-      return { invoice, wallet, logger }
+      yield { invoice, wallet, logger }
     } catch (err) {
+      console.error('failed to create user invoice:', err)
       logger.error(err.message, { status: true })
     }
   }
-
-  throw new Error('no wallet to receive available')
 }
 
 export async function createWrappedInvoice (userId,
   { msats, feePercent, description, descriptionHash, expiry = 360 },
   { paymentAttempt, predecessorId, models, me, lnd }) {
-  let logger, bolt11
-  try {
-    const { invoice, wallet } = await createUserInvoice(userId, {
-      // this is the amount the stacker will receive, the other (feePercent)% is our fee
-      msats: toPositiveBigInt(msats) * (100n - feePercent) / 100n,
-      description,
-      descriptionHash,
-      expiry
-    }, { paymentAttempt, predecessorId, models })
-
-    logger = walletLogger({ wallet, models })
-    bolt11 = invoice
-
-    const { invoice: wrappedInvoice, maxFee } =
-      await wrapInvoice({ bolt11, feePercent }, { msats, description, descriptionHash }, { me, lnd })
-
-    return {
-      invoice,
-      wrappedInvoice: wrappedInvoice.request,
-      wallet,
-      maxFee
+  // loop over all receiver wallet invoices until we successfully wrapped one
+  for await (const { invoice, logger, wallet } of createUserInvoice(userId, {
+    // this is the amount the stacker will receive, the other (feePercent)% is our fee
+    msats: toPositiveBigInt(msats) * (100n - feePercent) / 100n,
+    description,
+    descriptionHash,
+    expiry
+  }, { paymentAttempt, predecessorId, models })) {
+    let bolt11
+    try {
+      bolt11 = invoice
+      const { invoice: wrappedInvoice, maxFee } = await wrapInvoice({ bolt11, feePercent }, { msats, description, descriptionHash }, { me, lnd })
+      return {
+        invoice,
+        wrappedInvoice: wrappedInvoice.request,
+        wallet,
+        maxFee
+      }
+    } catch (e) {
+      console.error('failed to wrap invoice:', e)
+      logger?.error('failed to wrap invoice: ' + e.message, { bolt11 })
     }
-  } catch (e) {
-    logger?.error('invalid invoice: ' + e.message, { bolt11 })
-    throw e
   }
+
+  throw new Error('no wallet to receive available')
 }
 
 export async function getInvoiceableWallets (userId, { paymentAttempt, predecessorId, models }) {

--- a/wallets/server.js
+++ b/wallets/server.js
@@ -24,7 +24,7 @@ export default [lnd, cln, lnAddr, lnbits, nwc, phoenixd, blink, lnc, webln]
 
 const MAX_PENDING_INVOICES_PER_WALLET = 25
 
-export async function createInvoice (userId, { msats, description, descriptionHash, expiry = 360 }, { paymentAttempt, predecessorId, models }) {
+export async function createUserInvoice (userId, { msats, description, descriptionHash, expiry = 360 }, { paymentAttempt, predecessorId, models }) {
   // get the wallets in order of priority
   const wallets = await getInvoiceableWallets(userId, {
     paymentAttempt,
@@ -86,7 +86,7 @@ export async function createWrappedInvoice (userId,
   { paymentAttempt, predecessorId, models, me, lnd }) {
   let logger, bolt11
   try {
-    const { invoice, wallet } = await createInvoice(userId, {
+    const { invoice, wallet } = await createUserInvoice(userId, {
       // this is the amount the stacker will receive, the other (feePercent)% is our fee
       msats: toPositiveBigInt(msats) * (100n - feePercent) / 100n,
       description,

--- a/worker/autowithdraw.js
+++ b/worker/autowithdraw.js
@@ -1,6 +1,6 @@
 import { msatsSatsFloor, msatsToSats, satsToMsats } from '@/lib/format'
 import { createWithdrawal } from '@/api/resolvers/wallet'
-import { createInvoice } from '@/wallets/server'
+import { createUserInvoice } from '@/wallets/server'
 
 export async function autoWithdraw ({ data: { id }, models, lnd }) {
   const user = await models.user.findUnique({ where: { id } })
@@ -42,7 +42,7 @@ export async function autoWithdraw ({ data: { id }, models, lnd }) {
 
   if (pendingOrFailed.exists) return
 
-  const { invoice, wallet, logger } = await createInvoice(id, { msats, description: 'SN: autowithdrawal', expiry: 360 }, { models })
+  const { invoice, wallet, logger } = await createUserInvoice(id, { msats, description: 'SN: autowithdrawal', expiry: 360 }, { models })
 
   try {
     return await createWithdrawal(null,


### PR DESCRIPTION
## Description

Our loop over receiver wallets is setup in a way that if anything fails after we created the invoice, we will not try the next wallet since we already exited the loop.

This affects p2p zaps, direct payments and autowithdrawals.

This PR fixes this by making the caller aware of the loop via an [async generator function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator). This means the caller can continue the loop on any errors.

This is the first time we use generators in our codebase, but I think this is a very good use case for generators.

## Videos

bug + fix for p2p zaps:

https://github.com/user-attachments/assets/bbe40c6e-6032-4fbb-b95b-300fdeb6f9e9

bug + fix for direct payments:

https://github.com/user-attachments/assets/2aa644f7-cce3-4c2d-87d9-5b8e11492900

bug + fix for autowithdrawals:

https://github.com/user-attachments/assets/71fb26b4-0e20-49ae-aac0-b2511e643174

## Additional context

In the video for autowithdrawals, you can see that the logs are in a wrong order. I suspect that's because we don't await the logger calls. I will fix this in a different PR or while normalizing the wallet logs.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. See videos.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no