### PR TITLE
Non-word boundary Regex on user Mentions

### DIFF
--- a/lib/rehype-sn.js
+++ b/lib/rehype-sn.js
@@ -6,7 +6,7 @@ import { toString } from 'mdast-util-to-string'
 const userGroup = '[\\w_]+'
 const subGroup = '[A-Za-z][\\w_]+'
 
-const mentionRegex = new RegExp('(?:^|\\s)@(' + userGroup + '(?:\\/' + userGroup + ')?)', 'gi')
+const mentionRegex = new RegExp('\\B@(' + userGroup + '(?:\\/' + userGroup + ')*)', 'gi')
 const subRegex = new RegExp('~(' + subGroup + '(?:\\/' + subGroup + ')?)', 'gi')
 const nostrIdRegex = /\b((npub1|nevent1|nprofile1|note1|naddr1)[02-9ac-hj-np-z]+)\b/g
 
@@ -116,8 +116,8 @@ export default function rehypeSN (options = {}) {
             }
 
             const [fullMatch, mentionMatch, subMatch] = match
-            const replacement = mentionMatch ? replaceMention(fullMatch, mentionMatch) : replaceSub(fullMatch, subMatch)
 
+            const replacement = mentionMatch ? replaceMention(fullMatch, mentionMatch) : replaceSub(fullMatch, subMatch)
             if (replacement) {
               newChildren.push(replacement)
             } else {
@@ -238,10 +238,11 @@ export default function rehypeSN (options = {}) {
   }
 
   function replaceMention (value, username) {
+    // split the name by / to allow user paths and still show the user
     return {
       type: 'element',
       tagName: 'mention',
-      properties: { href: '/' + username, name: username },
+      properties: { href: '/' + username, name: username.split('/')[0] },
       children: [{ type: 'text', value }]
     }
   }

--- a/lib/rehype-sn.js
+++ b/lib/rehype-sn.js
@@ -6,7 +6,7 @@ import { toString } from 'mdast-util-to-string'
 const userGroup = '[\\w_]+'
 const subGroup = '[A-Za-z][\\w_]+'
 
-const mentionRegex = new RegExp('\\B@(' + userGroup + '(?:\\/' + userGroup + ')*)', 'gi')
+const mentionRegex = new RegExp('\\B@(' + userGroup + '(?:\\/' + userGroup + ')?)', 'gi')
 const subRegex = new RegExp('~(' + subGroup + '(?:\\/' + subGroup + ')?)', 'gi')
 const nostrIdRegex = /\b((npub1|nevent1|nprofile1|note1|naddr1)[02-9ac-hj-np-z]+)\b/g
 


### PR DESCRIPTION
## Description

Fixes #2076
This regex matches user mentions (also with paths) starting with `@`, like @sox or @sox/all.
It ensures that the `@` symbol is not preceded by a word character, that it has the `@` symbol and that we have a username that contains word characters or underscores. Optionally, it could have a single forward slash to indicate paths.

As a bonus, it fixes popovers for mentions with slashes by serving only the username part to the `Mention` component.

## Video
https://github.com/user-attachments/assets/da283057-dada-4103-942d-a36aeeb828a2

## Additional Context

I exponentially tested the possibility of abuse and the ms it took for the regex to conclude didn't grow.
Initially this regex contained * for more than one slash, it happens that user paths never have more than a single slash so it was removed.

## Checklist

**Are your changes backwards compatible? Please answer below:**
Only the client side regex pattern has changed, server-side we only need the username

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6, tested for vulnerabilities and functionality. Tested also with 5 common cases and edge cases like `.@mention.`

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a