### PR TITLE
Verify testCreateInvoice returns a payment request

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -854,7 +854,10 @@ async function upsertWallet (
 
   if (testCreateInvoice) {
     try {
-      await testCreateInvoice(data)
+      const pr = await testCreateInvoice(data)
+      if (!pr || typeof pr !== 'string' || !pr.startsWith('lnbc')) {
+        throw new Error('not a valid payment request')
+      }
     } catch (err) {
       const message = 'failed to create test invoice: ' + (err.message || err.toString?.())
       logger.error(message)

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -856,7 +856,7 @@ async function upsertWallet (
     try {
       const pr = await testCreateInvoice(data)
       if (!pr || typeof pr !== 'string' || !pr.startsWith('lnbc')) {
-        throw new Error('not a valid payment request')
+        throw new GqlInputError('not a valid payment request')
       }
     } catch (err) {
       const message = 'failed to create test invoice: ' + (err.message || err.toString?.())


### PR DESCRIPTION
## Description

`testCreateInvoice` only checks currently if it throws but not if it actually returned a payment request.

This PR fixes that.

## Additional Context

Considered to use this as the error message: `expected payment request, got: ${pr}` but I don't want to think if they might expose something to the user or store in logs we don't want

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. Tested with NWC recv on 06d05c7f when it returned `undefined` and when it returned a pr (b617ac0a).

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no