### PR TITLE
enhance: helpful error message on login

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -12,6 +12,7 @@ import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 import { datePivot } from '@/lib/time'
 import * as cookie from 'cookie'
 import { cookieOptions } from '@/lib/auth'
+import Link from 'next/link'
 
 export function EmailLoginForm ({ text, callbackUrl, multiAuth }) {
   const disabled = multiAuth
@@ -52,12 +53,26 @@ const authErrorMessages = {
   default: 'Auth failed. Try again or choose a different method.'
 }
 
-export function authErrorMessage (error) {
-  return error && (authErrorMessages[error] ?? authErrorMessages.default)
+export function authErrorMessage (error, signin) {
+  if (!error) return null
+
+  // workaround for signin/signup awareness due to missing support from next-auth
+  const message = error && (authErrorMessages[error] ?? authErrorMessages.default)
+  if (signin && (error === 'Callback' || error === 'CredentialsSignin')) {
+    return (
+      <>
+        We couldn't find an account with these credentials.
+        <br />
+        Did you want to <Link className='fw-bold' href='/signup'>sign up</Link> instead?
+      </>
+    )
+  }
+
+  return message
 }
 
 export default function Login ({ providers, callbackUrl, multiAuth, error, text, Header, Footer, signin }) {
-  const [errorMessage, setErrorMessage] = useState(authErrorMessage(error))
+  const [errorMessage, setErrorMessage] = useState(authErrorMessage(error, signin))
   const router = useRouter()
 
   // signup/signin awareness cookie

--- a/components/login.js
+++ b/components/login.js
@@ -58,12 +58,12 @@ export function authErrorMessage (error, signin) {
 
   // workaround for signin/signup awareness due to missing support from next-auth
   const message = error && (authErrorMessages[error] ?? authErrorMessages.default)
-  if (signin && (error === 'Callback' || error === 'CredentialsSignin')) {
+  if (signin) {
     return (
       <>
-        We couldn't find an account with these credentials.
+        {message}
         <br />
-        Did you want to <Link className='fw-bold' href='/signup'>sign up</Link> instead?
+        If you are new to Stacker News, please <Link className='fw-bold' href='/signup'>sign up</Link> first.
       </>
     )
   }

--- a/components/login.js
+++ b/components/login.js
@@ -56,8 +56,8 @@ const authErrorMessages = {
 export function authErrorMessage (error, signin) {
   if (!error) return null
 
-  // workaround for signin/signup awareness due to missing support from next-auth
   const message = error && (authErrorMessages[error] ?? authErrorMessages.default)
+  // workaround for signin/signup awareness due to missing support from next-auth
   if (signin) {
     return (
       <>


### PR DESCRIPTION
## Description
Fix #2067
Adds a message that asks the user if they wanted to sign up instead.

## Video
https://github.com/user-attachments/assets/ae6593e9-41b1-455f-a381-e1e1feb21b61

## Additional Context

This implementation is a workaround to next auth's missing custom error support.

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes, it falls back to the original errors if signin prop is not present

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6, the error shows only on sign in and only on errors that gets thrown by next auth in case of failure in returning the user object.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a