### PR TITLE
Fix privacy setting interfering with wallet prompt

### DIFF
--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -1092,6 +1092,9 @@ export default {
         return false
       }
       return !!user.tipRandomMin && !!user.tipRandomMax
+    },
+    hideWalletRecvPrompt: async (user, args, { models }) => {
+      return user.hideWalletRecvPrompt || user.hasRecvWallet
     }
   },
 

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -226,6 +226,7 @@ export default gql`
     horseStreak: Int
     hasSendWallet: Boolean
     hasRecvWallet: Boolean
+    hideWalletRecvPrompt: Boolean
     maxStreak: Int
     isContributor: Boolean
     githubId: String


### PR DESCRIPTION
## Description

The privacy setting to hide cowboy essentials was causing the wallet prompt to show up even with a wallet to receive attached.

## Additional Context

This was reported [here](https://stacker.news/items/959013?commentId=959068).

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`.

Tested by attaching a lightning address via the wallet prompt. Wallet prompt no longer shows up. When I enable the privacy setting to hide the horse, the wallet prompt starts showing up again. This change fixes that.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no