### PR TITLE
Also unsubscribe from any children

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -838,8 +838,16 @@ export default {
       const data = { itemId: Number(id), userId: me.id }
       const old = await models.threadSubscription.findUnique({ where: { userId_itemId: data } })
       if (old) {
-        await models.threadSubscription.delete({ where: { userId_itemId: data } })
-      } else await models.threadSubscription.create({ data })
+        await models.$executeRaw`
+          DELETE FROM "ThreadSubscription" ts
+          USING "Item" i
+          WHERE ts."userId" = ${me.id}
+          AND i.path <@ (SELECT path FROM "Item" WHERE id = ${Number(id)})
+          AND ts."itemId" = i.id
+        `
+      } else {
+        await models.threadSubscription.create({ data })
+      }
       return { id }
     },
     deleteItem: async (parent, { id }, { me, models }) => {

--- a/components/subscribe.js
+++ b/components/subscribe.js
@@ -20,6 +20,25 @@ export default function SubscribeDropdownItem ({ item: { id, meSubscription } })
           },
           optimistic: true
         })
+
+        const unsubscribed = !subscribeItem.meSubscription
+        if (!unsubscribed) return
+
+        const cacheState = cache.extract()
+        Object.keys(cacheState)
+          .filter(key => key.startsWith('Item:'))
+          .forEach(key => {
+            cache.modify({
+              id: key,
+              fields: {
+                meSubscription: (existing, { readField }) => {
+                  const path = readField('path')
+                  return !path || !path.includes(id) ? existing : false
+                }
+              },
+              optimistic: true
+            })
+          })
       }
     }
   )


### PR DESCRIPTION
## Description

Fix #2116 

Now, when you unsubscribe, we will also delete any subscriptions from nested items such that you are really fully unsubscribed from an item.

TODO:
- [x] update `meSubscription` in Apollo cache for nested items

## Additional Context

Since `unsubscribe` only shows up if you already have a subscription, stackers other than the author of the post would first need to subscribe so they can unsubscribe and delete all subscriptions they have in that item ...

This isn't great UX but should be enough to fix the notification spam caused be deeply nested replies in [item 948515](https://stacker.news/items/948515).

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested at various levels of nesting.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no