### PR TITLE
Add check for Sub.replyCost > 0

### DIFF
--- a/prisma/migrations/20250312223725_check_reply_cost_positive/migration.sql
+++ b/prisma/migrations/20250312223725_check_reply_cost_positive/migration.sql
@@ -1,0 +1,2 @@
+-- Add constraint to ensure replyCost is positive
+ALTER TABLE "Sub" ADD CONSTRAINT "Sub_replyCost_positive" CHECK ("replyCost" > 0);


### PR DESCRIPTION
## Description

It made me uneasy when I saw that we don't have this check on the database. I manually updated a sub with a negative reply cost and I was able to print cowboy credits via replies.

## Additional Context

I didn't add `NO VALID` since we don't have so many territories that we can't check them all at once.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. Tested replies but pretty confident this is good.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no