### PR TITLE
Fix wallet indicator blink via wallet loading state

### DIFF
--- a/components/wallet-indicator.js
+++ b/components/wallet-indicator.js
@@ -1,6 +1,6 @@
 import { useConfiguredWallets } from '@/wallets'
 
 export function useWalletIndicator () {
-  const wallets = useConfiguredWallets()
-  return wallets.length === 0
+  const { wallets, loading } = useConfiguredWallets()
+  return !loading && wallets.length === 0
 }

--- a/pages/wallets/index.js
+++ b/pages/wallets/index.js
@@ -3,7 +3,7 @@ import Layout from '@/components/layout'
 import styles from '@/styles/wallet.module.css'
 import Link from 'next/link'
 import { useWallets } from '@/wallets/index'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useIsClient } from '@/components/use-client'
 import WalletCard from '@/components/wallet-card'
 import { useToast } from '@/components/toast'
@@ -87,6 +87,7 @@ export default function Wallet ({ ssrData }) {
 
   const indicator = useWalletIndicator()
   const [showWallets, setShowWallets] = useState(!indicator)
+  useEffect(() => { setShowWallets(!indicator) }, [indicator])
 
   if (indicator && !showWallets) {
     return (

--- a/wallets/index.js
+++ b/wallets/index.js
@@ -67,6 +67,7 @@ export function WalletsProvider ({ children }) {
   const [setWalletPriority] = useMutation(SET_WALLET_PRIORITY)
   const [serverWallets, setServerWallets] = useState([])
   const client = useApolloClient()
+  const [loading, setLoading] = useState(true)
 
   const { data, refetch } = useQuery(WALLETS,
     SSR ? {} : { nextFetchPolicy: 'cache-and-network' })
@@ -102,6 +103,7 @@ export function WalletsProvider ({ children }) {
       }
 
       setServerWallets(wallets)
+      setLoading(false)
     }
     loadWallets()
   }, [data?.wallets, decrypt, isActive])
@@ -198,12 +200,13 @@ export function WalletsProvider ({ children }) {
   // and a function to set priorities
   const value = useMemo(() => ({
     wallets,
+    loading,
     reloadLocalWallets,
     setPriorities,
     onVaultKeySet: syncLocalWallets,
     beforeDisconnectVault: unsyncLocalWallets,
     removeLocalWallets
-  }), [wallets, reloadLocalWallets, setPriorities, syncLocalWallets, unsyncLocalWallets, removeLocalWallets])
+  }), [wallets, loading, reloadLocalWallets, setPriorities, syncLocalWallets, unsyncLocalWallets, removeLocalWallets])
   return (
     <WalletsContext.Provider value={value}>
       <RetryHandler>
@@ -223,8 +226,11 @@ export function useWallet (name) {
 }
 
 export function useConfiguredWallets () {
-  const { wallets } = useWallets()
-  return useMemo(() => wallets.filter(w => isConfigured(w)), [wallets])
+  const { wallets, loading } = useWallets()
+  return useMemo(() => ({
+    wallets: wallets.filter(w => isConfigured(w)),
+    loading
+  }), [wallets, loading])
 }
 
 export function useSendWallets () {


### PR DESCRIPTION
## Description

The wallet indicator currently shows up for everyone on first render because the wallets aren't loaded yet. Fixed that by exposing a loading state via `useWallets`.

However, this means that instead of going from `true` to `false` if there actually is a wallet attached, it now goes from `false` to `true` if there actually isn't a wallet attached, see video.

I think the way it is now (`false`to `true`) is better UX in most cases since most stackers will probably attach a wallet. 

Still something to think about.

<sub>I'm having a déjà vu :eyes:</sub>

## Video

https://github.com/user-attachments/assets/767a7263-1f25-4057-b584-f61911048334

## Additional Context

- https://stacker.news/items/939641?commentId=939788
- this new loading state for the wallets might have been very useful a long time ago already for other things :eyes: Will look into if we can use it to improve other code, UX etc.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested with and without wallets.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no