### PR TITLE
Also check for `user` before setting multi auth cookies

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -116,14 +116,6 @@ function getCallbacks (req, res) {
             }
           }
         }
-
-        // add multi_auth cookie for user that just logged in
-        if (res) {
-          const secret = process.env.NEXTAUTH_SECRET
-          const jwt = await encodeJWT({ token, secret })
-          const me = await prisma.user.findUnique({ where: { id: token.id } })
-          setMultiAuthCookies(new NodeNextRequest(req), new NodeNextResponse(res), { ...me, jwt })
-        }
       }
 
       if (token?.id) {
@@ -131,6 +123,14 @@ function getCallbacks (req, res) {
         // setting it here allows us to link multiple auth method to an account
         // ... in v3 this linking field was token.user.id
         token.sub = Number(token.id)
+      }
+
+      // add multi_auth cookie for user that just logged in
+      if (user && req && res) {
+        const secret = process.env.NEXTAUTH_SECRET
+        const jwt = await encodeJWT({ token, secret })
+        const me = await prisma.user.findUnique({ where: { id: token.id } })
+        setMultiAuthCookies(new NodeNextRequest(req), new NodeNextResponse(res), { ...me, jwt })
       }
 
       return token

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -116,6 +116,14 @@ function getCallbacks (req, res) {
             }
           }
         }
+
+        // add multi_auth cookie for user that just logged in
+        if (res) {
+          const secret = process.env.NEXTAUTH_SECRET
+          const jwt = await encodeJWT({ token, secret })
+          const me = await prisma.user.findUnique({ where: { id: token.id } })
+          setMultiAuthCookies(new NodeNextRequest(req), new NodeNextResponse(res), { ...me, jwt })
+        }
       }
 
       if (token?.id) {
@@ -123,17 +131,6 @@ function getCallbacks (req, res) {
         // setting it here allows us to link multiple auth method to an account
         // ... in v3 this linking field was token.user.id
         token.sub = Number(token.id)
-      }
-
-      // this only runs during a signup/login because response is only defined during signup/login
-      // and will add the multi_auth cookies for the user we just logged in as
-      if (req && res) {
-        req = new NodeNextRequest(req)
-        res = new NodeNextResponse(res)
-        const secret = process.env.NEXTAUTH_SECRET
-        const jwt = await encodeJWT({ token, secret })
-        const me = await prisma.user.findUnique({ where: { id: token.id } })
-        setMultiAuthCookies(req, res, { ...me, jwt })
       }
 
       return token


### PR DESCRIPTION
While reviewing #1904, I noticed checking `req && res` to detect if it's a login is weird. Not sure why I did that since `next-auth` already gives us a way to detect logins:

> The arguments _user_, _account_, _profile_ and _isNewUser_ are only passed the first time this callback is called on a new session, after the user signs in. In subsequent calls, only `token` will be available.

-- https://next-auth.js.org/configuration/callbacks#jwt-callback

So I moved the code into the existing `if (user)` block and tested that we can still:

1. login
2. add a new account
3. logout (until full logout)

Authentication is critical piece of code so to keep the `if (req && res)` check might make sense but `req` is definitely set (we also access it above) so I only added `if (res)`. `res` should also always be set ... but only afaict.

**Update**

Changed my mind regarding this PR, see https://github.com/stackernews/stacker.news/pull/1941#discussion_r1978479895