### PR TITLE
Dynamic loading optimizations

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -971,15 +971,24 @@ export function Select ({ label, items, info, groupClassName, onChange, noForm, 
   )
 }
 
+function DatePickerSkeleton () {
+  return (
+    <div className='react-datepicker-wrapper'>
+      <input className='form-control clouds fade-out p-0 px-2 mb-0' />
+    </div>
+  )
+}
+
+const ReactDatePicker = dynamic(() => import('react-datepicker').then(mod => mod.default), {
+  ssr: false,
+  loading: () => <DatePickerSkeleton />
+})
+
 export function DatePicker ({ fromName, toName, noForm, onChange, when, from, to, className, ...props }) {
   const formik = noForm ? null : useFormikContext()
   const [,, fromHelpers] = noForm ? [{}, {}, {}] : useField({ ...props, name: fromName })
   const [,, toHelpers] = noForm ? [{}, {}, {}] : useField({ ...props, name: toName })
   const { minDate, maxDate } = props
-  const ReactDatePicker = dynamic(() => import('react-datepicker').then(mod => mod.default), {
-    ssr: false,
-    loading: () => <span>loading date picker</span>
-  })
 
   const [[innerFrom, innerTo], setRange] = useState(whenRange(when, from, to))
 

--- a/components/text.js
+++ b/components/text.js
@@ -238,6 +238,17 @@ function Table ({ node, ...props }) {
   )
 }
 
+// prevent layout shifting when the code block is loading
+function CodeSkeleton ({ className, children, ...props }) {
+  return (
+    <div className='rounded' style={{ padding: '0.5em' }}>
+      <code className={`${className}`} {...props}>
+        {children}
+      </code>
+    </div>
+  )
+}
+
 function Code ({ node, inline, className, children, style, ...props }) {
   const [ReactSyntaxHighlighter, setReactSyntaxHighlighter] = useState(null)
   const [syntaxTheme, setSyntaxTheme] = useState(null)
@@ -247,7 +258,7 @@ function Code ({ node, inline, className, children, style, ...props }) {
     Promise.all([
       dynamic(() => import('react-syntax-highlighter').then(mod => mod.LightAsync), {
         ssr: false,
-        loading: () => <span>loading syntax highlighter</span>
+        loading: () => <CodeSkeleton className={className} {...props}>{children}</CodeSkeleton>
       }),
       import('react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark').then(mod => mod.default)
     ]), []
@@ -263,7 +274,7 @@ function Code ({ node, inline, className, children, style, ...props }) {
     }
   }, [inline])
 
-  if (inline) {
+  if (inline || !ReactSyntaxHighlighter) { // inline code doesn't have a border radius
     return (
       <code className={className} {...props}>
         {children}

--- a/components/text.js
+++ b/components/text.js
@@ -245,7 +245,10 @@ function Code ({ node, inline, className, children, style, ...props }) {
 
   const loadHighlighter = useCallback(() =>
     Promise.all([
-      dynamic(() => import('react-syntax-highlighter').then(mod => mod.LightAsync), { ssr: false }),
+      dynamic(() => import('react-syntax-highlighter').then(mod => mod.LightAsync), {
+        ssr: false,
+        loading: () => <span>loading syntax highlighter</span>
+      }),
       import('react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark').then(mod => mod.default)
     ]), []
   )
@@ -260,7 +263,7 @@ function Code ({ node, inline, className, children, style, ...props }) {
     }
   }, [inline])
 
-  if (inline || !ReactSyntaxHighlighter || !syntaxTheme) {
+  if (inline) {
     return (
       <code className={className} {...props}>
         {children}
@@ -269,9 +272,13 @@ function Code ({ node, inline, className, children, style, ...props }) {
   }
 
   return (
-    <ReactSyntaxHighlighter style={syntaxTheme} language={language} PreTag='div' customStyle={{ borderRadius: '0.3rem' }} {...props}>
-      {children}
-    </ReactSyntaxHighlighter>
+    <>
+      {ReactSyntaxHighlighter && syntaxTheme && (
+        <ReactSyntaxHighlighter style={syntaxTheme} language={language} PreTag='div' customStyle={{ borderRadius: '0.3rem' }} {...props}>
+          {children}
+        </ReactSyntaxHighlighter>
+      )}
+    </>
   )
 }
 


### PR DESCRIPTION
## Description

Addresses #1832
Dynamically loads React QR Scanner, React Datepicker with a loading placeholder.
It uses Next.js handling of dynamic loading instead of a state-based solution like we saw with syntax highlighting and MathJax

## Screenshots

QR Scanner + loading:
<img width="300" src="https://github.com/user-attachments/assets/e971e7d7-0109-4b3c-a63c-a09a5e67f0c5">

React Datepicker + loading:
<video width="300" src="https://github.com/user-attachments/assets/ee16aa33-6c1a-4085-b080-60db9714f676">

Also React Syntax Highlighter + loading:
<video src="https://github.com/user-attachments/assets/603226e9-7838-4408-99de-19b11104ea57">

## Additional Context

MathJax is not being considered for a loading placeholder for the fact that it's a plugin and not a component

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, modules gets lazy loaded correctly, code blocks have a slight padding shift

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No

## Bundle Analyzing
Before #1909 and #1910 
<img width="500" src="https://github.com/user-attachments/assets/88870123-1e5e-412e-a31a-f66a9e36cfdd">

After
<img width="500" src="https://github.com/user-attachments/assets/ed5b0f06-d825-4191-9a4f-66e80fedf3dd">

After this PR
<img width="500" src="https://github.com/user-attachments/assets/dde8c990-7370-4de8-bdd9-8eb6697a15e6">
7.31 MB to 6.53 MB _app stat size
3.12 to 2.77 _app parsed size

Throughout these PRs we can observe a total reduction from 1.71 MB to 990 kB, accumulating a **43% total reduction** of the bundle that gets shipped to stackers.
^The latest changes have a 114 kB reduction

 