### PR TITLE
Fix 0 sat lnaddr invoices

### DIFF
--- a/wallets/lightning-address/server.js
+++ b/wallets/lightning-address/server.js
@@ -17,11 +17,12 @@ export const createInvoice = async (
   const { min, callback, commentAllowed } = await lnAddrOptions(address, { signal })
   const callbackUrl = new URL(callback)
 
-  // most lnurl providers suck nards so we have to floor to nearest sat
   if (!msats) {
     // use min sendable amount by default
     msats = 1_000 * min
   }
+
+  // most lnurl providers suck nards so we have to floor to nearest sat
   msats = msatsSatsFloor(msats)
 
   callbackUrl.searchParams.append('amount', msats)

--- a/wallets/lightning-address/server.js
+++ b/wallets/lightning-address/server.js
@@ -22,6 +22,9 @@ export const createInvoice = async (
     msats = 1_000 * min
   }
 
+  // create invoices with a minimum amount of 1 sat
+  msats = Math.max(msats, 1_000)
+
   // most lnurl providers suck nards so we have to floor to nearest sat
   msats = msatsSatsFloor(msats)
 


### PR DESCRIPTION
## Description

Fix #2147 

The only explanation I have for #2147 is that `minSendable` is 0 and thus we multiply by 0 even though the report mentions that `minSendable` is 1:

> With lnurlp my minSendable is 1 not 0.

Anyway, it's good to make sure it's at least 1 sat.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested with calle@npub.cash.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no