### PR TITLE
Remove unused wallet resolvers

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -154,37 +154,6 @@ export function verifyHmac (hash, hmac) {
 const resolvers = {
   Query: {
     invoice: getInvoice,
-    wallet: async (parent, { id }, { me, models }) => {
-      if (!me) {
-        throw new GqlAuthenticationError()
-      }
-
-      return await models.wallet.findUnique({
-        where: {
-          userId: me.id,
-          id: Number(id)
-        },
-        include: {
-          vaultEntries: true
-        }
-      })
-    },
-    walletByType: async (parent, { type }, { me, models }) => {
-      if (!me) {
-        throw new GqlAuthenticationError()
-      }
-
-      const wallet = await models.wallet.findFirst({
-        where: {
-          userId: me.id,
-          type
-        },
-        include: {
-          vaultEntries: true
-        }
-      })
-      return wallet
-    },
     wallets: async (parent, args, { me, models }) => {
       if (!me) {
         throw new GqlAuthenticationError()

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -68,7 +68,7 @@ const typeDefs = `
     numBolt11s: Int!
     connectAddress: String!
     walletHistory(cursor: String, inc: String): History
-    wallets(includeReceivers: Boolean, includeSenders: Boolean, onlyEnabled: Boolean, prioritySort: String): [Wallet!]!
+    wallets: [Wallet!]!
     walletLogs(type: String, from: String, to: String, cursor: String): WalletLog!
     failedInvoices: [Invoice!]!
   }

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -69,8 +69,6 @@ const typeDefs = `
     connectAddress: String!
     walletHistory(cursor: String, inc: String): History
     wallets(includeReceivers: Boolean, includeSenders: Boolean, onlyEnabled: Boolean, prioritySort: String): [Wallet!]!
-    wallet(id: ID!): Wallet
-    walletByType(type: String!): Wallet
     walletLogs(type: String, from: String, to: String, cursor: String): WalletLog!
     failedInvoices: [Invoice!]!
   }

--- a/fragments/wallet.js
+++ b/fragments/wallet.js
@@ -173,25 +173,6 @@ export const WALLET_FIELDS = gql`
   }
 `
 
-export const WALLET = gql`
-  ${WALLET_FIELDS}
-  query Wallet($id: ID!) {
-    wallet(id: $id) {
-      ...WalletFields
-    }
-  }
-`
-
-// XXX [WALLET] this needs to be updated if another server wallet is added
-export const WALLET_BY_TYPE = gql`
-  ${WALLET_FIELDS}
-  query WalletByType($type: String!) {
-    walletByType(type: $type) {
-      ...WalletFields
-    }
-  }
-`
-
 export const WALLETS = gql`
   ${WALLET_FIELDS}
   query Wallets {


### PR DESCRIPTION
## Description

We don't use these wallet resolver and arguments anymore.

Removing them also means less stuff for me to migrate in #2092.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes since the resolvers weren't used

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. I noticed that the resolvers are unused because I found nothing referencing the fragments. Also tried to search manually for some references but none showed up.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no