### PR TITLE
Fix footnotes and overflow

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -49,10 +49,13 @@ export function SearchText ({ text }) {
 
 // this is one of the slowest components to render
 export default memo(function Text ({ rel = UNKNOWN_LINK_REL, imgproxyUrls, children, tab, itemId, outlawed, topLevel }) {
+  // would the text overflow on the current screen size?
   const [overflowing, setOverflowing] = useState(false)
-  const router = useRouter()
+  // should we show the full text?
   const [show, setShow] = useState(false)
   const containerRef = useRef(null)
+
+  const router = useRouter()
   const [mathJaxPlugin, setMathJaxPlugin] = useState(null)
 
   // we only need mathjax if there's math content between $$ tags

--- a/components/text.js
+++ b/components/text.js
@@ -69,9 +69,9 @@ export default memo(function Text ({ rel = UNKNOWN_LINK_REL, imgproxyUrls, child
 
   // if we are navigating to a hash, show the full text
   useEffect(() => {
-    setShow(router.asPath.includes('#') && !router.asPath.includes('#itemfn-'))
+    setShow(router.asPath.includes('#'))
     const handleRouteChange = (url, { shallow }) => {
-      setShow(url.includes('#') && !url.includes('#itemfn-'))
+      setShow(url.includes('#'))
     }
 
     router.events.on('hashChangeStart', handleRouteChange)


### PR DESCRIPTION
## Description

If you click on a footnote in a long post before you click `show full text`, the button disappears but the text is still contained:

https://github.com/user-attachments/assets/9df6a5ce-f842-4836-a8fb-3b65ae899b9a

However, this also happens if you clicked `show full text`. In that case, the text is contained again.

**Steps to reproduce**

1. Go to https://stacker.news/items/400430
2. Click on first footnote

## Additional Context

The fix is to remove code that was added in cc4bbf99e47862a4924510a5806c7f314ddd8854 and explicitly checks for the `#itemfn-` prefix. This looks like the code was added to fix something. But I couldn't tell what that would be. Why wouldn't we want to show the full text if we're navigating to a footnote? Wouldn't we want to handle it like clicking on a chapter? :thinking: 

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested clicking on footnotes, chapters, hard navigation, shallow navigation.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no