### PR TITLE
fix: capture lnbits v1.0+ payments model response

### DIFF
--- a/wallets/lnbits/server.js
+++ b/wallets/lnbits/server.js
@@ -67,5 +67,5 @@ export async function createInvoice (
   }
 
   const payment = await res.json()
-  return payment.payment_request
+  return payment?.payment_request || payment?.bolt11
 }


### PR DESCRIPTION
Closes #2161 

## Description

This enables LNBits (v1.0+) wallets  to connect to SN. And allows LNBits wallets version less than 1.0 to continue to connect. 

This occurs because the keyname for the invoice in json response from the LNBits API changed from `payment_request` to `bolt11`. Somewhere around v1.0 (?)

### API Response Model

This can be seen at the currently v1.1 docs here: https://demo.lnbits.com/docs#/Payments/api_payments_create_api_v1_payments_post

I've verified that older LNBits instances do respond to `/api/v1/payments` POST request with `payment_request` key containing the invoice. However currently they now use `bolt11` as the key name:

```bash
$ curl https://demo.lnbits.com/openapi.json | jq '.paths."\/api\/v1\/payments".post.responses."201".content."application\/json".schema."$ref"'
> "#/components/schemas/Payment"
        
$ curl https://demo.lnbits.com/openapi.json | jq '.components.schemas.Payment.properties | keys'
> [
            "amount",
            "bolt11",
            "checking_id",
            "created_at",
            "expiry",
            "extension",
            "extra",
            "fee",
            "memo",
            "payment_hash",
            "preimage",
            "status",
            "tag",
            "time",
            "updated_at",
            "wallet_id",
            "webhook",
            "webhook_status"
        ]
```

## Screenshots

## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes - This allows < v1.0 lnbits to wallets to connect using the `payment_request` key if delivered.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
4 - I don't have wallets configured on local dev so I can't verify it works.


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
N/A

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No