### PR TITLE
Remove unnecessary exports

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -43,7 +43,7 @@ export function setMultiAuthCookies (req, res, { id, jwt, name, photoId }) {
   res.appendHeader('Set-Cookie', cookie.serialize('multi_auth', b64Encode(newMultiAuth), jsOptions))
 }
 
-export function switchSessionCookie (request) {
+function switchSessionCookie (request) {
   // switch next-auth session cookie with multi_auth cookie if cookie pointer present
 
   // is there a cookie pointer?
@@ -80,7 +80,7 @@ export function switchSessionCookie (request) {
   return request
 }
 
-export function checkMultiAuthCookies (req, res) {
+function checkMultiAuthCookies (req, res) {
   if (!req.cookies.multi_auth || !req.cookies['multi_auth.user-id']) {
     return false
   }
@@ -95,7 +95,7 @@ export function checkMultiAuthCookies (req, res) {
   return true
 }
 
-export function resetMultiAuthCookies (req, res) {
+function resetMultiAuthCookies (req, res) {
   const httpOnlyOptions = cookieOptions({ expires: 0, maxAge: 0 })
   const jsOptions = { ...httpOnlyOptions, httpOnly: false }
 
@@ -110,7 +110,7 @@ export function resetMultiAuthCookies (req, res) {
   }
 }
 
-export async function refreshMultiAuthCookies (req, res) {
+async function refreshMultiAuthCookies (req, res) {
   const httpOnlyOptions = cookieOptions()
   const jsOptions = { ...httpOnlyOptions, httpOnly: false }
 


### PR DESCRIPTION
None of these functions are used anywhere else anymore. Only `setMultiAuthCookies` (for login) and `multiAuthMiddleware` (to switch the `next-auth.session-token` cookies on each request) needs to be exported.