### PR TITLE
Check if token expired before refresh

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -135,6 +135,13 @@ async function resetMultiAuthCookies (req, res) {
   setMultiAuthCookies(req, res, { ...decoded, jwt: token })
 }
 
+class JwtExpiredError extends Error {
+  constructor () {
+    super('token expired')
+    this.name = 'JwtExpiredError'
+  }
+}
+
 async function refreshMultiAuthCookies (req, res) {
   const httpOnlyOptions = cookieOptions()
   const jsOptions = { ...httpOnlyOptions, httpOnly: false }
@@ -145,8 +152,12 @@ async function refreshMultiAuthCookies (req, res) {
 
   const refreshToken = async (token) => {
     const secret = process.env.NEXTAUTH_SECRET
+    const decoded = await decodeJWT({ token, secret })
+    if (decoded.exp <= Date.now() / 1000) {
+      throw new JwtExpiredError()
+    }
     return await encodeJWT({
-      token: await decodeJWT({ token, secret }),
+      token: decoded,
       secret
     })
   }
@@ -161,7 +172,15 @@ async function refreshMultiAuthCookies (req, res) {
 
     if (MULTI_AUTH_JWT_REGEXP.test(key) || key === SESSION_COOKIE) {
       const oldToken = value
-      const newToken = await refreshToken(oldToken)
+      let newToken
+      try {
+        newToken = await refreshToken(oldToken)
+      } catch (err) {
+        if (err instanceof JwtExpiredError) {
+          continue
+        }
+        throw err
+      }
       res.appendHeader('Set-Cookie', cookie.serialize(key, newToken, httpOnlyOptions))
       continue
     }


### PR DESCRIPTION
## Description

This checks if the JWT we are about to refresh expired and skips that token in that case.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Looked at `decoded.exp` and it's in seconds so `decoded.exp <= Date.now() / 1000` will trigger when it expires. Tested the case in which it expires by flipping the statement. Token refresh is skipped in that case.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no