### PR TITLE
Don't poll failed invoices if anon

### DIFF
--- a/wallets/index.js
+++ b/wallets/index.js
@@ -236,6 +236,7 @@ function RetryHandler ({ children }) {
   const waitForWalletPayment = useWalletPayment()
   const invoiceHelper = useInvoice()
   const [getFailedInvoices] = useLazyQuery(FAILED_INVOICES, { fetchPolicy: 'network-only', nextFetchPolicy: 'network-only' })
+  const { me } = useMe()
 
   const retry = useCallback(async (invoice) => {
     const newInvoice = await invoiceHelper.retry({ ...invoice, newAttempt: true })
@@ -254,6 +255,8 @@ function RetryHandler ({ children }) {
   useEffect(() => {
     // we always retry failed invoices, even if the user has no wallets on any client
     // to make sure that failed payments will always show up in notifications eventually
+
+    if (!me) return
 
     const retryPoll = async () => {
       let failedInvoices
@@ -298,7 +301,7 @@ function RetryHandler ({ children }) {
 
     queuePoll()
     return stopPolling
-  }, [wallets, getFailedInvoices, retry])
+  }, [me?.id, wallets, getFailedInvoices, retry])
 
   return children
 }


### PR DESCRIPTION
## Description

Fixes error messages in the browser console:

> failed to fetch invoices to retry: ApolloError: you must be logged in

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested by switching between anon and user.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no