### PR TITLE
Top cowboys territory selector fix

### DIFF
--- a/components/sub-select.js
+++ b/components/sub-select.js
@@ -94,8 +94,13 @@ export default function SubSelect ({ prependSubs, sub, onChange, size, appendSub
           }
         } else {
           // we're currently on the home sub
-          // are we in a sub aware route?
-          if (router.pathname.startsWith('/~')) {
+          // if we're in top/cowboys and a territory is selected,
+          // go to ~sub/top/posts/day
+          if (router.pathname.endsWith('top/cowboys')) {
+            router.push(sub ? `/~${sub}/top/posts/day` : '/top/cowboys')
+            return
+          } else if (router.pathname.startsWith('/~')) {
+            // are we in a sub aware route?
             // if we are, go to the same path but in the sub
             asPath = `/~${sub}` + router.asPath
           } else {

--- a/components/sub-select.js
+++ b/components/sub-select.js
@@ -97,13 +97,13 @@ export default function SubSelect ({ prependSubs, sub, onChange, size, appendSub
           // if in /top/cowboys, /top/territories, or /top/stackers
           // and a territory is selected, go to /~sub/top/posts/day
           if (router.pathname.startsWith('/~/top/cowboys')) {
-            router.push(sub ? `/~${sub}/top/posts/day` : router.pathname)
+            router.push(sub ? `/~${sub}/top/posts/day` : '/top/cowboys')
             return
           } else if (router.pathname.startsWith('/~/top/stackers')) {
-            router.push(sub ? `/~${sub}/top/posts/day` : router.pathname)
+            router.push(sub ? `/~${sub}/top/posts/day` : 'top/stackers/day')
             return
           } else if (router.pathname.startsWith('/~/top/territories')) {
-            router.push(sub ? `/~${sub}/top/posts/day` : router.pathname)
+            router.push(sub ? `/~${sub}/top/posts/day` : '/top/territories/day')
             return
           } else if (router.pathname.startsWith('/~')) {
             // are we in a sub aware route?

--- a/components/sub-select.js
+++ b/components/sub-select.js
@@ -94,10 +94,16 @@ export default function SubSelect ({ prependSubs, sub, onChange, size, appendSub
           }
         } else {
           // we're currently on the home sub
-          // if we're in top/cowboys and a territory is selected,
-          // go to ~sub/top/posts/day
-          if (router.pathname.endsWith('/top/cowboys')) {
-            router.push(sub ? `/~${sub}/top/posts/day` : '/top/cowboys')
+          // if in /top/cowboys, /top/territories, or /top/stackers
+          // and a territory is selected, go to /~sub/top/posts/day
+          if (router.pathname.startsWith('/~/top/cowboys')) {
+            router.push(sub ? `/~${sub}/top/posts/day` : router.pathname)
+            return
+          } else if (router.pathname.startsWith('/~/top/stackers')) {
+            router.push(sub ? `/~${sub}/top/posts/day` : router.pathname)
+            return
+          } else if (router.pathname.startsWith('/~/top/territories')) {
+            router.push(sub ? `/~${sub}/top/posts/day` : router.pathname)
             return
           } else if (router.pathname.startsWith('/~')) {
             // are we in a sub aware route?

--- a/components/sub-select.js
+++ b/components/sub-select.js
@@ -96,7 +96,7 @@ export default function SubSelect ({ prependSubs, sub, onChange, size, appendSub
           // we're currently on the home sub
           // if we're in top/cowboys and a territory is selected,
           // go to ~sub/top/posts/day
-          if (router.pathname.endsWith('top/cowboys')) {
+          if (router.pathname.endsWith('/top/cowboys')) {
             router.push(sub ? `/~${sub}/top/posts/day` : '/top/cowboys')
             return
           } else if (router.pathname.startsWith('/~')) {

--- a/next.config.js
+++ b/next.config.js
@@ -194,6 +194,11 @@ module.exports = withPlausibleProxy()({
         source: '/top/cowboys/:when',
         destination: '/top/cowboys',
         permanent: true
+      },
+      {
+        source: '/~:sub/top/cowboys',
+        destination: '/top/cowboys',
+        permanent: true
       }
     ]
   },

--- a/next.config.js
+++ b/next.config.js
@@ -199,6 +199,16 @@ module.exports = withPlausibleProxy()({
         source: '/~:sub/top/cowboys',
         destination: '/top/cowboys',
         permanent: true
+      },
+      {
+        source: '/~:sub/top/stackers/:when*',
+        destination: '/top/stackers/:when*',
+        permanent: true
+      },
+      {
+        source: '/~:sub/top/territories/:when*',
+        destination: '/top/territories/:when*',
+        permanent: true
       }
     ]
   },


### PR DESCRIPTION
## Description

Closes https://github.com/stackernews/stacker.news/issues/1254

Selecting a territory while on `/top/cowboys` now sends you to `/~:sub/top/posts/day` (or stay in `top/cowboys` if home is selected). 

Redirects `/~:sub/top/cowboys` to `/top/cowboys`.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

9

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no