### PR TITLE
Allow any admin to toggle SNL banner

### DIFF
--- a/api/resolvers/admin.js
+++ b/api/resolvers/admin.js
@@ -1,3 +1,5 @@
+import { SN_ADMIN_IDS } from '@/lib/constants'
+
 export default {
   Query: {
     snl: async (parent, _, { models }) => {
@@ -7,7 +9,7 @@ export default {
   },
   Mutation: {
     onAirToggle: async (parent, _, { models, me }) => {
-      if (me.id !== 616) {
+      if (!me || !SN_ADMIN_IDS.includes(me.id)) {
         throw new Error('not an admin')
       }
       const { id, live } = await models.snl.findFirst()


### PR DESCRIPTION
I thought @huumn forgot to enable the SNL banner but I just had to refresh my page.

I think this is still a good idea.

QA: `9`. Tested that non-admins cannot toggle and tested that admins can with this patch and inserting a row into the `Snl` table:

```diff
diff --git a/lib/constants.js b/lib/constants.js
index a2feb4df..d904b291 100644
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -62,9 +62,10 @@ export const USER_ID = {
   anon: 27,
   ad: 9,
   delete: 106,
-  saloon: 17226
+  saloon: 17226,
+  test01: 21858
 }
-export const SN_ADMIN_IDS = [USER_ID.k00b, USER_ID.ek, USER_ID.sn]
+export const SN_ADMIN_IDS = [USER_ID.k00b, USER_ID.ek, USER_ID.sn, USER_ID.test01]
 export const SN_NO_REWARDS_IDS = [USER_ID.anon, USER_ID.sn, USER_ID.saloon]
 export const MAX_POLL_NUM_CHOICES = 10
 export const MIN_POLL_NUM_CHOICES = 2
```