### PR TITLE
hotfix: use URL constructor for imgproxy crop

### DIFF
--- a/worker/imgproxy.js
+++ b/worker/imgproxy.js
@@ -203,7 +203,7 @@ export async function processCrop ({ photoId, cropData }) {
   ].join('')
 
   const uploadsUrl = process.env.MEDIA_URL_DOCKER || process.env.NEXT_PUBLIC_MEDIA_URL
-  const url = uploadsUrl + `/${photoId}`
+  const url = new URL(photoId, uploadsUrl).toString()
   console.log('[imgproxy - cropjob] id:', photoId, '-- url:', url)
 
   const pathname = '/'


### PR DESCRIPTION
## Description

#2074 broke profile picture uploads by adding an unwanted slash after the NEXT_PUBLIC_MEDIA_URL env var.
This PR uses a URL constructor to avoid this kind of inconsistencies.

## Screenshots
n/a

## Additional Context
In dev it works without problems because we set the URL manually via env vars, while in prod we use S3 buckets to then compose a URL for m.stacker.news, without infos on that a URL constructor should delete any doubts.

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
9, it works with or without slashes in dev

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a