### PR TITLE
Reset multi_auth cookies on error

### DIFF
--- a/components/account.js
+++ b/components/account.js
@@ -8,39 +8,30 @@ import { useQuery } from '@apollo/client'
 import { UserListRow } from '@/components/user-list'
 import Link from 'next/link'
 import AddIcon from '@/svgs/add-fill.svg'
+import { MultiAuthErrorBanner } from '@/components/banners'
 
 const AccountContext = createContext()
 
+const CHECK_ERRORS_INTERVAL_MS = 5_000
+
 const b64Decode = str => Buffer.from(str, 'base64').toString('utf-8')
-const b64Encode = obj => Buffer.from(JSON.stringify(obj)).toString('base64')
 
 const maybeSecureCookie = cookie => {
   return window.location.protocol === 'https:' ? cookie + '; Secure' : cookie
 }
 
 export const AccountProvider = ({ children }) => {
-  const { me } = useMe()
   const [accounts, setAccounts] = useState([])
   const [meAnon, setMeAnon] = useState(true)
+  const [errors, setErrors] = useState([])
 
   const updateAccountsFromCookie = useCallback(() => {
-    try {
-      const { multi_auth: multiAuthCookie } = cookie.parse(document.cookie)
-      const accounts = multiAuthCookie
-        ? JSON.parse(b64Decode(multiAuthCookie))
-        : me ? [{ id: Number(me.id), name: me.name, photoId: me.photoId }] : []
-      setAccounts(accounts)
-      // required for backwards compatibility: sync cookie with accounts if no multi auth cookie exists
-      // this is the case for sessions that existed before we deployed account switching
-      if (!multiAuthCookie && !!me) {
-        document.cookie = maybeSecureCookie(`multi_auth=${b64Encode(accounts)}; Path=/`)
-      }
-    } catch (err) {
-      console.error('error parsing cookies:', err)
-    }
+    const { multi_auth: multiAuthCookie } = cookie.parse(document.cookie)
+    const accounts = multiAuthCookie
+      ? JSON.parse(b64Decode(multiAuthCookie))
+      : []
+    setAccounts(accounts)
   }, [])
-
-  useEffect(updateAccountsFromCookie, [])
 
   const addAccount = useCallback(user => {
     setAccounts(accounts => [...accounts, user])
@@ -59,15 +50,43 @@ export const AccountProvider = ({ children }) => {
     return switchSuccess
   }, [updateAccountsFromCookie])
 
-  useEffect(() => {
-    if (SSR) return
-    const { 'multi_auth.user-id': multiAuthUserIdCookie } = cookie.parse(document.cookie)
-    setMeAnon(multiAuthUserIdCookie === 'anonymous')
+  const checkErrors = useCallback(() => {
+    const {
+      multi_auth: multiAuthCookie,
+      'multi_auth.user-id': multiAuthUserIdCookie
+    } = cookie.parse(document.cookie)
+
+    const errors = []
+
+    if (!multiAuthCookie) errors.push('multi_auth cookie not found')
+    if (!multiAuthUserIdCookie) errors.push('multi_auth.user-id cookie not found')
+
+    setErrors(errors)
   }, [])
 
+  useEffect(() => {
+    if (SSR) return
+
+    updateAccountsFromCookie()
+
+    const { 'multi_auth.user-id': multiAuthUserIdCookie } = cookie.parse(document.cookie)
+    setMeAnon(multiAuthUserIdCookie === 'anonymous')
+
+    const interval = setInterval(checkErrors, CHECK_ERRORS_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [updateAccountsFromCookie, checkErrors])
+
   const value = useMemo(
-    () => ({ accounts, addAccount, removeAccount, meAnon, setMeAnon, nextAccount }),
-    [accounts, addAccount, removeAccount, meAnon, setMeAnon, nextAccount])
+    () => ({
+      accounts,
+      addAccount,
+      removeAccount,
+      meAnon,
+      setMeAnon,
+      nextAccount,
+      multiAuthErrors: errors
+    }),
+    [accounts, addAccount, removeAccount, meAnon, setMeAnon, nextAccount, errors])
   return <AccountContext.Provider value={value}>{children}</AccountContext.Provider>
 }
 
@@ -129,8 +148,22 @@ const AccountListRow = ({ account, ...props }) => {
 }
 
 export default function SwitchAccountList () {
-  const { accounts } = useAccounts()
+  const { accounts, multiAuthErrors } = useAccounts()
   const router = useRouter()
+
+  const hasError = multiAuthErrors.length > 0
+
+  if (hasError) {
+    return (
+      <>
+        <div className='my-2'>
+          <div className='d-flex flex-column flex-wrap mt-2 mb-3'>
+            <MultiAuthErrorBanner errors={multiAuthErrors} />
+          </div>
+        </div>
+      </>
+    )
+  }
 
   // can't show hat since the streak is not included in the JWT payload
   return (

--- a/components/banners.js
+++ b/components/banners.js
@@ -6,6 +6,7 @@ import { useMutation } from '@apollo/client'
 import { WELCOME_BANNER_MUTATION } from '@/fragments/users'
 import { useToast } from '@/components/toast'
 import Link from 'next/link'
+import AccordianItem from '@/components/accordian-item'
 
 export function WelcomeBanner ({ Banner }) {
   const { me } = useMe()
@@ -126,15 +127,21 @@ export function AuthBanner () {
 
 export function MultiAuthErrorBanner ({ errors }) {
   return (
-    <Alert className={`${styles.banner} mt-0`} key='info' variant='danger'>
+    <Alert className={styles.banner} key='info' variant='danger'>
       <div className='fw-bold mb-3'>Account switching is currently unavailable</div>
-      We have detected the following issues:
-      <ul>
-        {errors.map((err, i) => (
-          <li key={i}>{err}</li>
-        ))}
-      </ul>
-      To resolve these issues, please sign out and sign in again.
+      <AccordianItem
+        className='my-3'
+        header='We have detected the following issues:'
+        headerColor='var(--bs-danger-text-emphasis)'
+        body={
+          <ul>
+            {errors.map((err, i) => (
+              <li key={i}>{err}</li>
+            ))}
+          </ul>
+      }
+      />
+      <div className='mt-3'>To resolve these issues, please sign out and sign in again.</div>
     </Alert>
   )
 }

--- a/components/banners.js
+++ b/components/banners.js
@@ -123,3 +123,18 @@ export function AuthBanner () {
     </Alert>
   )
 }
+
+export function MultiAuthErrorBanner ({ errors }) {
+  return (
+    <Alert className={`${styles.banner} mt-0`} key='info' variant='danger'>
+      <div className='fw-bold mb-3'>Account switching is currently unavailable</div>
+      We have detected the following issues:
+      <ul>
+        {errors.map((err, i) => (
+          <li key={i}>{err}</li>
+        ))}
+      </ul>
+      To resolve these issues, please sign out and sign in again.
+    </Alert>
+  )
+}

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,0 +1,126 @@
+import { datePivot } from '@/lib/time'
+import * as cookie from 'cookie'
+import { NodeNextRequest } from 'next/dist/server/base-http/node'
+
+const b64Encode = obj => Buffer.from(JSON.stringify(obj)).toString('base64')
+const b64Decode = s => JSON.parse(Buffer.from(s, 'base64'))
+
+const userJwtRegexp = /^multi_auth\.\d+$/
+
+const cookieOptions = (args) => ({
+  path: '/',
+  secure: process.env.NODE_ENV === 'production',
+  // httpOnly cookies by default
+  httpOnly: true,
+  sameSite: 'lax',
+  // default expiration for next-auth JWTs is in 1 month
+  expires: datePivot(new Date(), { months: 1 }),
+  ...args
+})
+
+export function setMultiAuthCookies (req, res, { id, jwt, name, photoId }) {
+  const httpOnlyOptions = cookieOptions()
+  const jsOptions = { ...httpOnlyOptions, httpOnly: false }
+
+  // add JWT to **httpOnly** cookie
+  res.appendHeader('Set-Cookie', cookie.serialize(`multi_auth.${id}`, jwt, httpOnlyOptions))
+
+  // switch to user we just added
+  res.appendHeader('Set-Cookie', cookie.serialize('multi_auth.user-id', id, jsOptions))
+
+  let newMultiAuth = [{ id, name, photoId }]
+  if (req.cookies.multi_auth) {
+    const oldMultiAuth = b64Decode(req.cookies.multi_auth)
+    // make sure we don't add duplicates
+    if (oldMultiAuth.some(({ id: id_ }) => id_ === id)) return
+    newMultiAuth = [...oldMultiAuth, ...newMultiAuth]
+  }
+  res.appendHeader('Set-Cookie', cookie.serialize('multi_auth', b64Encode(newMultiAuth), jsOptions))
+}
+
+export function switchSessionCookie (request) {
+  // switch next-auth session cookie with multi_auth cookie if cookie pointer present
+
+  if (!request.cookies) {
+    // required to properly access parsed cookies via request.cookies
+    // and not unparsed via request.headers.cookie
+    request = new NodeNextRequest(request)
+  }
+
+  // is there a cookie pointer?
+  const cookiePointerName = 'multi_auth.user-id'
+  const hasCookiePointer = !!request.cookies[cookiePointerName]
+
+  const secure = process.env.NODE_ENV === 'production'
+
+  // is there a session?
+  const sessionCookieName = secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
+  const hasSession = !!request.cookies[sessionCookieName]
+
+  if (!hasCookiePointer || !hasSession) {
+    // no session or no cookie pointer. do nothing.
+    return request
+  }
+
+  const userId = request.cookies[cookiePointerName]
+  if (userId === 'anonymous') {
+    // user switched to anon. only delete session cookie.
+    delete request.cookies[sessionCookieName]
+    return request
+  }
+
+  const userJWT = request.cookies[`multi_auth.${userId}`]
+  if (!userJWT) {
+    // no JWT for account switching found
+    return request
+  }
+
+  if (userJWT) {
+    // use JWT found in cookie pointed to by cookie pointer
+    request.cookies[sessionCookieName] = userJWT
+    return request
+  }
+
+  return request
+}
+
+export function checkMultiAuthCookies (req, res) {
+  if (!req.cookies.multi_auth || !req.cookies['multi_auth.user-id']) {
+    return false
+  }
+
+  const accounts = b64Decode(req.cookies.multi_auth)
+  for (const account of accounts) {
+    if (!req.cookies[`multi_auth.${account.id}`]) {
+      return false
+    }
+  }
+
+  return true
+}
+
+export function resetMultiAuthCookies (req, res) {
+  const httpOnlyOptions = cookieOptions({ expires: 0, maxAge: 0 })
+  const jsOptions = { ...httpOnlyOptions, httpOnly: false }
+
+  if ('multi_auth' in req.cookies) res.appendHeader('Set-Cookie', cookie.serialize('multi_auth', '', jsOptions))
+  if ('multi_auth.user-id' in req.cookies) res.appendHeader('Set-Cookie', cookie.serialize('multi_auth.user-id', '', jsOptions))
+
+  for (const key of Object.keys(req.cookies)) {
+    // reset all user JWTs
+    if (userJwtRegexp.test(key)) {
+      res.appendHeader('Set-Cookie', cookie.serialize(key, '', httpOnlyOptions))
+    }
+  }
+}
+
+export function multiAuthMiddleware (req, res) {
+  req = switchSessionCookie(req)
+
+  const ok = checkMultiAuthCookies(req, res)
+  if (!ok) {
+    resetMultiAuthCookies(req, res)
+  }
+
+  return req
+}

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -125,7 +125,12 @@ export async function refreshMultiAuthCookies (req, res) {
     })
   }
 
+  const isAnon = req.cookies['multi_auth.user-id'] === 'anonymous'
+
   for (const [key, value] of Object.entries(req.cookies)) {
+    // only refresh session cookie manually if we switched to anon since else it's already handled by next-auth
+    if (key === SESSION_COOKIE_NAME && !isAnon) continue
+
     if (!key.startsWith('multi_auth') && key !== SESSION_COOKIE_NAME) continue
 
     if (userJwtRegexp.test(key) || key === SESSION_COOKIE_NAME) {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,11 +1,15 @@
 import { datePivot } from '@/lib/time'
 import * as cookie from 'cookie'
 import { NodeNextRequest } from 'next/dist/server/base-http/node'
+import { encode as encodeJWT, decode as decodeJWT } from 'next-auth/jwt'
 
 const b64Encode = obj => Buffer.from(JSON.stringify(obj)).toString('base64')
 const b64Decode = s => JSON.parse(Buffer.from(s, 'base64'))
 
 const userJwtRegexp = /^multi_auth\.\d+$/
+
+const HTTPS = process.env.NODE_ENV === 'production'
+const SESSION_COOKIE_NAME = HTTPS ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
 
 const cookieOptions = (args) => ({
   path: '/',
@@ -41,21 +45,12 @@ export function setMultiAuthCookies (req, res, { id, jwt, name, photoId }) {
 export function switchSessionCookie (request) {
   // switch next-auth session cookie with multi_auth cookie if cookie pointer present
 
-  if (!request.cookies) {
-    // required to properly access parsed cookies via request.cookies
-    // and not unparsed via request.headers.cookie
-    request = new NodeNextRequest(request)
-  }
-
   // is there a cookie pointer?
   const cookiePointerName = 'multi_auth.user-id'
   const hasCookiePointer = !!request.cookies[cookiePointerName]
 
-  const secure = process.env.NODE_ENV === 'production'
-
   // is there a session?
-  const sessionCookieName = secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
-  const hasSession = !!request.cookies[sessionCookieName]
+  const hasSession = !!request.cookies[SESSION_COOKIE_NAME]
 
   if (!hasCookiePointer || !hasSession) {
     // no session or no cookie pointer. do nothing.
@@ -65,7 +60,7 @@ export function switchSessionCookie (request) {
   const userId = request.cookies[cookiePointerName]
   if (userId === 'anonymous') {
     // user switched to anon. only delete session cookie.
-    delete request.cookies[sessionCookieName]
+    delete request.cookies[SESSION_COOKIE_NAME]
     return request
   }
 
@@ -77,7 +72,7 @@ export function switchSessionCookie (request) {
 
   if (userJWT) {
     // use JWT found in cookie pointed to by cookie pointer
-    request.cookies[sessionCookieName] = userJWT
+    request.cookies[SESSION_COOKIE_NAME] = userJWT
     return request
   }
 
@@ -114,13 +109,48 @@ export function resetMultiAuthCookies (req, res) {
   }
 }
 
-export function multiAuthMiddleware (req, res) {
-  req = switchSessionCookie(req)
+export async function refreshMultiAuthCookies (req, res) {
+  const httpOnlyOptions = cookieOptions()
+  const jsOptions = { ...httpOnlyOptions, httpOnly: false }
+
+  const refreshCookie = (name) => {
+    res.appendHeader('Set-Cookie', cookie.serialize(name, req.cookies[name], jsOptions))
+  }
+
+  const refreshToken = async (token) => {
+    const secret = process.env.NEXTAUTH_SECRET
+    return await encodeJWT({
+      token: await decodeJWT({ token, secret }),
+      secret
+    })
+  }
+
+  for (const [key, value] of Object.entries(req.cookies)) {
+    if (!key.startsWith('multi_auth') && key !== SESSION_COOKIE_NAME) continue
+
+    if (userJwtRegexp.test(key) || key === SESSION_COOKIE_NAME) {
+      const oldToken = value
+      const newToken = await refreshToken(oldToken)
+      res.appendHeader('Set-Cookie', cookie.serialize(key, newToken, httpOnlyOptions))
+      continue
+    }
+
+    refreshCookie(key)
+  }
+}
+
+export async function multiAuthMiddleware (req, res) {
+  if (!req.cookies) {
+    // required to properly access parsed cookies via req.cookies and not unparsed via req.headers.cookie
+    req = new NodeNextRequest(req)
+  }
 
   const ok = checkMultiAuthCookies(req, res)
   if (!ok) {
     resetMultiAuthCookies(req, res)
+    return switchSessionCookie(req)
   }
 
-  return req
+  await refreshMultiAuthCookies(req, res)
+  return switchSessionCookie(req)
 }

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -17,8 +17,8 @@ const cookieOptions = (args) => ({
   // httpOnly cookies by default
   httpOnly: true,
   sameSite: 'lax',
-  // default expiration for next-auth JWTs is in 1 month
-  expires: datePivot(new Date(), { months: 1 }),
+  // default expiration for next-auth JWTs is in 30 days
+  expires: datePivot(new Date(), { days: 30 }),
   ...args
 })
 

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -14,6 +14,7 @@ import { hashEmail } from '@/lib/crypto'
 import { multiAuthMiddleware, setMultiAuthCookies } from '@/lib/auth'
 import { BECH32_CHARSET } from '@/lib/constants'
 import { NodeNextRequest } from 'next/dist/server/base-http/node'
+import * as cookie from 'cookie'
 
 /**
  * Stores userIds in user table
@@ -726,7 +727,7 @@ const newUserHtml = ({ url, token, site, email }) => {
                   <tbody>
                     <tr>
                       <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Helvetica, Arial, sans-serif;font-size:14px;line-height:20px;text-align:left;color:#000000;">Stacker News is like Reddit or Hacker News, but it <b>pays you Bitcoin</b>. Instead of giving posts or comments “upvotes,” Stacker News users (aka stackers) send you small amounts of Bitcoin called sats.</div>
+                        <div style="font-family:Helvetica, Arial, sans-serif;font-size:14px;line-height:20px;text-align:left;color:#000000;">Stacker News is like Reddit or Hacker News, but it <b>pays you Bitcoin</b>. Instead of giving posts or comments "upvotes," Stacker News users (aka stackers) send you small amounts of Bitcoin called sats.</div>
                       </td>
                     </tr>
                     <tr>
@@ -741,7 +742,7 @@ const newUserHtml = ({ url, token, site, email }) => {
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Helvetica, Arial, sans-serif;font-size:14px;line-height:20px;text-align:left;color:#000000;">If you’re not sure what to share, <a href="${dailyUrl}"><b><i>click here to introduce yourself to the community</i></b></a> with a comment on the daily discussion thread.</div>
+                        <div style="font-family:Helvetica, Arial, sans-serif;font-size:14px;line-height:20px;text-align:left;color:#000000;">If you're not sure what to share, <a href="${dailyUrl}"><b><i>click here to introduce yourself to the community</i></b></a> with a comment on the daily discussion thread.</div>
                       </td>
                     </tr>
                     <tr>
@@ -751,7 +752,7 @@ const newUserHtml = ({ url, token, site, email }) => {
                     </tr>
                     <tr>
                       <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                        <div style="font-family:Helvetica, Arial, sans-serif;font-size:14px;line-height:20px;text-align:left;color:#000000;">If anything isn’t clear, comment on the FAQ post and we’ll answer your question.</div>
+                        <div style="font-family:Helvetica, Arial, sans-serif;font-size:14px;line-height:20px;text-align:left;color:#000000;">If anything isn't clear, comment on the FAQ post and we'll answer your question.</div>
                       </td>
                     </tr>
                     <tr>

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -161,7 +161,7 @@ async function pubkeyAuth (credentials, req, res, pubkeyColumnName) {
       let user = await prisma.user.findUnique({ where: { [pubkeyColumnName]: pubkey } })
 
       // make following code aware of cookie pointer for account switching
-      req = multiAuthMiddleware(req, res)
+      req = await multiAuthMiddleware(req, res)
       // token will be undefined if we're not logged in at all or if we switched to anon
       const token = await getToken({ req })
       if (!user) {

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -68,7 +68,7 @@ export default startServerAndCreateNextHandler(apolloServer, {
         session = { user: { ...sessionFields, apiKey: true } }
       }
     } else {
-      req = multiAuthMiddleware(req, res)
+      req = await multiAuthMiddleware(req, res)
       session = await getServerSession(req, res, getAuthOptions(req))
     }
     return {

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -11,7 +11,7 @@ import {
   ApolloServerPluginLandingPageLocalDefault,
   ApolloServerPluginLandingPageProductionDefault
 } from '@apollo/server/plugin/landingPage/default'
-import { NodeNextRequest } from 'next/dist/server/base-http/node'
+import { multiAuthMiddleware } from '@/lib/auth'
 
 const apolloServer = new ApolloServer({
   typeDefs,
@@ -68,7 +68,7 @@ export default startServerAndCreateNextHandler(apolloServer, {
         session = { user: { ...sessionFields, apiKey: true } }
       }
     } else {
-      req = multiAuthMiddleware(req)
+      req = multiAuthMiddleware(req, res)
       session = await getServerSession(req, res, getAuthOptions(req))
     }
     return {
@@ -82,49 +82,3 @@ export default startServerAndCreateNextHandler(apolloServer, {
     }
   }
 })
-
-export function multiAuthMiddleware (request) {
-  // switch next-auth session cookie with multi_auth cookie if cookie pointer present
-
-  if (!request.cookies) {
-    // required to properly access parsed cookies via request.cookies
-    // and not unparsed via request.headers.cookie
-    request = new NodeNextRequest(request)
-  }
-
-  // is there a cookie pointer?
-  const cookiePointerName = 'multi_auth.user-id'
-  const hasCookiePointer = !!request.cookies[cookiePointerName]
-
-  const secure = process.env.NODE_ENV === 'production'
-
-  // is there a session?
-  const sessionCookieName = secure ? '__Secure-next-auth.session-token' : 'next-auth.session-token'
-  const hasSession = !!request.cookies[sessionCookieName]
-
-  if (!hasCookiePointer || !hasSession) {
-    // no session or no cookie pointer. do nothing.
-    return request
-  }
-
-  const userId = request.cookies[cookiePointerName]
-  if (userId === 'anonymous') {
-    // user switched to anon. only delete session cookie.
-    delete request.cookies[sessionCookieName]
-    return request
-  }
-
-  const userJWT = request.cookies[`multi_auth.${userId}`]
-  if (!userJWT) {
-    // no JWT for account switching found
-    return request
-  }
-
-  if (userJWT) {
-    // use JWT found in cookie pointed to by cookie pointer
-    request.cookies[sessionCookieName] = userJWT
-    return request
-  }
-
-  return request
-}


### PR DESCRIPTION
## Description

fix #1821 based on #1956 #1974 supersedes #1904

I found out that we have a race condition on logout that exists without any account switching code: if a request starts before we receive the signout response (that deletes `next-auth.session-token`) and finishes after it, we're logged back in because it includes `next-auth.session-token` in the request headers and therefore also in the response headers thanks to the implicit token refresh on all requests.

However, I have also seen in the timings of the network tab that it's possible that a request still includes the cookie _after_ it was deleted AND _after_ we reloaded the page. This is somehow related to slow requests since this is reliably reproducible if we poll for `me` every second but sleep for 5 seconds on the server before replying. I don't know how it is possible to include a cookie in a request header that we previously deleted. It must be something the browser is doing like a request retry, but I don't think it makes sense for a browser to retry a request after a page was reloaded and any client-side code would be running in JS and JS can't set `httpOnly` cookies.

Since I wasn't able to prevent this from happening and I am not 100% sure that this is what causes #1821 or other issues with account switching that appear non-deterministic, I decided to show an error in the account switch dialog when we noticed that something is off with the cookies on the server.

This PR also includes the changes of #1904 so it also refreshes the cookies if there was no error.

## Screenshots

![2025-03-17-171124_513x393_scrot](https://github.com/user-attachments/assets/778f3ce4-8768-4633-b9a1-f1f3118dc52d)

## Additional context

1. `next-auth.session-token` returned to refresh while switched to anon

This also refreshes the session token while we're switched to anon. However, this means that we now return a response header that includes the session token even when we're switched to anon.

This might be unexpected but since we still delete the session token on the server (just for the request lifecycle) when switched to anon and thus the server still returns responses as if we're logged out, I don't think this breaks anything.

But I wanted to mention this since it can be weird to return a session token even though we're not considered logged in.

This only happens if the multi auth check is successful. If we're completely logged out, there are no multi auth cookies and thus this does not happen.

2. no checks for invalid tokens

> Decided to not check for invalid tokens because it's not just a try/catch but also requires logic to update the list and switch to the next account which might not exist if the last token ended up becoming invalid. However, I think tokens can only become invalid if they expired so I think this complexity isn't worth it. I am pretty confident the issues we're seeing with account switching aren't related to invalid tokens that didn't expire yet.

-- https://github.com/stackernews/stacker.news/pull/1957#issuecomment-2726165243

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested switching between users and anon; switching to next account on logout; deleting any `multi_auth` cookie deletes all `multi_auth` cookies; token refresh

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

yes, tested mobile, light and dark mode

**Did you introduce any new environment variables? If so, call them out explicitly here:**

yes