### PR TITLE
Fix no pw manager autofill for device sync password

### DIFF
--- a/pages/settings/passphrase/index.js
+++ b/pages/settings/passphrase/index.js
@@ -131,7 +131,6 @@ function Enabled ({ setVaultKey, clearVault }) {
           placeholder=''
           required
           autoFocus
-          rows={3}
           qr
         />
         <div className='mt-3'>

--- a/pages/settings/passphrase/index.js
+++ b/pages/settings/passphrase/index.js
@@ -131,7 +131,6 @@ function Enabled ({ setVaultKey, clearVault }) {
           placeholder=''
           required
           autoFocus
-          as='textarea'
           rows={3}
           qr
         />


### PR DESCRIPTION
## Description

fix #1950

I think that we use `<textarea>` instead of `<input>` is related, see video.

I tried yesterday to get my password manager autofill to work with `<textarea>`, which is what we currently use for the device sync password input, but I am not sure it's possible even though it has `autocomplete="current-password"` and `type="password"` set. So I think we need to switch to `<input>`.

## Video

https://github.com/user-attachments/assets/c291b846-7b1d-4eaf-aed1-d5a270d215d1

## Additional Context

Password manager autofill is also related to us wanting to switch to a dedicated input component for bip39 with separate inputs for each word: I guess with separate inputs you can't use password manager autofill 🤔

edit: or maybe it could work by using autofill on the first word input and then our code puts each word into its own input by splitting on whitespace :thinking:  

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. See video.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no