### PR TITLE
Add check to prevent Markdown Heading links from rendering in notifcations

### DIFF
--- a/components/link-to-context.module.css
+++ b/components/link-to-context.module.css
@@ -36,6 +36,11 @@
     pointer-events: auto !important;
 }
 
-.linkBoxParent a[href^="/notifications#"] {
+.linkBoxParent h1 a,
+.linkBoxParent h2 a,
+.linkBoxParent h3 a,
+.linkBoxParent h4 a,
+.linkBoxParent h5 a,
+.linkBoxParent h6 a {
     pointer-events: none !important;
 }

--- a/components/link-to-context.module.css
+++ b/components/link-to-context.module.css
@@ -35,3 +35,7 @@
 .linkBoxParent img {
     pointer-events: auto !important;
 }
+
+.linkBoxParent a[href^="/notifications#"] {
+    pointer-events: none !important;
+}


### PR DESCRIPTION
## Description

Fixes issue where if markdown for a heading is used in a comment, the notification would contain the the markdown rendered into Html containing a heading anchor link overriding the notification link to the actual comment. 

Edit: changed solution to using css that targets the anchor tags in the notification body

Closes #2142 


## Screenshots
<img width="350" alt="Screenshot 2025-05-12 at 17 17 23" src="https://github.com/user-attachments/assets/3583d254-36c4-4d3d-9706-94d60cda2e88" />


https://github.com/user-attachments/assets/8aa9a4fd-dd6c-4743-977d-93e07686ad61



## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10
*For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
N/A

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No