### PR TITLE
allow sort for search queries with only filters

### DIFF
--- a/api/resolvers/search.js
+++ b/api/resolvers/search.js
@@ -276,11 +276,15 @@ export default {
       // if nym, items must contain nym
       if (nym) {
         filters.push({ wildcard: { 'user.name': `*${nym.slice(1).toLowerCase()}*` } })
+        // push same requirement to termQueries to avoid empty should clause
+        termQueries.push({ wildcard: { 'user.name': `*${nym.slice(1).toLowerCase()}*` } })
       }
 
       // if territory, item must be from territory
       if (territory) {
         filters.push({ match: { 'sub.name': territory.slice(1) } })
+        // push same requirement to termQueries to avoid empty should clause
+        termQueries.push({ match: { 'sub.name': territory.slice(1) } })
       }
 
       // if quoted phrases, items must contain entire phrase


### PR DESCRIPTION
## Description

Closes https://github.com/stackernews/stacker.news/issues/2004

The problem was that if a search query contained only `@nym` and `~territory` terms, the `termQueries` object would be empty. This causes the resulting search query passed to OpenSearch to contain only a `filter` clause and an empty `should` clause. However, `filter` does not apply a numerical score to the items returned by OpenSearch.  Since all of our search modes work by applying a multiplicative modifier to the item's score, not having a score means not being able to sort.

The solution is to include the nym and territory filters also in the `should` clause. This ensures that the `should` clause is not empty so all items can have a numerical score which can be modified by the sorts. 

(This may not be the most efficient way to fix, but it requires the least modification to the existing query and is consistent with how quotes are handled.) 

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

6. Tested with dev DB. It does fix the problem (allowing sorts on queries with only `@nym` and `~territory` terms). More testing should still be done on prod db. 

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no