### PR TITLE
Auto-populate YouTube video titles server-side and enforce title length.

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -28,6 +28,8 @@ import { verifyHmac } from './wallet'
 import { parse } from 'tldts'
 import { shuffleArray } from '@/lib/rand'
 
+metadataRuleSets.title.rules.unshift(['h1 > yt-formatted-string.ytd-watch-metadata', el => el.getAttribute('title')])
+
 function commentsOrderByClause (me, models, sort) {
   const sharedSortsArray = []
   sharedSortsArray.push('("Item"."pinId" IS NOT NULL) DESC')


### PR DESCRIPTION
## Description
Auto populate the title field if youtube link is used in the Link Form. 
Closes https://github.com/stackernews/stacker.news/issues/2164

## Screenshots

https://github.com/user-attachments/assets/a452dd57-d88c-4ed0-b0d7-804599c3c9fb



## Checklist

**Are your changes backwards compatible? Please answer below:**
yes
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
no