### PR TITLE
Fix FAQ hydration error

### DIFF
--- a/lib/rehype-sn.js
+++ b/lib/rehype-sn.js
@@ -6,7 +6,7 @@ import { toString } from 'mdast-util-to-string'
 const userGroup = '[\\w_]+'
 const subGroup = '[A-Za-z][\\w_]+'
 
-const mentionRegex = new RegExp('@(' + userGroup + '(?:\\/' + userGroup + ')?)', 'gi')
+const mentionRegex = new RegExp('(?:^|\\s)@(' + userGroup + '(?:\\/' + userGroup + ')?)', 'gi')
 const subRegex = new RegExp('~(' + subGroup + '(?:\\/' + subGroup + ')?)', 'gi')
 const nostrIdRegex = /\b((npub1|nevent1|nprofile1|note1|naddr1)[02-9ac-hj-np-z]+)\b/g
 


### PR DESCRIPTION
## Description

We have hydration errors in our FAQ and I believe they are causing scroll issues since "as a result this tree will be regenerated on the client."

> Hydration failed because the server rendered [missing argument] didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:
>
> - A server/client branch `if (typeof window !== 'undefined')`.
> - Variable input such as `Date.now()` or `Math.random()` which changes each time it's called.
> - Date formatting in a user's locale which doesn't match the server.
> - External changing data without sending a snapshot of it along with the HTML.
> - Invalid HTML tag nesting.
> 
> It can also happen if the client has a browser extension installed which messes with the HTML before React loaded.
>
> https://react.dev/link/hydration-mismatch[missing argument]

-- https://react.dev/errors/418?invariant=418

In the dev build, we also get this information:

```
Warning: Expected server HTML to contain a matching <a> in <span>. Error Component Stack
    at a (<anonymous>)
    at LinkComponent (link.js:119:19)
    at span (<anonymous>)
    at OverlayTrigger (OverlayTrigger.js:55:11)
    at HoverablePopover (hoverable-popover.js:5:45)
    at UserPopover (user-popover.js:25:40)
    at Mention (text.js:187:21)
```

The hydration error happens when there is a mention inside a link, like `hello@stacker.news`. This will be parsed as a mailto: link with a mention inside, so the tree is like this: 

```html
<a target="_blank" rel="noopener noreferrer" href="mailto:security@stacker.news">
    security
    <span><a href="/stacker">@stacker</a></span>
    .news
</a>
```

Since this shouldn't be parsed as a mention anyway, I fixed this by updating the regexp to only match when there is leading whitespace or it's at the start of a line.

## Video

<details>
<summary>bug</summary>

https://github.com/user-attachments/assets/82c70e9b-d77a-4d31-8407-15b12b6be0a9

</details>

<details>
<summary>identifying the problem</summary>

https://github.com/user-attachments/assets/58d9c255-bb0a-40b5-9d09-d74160ea728c

</details>

## Additional Context

1. I did not change how the server detects mentions so it might still send out a push notification even though the client does not detect it as a mention anymore. But the regexp were already out of sync, see #1625. I tried in there to fix weird parsing of mention in both places but it became quite a rabbit hole at the time with all the testing required. I think this PR is a simple fix for a more important issue without much potential collateral damage.

## Checklist

**Are your changes backwards compatible? Please answer below:**

kind of, but client and server are not out of sync. server should also not detect it as a mention.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. Only tested that FAQ no longer has hydration errors but change is simple.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no