### PR TITLE
Support / at the end of LNbits URL

### DIFF
--- a/wallets/lnbits/server.js
+++ b/wallets/lnbits/server.js
@@ -33,7 +33,7 @@ export async function createInvoice (
     out: false
   })
 
-  let hostname = url.replace(/^https?:\/\//, '')
+  let hostname = url.replace(/^https?:\/\//, '').replace(/\/+$/, '')
   const agent = getAgent({ hostname })
 
   if (process.env.NODE_ENV !== 'production' && hostname.startsWith('localhost:')) {


### PR DESCRIPTION
## Description

Fix #1959

Strip trailing slashes from url, since path always starts with a slash. Similar to how client.js already does.
