### PR TITLE
Remove multi auth error checking

### DIFF
--- a/components/banners.js
+++ b/components/banners.js
@@ -6,7 +6,6 @@ import { useMutation } from '@apollo/client'
 import { WELCOME_BANNER_MUTATION } from '@/fragments/users'
 import { useToast } from '@/components/toast'
 import Link from 'next/link'
-import AccordianItem from '@/components/accordian-item'
 
 export function WelcomeBanner ({ Banner }) {
   const { me } = useMe()
@@ -121,27 +120,6 @@ export function AuthBanner () {
   return (
     <Alert className={`${styles.banner} mt-0`} key='info' variant='danger'>
       Please add a second auth method to avoid losing access to your account.
-    </Alert>
-  )
-}
-
-export function MultiAuthErrorBanner ({ errors }) {
-  return (
-    <Alert className={styles.banner} key='info' variant='danger'>
-      <div className='fw-bold mb-3'>Account switching is currently unavailable</div>
-      <AccordianItem
-        className='my-3'
-        header='We have detected the following issues:'
-        headerColor='var(--bs-danger-text-emphasis)'
-        body={
-          <ul>
-            {errors.map((err, i) => (
-              <li key={i}>{err}</li>
-            ))}
-          </ul>
-      }
-      />
-      <div className='mt-3'>To resolve these issues, please sign out and sign in again.</div>
     </Alert>
   )
 }


### PR DESCRIPTION
## Description

Based on #2010

Since we will remove this error checking code in #2007 anyway, I want to already remove it in this separate PR to get it out of the way of refactoring the client code for account switching for #2007.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. This only removes future dead code. I searched for `multiAuthError` to make sure I didn't miss any reference to it.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no