### PR TITLE
Fix space before question mark in delete prompt

### DIFF
--- a/components/wallet-logger.js
+++ b/components/wallet-logger.js
@@ -62,7 +62,11 @@ function DeleteWalletLogsObstacle ({ wallet, setLogs, onClose }) {
   const { deleteLogs } = useWalletLogManager(setLogs)
   const toaster = useToast()
 
-  const prompt = `Do you really want to delete all ${wallet ? '' : 'wallet'} logs ${wallet ? 'of this wallet' : ''}?`
+  let prompt = 'Do you really want to delete all wallet logs?'
+  if (wallet) {
+    prompt = 'Do you really want to delete all logs of this wallet?'
+  }
+
   return (
     <div className='text-center'>
       {prompt}


### PR DESCRIPTION
If one wants to delete all wallet logs, the message included a space before the question mark:

> Do you really want to delete all wallet logs ?

