### PR TITLE
Run social poster only in prod

### DIFF
--- a/worker/socialPoster.js
+++ b/worker/socialPoster.js
@@ -2,8 +2,11 @@ import Nostr from '@/lib/nostr'
 import { TwitterApi } from 'twitter-api-v2'
 import { msatsToSats, numWithUnits } from '@/lib/format'
 
+const isProd = process.env.NODE_ENV === 'production'
+
 async function postToTwitter ({ message }) {
-  if (!process.env.TWITTER_POSTER_API_KEY ||
+  if (!isProd ||
+    !process.env.TWITTER_POSTER_API_KEY ||
     !process.env.TWITTER_POSTER_API_KEY_SECRET ||
     !process.env.TWITTER_POSTER_ACCESS_TOKEN ||
     !process.env.TWITTER_POSTER_ACCESS_TOKEN_SECRET) {
@@ -38,7 +41,7 @@ const RELAYS = [
 ]
 
 async function postToNostr ({ message }) {
-  if (!process.env.NOSTR_PRIVATE_KEY) {
+  if (!isProd || !process.env.NOSTR_PRIVATE_KEY) {
     console.log('Nostr poster not configured')
     return
   }


### PR DESCRIPTION
## Description

`NOSTR_PRIVATE_KEY` is defined in .env.development so the social poster will try to publish these events during development.

This PR makes sure the social poster only runs in production.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

0

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no