### PR TITLE
Fix issue #1924, require nostr prefixes start with slash

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -93,7 +93,7 @@ export function parseEmbedUrl (href) {
     const { hostname, pathname, searchParams } = new URL(href)
 
     // nostr prefixes: [npub1, nevent1, nprofile1, note1]
-    const nostr = href.match(/(?<id>(?<type>npub1|nevent1|nprofile1|note1|naddr1)[02-9ac-hj-np-z]+)/)
+    const nostr = href.match(/\/(?<id>(?<type>npub1|nevent1|nprofile1|note1|naddr1)[02-9ac-hj-np-z]+)/)
     if (nostr?.groups?.id) {
       let id = nostr.groups.id
       if (nostr.groups.type === 'npub1') {


### PR DESCRIPTION
## Description

Added a leading slash to the regular expression matching for nostr links, so the prefixes only match if preceded by a slash.

Tested that the changes fixes the issue.

Tested that nostr links still match.

I don't know all other sites that use nostr prefixes in their URLs, though.