### PR TITLE
Fix lnaddr attach fails if minSendable > 1000

### DIFF
--- a/wallets/lightning-address/server.js
+++ b/wallets/lightning-address/server.js
@@ -6,8 +6,7 @@ import { assertContentTypeJson, assertResponseOk } from '@/lib/url'
 export * from '@/wallets/lightning-address'
 
 export const testCreateInvoice = async ({ address }, { signal }) => {
-  const { min } = await lnAddrOptions(address, { signal })
-  return await createInvoice({ msats: 1_000 * min }, { address }, { signal })
+  return await createInvoice({ msats: undefined }, { address }, { signal })
 }
 
 export const createInvoice = async (
@@ -15,10 +14,14 @@ export const createInvoice = async (
   { address },
   { signal }
 ) => {
-  const { callback, commentAllowed } = await lnAddrOptions(address, { signal })
+  const { min, callback, commentAllowed } = await lnAddrOptions(address, { signal })
   const callbackUrl = new URL(callback)
 
   // most lnurl providers suck nards so we have to floor to nearest sat
+  if (!msats) {
+    // use min sendable amount by default
+    msats = 1_000 * min
+  }
   msats = msatsSatsFloor(msats)
 
   callbackUrl.searchParams.append('amount', msats)

--- a/wallets/lightning-address/server.js
+++ b/wallets/lightning-address/server.js
@@ -6,7 +6,8 @@ import { assertContentTypeJson, assertResponseOk } from '@/lib/url'
 export * from '@/wallets/lightning-address'
 
 export const testCreateInvoice = async ({ address }, { signal }) => {
-  return await createInvoice({ msats: 1000 }, { address }, { signal })
+  const { min } = await lnAddrOptions(address, { signal })
+  return await createInvoice({ msats: 1_000 * min }, { address }, { signal })
 }
 
 export const createInvoice = async (


### PR DESCRIPTION
## Description

Test invoices for a lightning address can fail if we're requesting an invoice for an amount it does not support.

Example: https://breez.fun/.well-known/lnurlp/needcreations

This was reported [here](https://stacker.news/items/958590?commentId=960241).

## Additional Context

The other issue that one can see in the [report](https://stacker.news/items/958590?commentId=960241) is that [`assertContentTypeJson`](https://github.com/stackernews/stacker.news/blob/4ad64d658fcf33d34ff3b3224d32d1ef9c7e513a/lib/url.js#L236-L241) would also throw `ResponseAssertError` which will log a confusing error message with 200 OK instead of "expected json, got html."

I will fix this in another PR.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Made sure that `lnAddrOptions` will always return `min` in sats and tested attaching a lightning address with calle@npub.cash.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no