### PR TITLE
Fix push notification sent without own thread subscription

### DIFF
--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -259,7 +259,7 @@ export const notifyItemParents = async ({ models, item }) => {
       )
       AND EXISTS (
         -- check that there is at least one parent subscribed to this thread
-        SELECT 1 FROM "ThreadSubscription" ts WHERE p.id = ts."itemId"
+        SELECT 1 FROM "ThreadSubscription" ts WHERE p.id = ts."itemId" AND p."userId" = ts."userId"
       )`
     await Promise.allSettled(
       parents.map(({ userId, isDirect }) => {


### PR DESCRIPTION
## Description

I should have tested #2118 with a reply from someone else in between.

The current filter only checks if any parent of a reply has a thread subscription. If that's the case, it will still continue to send out push notifications for all of them.

This PR fixes this by also checking that the thread subscription belongs to the parent.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

Now for real a `8`:

I ran this current query with the bug:

```sql
SELECT DISTINCT p."userId", i."userId" = p."userId" as "isDirect"
FROM "Item" i
JOIN "Item" p ON p.path @> i.path
WHERE i.id = 949729 and p."userId" <> 25629
AND NOT EXISTS (
  SELECT 1 FROM "Mute" m
  WHERE m."muterId" = p."userId" AND m."mutedId" = 25629
)
AND EXISTS (
  -- check that there is at least one parent subscribed to this thread
  SELECT 1 FROM "ThreadSubscription" ts WHERE p.id = ts."itemId"
)
```

which returns two users (me and Undisciplined), even though I am not subscribed to any parent. However, Undisciplined is subscribed to his own reply (by default) so I get the push notification anyway.

Then I noticed that I am missing this

```diff
-  SELECT 1 FROM "ThreadSubscription" ts WHERE p.id = ts."itemId"
+  SELECT 1 FROM "ThreadSubscription" ts WHERE p.id = ts."itemId" AND p."userId" = ts."userId"
```

which fixes this.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no