### PR TITLE
remodel paid actions schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -149,6 +149,7 @@ model User {
   DirectPaymentReceived     DirectPayment[]      @relation("DirectPaymentReceived")
   DirectPaymentSent         DirectPayment[]      @relation("DirectPaymentSent")
   UserSubTrust              UserSubTrust[]
+  PayIn                     PayIn[]
 
   @@index([photoId])
   @@index([createdAt], map: "users.created_at_index")
@@ -1292,4 +1293,102 @@ enum LogLevel {
   WARN
   ERROR
   SUCCESS
+}
+
+enum PayInType {
+  BUY_CREDITS
+  ITEM_CREATE
+  ITEM_UPDATE
+  ZAP
+  DOWN_ZAP
+  BOOST
+  DONATE
+  POLL_VOTE
+  INVITE_GIFT
+  TERRITORY_CREATE
+  TERRITORY_UPDATE
+  TERRITORY_BILLING
+  TERRITORY_UNARCHIVE
+  PROXY_PAYMENT
+  REWARDS
+}
+
+enum PayInState {
+  PENDING
+  PENDING_HELD
+  HELD
+  PAID
+  FAILED
+  FORWARDING
+  FORWARDED
+  FAILED_FORWARD
+  CANCELING
+}
+
+model PayIn {
+  id        Int      @id @default(autoincrement())
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+  cost      Int
+
+  payInType  PayInType
+  payInState PayInState
+  userId     Int
+  user       User       @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  mcreditsAfter BigInt
+  msatsAfter    BigInt
+
+  PayMethod      PayMethod[]
+  PessimisticEnv PessimisticEnv[]
+  PayOut         PayOut[]
+
+  @@index([userId])
+  @@index([payInType])
+}
+
+enum PayInMethodType {
+  COWBOY_CREDITS
+  REWARD_SATS
+}
+
+model PayMethod {
+  id            Int             @id @default(autoincrement())
+  payId         Int
+  payIn         PayIn           @relation(fields: [payId], references: [id], onDelete: Cascade)
+  msats         BigInt
+  payMethodType PayInMethodType
+}
+
+model PessimisticEnv {
+  id      Int   @id @default(autoincrement())
+  payInId Int
+  payIn   PayIn @relation(fields: [payInId], references: [id], onDelete: Cascade)
+
+  args   Json?   @db.JsonB
+  result Json?   @db.JsonB
+  error  String?
+}
+
+enum PayOutType {
+  TERRITORY_REVENUE
+  REWARDS_POOL
+  PROXY_PAYMENT_RECEIVE
+  ZAP_RECEIVE
+  REWARDS_RECEIVE
+  INVITE_GIFT_RECEIVE
+}
+
+model PayOut {
+  id         Int        @id @default(autoincrement())
+  createdAt  DateTime   @default(now()) @map("created_at")
+  updatedAt  DateTime   @default(now()) @updatedAt @map("updated_at")
+  userId     Int
+  payInId    Int
+  payIn      PayIn      @relation(fields: [payInId], references: [id], onDelete: Cascade)
+  msats      BigInt
+  payOutType PayOutType
+
+  msatsAfter    BigInt
+  mcreditsAfter BigInt
 }


### PR DESCRIPTION
Notes for d517479ce2d04da408344cc659b1a04416a824d3:

These are my WIP schema changes. They haven't been integrated with the rest of the schema yet, because the changes will be dramatic.

----------

This PR aims to accomplish:
1. simple and fine grained satistics gathering - per customer and in aggregate
    - `PayIn` will have ALL customer spending with a type
    - `PayOut` will have ALL customer earning with a type
2. trivial audibility - which assets were spent and earned, and what the effect of the action was on the balance of the assets for each the spender and earner
3. multiple payment methods for the same "action", e.g. 20 CCs + 20 reward sats + 60 sat invoice for an "action" that costs 100 sats while maintaining audit-ability and atomic refunds
4. realtime revenue for territory founders (this was not intended but was a bonus of the design), i.e territory revenue is not paid out each night anymore ... it happens when the action happens
    - similarly, actions that increase the rewards pool are no longer deduced but represented by a row in `PayOut` 
        - consideration was given to future plans like territory-specific rewards pools and the design is conducive to that
5. the design should greatly improve the readability and reliability of retries and auto-retries
    - I haven't explicitly considered this in the design tbh, but given that we aren't overloading `Invoice` and `Withdrawl` with state, intuition would suggest this is the case. Regardless, wip/tbd.
7. "prisms" (to be implemented later using the fact that `PayOut` is decoupled from `PayIn`)

