### PR TITLE
Fix PGP fingerprint in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Open a [discussion](http://github.com/stackernews/stacker.news/discussions) or [
 
 # Responsible disclosure
 
-If you found a vulnerability, we would greatly appreciate it if you contact us via [security@stacker.news](mailto:security@stacker.news) or open a [security advisory](https://github.com/stackernews/stacker.news/security/advisories/new). Our PGP key can be found [here](https://stacker.news/pgp.txt) (EBAF 75DA 7279 CB48).
+If you found a vulnerability, we would greatly appreciate it if you contact us via [security@stacker.news](mailto:security@stacker.news) or open a [security advisory](https://github.com/stackernews/stacker.news/security/advisories/new). Our PGP key can be found [here](https://stacker.news/pgp.txt) (FEE1 E768 E0B3 81F5).
 
 <br>
 


### PR DESCRIPTION
## Description

I noticed that I added the fingerprint of [my own PGP key](https://keybase.io/ekzyis/pgp_keys.asc) to our Github README.

The last four blocks of the real fingerprint is `FEE1 E768 E0B3 81F5`:

```
$ curl --silent https://stacker.news/pgp.txt | gpg --import && gpg --list-keys --fingerprint security@stacker.news
gpg: key FEE1E768E0B381F5: "Stacker News <security@stacker.news>" not changed
gpg: Total number processed: 1
gpg:              unchanged: 1
pub   rsa4096 2024-03-11 [SC]
      C522 091E C2B7 F3C4 0408  7605 FEE1 E768 E0B3 81F5
uid           [ unknown] Stacker News <security@stacker.news>
sub   rsa4096 2024-03-11 [E] [expires: 2027-04-01]
sub   rsa4096 2024-03-11 [S] [expires: 2027-04-01]
```

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`, see `curl` command

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no