### PR TITLE
fix duplicate search highlights

### DIFF
--- a/api/resolvers/search.js
+++ b/api/resolvers/search.js
@@ -510,8 +510,8 @@ export default {
         item.searchTitle = e.highlight?.title?.[0] || e.highlight?.['title.exact']?.[0] || item.title
 
         // prefer the exact highlight for text
-        const searchTextHighlight = [...(e.highlight?.['text.exact'] || []), ...(e.highlight?.text || [])]
-        item.searchText = searchTextHighlight?.slice(0, 5)?.join(' ... ')
+        const searchTextHighlight = e.highlight?.['text.exact'] || e.highlight?.text || []
+        item.searchText = searchTextHighlight?.join(' ... ')
 
         return item
       })


### PR DESCRIPTION
## Description

_A clear and concise description of what you changed and why._

fixes #2181 

Avoid including both exact matches and item text in search results.

## Screenshots

Before
![before](https://github.com/user-attachments/assets/801560b5-587a-454e-bc11-36dd9afba837)

After
![after](https://github.com/user-attachments/assets/1f883348-db82-4b02-95af-b6f5ae3d216f)

## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_

## Checklist

**Are your changes backwards compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Tested on laptop only

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No