### PR TITLE
Fix issue #787: Exclude posts in own subs from spam detection

### DIFF
--- a/prisma/migrations/20250305175301/migration.sql
+++ b/prisma/migrations/20250305175301/migration.sql
@@ -1,0 +1,47 @@
+-- exclude posts in own subs from spam detection
+CREATE OR REPLACE FUNCTION item_spam(parent_id INTEGER, user_id INTEGER, within INTERVAL)
+RETURNS INTEGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    repeats INTEGER;
+    self_replies INTEGER;
+BEGIN
+    -- no fee escalation
+    IF within = interval '0' THEN
+        RETURN 0;
+    END IF;
+
+    SELECT count(*) INTO repeats
+    FROM "Item"
+    JOIN "Sub" ON "Sub"."name" = "Item"."subName"
+    WHERE (
+        (parent_id IS NULL AND "parentId" IS NULL)
+        OR
+        ("parentId" = parent_id AND user_id <> (SELECT i."userId" FROM "Item" i WHERE i.id = "Item"."rootId"))
+    )
+    AND "Item"."userId" = user_id
+    AND "bio" = 'f'
+    AND "Sub"."userId" <> user_id
+    AND "Item".created_at > now_utc() - within;
+
+    IF parent_id IS NULL THEN
+        RETURN repeats;
+    END IF;
+
+    WITH RECURSIVE base AS (
+        SELECT "Item".id, "Item"."parentId", "Item"."userId"
+        FROM "Item"
+        WHERE id = parent_id
+        AND "userId" = user_id
+        AND created_at > now_utc() - within
+        AND user_id <> (SELECT i."userId" FROM "Item" i WHERE i.id = "Item"."rootId")
+      UNION ALL
+        SELECT "Item".id, "Item"."parentId", "Item"."userId"
+        FROM base p
+        JOIN "Item" ON "Item".id = p."parentId" AND "Item"."userId" = p."userId" AND "Item".created_at > now_utc() - within)
+    SELECT count(*) INTO self_replies FROM base;
+
+    RETURN repeats + self_replies;
+END;
+$$;


### PR DESCRIPTION
## Description

Fix #787 

Modify SQL function item_spam to ignore posts made in own subs:

```
 CREATE OR REPLACE FUNCTION item_spam(parent_id INTEGER, user_id INTEGER, within INTERVAL)
 RETURNS INTEGER
 LANGUAGE plpgsql
@@ -14,14 +14,16 @@
 
     SELECT count(*) INTO repeats
     FROM "Item"
+    JOIN "Sub" ON "Sub"."name" = "Item"."subName"
     WHERE (
         (parent_id IS NULL AND "parentId" IS NULL)
         OR
         ("parentId" = parent_id AND user_id <> (SELECT i."userId" FROM "Item" i WHERE i.id = "Item"."rootId"))
     )
-    AND "userId" = user_id
+    AND "Item"."userId" = user_id
     AND "bio" = 'f'
-    AND created_at > now_utc() - within;
+    AND "Sub"."userId" <> user_id
+    AND "Item".created_at > now_utc() - within;
 
     IF parent_id IS NULL THEN
         RETURN repeats;

```
I tested by running the replaced function through **./sndev psql** and

`stackernews=# select item_spam(NULL, 15556, interval '1' hour);
`

And testing by posting as territory owner in the web interface.

Note that this will only ignore posts made by a territory owner in their own subs. Posts made in others' subs still count. As they should, IMO.
