### PR TITLE
Remove unnecessary wrapping with NodeNext(Request|Response)

### DIFF
--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -11,6 +11,7 @@ import {
   ApolloServerPluginLandingPageLocalDefault,
   ApolloServerPluginLandingPageProductionDefault
 } from '@apollo/server/plugin/landingPage/default'
+import { NodeNextRequest } from 'next/dist/server/base-http/node'
 
 const apolloServer = new ApolloServer({
   typeDefs,
@@ -84,6 +85,12 @@ export default startServerAndCreateNextHandler(apolloServer, {
 
 export function multiAuthMiddleware (request) {
   // switch next-auth session cookie with multi_auth cookie if cookie pointer present
+
+  if (!request.cookies) {
+    // required to properly access parsed cookies via request.cookies
+    // and not unparsed via request.headers.cookie
+    request = new NodeNextRequest(request)
+  }
 
   // is there a cookie pointer?
   const cookiePointerName = 'multi_auth.user-id'


### PR DESCRIPTION
## Description

It confused me why I wrapped `req` and `res` with `NodeNextRequest` and `NodeNextResponse` even though it wasn't needed.

It's only needed when one wants to access parsed cookies via `request.cookies` else they are just available as a string under `request.headers.cookie`.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested email login, adding a nostr account and switching between users and anon.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no