### PR TITLE
fix(extend-awards): add check for existing branch with pending awards

### DIFF
--- a/.github/workflows/extend-awards.yml
+++ b/.github/workflows/extend-awards.yml
@@ -22,14 +22,36 @@ jobs:
         with:
           python-version: '3.13' 
       - run: pip install requests
+      - name: Check if branch exists
+        id: check_branch
+        run: |
+          git fetch origin extend-awards/patch || echo "Branch does not exist"
+          if git show-ref --verify --quiet refs/remotes/origin/extend-awards/patch; then
+            echo "exists=true" >> $GITHUB_ENV
+          else
+            echo "exists=false" >> $GITHUB_ENV
+          fi
+      - name: Checkout to existing branch
+        if: env.exists == 'true'
+        run: |
+          git checkout extend-awards/patch
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
       - run: python extend-awards.py
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_CONTEXT: ${{ toJson(github) }}
+      - name: Commit changes and push to existing branch
+        if: env.exists == 'true'
+        run: |
+          git commit -am "Extending awards.csv"
+          git push origin extend-awards/patch
       - uses: peter-evans/create-pull-request@v7
+        if: env.exists == 'false'
         with:
           add-paths: awards.csv
           branch: extend-awards/patch
           commit-message: Extending awards.csv
           title: Extending awards.csv
-          body: A PR was merged that solves an issue and awards.csv should be extended.
+          body: One or more PR's were merged that solve an issue(s) and awards.csv should be extended. Remembere to delete the branch after merging.
+          delete-branch: true

--- a/docs/dev/extend-awards.md
+++ b/docs/dev/extend-awards.md
@@ -21,6 +21,20 @@ The primary job consists of several steps:
   - a script (see below) is executed, which appends lines to [awards.csv](awards.csv) if needed
   - [create-pull-request](https://github.com/peter-evans/create-pull-request) looks for modified files and creates (or updates) a PR
 
+### Branch Existence Check
+
+The workflow includes functionality to check if the branch `extend-awards/patch` already exists. This ensures that if a PR is already open for extending `awards.csv`, the workflow will add a commit to the existing branch instead of creating a new PR. The steps are as follows:
+
+1. **Check if the branch exists**:
+   - The workflow fetches the branch `extend-awards/patch` from the remote repository.
+   - If the branch exists, an environment variable `exists=true` is set; otherwise, `exists=false`.
+
+2. **Handle existing branch**:
+   - If the branch exists (`exists=true`), the workflow checks out the branch, configures the Github bot user, and commits the changes directly to the branch.
+   - If the branch does not exist (`exists=false`), the workflow creates a new branch and opens a new PR using the `create-pull-request` action.
+
+This ensures that changes are consolidated into a single PR when possible. 
+
 ## Script
 
 The script is [extend-awards.py](extend-awards.py).
@@ -41,7 +55,7 @@ Finally, it appends zero, one, or two lines to the awards.csv file.
 
 ## Diagnostics
 
-In the GitHub web interface under 'Actions' each invokation of the action can be viewed, including environment and [output and errors](https://en.wikipedia.org/wiki/Standard_streams) of the script. First, the specific invokation is selected, then the job 'if_merged', then the step 'Run python extend-awards.py'. The environment is found by expanding the inner 'Run python extended-awards.py' on the first line.
+In the GitHub web interface under 'Actions' each invocation of the action can be viewed, including environment and [output and errors](https://en.wikipedia.org/wiki/Standard_streams) of the script. First, the specific invocation is selected, then the job 'if_merged', then the step 'Run python extend-awards.py'. The environment is found by expanding the inner 'Run python extended-awards.py' on the first line.
 
 The normal output includes details about the issue number found, the amount calculation, or the reason for not appending lines.
 


### PR DESCRIPTION
## Description
Currently as described in #1991, when a PR is merged while a PR previously opened by the `extend-awards` workflow is still opened & unmerged into master, the workflow runs again and overwrites the prior changes. 

This PR addresses this issue by adding steps in the workflow to first check if the branch that the workflow creates is available, signalling that there is still a PR open trying to extend the awards.csv file. If there is a branch, the workflow instead pushes a commit to that branch rather than creating a new PR and overwriting changes. 

I checked on alternative approaches. Based on the docs for the [create-pull-request](https://github.com/peter-evans/create-pull-request) there is no obvious application/example that addresses this issue. Also, creating differently named branches for each github workflow run would create conflicts as the master branch would change and the master that earlier PR's would be made with would be outdated with new extensions. So I think this is the simplest, most straight forward approach.

Closes #1991 

## Screenshots
My testing approach was to run this workflow on my fork of this repo and created a [test repo](https://github.com/brymut/test-repo/issues)with the labels used for `extend-awards` replicated there. Here is a screen recording demonstrating fixed functionality using the Github web UI:

https://github.com/user-attachments/assets/6c5e8f78-a214-4f7a-9f1c-f854bac75cc0


## Additional Context

**Branch deletion:** Since this approach relies on checking if the `extend-awards/patch` exists to detect if there is an open PR since this workflow creates that branch, we need to delete that branch when we have merged back into master so I have added the "delete-branch" option to the `create-pull-request` step to do so. As explained in the [docs for the Github action](https://github.com/peter-evans/create-pull-request/tree/main?tab=readme-ov-file#delete-branch), this doesn't delete the branch immediately, so I would recommend that the person merging deletes the branch when they are done. I have added a reminder to the PR message with the same. Alternatively, as [mentioned in the docs](https://github.com/peter-evans/create-pull-request/tree/main?tab=readme-ov-file#delete-branch), the repo could use GitHub's `Automatically delete head branches` feature in the repository settings.

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes, AFAIK

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10
