### PR TITLE
Add territory link in post form info

### DIFF
--- a/components/post.js
+++ b/components/post.js
@@ -110,7 +110,7 @@ export function PostForm ({ type, sub, children }) {
           noForm
           size='medium'
           sub={sub?.name}
-          info={sub && <TerritoryInfo sub={sub} />}
+          info={sub && <TerritoryInfo sub={sub} includeLink />}
           hint={sub?.moderated && 'this territory is moderated'}
         />
         <div>
@@ -176,7 +176,7 @@ export default function Post ({ sub }) {
             className='d-flex'
             size='medium'
             label='territory'
-            info={sub && <TerritoryInfo sub={sub} />}
+            info={sub && <TerritoryInfo sub={sub} includeLink />}
             hint={sub?.moderated && 'this territory is moderated'}
           />}
       </PostForm>

--- a/components/territory-header.js
+++ b/components/territory-header.js
@@ -42,9 +42,10 @@ export function TerritoryInfoSkeleton ({ children, className }) {
   )
 }
 
-export function TerritoryInfo ({ sub }) {
+export function TerritoryInfo ({ sub, includeLink }) {
   return (
     <>
+      {includeLink && <Link href={`/~${sub.name}`}>{sub.name}</Link>}
       <div className='py-2'>
         <Text>{sub.desc}</Text>
       </div>


### PR DESCRIPTION
## Description

Almost always when I want to post something and I am looking for the right territory, I find some that I would like to visit.

This is currently annoying because there is no link to the territory anywhere while posting.

This PR includes the link in the territory info, but only while posting. In all other places, there is already a link available on the same page ([top territories](https://stacker.news/top/territories/day)) or we're already looking at the territory.

## Screenshots

![localhost_3000_~tech_post_type=discussion(iPhone SE)](https://github.com/user-attachments/assets/c76445dd-d1bf-424e-ae93-3797ed28f157)

## Additional Context

This is mostly just a PR to mention this problem with the laziest solution possible. I followed the path of least resistance.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Since this only includes the link if explicitly told so, this does not change the UI in other places.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

yes, uses common color scheme

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no