### PR TITLE
Add welcome banner back

### DIFF
--- a/pages/~/index.js
+++ b/pages/~/index.js
@@ -7,6 +7,7 @@ import Snl from '@/components/snl'
 import { useQuery } from '@apollo/client'
 import PageLoading from '@/components/page-loading'
 import TerritoryHeader from '@/components/territory-header'
+import { WelcomeBanner } from '@/components/banners'
 
 export const getServerSideProps = getGetServerSideProps({
   query: SUB_ITEMS,
@@ -28,6 +29,7 @@ export default function Sub ({ ssrData }) {
         : (
           <>
             <Snl />
+            <WelcomeBanner />
           </>)}
       <Items ssrData={ssrData} variables={variables} />
     </Layout>


### PR DESCRIPTION
## Description

It was removed in https://github.com/stackernews/stacker.news/commit/f2ba61e64bcc0a7ff06a3aa8eec6df3fd8cf7ac9 as an accident I suppose.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Hiding it still works.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

works like before

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no