### PR TITLE
Fix missing max-age cookie option

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -19,6 +19,7 @@ const cookieOptions = (args) => ({
   sameSite: 'lax',
   // default expiration for next-auth JWTs is in 30 days
   expires: datePivot(new Date(), { days: 30 }),
+  maxAge: 2592000, // 30 days in seconds
   ...args
 })
 


### PR DESCRIPTION
## Description

We were missing the [`Max-Age`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#max-agenumber) option for cookies.

## Additional Context

Interestingly, `next-auth` does not set `Max-Age` for `next-auth.session-token`, only `Expires` :eyes: 

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested switching between users and anon and logout until fully logged out.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no