### PR TITLE
Fix warning about missing key for children

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -112,6 +112,7 @@ export default function Login ({ providers, callbackUrl, multiAuth, error, text,
           default:
             return (
               <OverlayTrigger
+                key={provider.id}
                 placement='bottom'
                 overlay={multiAuth ? <Tooltip>not available for account switching yet</Tooltip> : <></>}
                 trigger={['hover', 'focus']}
@@ -119,7 +120,6 @@ export default function Login ({ providers, callbackUrl, multiAuth, error, text,
                 <div className='w-100'>
                   <LoginButton
                     className={`mt-2 ${styles.providerButton}`}
-                    key={provider.id}
                     type={provider.id.toLowerCase()}
                     onClick={() => signIn(provider.id, { callbackUrl, multiAuth })}
                     text={`${text || 'Login'} with`}


### PR DESCRIPTION
## Description

When visiting /login, the following warning was logged to the console:

```
Warning: Each child in a list should have a unique "key" prop.
```

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`. Warning is gone.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no