### PR TITLE
Fix error message on content-type mismatch

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -214,16 +214,22 @@ export function parseNwcUrl (walletConnectUrl) {
 }
 
 export class ResponseAssertError extends Error {
-  constructor (res, { method } = {}) {
-    if (method) {
-      super(`${method} ${res.url}: ${res.status} ${res.statusText}`)
-    } else {
-      super(`${res.url}: ${res.status} ${res.statusText}`)
-    }
+  constructor (res, { message, method } = {}) {
+    const urlPart = method ? `${method} ${res.url}` : res.url
+    const msgPart = message ?? `${res.status} ${res.statusText}`
+    super(`${urlPart}: ${msgPart}`)
     this.name = 'ResponseAssertError'
     // consume response body to avoid memory leaks
     // see https://github.com/nodejs/node/issues/51162
     res.text().catch(() => {})
+  }
+}
+
+class ContentTypeAssertError extends ResponseAssertError {
+  constructor (res, { method, expected, actual } = {}) {
+    const message = `wrong content-type: expected: ${expected}, got: ${actual}`
+    super(res, { method, message })
+    this.name = 'ContentTypeAssertError'
   }
 }
 
@@ -234,9 +240,12 @@ export function assertResponseOk (res, { method } = {}) {
 }
 
 export function assertContentTypeJson (res, { method } = {}) {
+  const expected = 'application/json'
   const contentType = res.headers.get('content-type')
-  if (!contentType || !contentType.includes('application/json')) {
-    throw new ResponseAssertError(res, { method })
+  if (!contentType || !contentType.includes(expected)) {
+    // get first part of content-type without parameters like charset=utf-8 for less verbose error message
+    const actual = contentType.split(';')[0]
+    throw new ContentTypeAssertError(res, { method, expected, actual })
   }
 }
 


### PR DESCRIPTION
## Description

The error message if our assertion for the `Content-Type` header failed didn't mention that it failed because of the header, not because of the status code, see [here](https://stacker.news/items/958590?commentId=960241).

This PR fixes this.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested with this patch and calle@npub.cash:

```diff
diff --git a/lib/url.js b/lib/url.js
index c6871fc8..3b57920a 100644
--- a/lib/url.js
+++ b/lib/url.js
@@ -242,7 +242,7 @@ export function assertResponseOk (res, { method } = {}) {
 export function assertContentTypeJson (res, { method } = {}) {
   const expected = 'application/json'
   const contentType = res.headers.get('content-type')
-  if (!contentType || !contentType.includes(expected)) {
+  if (!contentType || contentType.includes(expected)) {
     // get first part of content-type without parameters like charset=utf-8 for less verbose error message
     const actual = contentType.split(';')[0]
     throw new ContentTypeAssertError(res, { method, expected, actual })
```

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no