### PR TITLE
Include name in mention push notification

### DIFF
--- a/api/paidAction/itemUpdate.js
+++ b/api/paidAction/itemUpdate.js
@@ -163,7 +163,8 @@ export async function nonCriticalSideEffects ({ invoice, id }, { models }) {
     where: invoice ? { invoiceId: invoice.id } : { id: parseInt(id) },
     include: {
       mentions: true,
-      itemReferrers: { include: { refereeItem: true } }
+      itemReferrers: { include: { refereeItem: true } },
+      user: true
     }
   })
   // compare timestamps to only notify if mention or item referral was just created to avoid duplicates on edits

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -319,14 +319,14 @@ export const notifyZapped = async ({ models, item }) => {
 export const notifyMention = async ({ models, userId, item }) => {
   try {
     const muted = await isMuted({ models, muterId: userId, mutedId: item.userId })
-    if (!muted) {
-      await sendUserNotification(userId, {
-        title: 'you were mentioned',
-        body: item.text,
-        item,
-        tag: 'MENTION'
-      })
-    }
+    if (muted) return
+
+    await sendUserNotification(userId, {
+      title: `@${item.user.name} mentioned you`,
+      body: item.text,
+      item,
+      tag: 'MENTION'
+    })
   } catch (err) {
     console.error(err)
   }


### PR DESCRIPTION
## Description

Every time I get a push notification that I was mentioned, my first question is who mentioned me.

So instead of `you were mentioned`, it now shows `@user mentioned you`.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested push notifications if mentioned on `ITEM_CREATE` or `ITEM_UPDATE`.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no