### PR TITLE
Fix saloon replies

### DIFF
--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -27,8 +27,8 @@ export async function getBaseCost ({ models, bio, parentId, subName }) {
       LEFT JOIN "Sub" s ON s.name = COALESCE(r."subName", i."subName")
       WHERE i.id = ${Number(parentId)}`
 
-    if (!sub) return DEFAULT_ITEM_COST
-    return satsToMsats(sub.replyCost)
+    if (sub?.replyCost) return satsToMsats(sub.replyCost)
+    return DEFAULT_ITEM_COST
   }
 
   const sub = await models.sub.findUnique({ where: { name: subName } })


### PR DESCRIPTION
## Description

The query will return `{ replyCost: null }` if no sub was found because of the left join.

Instead of changing the query to use a inner join for the `Sub` table, I decided to check `sub?.replyCost` instead. Using a different join to keep `if (!sub)` felt wrong but not really sure why.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested replies to items with no sub (like the saloon would be in prod) and with subs.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no