### PR TITLE
Fix item deletion hits constraint

### DIFF
--- a/prisma/migrations/20250411220921_fix_item_delete/migration.sql
+++ b/prisma/migrations/20250411220921_fix_item_delete/migration.sql
@@ -9,4 +9,4 @@ ALTER TABLE "Item" ADD CONSTRAINT "Item_unique_time_constraint"
     md5(COALESCE("text", '')) WITH =,
     tsrange(created_at, created_at + INTERVAL '10 minutes') WITH &&
   )
-  WHERE (created_at > '2024-12-30' AND text <> '*deleted by author*');
+  WHERE (created_at > '2024-12-30' AND "deletedAt" IS NULL);

--- a/prisma/migrations/20250411220921_fix_item_delete/migration.sql
+++ b/prisma/migrations/20250411220921_fix_item_delete/migration.sql
@@ -1,0 +1,12 @@
+-- make sure we can still delete items within 10 minutes
+ALTER TABLE "Item" DROP CONSTRAINT "Item_unique_time_constraint";
+ALTER TABLE "Item" ADD CONSTRAINT "Item_unique_time_constraint"
+  EXCLUDE USING gist (
+    "userId" WITH =,
+    COALESCE("parentId", -1) WITH =,
+    md5(COALESCE("title", '')) WITH =,
+    md5(COALESCE("subName", '')) WITH =,
+    md5(COALESCE("text", '')) WITH =,
+    tsrange(created_at, created_at + INTERVAL '10 minutes') WITH &&
+  )
+  WHERE (created_at > '2024-12-30' AND text <> '*deleted by author*');


### PR DESCRIPTION
## Description

Fix #2095 

This excludes the text `*deleted by author*` from hitting the constraint that I added in https://github.com/stackernews/stacker.news/pull/1747.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes, it should be because this is excluding more from the constraint so anything that exists should already be valid according to it

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Made sure this fixes the issue.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no