### PR TITLE
fix: Nested new comments are not highlighted

### DIFF
--- a/lib/new-comments.js
+++ b/lib/new-comments.js
@@ -1,6 +1,6 @@
 const COMMENTS_VIEW_PREFIX = 'commentsViewedAt'
 const COMMENTS_NUM_PREFIX = 'commentsViewNum'
-
+const COMMENTS_NUM_PREFIX_THREAD = 'commentsViewNumThread'
 export function commentsViewed (item) {
   if (!item.parentId && item.lastCommentAt) {
     window.localStorage.setItem(`${COMMENTS_VIEW_PREFIX}:${item.id}`, new Date(item.lastCommentAt).getTime())
@@ -29,4 +29,12 @@ export function newComments (item) {
   }
 
   return false
+}
+
+export function commentThreadNumViewed (item) {
+  window.localStorage.setItem(`${COMMENTS_NUM_PREFIX_THREAD}:${item.id}`, item.ncomments)
+}
+
+export function commentThreadNum (item) {
+  return window.localStorage.getItem(`${COMMENTS_NUM_PREFIX_THREAD}:${item.id}`)
 }


### PR DESCRIPTION
## Description

Fixes #2127
Tracks variances of `ncomments` on a comment that has at least 7 items in its path, meaning it could be a thread with nested comments.
It accesses the cache to gather the latest `ncomments`

## Screenshots
tbd

## Additional Context

It also merges `ViewAllReplies` with `ReplyOnAnotherPage` since they share the same logic and design and would have had duplicate code for comment highlighting.

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes, logic is the same for anything else

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
5, tbd testing

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**
