### PR TITLE
hotfix: Email addresses should be case insensitive

### DIFF
--- a/pages/email.js
+++ b/pages/email.js
@@ -22,7 +22,7 @@ export default function Email () {
     const params = new URLSearchParams()
     if (callback.callbackUrl) params.set('callbackUrl', callback.callbackUrl)
     params.set('token', token)
-    params.set('email', callback.email)
+    params.set('email', callback.email.toLowerCase())
     const url = `/api/auth/callback/email?${params.toString()}`
     router.push(url)
   }, [callback, router])


### PR DESCRIPTION
## Description

Emails are stored in lower-case and the verification is case-sensitive.
This PR converts the email address saved in session storage to lower case at the time of callbackUrl building, preventing unexpected login errors.

## Screenshots

## Additional Context
Code-entering page displays the email inserted by the user as-is to maintain the email as expected by the user, this fix operates behind the scenes

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, inserted all types of emails, as long as the email is correct whether UPPERCASE or lowercase it can't give an error.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No