### PR TITLE
Fix @remindme does not support weeks

### DIFF
--- a/lib/time.js
+++ b/lib/time.js
@@ -23,11 +23,11 @@ export function timeSince (timeStamp) {
 }
 
 export function datePivot (date,
-  { years = 0, months = 0, days = 0, hours = 0, minutes = 0, seconds = 0, milliseconds = 0 }) {
+  { years = 0, months = 0, weeks = 0, days = 0, hours = 0, minutes = 0, seconds = 0, milliseconds = 0 }) {
   return new Date(
     date.getFullYear() + years,
     date.getMonth() + months,
-    date.getDate() + days,
+    date.getDate() + days + weeks * 7,
     date.getHours() + hours,
     date.getMinutes() + minutes,
     date.getSeconds() + seconds,


### PR DESCRIPTION
## Description

Our `@remindme` bot did apparently never support the `week` notation.

## Video

https://github.com/user-attachments/assets/ad0450d7-5e20-4c81-97df-86572049c9ff

## Checklist

**Are your changes backwards compatible? Please answer below:**


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`3`. Only tested `@remindme in 2 weeks` as a comment but pretty sure this is at least not a regression.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

n/a