### PR TITLE
Prevent new account creation on login

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -53,14 +53,14 @@ export function authErrorMessage (error) {
   return error && (authErrorMessages[error] ?? authErrorMessages.default)
 }
 
-export default function Login ({ providers, callbackUrl, multiAuth, error, text, Header, Footer, signup }) {
+export default function Login ({ providers, callbackUrl, multiAuth, error, text, Header, Footer, signin }) {
   const [errorMessage, setErrorMessage] = useState(authErrorMessage(error))
   const router = useRouter()
 
   // signup/signin awareness cookie
   useEffect(() => {
     const cookieOptions = [
-      `signup=${!!signup}`,
+      `signin=${!!signin}`,
       'path=/',
       'max-age=' + 60 * 60 * 24, // 24 hours
       'SameSite=Lax',
@@ -68,7 +68,7 @@ export default function Login ({ providers, callbackUrl, multiAuth, error, text,
     ].filter(Boolean).join(';')
 
     document.cookie = cookieOptions
-  }, [signup])
+  }, [signin])
 
   if (router.query.type === 'lightning') {
     return <LightningAuthWithExplainer callbackUrl={callbackUrl} text={text} multiAuth={multiAuth} />

--- a/components/login.js
+++ b/components/login.js
@@ -1,7 +1,7 @@
 import { signIn } from 'next-auth/react'
 import styles from './login.module.css'
 import { Form, Input, SubmitButton } from '@/components/form'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Alert from 'react-bootstrap/Alert'
 import { useRouter } from 'next/router'
 import { LightningAuthWithExplainer } from './lightning-auth'
@@ -53,9 +53,25 @@ export function authErrorMessage (error) {
   return error && (authErrorMessages[error] ?? authErrorMessages.default)
 }
 
-export default function Login ({ providers, callbackUrl, multiAuth, error, text, Header, Footer }) {
+export default function Login ({ providers, callbackUrl, multiAuth, error, text, Header, Footer, signup }) {
   const [errorMessage, setErrorMessage] = useState(authErrorMessage(error))
   const router = useRouter()
+
+  const setSignupCookie = (isSignup) => {
+    const cookieOptions = [
+      `signup=${isSignup}`,
+      'path=/',
+      'max-age=300',
+      'SameSite=Lax',
+      process.env.NODE_ENV === 'production' ? 'Secure' : ''
+    ].filter(Boolean).join(';')
+
+    document.cookie = cookieOptions
+  }
+
+  useEffect(() => {
+    setSignupCookie(!!signup)
+  }, [signup])
 
   if (router.query.type === 'lightning') {
     return <LightningAuthWithExplainer callbackUrl={callbackUrl} text={text} multiAuth={multiAuth} />

--- a/components/login.js
+++ b/components/login.js
@@ -42,10 +42,10 @@ const authErrorMessages = {
   OAuthCallback: 'Error handling OAuth response. Try again or choose a different method.',
   OAuthCreateAccount: 'Could not create OAuth account. Try again or choose a different method.',
   EmailCreateAccount: 'Could not create Email account. Try again or choose a different method.',
-  Callback: 'Try again or choose a different method.',
+  Callback: 'Could not authenticate. Try again or choose a different method.',
   OAuthAccountNotLinked: 'This auth method is linked to another account. To link to this account first unlink the other account.',
   EmailSignin: 'Failed to send email. Make sure you entered your email address correctly.',
-  CredentialsSignin: 'Auth failed. Try again or choose a different method.',
+  CredentialsSignin: 'Could not authenticate. Try again or choose a different method.',
   default: 'Auth failed. Try again or choose a different method.'
 }
 

--- a/components/login.js
+++ b/components/login.js
@@ -62,7 +62,7 @@ export default function Login ({ providers, callbackUrl, multiAuth, error, text,
     const cookieOptions = [
       `signin=${!!signin}`,
       'path=/',
-      'max-age=' + 60 * 60 * 24, // 24 hours
+      'max-age=' + (signin ? 60 * 60 * 24 : 0), // 24 hours if signin is true, expire the cookie otherwise
       'SameSite=Lax',
       process.env.NODE_ENV === 'production' ? 'Secure' : ''
     ].filter(Boolean).join(';')

--- a/components/login.js
+++ b/components/login.js
@@ -57,20 +57,17 @@ export default function Login ({ providers, callbackUrl, multiAuth, error, text,
   const [errorMessage, setErrorMessage] = useState(authErrorMessage(error))
   const router = useRouter()
 
-  const setSignupCookie = (isSignup) => {
+  // signup/signin awareness cookie
+  useEffect(() => {
     const cookieOptions = [
-      `signup=${isSignup}`,
+      `signup=${!!signup}`,
       'path=/',
-      'max-age=300',
+      'max-age=' + 60 * 60 * 24, // 24 hours
       'SameSite=Lax',
       process.env.NODE_ENV === 'production' ? 'Secure' : ''
     ].filter(Boolean).join(';')
 
     document.cookie = cookieOptions
-  }
-
-  useEffect(() => {
-    setSignupCookie(!!signup)
   }, [signup])
 
   if (router.query.type === 'lightning') {

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -94,6 +94,8 @@ function getCallbacks (req, res) {
      */
     async jwt ({ token, user, account, profile, isNewUser }) {
       if (user) {
+        // reset signup cookie if any
+        res.setHeader('Set-Cookie', cookie.serialize('signup', '', { path: '/', expires: 0, maxAge: 0 }))
         // token won't have an id on it for new logins, we add it
         // note: token is what's kept in the jwt
         token.id = Number(user.id)
@@ -319,7 +321,7 @@ export const getAuthOptions = (req, res) => ({
   adapter: {
     ...PrismaAdapter(prisma),
     createUser: data => {
-      if (req.cookies.signup === 'true') {
+      if (req.cookies.signup === 'true') { // are we signing up?
         // replace email with email hash in new user payload
         if (data.email) {
           const { email } = data

--- a/pages/login.js
+++ b/pages/login.js
@@ -81,6 +81,7 @@ export default function LoginPage (props) {
       <Login
         Footer={() => <LoginFooter callbackUrl={props.callbackUrl} />}
         Header={() => <LoginHeader />}
+        signin
         {...props}
       />
     </StaticLayout>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -27,7 +27,6 @@ export default function SignUp ({ ...props }) {
         Header={() => <SignUpHeader />}
         Footer={() => <SignUpFooter callbackUrl={props.callbackUrl} />}
         text='Sign up'
-        signup
         {...props}
       />
     </StaticLayout>

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -27,6 +27,7 @@ export default function SignUp ({ ...props }) {
         Header={() => <SignUpHeader />}
         Footer={() => <SignUpFooter callbackUrl={props.callbackUrl} />}
         text='Sign up'
+        signup
         {...props}
       />
     </StaticLayout>


### PR DESCRIPTION
## Description

Fixes #1239 and #841 
Applies a cookie to remember the user’s choice between logging in or signing up.
NextAuth picks up this cookie for the general purpose `createUser` function used by Email and Providers (social media) authentication methods, as well as for `pubkeyAuth`, which is used by Lightning and Nostr Credentials Providers.

## Screenshots
<img width="330" alt="image" src="https://github.com/user-attachments/assets/87b09572-cb70-4695-aea7-ee138c4d55a1" />

## Additional Context

I first tried by passing `signup` to the signIn method, this works but not for OAuth since there are a lot of steps before landing back to the callback and every additional option is lost.
Cookies are a reliable method of persistence in this case.

Email and OAuth throws `Callback` and CredentialsProvider throws `CredentialsSignIn`, as Next Auth doesn't support custom error messages, a not invasive way to handle this is to show a vague generic message that applies to every scenario. Implementing a custom error system for Next Auth is something that can be done but it would be too invasive imo.

## Checklist

**Are your changes backwards compatible? Please answer below:**
Doesn't create a user anymore during login process, only during signup.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6, Nostr is not yet tested; Twitter uses a paid model.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a