### PR TITLE
Refactor(dupes): filter dupes by PAID or NULL invoiceActionState

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -650,7 +650,7 @@ export default {
         query: `
           ${SELECT}
           FROM "Item"
-          WHERE url ~* $1
+          WHERE url ~* $1 AND ("Item"."invoiceActionState" IS NULL OR "Item"."invoiceActionState" = 'PAID')
           ORDER BY created_at DESC
           LIMIT 3`
       }, similar)


### PR DESCRIPTION
## Description

Dupes resolver to only show items with invoiceActionState as PAID or NULL. Based on [feedback provided ](https://github.com/stackernews/stacker.news/issues/2173#issuecomment-2898194663)
Closes https://github.com/stackernews/stacker.news/issues/2173

## Screenshots

## Additional Context


## Checklist

**Are your changes backwards compatible? Please answer below:**


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**
no