### PR TITLE
Reset multi_auth to initial state on error

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -92,7 +92,7 @@ function switchSessionCookie (request) {
 }
 
 async function checkMultiAuthCookies (req, res) {
-  if (!req.cookies[MULTI_AUTH_LIST] || !req.cookies[MULTI_AUTH_POINTER]) {
+  if (!req.cookies[MULTI_AUTH_LIST] || !req.cookies[MULTI_AUTH_POINTER] || !req.cookies[SESSION_COOKIE]) {
     return false
   }
 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -116,15 +116,23 @@ async function checkMultiAuthCookies (req, res) {
   return true
 }
 
-function resetMultiAuthCookies (req, res) {
+async function resetMultiAuthCookies (req, res) {
   const httpOnlyOptions = cookieOptions({ expires: 0, maxAge: 0 })
   const jsOptions = { ...httpOnlyOptions, httpOnly: false }
 
+  // remove all multi_auth cookies ...
   for (const key of Object.keys(req.cookies)) {
     if (!MULTI_AUTH_REGEXP.test(key)) continue
     const options = MULTI_AUTH_JWT_REGEXP.test(key) ? httpOnlyOptions : jsOptions
     res.appendHeader('Set-Cookie', cookie.serialize(key, '', options))
   }
+
+  // ... and reset to initial state if they are logged in
+  const token = req.cookies[SESSION_COOKIE]
+  if (!token) return
+
+  const decoded = await decodeJWT({ token, secret: process.env.NEXTAUTH_SECRET })
+  setMultiAuthCookies(req, res, { ...decoded, jwt: token })
 }
 
 async function refreshMultiAuthCookies (req, res) {
@@ -170,7 +178,7 @@ export async function multiAuthMiddleware (req, res) {
 
   const ok = await checkMultiAuthCookies(req, res)
   if (!ok) {
-    resetMultiAuthCookies(req, res)
+    await resetMultiAuthCookies(req, res)
     return switchSessionCookie(req)
   }
 


### PR DESCRIPTION
## Description

Based on ~#1998~ ~#2018~ ~#2019~

Instead of just removing all `multi_auth` cookies on error, we now reset to the initial state.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested by removing each `multi_auth` cookie and seeing it getting set again.

https://github.com/user-attachments/assets/c65f7a53-ef14-4940-8bf5-006a32299021

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no