### PR TITLE
Fix fetching of user items in welcome script

### DIFF
--- a/scripts/welcome.js
+++ b/scripts/welcome.js
@@ -176,7 +176,7 @@ async function fetchItem (id) {
 async function fetchUserItems (name) {
   const data = await gql(`
     query UserItems($name: String!) {
-      items(sort: "user", name: $name) {
+      items(sort: "user", type: "all", limit: 999, name: $name) {
         items {
           id
           createdAt


### PR DESCRIPTION
https://stacker.news/items/904090

I originally wanted to use `limit: 9999` but then our API returns 400 Bad Request for some reason:

```gql
query UserItems {
  items(sort: "user", name: "bxu", type: "all", limit: 9999) {
    items {
      id
      createdAt
      sats
      credits
    }
  }
}
```

```json
{
  "errors": [
    {
      "message": "code=maximum",
      "locations": [
        {
          "line": 2,
          "column": 56
        }
      ],
      "extensions": {
        "code": "GRAPHQL_VALIDATION_FAILED"
      }
    }
  ]
}
```