### PR TITLE
Fix item cost in details

### DIFF
--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -30,8 +30,14 @@ export async function getBaseCost ({ models, bio, parentId, subName }) {
 
     const root = parent.root ?? parent
 
-    if (!root.sub) return DEFAULT_ITEM_COST
-    return satsToMsats(root.sub.replyCost)
+    // XXX Prisma does not support case-insensitive joins on CITEXT column
+    // so we fetch the territory in a separate query
+    const sub = await models.sub.findUnique({
+      where: { name: root.subName }
+    })
+
+    if (!sub) return DEFAULT_ITEM_COST
+    return satsToMsats(sub.replyCost)
   }
 
   const sub = await models.sub.findUnique({ where: { name: subName } })

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -108,6 +108,7 @@ export const ITEM_FULL_FIELDS = gql`
         moderated
         meMuteSub
         meSubscription
+        replyCost
       }
     }
     forwards {


### PR DESCRIPTION
## Description

Fix https://stacker.news/items/909192?commentId=909224

As @huumn guessed, the issue was that Prisma can't join on `CITEXT` in a case-insensitive way, see https://github.com/prisma/prisma/issues/14935.

To fix that, I fetch the territory in a separate query now.

## Video

https://github.com/user-attachments/assets/cf44c2ed-9585-41c1-af45-3811510a666e

## Additional Context

Apparently, [we could also just use the preview feature `relationJoins`](https://www.prisma.io/docs/orm/prisma-client/queries/relation-queries#relation-load-strategies-preview), but I don't think we want to trust Prisma with preview features.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. See video.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no