### PR TITLE
Safari media enhancements

### DIFF
--- a/components/text.module.css
+++ b/components/text.module.css
@@ -167,7 +167,6 @@
     width: 100%;
     max-width: 100%;
     height: auto;
-    overflow: hidden;
     max-height: 25vh;
     aspect-ratio: var(--aspect-ratio);
     margin: 0;
@@ -196,14 +195,11 @@
 .p:has(> .mediaContainer) .mediaContainer video
 {
     block-size: revert-layer;
+    min-width: 30%;
     max-width: stretch;
 }
 
 .p.onlyImages {
-    display: block;
-}
-
-.p.onlyImages:has(> .mediaContainer.loaded) {
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;


### PR DESCRIPTION
## Description

Applies a workaround for Safari's poor handling of `block: revert-layer` by declaring a minimum width, acting as a fallback for size miscalculation during re-rendering.

Removes `overflow: hidden` from mediaContainer as Safari was probably calculating its area of effect based on wrong aspect-ratio during loading.

Reverts #1886 per above

## Screenshots
Testing in production
L: response local override on prod
R: unmodified prod

fix: Video disappearing or not showing[^1]

https://github.com/user-attachments/assets/062955a0-d287-4e5e-a97d-45be089cf37a

fix: Image clipping or not showing

https://github.com/user-attachments/assets/7ed1862f-433d-4bb0-b001-cf61205fcd2e

## Additional Context

Drafting a bit to test more, avoiding flukes

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6.5, tested for hours on prod, still testing

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

[^1]: The black screen on full screen is related to my system performances in that moment