### PR TITLE
Use wallets instead of wallets.length as useZap dependency

### DIFF
--- a/components/item-act.js
+++ b/components/item-act.js
@@ -327,7 +327,7 @@ export function useZap () {
       // but right now this toast is noisy for optimistic zaps
       console.error(error)
     }
-  }, [act, toaster, strike, wallets.length])
+  }, [act, toaster, strike, wallets])
 }
 
 export class ActCanceledError extends Error {

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -196,17 +196,16 @@ export function WalletsProvider ({ children }) {
 
   // provides priority sorted wallets to children, a function to reload local wallets,
   // and a function to set priorities
+  const value = useMemo(() => ({
+    wallets,
+    reloadLocalWallets,
+    setPriorities,
+    onVaultKeySet: syncLocalWallets,
+    beforeDisconnectVault: unsyncLocalWallets,
+    removeLocalWallets
+  }), [wallets, reloadLocalWallets, setPriorities, syncLocalWallets, unsyncLocalWallets, removeLocalWallets])
   return (
-    <WalletsContext.Provider
-      value={{
-        wallets,
-        reloadLocalWallets,
-        setPriorities,
-        onVaultKeySet: syncLocalWallets,
-        beforeDisconnectVault: unsyncLocalWallets,
-        removeLocalWallets
-      }}
-    >
+    <WalletsContext.Provider value={value}>
       <RetryHandler>
         {children}
       </RetryHandler>


### PR DESCRIPTION
## Description

Potential fix for #1656

## Additional Context

Could not reproduce bug but using `wallets` instead of `wallets.length` should be fine sine `useSendWallets` returns a memoized value.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. Tested zapping with NWC. Still works.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no