### PR TITLE
feat: attribute multiple issues addressed in a single PR in awards.csv

### DIFF
--- a/.github/workflows/extend-awards.yml
+++ b/.github/workflows/extend-awards.yml
@@ -53,5 +53,5 @@ jobs:
           branch: extend-awards/patch
           commit-message: Extending awards.csv
           title: Extending awards.csv
-          body: One or more PR's were merged that solve an issue(s) and awards.csv should be extended. Remembere to delete the branch after merging.
+          body: One or more PR's were merged that solve an issue(s) and awards.csv should be extended. Remember to delete the branch after merging.
           delete-branch: true

--- a/extend-awards.py
+++ b/extend-awards.py
@@ -15,15 +15,17 @@ def getIssue(n):
 	j = json.loads(r.text)
 	return j
 
-def findIssueInPR(j):
+def findIssuesInPR(j):
 	p = re.compile('(#|https://github.com/stackernews/stacker.news/issues/)([0-9]+)')
+	issues = set()
 	for m in p.finditer(j['title']):
-		return m.group(2)
+		issues.add(m.group(2))
 	if not 'body' in j or j['body'] is None:
 		return
 	for s in j['body'].split('\n'):
 		for m in p.finditer(s):
-			return m.group(2)
+			issues.add(m.group(2))
+	return list(issues)
 
 def addAward(user, kind, pr, issue, difficulty, priority, count, amount):
 	if amount >= 1000000 and amount % 1000000 == 0:
@@ -59,41 +61,42 @@ def countReviews(pr):
 def checkPR(i):
 	pr = str(i['number'])
 	print('pr %s' % pr)
-	n = findIssueInPR(i)
-	if not n:
-		print('pr %s does not solve an issue' % pr)
+	issue_numbers = findIssuesInPR(i)
+	if not issue_numbers:
+		print('pr %s does not solve any issues' % pr)
 		return
-	print('solves issue %s' % n)
-	j = getIssue(n)
-	difficulty = ''
-	amount = 0
-	priority = ''
-	multiplier = 1
-	for l in j['labels']:
-		for d in difficulties:
-			if l['name'] == 'difficulty:' + d:
-				difficulty = d
-				amount = difficulties[d]
-		for p in priorities:
-			if l['name'] == 'priority:' + p:
-				priority = p
-				multiplier = priorities[p]
-	if amount * multiplier <= 0:
-		print('issue gives no award')
-		return
-	count = countReviews(pr)
-	if count >= 10:
-		print('too many reviews, no award')
-		return
-	if count > 0:
-		print('%d reviews, %d%% reduction' % (count, count * 10))
-	award = amount * multiplier * (10 - count) / 10
-	print('award is %d' % award)
-	if i['user']['login'] not in ignored:
-		addAward(i['user']['login'], 'pr', '#' + pr, '#' + n, difficulty, priority, count, award)
-	if j['user']['login'] not in ignored:
-		count = 0
-		addAward(j['user']['login'], 'issue', '#' + pr, '#' + n, difficulty, priority, count, int(award / 10))
+	for n in issue_numbers:
+		print('solves issue %s' % n)
+		j = getIssue(n)
+		difficulty = ''
+		amount = 0
+		priority = ''
+		multiplier = 1
+		for l in j['labels']:
+			for d in difficulties:
+				if l['name'] == 'difficulty:' + d:
+					difficulty = d
+					amount = difficulties[d]
+			for p in priorities:
+				if l['name'] == 'priority:' + p:
+					priority = p
+					multiplier = priorities[p]
+		if amount * multiplier <= 0:
+			print('issue gives no award')
+			continue
+		count = countReviews(pr)
+		if count >= 10:
+			print('too many reviews, no award')
+			continue
+		if count > 0:
+			print('%d reviews, %d%% reduction' % (count, count * 10))
+		award = amount * multiplier * (10 - count) / 10
+		print('award is %d' % award)
+		if i['user']['login'] not in ignored:
+			addAward(i['user']['login'], 'pr', '#' + pr, '#' + n, difficulty, priority, count, award)
+		if j['user']['login'] not in ignored:
+			count = 0
+			addAward(j['user']['login'], 'issue', '#' + pr, '#' + n, difficulty, priority, count, int(award / 10))
 
 with open(fn, 'r') as f:
 	for s in f:


### PR DESCRIPTION
## Description

Modify extend-awards.py so that when a pull request references and fixes multiple issues, each issue is attributed and awarded accordingly. Also fixed typo in Github bot message.

Test PR from my fork of this repo demonstrating functionality: https://github.com/brymut/stacker.news/pull/57
Resultant PR extending awards with all attributed issues: https://github.com/brymut/stacker.news/pull/58

closes #2087 

## Screenshots

https://github.com/user-attachments/assets/db8a183b-7d49-44d0-ad6c-43a0dea5f566


## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
N/A

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No