### PR TITLE
Fix wrong method in error message

### DIFF
--- a/lib/cln.js
+++ b/lib/cln.js
@@ -10,10 +10,11 @@ export const createInvoice = async ({ msats, description, expiry }, { socket, ru
 
   const url = `${agent.protocol}//${socket}/v1/invoice`
 
+  const method = 'POST'
   let res
   try {
     res = await fetch(url, {
-      method: 'POST',
+      method,
       headers: {
         'Content-Type': 'application/json',
         Rune: rune,
@@ -41,8 +42,8 @@ export const createInvoice = async ({ msats, description, expiry }, { socket, ru
     throw err
   }
 
-  assertResponseOk(res)
-  assertContentTypeJson(res)
+  assertResponseOk(res, { method })
+  assertContentTypeJson(res, { method })
 
   const inv = await res.json()
   if (inv.error) {

--- a/lib/url.js
+++ b/lib/url.js
@@ -213,22 +213,30 @@ export function parseNwcUrl (walletConnectUrl) {
   return params
 }
 
-export function assertResponseOk (res) {
-  if (!res.ok) {
+class ResponseAssertError extends Error {
+  constructor (res, { method } = {}) {
+    if (method) {
+      super(`${method} ${res.url}: ${res.status} ${res.statusText}`)
+    } else {
+      super(`${res.url}: ${res.status} ${res.statusText}`)
+    }
+    this.name = 'ResponseAssertError'
     // consume response body to avoid memory leaks
     // see https://github.com/nodejs/node/issues/51162
     res.text().catch(() => {})
-    throw new Error(`POST ${res.url}: ${res.status} ${res.statusText}`)
   }
 }
 
-export function assertContentTypeJson (res) {
+export function assertResponseOk (res, { method } = {}) {
+  if (!res.ok) {
+    throw new ResponseAssertError(res, { method })
+  }
+}
+
+export function assertContentTypeJson (res, { method } = {}) {
   const contentType = res.headers.get('content-type')
   if (!contentType || !contentType.includes('application/json')) {
-    // consume response body to avoid memory leaks
-    // see https://github.com/nodejs/node/issues/51162
-    res.text().catch(() => {})
-    throw new Error(`POST ${res.url}: ${res.status} ${res.statusText}`)
+    throw new ResponseAssertError(res, { method })
   }
 }
 

--- a/wallets/blink/common.js
+++ b/wallets/blink/common.js
@@ -35,8 +35,9 @@ export async function getWallet ({ apiKey, currency }, { signal }) {
 }
 
 export async function request ({ apiKey, query, variables = {} }, { signal }) {
+  const method = 'POST'
   const res = await fetchWithTimeout(galoyBlinkUrl, {
-    method: 'POST',
+    method,
     headers: {
       'Content-Type': 'application/json',
       'X-API-KEY': apiKey
@@ -45,8 +46,8 @@ export async function request ({ apiKey, query, variables = {} }, { signal }) {
     signal
   })
 
-  assertResponseOk(res)
-  assertContentTypeJson(res)
+  assertResponseOk(res, { method })
+  assertContentTypeJson(res, { method })
 
   return res.json()
 }

--- a/wallets/lightning-address/server.js
+++ b/wallets/lightning-address/server.js
@@ -27,10 +27,11 @@ export const createInvoice = async (
   }
 
   // call callback with amount and conditionally comment
-  const res = await fetchWithTimeout(callbackUrl.toString(), { signal })
+  const method = 'GET'
+  const res = await fetchWithTimeout(callbackUrl.toString(), { method, signal })
 
-  assertResponseOk(res)
-  assertContentTypeJson(res)
+  assertResponseOk(res, { method })
+  assertContentTypeJson(res, { method })
 
   const body = await res.json()
   if (body.status === 'ERROR') {

--- a/wallets/lnbits/client.js
+++ b/wallets/lnbits/client.js
@@ -33,9 +33,10 @@ async function getWallet ({ url, adminKey, invoiceKey }, { signal }) {
   headers.append('Content-Type', 'application/json')
   headers.append('X-Api-Key', adminKey || invoiceKey)
 
-  const res = await fetchWithTimeout(url + path, { method: 'GET', headers, signal })
+  const method = 'GET'
+  const res = await fetchWithTimeout(url + path, { method, headers, signal })
 
-  assertContentTypeJson(res)
+  assertContentTypeJson(res, { method })
   if (!res.ok) {
     const errBody = await res.json()
     throw new Error(errBody.detail)
@@ -55,9 +56,10 @@ async function postPayment (bolt11, { url, adminKey }, { signal }) {
 
   const body = JSON.stringify({ bolt11, out: true })
 
-  const res = await fetchWithTimeout(url + path, { method: 'POST', headers, body, signal })
+  const method = 'POST'
+  const res = await fetchWithTimeout(url + path, { method, headers, body, signal })
 
-  assertContentTypeJson(res)
+  assertContentTypeJson(res, { method })
   if (!res.ok) {
     const errBody = await res.json()
     throw new Error(errBody.detail)
@@ -75,9 +77,10 @@ async function getPayment (paymentHash, { url, adminKey }, { signal }) {
   headers.append('Content-Type', 'application/json')
   headers.append('X-Api-Key', adminKey)
 
-  const res = await fetchWithTimeout(url + path, { method: 'GET', headers, signal })
+  const method = 'GET'
+  const res = await fetchWithTimeout(url + path, { method, headers, signal })
 
-  assertContentTypeJson(res)
+  assertContentTypeJson(res, { method })
   if (!res.ok) {
     const errBody = await res.json()
     throw new Error(errBody.detail)

--- a/wallets/lnbits/server.js
+++ b/wallets/lnbits/server.js
@@ -42,9 +42,10 @@ export async function createInvoice (
   }
 
   let res
+  const method = 'POST'
   try {
     res = await fetch(`${agent.protocol}//${hostname}${path}`, {
-      method: 'POST',
+      method,
       headers,
       agent,
       body,
@@ -54,12 +55,12 @@ export async function createInvoice (
     if (err.name === 'AbortError') {
       // XXX node-fetch doesn't throw our custom TimeoutError but throws a generic error so we have to handle that manually.
       // see https://github.com/node-fetch/node-fetch/issues/1462
-      throw new FetchTimeoutError('POST', url, WALLET_CREATE_INVOICE_TIMEOUT_MS)
+      throw new FetchTimeoutError(method, url, WALLET_CREATE_INVOICE_TIMEOUT_MS)
     }
     throw err
   }
 
-  assertContentTypeJson(res)
+  assertContentTypeJson(res, { method })
   if (!res.ok) {
     const errBody = await res.json()
     throw new Error(errBody.detail)

--- a/wallets/phoenixd/client.js
+++ b/wallets/phoenixd/client.js
@@ -22,15 +22,16 @@ export async function sendPayment (bolt11, { url, primaryPassword }, { signal })
   const body = new URLSearchParams()
   body.append('invoice', bolt11)
 
+  const method = 'POST'
   const res = await fetchWithTimeout(url + path, {
-    method: 'POST',
+    method,
     headers,
     body,
     signal
   })
 
-  assertResponseOk(res)
-  assertContentTypeJson(res)
+  assertResponseOk(res, { method })
+  assertContentTypeJson(res, { method })
 
   const payment = await res.json()
   const preimage = payment.paymentPreimage

--- a/wallets/phoenixd/server.js
+++ b/wallets/phoenixd/server.js
@@ -31,16 +31,17 @@ export async function createInvoice (
   const hostname = url.replace(/^https?:\/\//, '').replace(/\/+$/, '')
   const agent = getAgent({ hostname })
 
+  const method = 'POST'
   const res = await fetchWithTimeout(`${agent.protocol}//${hostname}${path}`, {
-    method: 'POST',
+    method,
     headers,
     agent,
     body,
     signal
   })
 
-  assertResponseOk(res)
-  assertContentTypeJson(res)
+  assertResponseOk(res, { method })
+  assertContentTypeJson(res, { method })
 
   const payment = await res.json()
   return payment.serialized


### PR DESCRIPTION
## Description

Our error messages on fetch errors are misleading: they always use `POST` as the method.

Unfortunately, afaict, it is not possible to go from [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) to request method so we have to manually pass it.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. Only tested with a lightning address that times out but changes are simple so ... lgtm :eyes: 

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no