### PR TITLE
Remove 'originally posted at'

### DIFF
--- a/components/use-crossposter.js
+++ b/components/use-crossposter.js
@@ -17,7 +17,7 @@ function itemToContent (item, { includeTitle = true } = {}) {
     content += `\n\n${item.text}`
   }
 
-  content += `\n\noriginally posted at https://stacker.news/items/${item.id}`
+  content += `\n\nhttps://stacker.news/items/${item.id}`
 
   return content.trim()
 }


### PR DESCRIPTION
## Description

So far nobody complained, but I think the crossposted notes on nostr look way cleaner without "originally posted at."

Example: [naddr1qvzqqqr4gupzq5064fm3wsdd252sacufuksxa0t29fp249q545lsvmqhdukzvc2mqqrrjde3xgmnw6lyklj](https://njump.me/naddr1qvzqqqr4gupzq5064fm3wsdd252sacufuksxa0t29fp249q545lsvmqhdukzvc2mqqrrjde3xgmnw6lyklj)

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

0

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no