### PR TITLE
Delete duplicate wallets

### DIFF
--- a/prisma/migrations/20250513212337_delete_duplicate_wallets/migration.sql
+++ b/prisma/migrations/20250513212337_delete_duplicate_wallets/migration.sql
@@ -1,0 +1,14 @@
+-- delete duplicate wallets per user
+WITH duplicates AS (
+    SELECT
+        "userId",
+        "type",
+        (array_agg(id ORDER BY updated_at DESC))[2:] AS id
+    FROM "Wallet"
+    GROUP BY "userId", "type"
+    HAVING COUNT(id) > 1
+    ORDER BY COUNT(id) DESC, "userId" ASC
+)
+DELETE FROM "Wallet"
+WHERE id in (SELECT unnest(id) FROM duplicates);
+

--- a/prisma/migrations/20250513212337_delete_duplicate_wallets/migration.sql
+++ b/prisma/migrations/20250513212337_delete_duplicate_wallets/migration.sql
@@ -12,3 +12,5 @@ WITH duplicates AS (
 DELETE FROM "Wallet"
 WHERE id in (SELECT unnest(id) FROM duplicates);
 
+-- CreateIndex
+CREATE UNIQUE INDEX "Wallet_userId_type_key" ON "Wallet"("userId", "type");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -246,6 +246,7 @@ model Wallet {
   InvoiceForward InvoiceForward[]
   DirectPayment  DirectPayment[]
 
+  @@unique([userId, type])
   @@index([userId])
   @@index([priority])
 }


### PR DESCRIPTION
## Description

Temporary fix for any user affected by #2160.

## Additional Context

This does not fix the root cause so it might still be possible to create duplicate wallets. I know that #2059 made it possible to save a lightning address multiple times because if the user was hiding their wallet badges, the prompt would still show up. This was fixed in #2134.

However, I believe creating multiple/duplicate wallets per type was possible even before #2059.

This also doesn't check that the wallets are indeed duplicates (same values), but in that case, we would need to decide ourselves which wallet we're going to keep per user anyway. I decided to keep the wallet that was most recently updated.

The root cause will be fixed via #2092, #2146 and related changes.

We can also run this query manually, we don't need to deploy this as a migration.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes, they only delete wallets but don't change any code

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`4`. I did not test this with production data, but I made sure that only the most recent updated wallet per type is kept per user.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no