### PR TITLE
Dynamically import MathJax

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -57,7 +57,7 @@ export default memo(function Text ({ rel = UNKNOWN_LINK_REL, imgproxyUrls, child
 
   // we only need mathjax if there's math content between $$ tags
   useEffect(() => {
-    if (/\$\$(.*?)\$\$/g.test(children)) {
+    if (/\$\$(.|\n)+\$\$/g.test(children)) {
       import('rehype-mathjax').then(mod => {
         setMathJaxPlugin(() => mod.default)
       }).catch(err => {

--- a/components/text.js
+++ b/components/text.js
@@ -55,9 +55,9 @@ export default memo(function Text ({ rel = UNKNOWN_LINK_REL, imgproxyUrls, child
   const containerRef = useRef(null)
   const [mathJaxPlugin, setMathJaxPlugin] = useState(null)
 
-  // we only need mathjax if there's math content
+  // we only need mathjax if there's math content between $$ tags
   useEffect(() => {
-    if (children?.includes('$$')) {
+    if (/\$\$(.*?)\$\$/g.test(children)) {
       import('rehype-mathjax').then(mod => {
         setMathJaxPlugin(() => mod.default)
       }).catch(err => {
@@ -144,7 +144,7 @@ export default memo(function Text ({ rel = UNKNOWN_LINK_REL, imgproxyUrls, child
     <ReactMarkdown
       components={components}
       remarkPlugins={remarkPlugins}
-      rehypePlugins={[rehypeSNStyled, ...(mathJaxPlugin ? [mathJaxPlugin] : [])]}
+      rehypePlugins={[rehypeSNStyled, mathJaxPlugin].filter(Boolean)}
       remarkRehypeOptions={{ clobberPrefix: `itemfn-${itemId}-` }}
     >
       {children}

--- a/components/text.js
+++ b/components/text.js
@@ -241,6 +241,7 @@ function Table ({ node, ...props }) {
 function Code ({ node, inline, className, children, style, ...props }) {
   const [ReactSyntaxHighlighter, setReactSyntaxHighlighter] = useState(null)
   const [syntaxTheme, setSyntaxTheme] = useState(null)
+  const language = className?.match(/language-(\w+)/)?.[1] || 'text'
 
   const loadHighlighter = useCallback(() =>
     Promise.all([
@@ -250,7 +251,7 @@ function Code ({ node, inline, className, children, style, ...props }) {
   )
 
   useEffect(() => {
-    if (!inline) {
+    if (!inline && language !== 'math') { // MathJax should handle math
       // loading the syntax highlighter and theme only when needed
       loadHighlighter().then(([highlighter, theme]) => {
         setReactSyntaxHighlighter(() => highlighter)
@@ -266,8 +267,6 @@ function Code ({ node, inline, className, children, style, ...props }) {
       </code>
     )
   }
-
-  const language = className?.match(/language-(\w+)/)?.[1] || 'text'
 
   return (
     <ReactSyntaxHighlighter style={syntaxTheme} language={language} PreTag='div' customStyle={{ borderRadius: '0.3rem' }} {...props}>

--- a/components/text.js
+++ b/components/text.js
@@ -20,7 +20,6 @@ import rehypeSN from '@/lib/rehype-sn'
 import remarkUnicode from '@/lib/remark-unicode'
 import Embed from './embed'
 import remarkMath from 'remark-math'
-import rehypeMathjax from 'rehype-mathjax'
 
 const rehypeSNStyled = () => rehypeSN({
   stylers: [{
@@ -35,7 +34,6 @@ const rehypeSNStyled = () => rehypeSN({
 })
 
 const remarkPlugins = [gfm, remarkUnicode, [remarkMath, { singleDollarTextMath: false }]]
-const rehypePlugins = [rehypeSNStyled, rehypeMathjax]
 
 export function SearchText ({ text }) {
   return (
@@ -55,6 +53,19 @@ export default memo(function Text ({ rel = UNKNOWN_LINK_REL, imgproxyUrls, child
   const router = useRouter()
   const [show, setShow] = useState(false)
   const containerRef = useRef(null)
+  const [mathJaxPlugin, setMathJaxPlugin] = useState(null)
+
+  // we only need mathjax if there's math content
+  useEffect(() => {
+    if (children?.includes('$$')) {
+      import('rehype-mathjax').then(mod => {
+        setMathJaxPlugin(() => mod.default)
+      }).catch(err => {
+        console.error('error loading mathjax', err)
+        setMathJaxPlugin(null)
+      })
+    }
+  }, [children])
 
   // if we are navigating to a hash, show the full text
   useEffect(() => {
@@ -133,12 +144,12 @@ export default memo(function Text ({ rel = UNKNOWN_LINK_REL, imgproxyUrls, child
     <ReactMarkdown
       components={components}
       remarkPlugins={remarkPlugins}
-      rehypePlugins={rehypePlugins}
+      rehypePlugins={[rehypeSNStyled, ...(mathJaxPlugin ? [mathJaxPlugin] : [])]}
       remarkRehypeOptions={{ clobberPrefix: `itemfn-${itemId}-` }}
     >
       {children}
     </ReactMarkdown>
-  ), [components, remarkPlugins, rehypePlugins, children, itemId])
+  ), [components, remarkPlugins, mathJaxPlugin, children, itemId])
 
   const showOverflow = useCallback(() => setShow(true), [setShow])
 


### PR DESCRIPTION
## Description

Addresses #1832 
Dynamically imports MathJax whenever is needed. Checks for `$$some math$$` inside the text to be processed and loads MathJax when positive.

## Screenshots
<img width="554" alt="image" src="https://github.com/user-attachments/assets/642f6754-0705-462e-bfd3-4084b496d99b" />

## Additional Context

It created two chunks containing MathJax-full and MathJax's LaTeX font, configuring a 1.5MB download client-side when is needed.

I noticed that on Math blocks we load Code. I added a condition for React Syntax Highlighter that catches 'math' language and avoids loading the library since MathJax should handle math.

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, loads MathJax only on "$$math$$" and displays correctly, conditional rendering is also correct. RSH avoidance works correctly.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No

## Bundle Analysis
First Load JS 
~35% reduction of _app First Load JS
Before
![image](https://github.com/user-attachments/assets/cb74f9e8-021a-4bee-9311-6e7384c1e6bf)

After
![image](https://github.com/user-attachments/assets/f0b16087-3746-4089-8c6e-73c3f9adf31e)

Bundle:
~35% reduction of the _app bundle reduction, from 4.59MB down to 3.12MB.
Before
![image](https://github.com/user-attachments/assets/647c0589-10db-4767-9ee9-f35985c4d651)
After
![image](https://github.com/user-attachments/assets/786ce23a-495d-4ba2-a8f5-a3863534439b)

