### PR TITLE
Merge follow-up replies with normal replies

### DIFF
--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -99,6 +99,11 @@ async function sendUserNotification (userId, notification) {
       delete notification.item
     }
     const userFilter = createUserFilter(notification.tag)
+
+    // XXX we only want to use the tag to filter follow-up replies by user settings
+    // but still merge them with normal replies
+    if (notification.tag === 'THREAD') notification.tag = 'REPLY'
+
     const payload = createPayload(notification)
     const subscriptions = await models.pushSubscription.findMany({
       where: { userId, ...userFilter }
@@ -250,7 +255,7 @@ export const notifyItemParents = async ({ models, item }) => {
     Promise.allSettled(
       parents.map(({ userId, isDirect }) => {
         return sendUserNotification(userId, {
-          title: `@${user.name} ${isDirect ? 'replied to you' : 'replied to someone that replied to you'}`,
+          title: `@${user.name} replied to you`,
           body: item.text,
           item,
           tag: isDirect ? 'REPLY' : 'THREAD'

--- a/sw/eventListener.js
+++ b/sw/eventListener.js
@@ -91,7 +91,7 @@ const mergeNotification = (event, sw, payload, currentNotifications, tag, nid) =
   // merge notifications into single notification payload
   // ---
   // tags that need to know the amount of notifications with same tag for merging
-  const AMOUNT_TAGS = ['REPLY', 'THREAD', 'MENTION', 'ITEM_MENTION', 'REFERRAL', 'INVITE', 'FOLLOW', 'TERRITORY_POST']
+  const AMOUNT_TAGS = ['REPLY', 'MENTION', 'ITEM_MENTION', 'REFERRAL', 'INVITE', 'FOLLOW', 'TERRITORY_POST']
   // tags that need to know the sum of sats of notifications with same tag for merging
   const SUM_SATS_TAGS = ['DEPOSIT', 'WITHDRAWAL']
   // this should reflect the amount of notifications that were already merged before
@@ -116,8 +116,6 @@ const mergeNotification = (event, sw, payload, currentNotifications, tag, nid) =
   if (AMOUNT_TAGS.includes(compareTag)) {
     if (compareTag === 'REPLY') {
       title = `you have ${amount} new replies`
-    } else if (compareTag === 'THREAD') {
-      title = `you have ${amount} new follow-up replies`
     } else if (compareTag === 'MENTION') {
       title = `you were mentioned ${amount} times`
     } else if (compareTag === 'ITEM_MENTION') {


### PR DESCRIPTION
## Description

This merges `THREAD` push notifications with `REPLY` push notifications but still respects the user setting for `THREAD` push notifications.

## Video

https://github.com/user-attachments/assets/0ab80a13-8cc5-4113-b64b-9b82d895cbea

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. See video.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no