### PR TITLE
Fix useQuery lifecycle anti-pattern

### DIFF
--- a/components/account.js
+++ b/components/account.js
@@ -100,17 +100,15 @@ const AccountListRow = ({ account, ...props }) => {
   const router = useRouter()
 
   // fetch updated names and photo ids since they might have changed since we were issued the JWTs
-  const [name, setName] = useState(account.name)
-  const [photoId, setPhotoId] = useState(account.photoId)
-  useQuery(USER,
+  const { data, error } = useQuery(USER,
     {
-      variables: { id: account.id },
-      onCompleted ({ user: { name, photoId } }) {
-        if (photoId) setPhotoId(photoId)
-        if (name) setName(name)
-      }
+      variables: { id: account.id }
     }
   )
+  if (error) console.error(`query for user ${account.id} failed:`, error)
+
+  const name = data?.user?.name || account.name
+  const photoId = data?.user?.photoId || account.photoId
 
   const onClick = async (e) => {
     // prevent navigation


### PR DESCRIPTION
## Description

I did exactly what one shouldn't do with `onCompleted`: to use it for state syncing, see [this blog post](https://tkdodo.eu/blog/breaking-react-querys-api-on-purpose#state-syncing).

Apparently so many people were misusing `onCompleted` that it will be deprecated in the next release, see https://github.com/apollographql/apollo-client/issues/12352

## Additional context

There are more cases like this that one can find by searching for `onCompleted:`. Examples:

https://github.com/stackernews/stacker.news/blob/a83783f008702db5d8220e9883260511a64c2d7b/components/wallet-logger.js#L139-L141

https://github.com/stackernews/stacker.news/blob/a83783f008702db5d8220e9883260511a64c2d7b/components/form.js#L625-L633

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`. Tested by changing the name of the anon user and seeing it get updated in the UI when I open the switch account dialog.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no