### PR TITLE
Remove unused vault resolvers

### DIFF
--- a/api/resolvers/vault.js
+++ b/api/resolvers/vault.js
@@ -2,18 +2,6 @@ import { E_VAULT_KEY_EXISTS, GqlAuthenticationError, GqlInputError } from '@/lib
 
 export default {
   Query: {
-    getVaultEntry: async (parent, { key }, { me, models }, info) => {
-      if (!me) throw new GqlAuthenticationError()
-      if (!key) throw new GqlInputError('must have key')
-
-      const k = await models.vault.findUnique({
-        where: {
-          key,
-          userId: me.id
-        }
-      })
-      return k
-    },
     getVaultEntries: async (parent, { keysFilter }, { me, models }, info) => {
       if (!me) throw new GqlAuthenticationError()
 

--- a/api/typeDefs/vault.js
+++ b/api/typeDefs/vault.js
@@ -18,8 +18,7 @@ export default gql`
   }
 
   extend type Query {
-    getVaultEntry(key: String!): VaultEntry
-    getVaultEntries(keysFilter: [String!]): [VaultEntry!]!
+    getVaultEntries: [VaultEntry!]!
   }
 
   extend type Mutation {

--- a/fragments/vault.js
+++ b/fragments/vault.js
@@ -11,17 +11,6 @@ export const VAULT_ENTRY_FIELDS = gql`
   }
 `
 
-export const GET_VAULT_ENTRY = gql`
-  ${VAULT_ENTRY_FIELDS}
-  query GetVaultEntry(
-    $key: String!
-  ) {
-    getVaultEntry(key: $key) {
-      ...VaultEntryFields
-    }
-  }
-`
-
 export const GET_VAULT_ENTRIES = gql`
   ${VAULT_ENTRY_FIELDS}
   query GetVaultEntries {


### PR DESCRIPTION
## Description

Just like #2104, this removes vault resolvers and the `keysFilter` argument for `getVaultEntries` since they weren't used anywhere.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested by rebasing #2092 on this branch and enabling, disconnecting, resetting and re-enabling device sync. Also saved LNbits with and without admin key etc. 

It's really not used; I didn't miss a reference.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no