### PR TITLE
Rename to /api/next-account

### DIFF
--- a/components/account.js
+++ b/components/account.js
@@ -51,7 +51,7 @@ export const AccountProvider = ({ children }) => {
   }, [])
 
   const multiAuthSignout = useCallback(async () => {
-    const { status } = await fetch('/api/signout', { credentials: 'include' })
+    const { status } = await fetch('/api/next-account', { credentials: 'include' })
     // if status is 302, this means the server was able to switch us to the next available account
     // and the current account was simply removed from the list of available accounts including the corresponding JWT.
     const switchSuccess = status === 302

--- a/pages/api/next-account.js
+++ b/pages/api/next-account.js
@@ -1,5 +1,5 @@
 import * as cookie from 'cookie'
-import { datePivot } from '../../lib/time'
+import { datePivot } from '@/lib/time'
 
 /**
  * @param  {NextApiRequest}  req


### PR DESCRIPTION
Using /api/signout just because we use it during signout was a terrible naming choice imo. 'next-account' describes way better what this route does.