### PR TITLE
Hide pull-to-refresh when not pulling

### DIFF
--- a/components/pull-to-refresh.js
+++ b/components/pull-to-refresh.js
@@ -72,7 +72,10 @@ export default function PullToRefresh ({ children, className }) {
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
     >
-      <p className={`${styles.pullMessage}`} style={{ top: `${Math.max(-20, Math.min(-20 + pullDistance / 2, 5))}px` }}>
+      <p
+        className={`${styles.pullMessage}`}
+        style={{ opacity: pullDistance > 0 ? 1 : 0, top: `${Math.max(-20, Math.min(-20 + pullDistance / 2, 5))}px` }}
+      >
         {pullMessage}
       </p>
       {children}


### PR DESCRIPTION
## Description

Fixes #1985 
Shows pull-to-refresh message only when we're actually pulling

## Screenshots

## Additional Context

It's based on conditional styling via pullDistance

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6, it doesn't show a message in odd resolutions when not pulling; vice versa it shows a message only if we're pulling

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a