### PR TITLE
Fix missing method in lnurlp error

### DIFF
--- a/lib/lnurl.js
+++ b/lib/lnurl.js
@@ -39,11 +39,12 @@ export async function lnAddrOptions (addr, { signal } = {}) {
 
   const unexpectedErrorMessage = 'Lightning address validation failed. Make sure you entered the correct address.'
   let body
+  const method = 'GET'
   const url = `${protocol}://${domain}/.well-known/lnurlp/${name}`
   try {
-    const res = await fetch(url, { signal })
-    assertResponseOk(res)
-    assertContentTypeJson(res)
+    const res = await fetch(url, { method, signal })
+    assertResponseOk(res, { method })
+    assertContentTypeJson(res, { method })
     body = await res.json()
   } catch (err) {
     console.log('Error fetching lnurlp:', err)


### PR DESCRIPTION
On lnurlp errors, the message didn't include the used fetch method which was inconsistent with other error messages.