### PR TITLE
Live updates to comment threads

### DIFF
--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -11,6 +11,7 @@ export default gql`
     auctionPosition(sub: String, id: ID, boost: Int): Int!
     boostPosition(sub: String, id: ID, boost: Int): BoostPositions!
     itemRepetition(parentId: ID): Int!
+    newComments(rootId: ID, after: Date): NewComments
   }
 
   type BoostPositions {
@@ -96,6 +97,10 @@ export default gql`
     comments: [Item!]!
   }
 
+  type NewComments {
+    comments: [Item]
+  }
+
   enum InvoiceActionState {
     PENDING
     PENDING_HELD
@@ -148,6 +153,7 @@ export default gql`
     ncomments: Int!
     nDirectComments: Int!
     comments(sort: String, cursor: String): Comments!
+    newComments(rootId: ID, after: Date): NewComments
     path: String
     position: Int
     prior: Int

--- a/components/comment.module.css
+++ b/components/comment.module.css
@@ -136,3 +136,26 @@
 .comment:has(.comment) + .comment{
     padding-top: .5rem;
 }
+
+.newCommentDot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background-color: var(--bs-primary);
+    animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+    0% {
+        background-color: #FADA5E;
+        opacity: 0.7;
+    }
+    50% {
+        background-color: #F6911D;
+        opacity: 1;
+    }
+    100% {
+        background-color: #FADA5E;
+        opacity: 0.7;
+    }
+}

--- a/components/comments.js
+++ b/components/comments.js
@@ -1,5 +1,5 @@
 import { Fragment, useMemo } from 'react'
-import Comment, { CommentSkeleton } from './comment'
+import Comment, { CommentSkeleton, ShowNewComments } from './comment'
 import styles from './header.module.css'
 import Nav from 'react-bootstrap/Nav'
 import Navbar from 'react-bootstrap/Navbar'
@@ -8,6 +8,7 @@ import { defaultCommentSort } from '@/lib/item'
 import { useRouter } from 'next/router'
 import MoreFooter from './more-footer'
 import { FULL_COMMENTS_THRESHOLD } from '@/lib/constants'
+import { useLiveComments } from './use-live-comments'
 
 export function CommentsHeader ({ handleSort, pinned, bio, parentCreatedAt, commentSats }) {
   const router = useRouter()
@@ -64,9 +65,11 @@ export function CommentsHeader ({ handleSort, pinned, bio, parentCreatedAt, comm
 
 export default function Comments ({
   parentId, pinned, bio, parentCreatedAt,
-  commentSats, comments, commentsCursor, fetchMoreComments, ncomments, ...props
+  commentSats, comments, commentsCursor, fetchMoreComments, ncomments, newComments, lastCommentAt, ...props
 }) {
   const router = useRouter()
+  // update item.newComments in cache
+  useLiveComments(parentId, lastCommentAt || parentCreatedAt)
 
   const pins = useMemo(() => comments?.filter(({ position }) => !!position).sort((a, b) => a.position - b.position), [comments])
 
@@ -102,6 +105,9 @@ export default function Comments ({
           count={comments?.length}
           Skeleton={CommentsSkeleton}
         />}
+      {newComments?.length > 0 && (
+        <ShowNewComments updateQuery newComments={newComments} itemId={parentId} />
+      )}
     </>
   )
 }

--- a/components/item-full.js
+++ b/components/item-full.js
@@ -182,17 +182,18 @@ export default function ItemFull ({ item, fetchMoreComments, bio, rank, ...props
                 ? <BioItem item={item} {...props} />
                 : <TopLevelItem item={item} {...props} />}
               </div>)}
-          {item.comments &&
-            <div className={styles.comments}>
-              <Comments
-                parentId={item.id} parentCreatedAt={item.createdAt}
-                pinned={item.position} bio={bio} commentSats={item.commentSats}
-                ncomments={item.ncomments}
-                comments={item.comments.comments}
-                commentsCursor={item.comments.cursor}
-                fetchMoreComments={fetchMoreComments}
-              />
-            </div>}
+          <div className={styles.comments}>
+            <Comments
+              parentId={item.id} parentCreatedAt={item.createdAt}
+              pinned={item.position} bio={bio} commentSats={item.commentSats}
+              ncomments={item.ncomments}
+              comments={item.comments.comments}
+              commentsCursor={item.comments.cursor}
+              fetchMoreComments={fetchMoreComments}
+              newComments={item.newComments}
+              lastCommentAt={item.lastCommentAt}
+            />
+          </div>
         </CarouselProvider>
       </RootProvider>
     </>

--- a/components/use-live-comments.js
+++ b/components/use-live-comments.js
@@ -1,0 +1,91 @@
+import { useQuery, useApolloClient } from '@apollo/client'
+import { SSR } from '../lib/constants'
+import { GET_NEW_COMMENTS, COMMENT_WITH_NEW } from '../fragments/comments'
+import { ITEM_FULL } from '../fragments/items'
+import { useState } from 'react'
+
+export function useLiveComments (rootId, after) {
+  const client = useApolloClient()
+  const [lastChecked, setLastChecked] = useState(after)
+  const { data, error } = useQuery(GET_NEW_COMMENTS, SSR
+    ? {}
+    : {
+        pollInterval: 10000,
+        variables: { rootId, after: lastChecked }
+      })
+
+  console.log('error', error)
+
+  if (data && data.newComments) {
+    saveNewComments(client, rootId, data.newComments.comments)
+    const latestCommentCreatedAt = getLastCommentCreatedAt(data.newComments.comments)
+    if (latestCommentCreatedAt) {
+      setLastChecked(latestCommentCreatedAt)
+    }
+  }
+
+  return null
+}
+
+export function saveNewComments (client, rootId, newComments) {
+  console.log('newComments', newComments)
+  for (const comment of newComments) {
+    console.log('comment', comment)
+    const parentId = comment.parentId
+    if (Number(parentId) === Number(rootId)) {
+      console.log('parentId', parentId)
+      client.cache.updateQuery({
+        query: ITEM_FULL,
+        variables: { id: rootId }
+      }, (data) => {
+        console.log('data', data)
+        if (!data) return data
+        console.log('dataTopLevel', data)
+
+        const { item } = data
+
+        return { item: dedupeComment(item, comment) }
+      })
+    } else {
+      console.log('not top level', parentId)
+      client.cache.updateFragment({
+        id: `Item:${parentId}`,
+        fragment: COMMENT_WITH_NEW,
+        fragmentName: 'CommentWithNew'
+      }, (data) => {
+        if (!data) return data
+
+        console.log('data', data)
+
+        return dedupeComment(data, comment)
+      })
+      console.log('fragment', client.cache.readFragment({
+        id: `Item:${parentId}`,
+        fragment: COMMENT_WITH_NEW,
+        fragmentName: 'CommentWithNew'
+      }))
+    }
+  }
+}
+
+function dedupeComment (item, newComment) {
+  const existingNewComments = item.newComments || []
+  const alreadyInNewComments = existingNewComments.some(c => c.id === newComment.id)
+  const updatedNewComments = alreadyInNewComments ? existingNewComments : [...existingNewComments, newComment]
+  console.log(item)
+  const filteredComments = updatedNewComments.filter((comment) => !item.comments?.comments?.some(c => c.id === comment.id))
+  const final = { ...item, newComments: filteredComments }
+  console.log('final', final)
+  return final
+}
+
+function getLastCommentCreatedAt (comments) {
+  if (comments.length === 0) return null
+  let latest = comments[0].createdAt
+  for (const comment of comments) {
+    if (comment.createdAt > latest) {
+      latest = comment.createdAt
+    }
+  }
+  return latest
+}

--- a/fragments/comments.js
+++ b/fragments/comments.js
@@ -47,6 +47,7 @@ export const COMMENT_FIELDS = gql`
     otsHash
     ncomments
     nDirectComments
+    newComments @client
     imgproxyUrls
     rel
     apiKey
@@ -116,3 +117,30 @@ export const COMMENTS = gql`
       }
     }
   }`
+
+export const COMMENT_WITH_NEW = gql`
+  ${COMMENT_FIELDS}
+  ${COMMENTS}
+  
+  fragment CommentWithNew on Item {
+    ...CommentFields
+    comments {
+      comments {
+        ...CommentsRecursive
+      }
+    }
+    newComments @client
+  }
+`
+
+export const GET_NEW_COMMENTS = gql`
+  ${COMMENT_FIELDS}
+
+  query GetNewComments($rootId: ID, $after: Date) {
+    newComments(rootId: $rootId, after: $after) {
+      comments {
+        ...CommentFields
+      }
+    }
+  }
+`

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -59,6 +59,7 @@ export const ITEM_FIELDS = gql`
     bio
     ncomments
     nDirectComments
+    newComments @client
     commentSats
     commentCredits
     lastCommentAt

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -313,6 +313,12 @@ function getClient (uri) {
                 }
               }
             },
+            newComments: {
+              read (newComments) {
+                console.log('newComments', newComments)
+                return newComments || []
+              }
+            },
             meAnonSats: {
               read (existingAmount, { readField }) {
                 if (SSR) return null


### PR DESCRIPTION
## Description

Closes #791 
Polls every 10 seconds a new query called `GetNewComments`, returning an array of new comments based on the parent Item and appropriately pushes them to the related `Item` or `Comment` Apollo Cache fragment.

## Screenshots
tbd

## Additional Context
tbd

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
5, iterative testing, tbd

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

## TODOs
_Subject to updates_

- [ ] Count also new comments of a new comment
- [ ] Revisit Apollo Cache logic
- [ ] Test
- [ ] Cleanup