### PR TITLE
Fix unnecessary $queryRawUnsafe and missing await

### DIFF
--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -257,7 +257,7 @@ export const notifyItemParents = async ({ models, item }) => {
         SELECT 1 FROM "Mute" m
         WHERE m."muterId" = p."userId" AND m."mutedId" = ${Number(user.id)}
       )`
-    Promise.allSettled(
+    await Promise.allSettled(
       parents.map(({ userId, isDirect }) => {
         return sendUserNotification(userId, {
           title: `@${user.name} replied to you`,

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -248,10 +248,15 @@ export const notifyThreadSubscribers = async ({ models, item }) => {
 export const notifyItemParents = async ({ models, item }) => {
   try {
     const user = await models.user.findUnique({ where: { id: item.userId } })
-    const parents = await models.$queryRawUnsafe(
-      'SELECT DISTINCT p."userId", i."userId" = p."userId" as "isDirect" FROM "Item" i JOIN "Item" p ON p.path @> i.path WHERE i.id = $1 and p."userId" <> $2 ' +
-      'AND NOT EXISTS (SELECT 1 FROM "Mute" m WHERE m."muterId" = p."userId" AND m."mutedId" = $2)',
-      Number(item.parentId), Number(user.id))
+    const parents = await models.$queryRaw`
+      SELECT DISTINCT p."userId", i."userId" = p."userId" as "isDirect"
+      FROM "Item" i
+      JOIN "Item" p ON p.path @> i.path
+      WHERE i.id = ${Number(item.parentId)} and p."userId" <> ${Number(user.id)}
+      AND NOT EXISTS (
+        SELECT 1 FROM "Mute" m
+        WHERE m."muterId" = p."userId" AND m."mutedId" = ${Number(user.id)}
+      )`
     Promise.allSettled(
       parents.map(({ userId, isDirect }) => {
         return sendUserNotification(userId, {


### PR DESCRIPTION
## Description

Found this while looking into #2116.

Not sure why this used `$queryRawUnsafe`. We edited  this query multiple times but always kept `$queryRawUnsafe`, lol

Works fine with `$queryRaw`.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`. Tested with a reply from anon that the query runs as expected w/o syntax errors. Then I muted anon and query still runs as expected.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no