### PR TITLE
Fix push notifications sent without thread subscription

### DIFF
--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -259,8 +259,7 @@ export const notifyItemParents = async ({ models, item }) => {
       )
       AND EXISTS (
         -- check that there is at least one parent subscribed to this thread
-        SELECT 1 FROM "ThreadSubscription" ts
-        WHERE p.id = ts."itemId" AND p.path @> i.path
+        SELECT 1 FROM "ThreadSubscription" ts WHERE p.id = ts."itemId"
       )`
     await Promise.allSettled(
       parents.map(({ userId, isDirect }) => {

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -256,6 +256,11 @@ export const notifyItemParents = async ({ models, item }) => {
       AND NOT EXISTS (
         SELECT 1 FROM "Mute" m
         WHERE m."muterId" = p."userId" AND m."mutedId" = ${Number(user.id)}
+      )
+      AND EXISTS (
+        -- check that there is at least one parent subscribed to this thread
+        SELECT 1 FROM "ThreadSubscription" ts
+        WHERE p.id = ts."itemId" AND p.path @> i.path
       )`
     await Promise.allSettled(
       parents.map(({ userId, isDirect }) => {


### PR DESCRIPTION
## Description

Based on #2117 

Fix 50% of #2116 because this only fixes the "ghost push notification" mentioned in #2116 (push notification received but none in /notifications).

The other issue is that when we unsubscribe from the root, we are still subscribed to replies to our own replies in that post.

I think if we unsubscribe from an item, we should also unsubscribe from all children.

I will do this in another PR.

## Video

tbd (ETA tomorrow)

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

~lgtm rn, but will test again tomorrow and make sure this (simple?) fix still makes sense~

`9`. Tested with two levels of subscription: subscription to root item and subscription to own reply replying to root item.

If I unsubscribe from root, I don't receive push notifications for root replies anymore but I still get them if someone replies to my reply. If I unsubscribe from both, I don't receive any push notifications anymore. If I unsubscribe from reply but keep the subscription on root, I still get push notifications for everything.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no