### PR TITLE
Wallet indicators

### DIFF
--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -22,6 +22,7 @@ import classNames from 'classnames'
 import SnIcon from '@/svgs/sn.svg'
 import { useHasNewNotes } from '../use-has-new-notes'
 import { useWallets } from '@/wallets/index'
+import { useWalletIndicator } from '@/components/wallet-indicator'
 import SwitchAccountList, { nextAccount, useAccounts } from '@/components/account'
 import { useShowModal } from '@/components/modal'
 import { numWithUnits } from '@/lib/format'
@@ -190,6 +191,8 @@ export function MeDropdown ({ me, dropNavKey }) {
   if (!me) return null
 
   const profileIndicator = !me.bioId
+  const walletIndicator = useWalletIndicator()
+  const indicator = profileIndicator || walletIndicator
 
   return (
     <div className=''>
@@ -198,7 +201,7 @@ export function MeDropdown ({ me, dropNavKey }) {
           <div className='d-flex align-items-center'>
             <Nav.Link eventKey={me.name} as='span' className='p-0 position-relative'>
               {`@${me.name}`}
-              {profileIndicator && <Indicator superscript />}
+              {indicator && <Indicator superscript />}
             </Nav.Link>
             <Badges user={me} />
           </div>
@@ -214,7 +217,10 @@ export function MeDropdown ({ me, dropNavKey }) {
             <Dropdown.Item active={me.name + '/bookmarks' === dropNavKey}>bookmarks</Dropdown.Item>
           </Link>
           <Link href='/wallets' passHref legacyBehavior>
-            <Dropdown.Item eventKey='wallets'>wallets</Dropdown.Item>
+            <Dropdown.Item eventKey='wallets'>
+              wallets
+              {walletIndicator && <Indicator />}
+            </Dropdown.Item>
           </Link>
           <Link href='/credits' passHref legacyBehavior>
             <Dropdown.Item eventKey='credits'>credits</Dropdown.Item>

--- a/components/nav/mobile/offcanvas.js
+++ b/components/nav/mobile/offcanvas.js
@@ -7,6 +7,7 @@ import AnonIcon from '@/svgs/spy-fill.svg'
 import styles from './footer.module.css'
 import canvasStyles from './offcanvas.module.css'
 import classNames from 'classnames'
+import { useWalletIndicator } from '@/components/wallet-indicator'
 
 export default function OffCanvas ({ me, dropNavKey }) {
   const [show, setShow] = useState(false)
@@ -26,6 +27,7 @@ export default function OffCanvas ({ me, dropNavKey }) {
     : <span className='text-muted pointer'><AnonIcon onClick={onClick} width='22' height='22' /></span>
 
   const profileIndicator = me && !me.bioId
+  const walletIndicator = useWalletIndicator()
 
   return (
     <>
@@ -59,7 +61,10 @@ export default function OffCanvas ({ me, dropNavKey }) {
                     <Dropdown.Item active={me.name + '/bookmarks' === dropNavKey}>bookmarks</Dropdown.Item>
                   </Link>
                   <Link href='/wallets' passHref legacyBehavior>
-                    <Dropdown.Item eventKey='wallets'>wallets</Dropdown.Item>
+                    <Dropdown.Item eventKey='wallets'>
+                      wallets
+                      {walletIndicator && <Indicator />}
+                    </Dropdown.Item>
                   </Link>
                   <Link href='/credits' passHref legacyBehavior>
                     <Dropdown.Item eventKey='credits'>credits</Dropdown.Item>

--- a/components/wallet-indicator.js
+++ b/components/wallet-indicator.js
@@ -1,0 +1,6 @@
+import { useConfiguredWallets } from '@/wallets'
+
+export function useWalletIndicator () {
+  const wallets = useConfiguredWallets()
+  return wallets.length === 0
+}

--- a/pages/wallets/index.js
+++ b/pages/wallets/index.js
@@ -12,6 +12,8 @@ import RecvIcon from '@/svgs/arrow-left-down-line.svg'
 import SendIcon from '@/svgs/arrow-right-up-line.svg'
 import { useRouter } from 'next/router'
 import { supportsReceive, supportsSend } from '@/wallets/common'
+import { useWalletIndicator } from '@/components/wallet-indicator'
+import { Button } from 'react-bootstrap'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
 
@@ -82,6 +84,24 @@ export default function Wallet ({ ssrData }) {
       router.replace({ query: { ...router.query, [key]: e.target.checked } }, undefined, { shallow: true })
     }
   }, [router])
+
+  const indicator = useWalletIndicator()
+  const [showWallets, setShowWallets] = useState(!indicator)
+
+  if (indicator && !showWallets) {
+    return (
+      <Layout>
+        <div className='py-5 text-center d-flex flex-column align-items-center justify-content-center flex-grow-1'>
+          <Button
+            onClick={() => setShowWallets(true)}
+            size='md' variant='secondary'
+          >attach wallet
+          </Button>
+          <small className='d-block mt-3 text-muted'>attach a wallet to send and receive sats</small>
+        </div>
+      </Layout>
+    )
+  }
 
   return (
     <Layout>

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -223,6 +223,11 @@ export function useWallet (name) {
   return wallets.find(w => w.def.name === name)
 }
 
+export function useConfiguredWallets () {
+  const { wallets } = useWallets()
+  return useMemo(() => wallets.filter(w => isConfigured(w)), [wallets])
+}
+
 export function useSendWallets () {
   const { wallets } = useWallets()
   // return all enabled wallets that are available and can send


### PR DESCRIPTION
## Description

~based on #2046~ _(merged)_

Show an indicator if no wallet has been setup yet like we do for bios.

TODO:

- [x] show orange button similar to the 'create bio' button

## Additional context

1. This will always show an indicator if no wallet is configured, not only the first time.
2. On back navigation, the button should maybe not show up again? It's at least annoying during development.

## Screenshots

![localhost_3000_wallets(iPhone SE) (2)](https://github.com/user-attachments/assets/07bb0b7e-06d1-425d-b7cd-c90a301979b7)

![localhost_3000_wallets(iPhone SE) (1)](https://github.com/user-attachments/assets/7687f167-2b65-4f8d-898d-e2f0975292e9)

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested that wallet indicator disappers if recv or send wallet is attached. Indicator appears again when all wallets are detached.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no