### PR TITLE
hotfix: return correct uploads url for imgproxy crop

### DIFF
--- a/worker/imgproxy.js
+++ b/worker/imgproxy.js
@@ -202,8 +202,10 @@ export async function processCrop ({ photoId, cropData }) {
     `/rs:fill:${size}:${size}`
   ].join('')
 
-  const uploadsUrl = process.env.MEDIA_URL_DOCKER || process.env.NEXT_PUBLIC_MEDIA_URL
-  const url = new URL(photoId, uploadsUrl).toString()
+  // in dev we may use MEDIA_URL_DOCKER or NEXT_PUBLIC_MEDIA_URL
+  // in prod we use NEXT_PUBLIC_MEDIA_DOMAIN
+  const uploadsUrl = process.env.MEDIA_URL_DOCKER || process.env.NEXT_PUBLIC_MEDIA_URL || `https://${process.env.NEXT_PUBLIC_MEDIA_DOMAIN}`
+  const url = `${uploadsUrl}/${photoId}`
   console.log('[imgproxy - cropjob] id:', photoId, '-- url:', url)
 
   const pathname = '/'


### PR DESCRIPTION
## Description

It uses the correct environment variable for production, which is `NEXT_PUBLIC_MEDIA_DOMAIN`

## Screenshots
n/a

## Additional Context
Production handles uploads url differently than dev, it doesn't use `NEXT_PUBLIC_MEDIA_URL`
Also reverted the usage of URL constructor as we don't need to normalize slashes for how we already compose the environment variables we use.

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6, it works in dev and it **_should!_** in prod.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a