### PR TITLE
enhance: Allow switching to a more expensive territory

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1474,14 +1474,6 @@ export const updateItem = async (parent, { sub: subName, forward, hash, hmac, ..
     throw new GqlInputError('item does not belong to you')
   }
 
-  const differentSub = subName && old.subName !== subName
-  if (differentSub) {
-    const sub = await models.sub.findUnique({ where: { name: subName } })
-    if (sub.baseCost > old.sub.baseCost) {
-      throw new GqlInputError('cannot change to a more expensive sub')
-    }
-  }
-
   // in case they lied about their existing boost
   await validateSchema(advSchema, { boost: item.boost }, { models, me, existingBoost: old.boost })
 


### PR DESCRIPTION
## Description

Fixes #1918 
Allows switching to a more expensive territories during post editing by paying just the difference between the old territory post cost and the new one. 
A downgrade will have 0 cost.

## Screenshots
I'm moving from B2B which costs 1 sat to everythinghere that costs 2780 sats.
The edit cost will be 2779 then
<img width="501" alt="image" src="https://github.com/user-attachments/assets/a2812acb-7fcb-4676-a27d-1c68382383b3" />

## Additional Context

Perpetual Edits will allow this change to be done indefinitely

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, tested before on perpetual edits, tested on multiple territories, downgrade has 0 cost

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No