### PR TITLE
Add CLN send via CLNRest

### DIFF
--- a/wallets/cln/client.js
+++ b/wallets/cln/client.js
@@ -1,1 +1,39 @@
+import { fetchWithTimeout } from '@/lib/fetch'
+import { assertContentTypeJson, assertResponseOk } from '@/lib/url'
+
 export * from '@/wallets/cln'
+
+export async function testSendPayment ({ socket, runePay }, { logger, signal }) {
+  // TODO: check rune
+}
+
+export async function sendPayment (bolt11, { socket, runePay }, { logger, signal }) {
+  const url = `https://${socket}/v1/pay`
+
+  const headers = new Headers()
+  headers.set('Content-Type', 'application/json')
+  headers.set('Rune', runePay)
+  // see nodeId in lib/cln.js
+  headers.set('nodeId', '02cb2e2d5a6c5b17fa67b1a883e2973c82e328fb9bd08b2b156a9e23820c87a490')
+
+  const body = new URLSearchParams()
+  body.append('bolt11', bolt11)
+
+  const res = await fetchWithTimeout(url, {
+    method: 'POST',
+    headers,
+    body,
+    signal
+  })
+
+  assertResponseOk(res)
+  assertContentTypeJson(res)
+
+  const payment = await res.json()
+  const preimage = payment.data.payment_preimage
+  if (!preimage) {
+    throw new Error(payment.reason)
+  }
+
+  return preimage
+}

--- a/wallets/cln/index.js
+++ b/wallets/cln/index.js
@@ -14,7 +14,6 @@ export const fields = [
     placeholder: '55.5.555.55:3010',
     hint: 'tor or clearnet',
     clear: true,
-    serverOnly: true,
     validate: string().socket()
   },
   {
@@ -33,10 +32,13 @@ export const fields = [
     hint: 'must be restricted to method=invoice',
     clear: true,
     serverOnly: true,
+    optional: 'for receiving',
+    requiredWithout: 'runePay',
     validate: string().matches(B64_URL_REGEX, { message: 'invalid rune' })
       .test({
         name: 'rune',
         test: (v, context) => {
+          if (!v) return true
           const decoded = decodeRune(v)
           if (!decoded) return context.createError({ message: 'invalid rune' })
           if (decoded.restrictions.length === 0) {
@@ -48,6 +50,27 @@ export const fields = [
           if (decoded.restrictions[0].alternatives[0] !== 'method=invoice') {
             return context.createError({ message: 'rune must be restricted to method=invoice only' })
           }
+          return true
+        }
+      })
+  },
+  {
+    name: 'runePay',
+    label: 'pay rune',
+    type: 'text',
+    placeholder: 'S34KtUW-6gqS_hD_9cc_PNhfF-NinZyBOCgr1aIrark9NCZtZXRob2Q9aW52b2ljZQ==',
+    hint: 'must allow method=pay',
+    clear: true,
+    clientOnly: true,
+    optional: 'for sending',
+    requiredWithout: 'rune',
+    validate: string().matches(B64_URL_REGEX, { message: 'invalid rune' })
+      .test({
+        name: 'runePay',
+        test: (v, context) => {
+          if (!v) return true
+          const decoded = decodeRune(v)
+          if (!decoded) return context.createError({ message: 'invalid rune' })
           return true
         }
       })


### PR DESCRIPTION
## Description

Fix #1967

Adds client.js to wallets/cln

## Screenshots

## Additional Context

I tested the /v1/pay call against the demo server cln-regtest-demo.blockstream.com with their demo rune.
First created an invoice, then paid that invoice.
The demo calls showed the syntax for parameters and result.

## Checklist

**Are your changes backwards compatible? Please answer below:**

If the new field runePay isn't filled, there should be no regressions. Couldn't test configuring a server-only CLN wallet, though.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

1

Ran sndev with COMPOSE_PROFILES=minimal,payments, configured cln wallet for sending, zapped a post to make a payment. It failed due to the demo credentials, of course.

So this will definitely require testing with a real CLNRest server.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Desktop only.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.
