### PR TITLE
don't send a verification email during sign in if no match

### DIFF
--- a/pages/email.js
+++ b/pages/email.js
@@ -12,8 +12,10 @@ export const getServerSideProps = getGetServerSideProps({ query: null })
 export default function Email () {
   const router = useRouter()
   const [callback, setCallback] = useState(null) // callback.email, callback.callbackUrl
+  const [signin, setSignin] = useState(false)
 
   useEffect(() => {
+    setSignin(document.cookie.includes('signin='))
     setCallback(JSON.parse(window.sessionStorage.getItem('callback')))
   }, [])
 
@@ -27,6 +29,13 @@ export default function Email () {
     router.push(url)
   }, [callback, router])
 
+  const buildMessage = useCallback(() => {
+    const email = callback?.email || 'your email address'
+    return signin
+      ? `if there's a match, a magic code will be sent to ${email}`
+      : `a magic code has been sent to ${email}`
+  }, [callback, signin])
+
   return (
     <StaticLayout>
       <div className='p-4 text-center'>
@@ -35,14 +44,14 @@ export default function Email () {
           <Image className='rounded-1 shadow-sm' width='640' height='302' src={`${process.env.NEXT_PUBLIC_ASSET_PREFIX}/cowboy-saloon.gif`} fluid />
         </video>
         <h2 className='pt-4'>Check your email</h2>
-        <h4 className='text-muted pt-2 pb-4'>if there's a match, a magic code will be sent to {callback ? callback.email : 'your email address'}</h4>
-        <MagicCodeForm onSubmit={(token) => pushCallback(token)} disabled={!callback} />
+        <h4 className='text-muted pt-2 pb-4'>{buildMessage()}</h4>
+        <MagicCodeForm onSubmit={(token) => pushCallback(token)} disabled={!callback} signin={signin} />
       </div>
     </StaticLayout>
   )
 }
 
-export const MagicCodeForm = ({ onSubmit, disabled }) => {
+export const MagicCodeForm = ({ onSubmit, disabled, signin }) => {
   return (
     <Form
       initial={{
@@ -64,7 +73,7 @@ export const MagicCodeForm = ({ onSubmit, disabled }) => {
         hideError // hide error message on every input, allow custom error message
         disabled={disabled} // disable the form if no callback is provided
       />
-      <SubmitButton variant='primary' className='px-4' disabled={disabled}>login</SubmitButton>
+      <SubmitButton variant='primary' className='px-4' disabled={disabled}>{signin ? 'login' : 'signup'}</SubmitButton>
     </Form>
   )
 }

--- a/pages/email.js
+++ b/pages/email.js
@@ -29,12 +29,12 @@ export default function Email () {
     router.push(url)
   }, [callback, router])
 
-  const buildMessage = useCallback(() => {
+  const buildMessage = () => {
     const email = callback?.email || 'your email address'
     return signin
       ? `if there's a match, a magic code will be sent to ${email}`
       : `a magic code has been sent to ${email}`
-  }, [callback, signin])
+  }
 
   return (
     <StaticLayout>

--- a/pages/email.js
+++ b/pages/email.js
@@ -35,7 +35,7 @@ export default function Email () {
           <Image className='rounded-1 shadow-sm' width='640' height='302' src={`${process.env.NEXT_PUBLIC_ASSET_PREFIX}/cowboy-saloon.gif`} fluid />
         </video>
         <h2 className='pt-4'>Check your email</h2>
-        <h4 className='text-muted pt-2 pb-4'>a magic code has been sent to {callback ? callback.email : 'your email address'}</h4>
+        <h4 className='text-muted pt-2 pb-4'>if there's a match, a magic code will be sent to {callback ? callback.email : 'your email address'}</h4>
         <MagicCodeForm onSubmit={(token) => pushCallback(token)} disabled={!callback} />
       </div>
     </StaticLayout>

--- a/pages/email.js
+++ b/pages/email.js
@@ -1,4 +1,5 @@
 import Image from 'react-bootstrap/Image'
+import * as cookie from 'cookie'
 import { StaticLayout } from '@/components/layout'
 import { getGetServerSideProps } from '@/api/ssrApollo'
 import { useRouter } from 'next/router'
@@ -15,7 +16,7 @@ export default function Email () {
   const [signin, setSignin] = useState(false)
 
   useEffect(() => {
-    setSignin(document.cookie.includes('signin='))
+    setSignin(!!cookie.parse(document.cookie).signin)
     setCallback(JSON.parse(window.sessionStorage.getItem('callback')))
   }, [])
 


### PR DESCRIPTION
## Description

Updates #1976 
If we're in `signin` mode (cookie) and can't find a user with the inserted email, we resolve earlier and don't send a verification email. This works by passing `req` to `sendVerificationRequest`, this way we're able to access cookies and check for `signin`

## Screenshots
n/a

## Additional Context
I added some _mystery_ to the email.js message, in line with major websites behavior

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes, we're just passing req to check the `signin` cookie

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, I can receive an email if I'm registered and I don't receive an email if I'm not registered.


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a