### PR TITLE
Add security advisory payout to awards.csv

### DIFF
--- a/awards.csv
+++ b/awards.csv
@@ -234,3 +234,4 @@ SouthKoreaLN,issue,#2171,#2164,easy,,,,10k,south_korea_ln@stacker.news,2025-05-2
 brymut,pr,#2175,#2173,good-first-issue,,,,20k,brymut@stacker.news,2025-05-21
 sutt,pr,#2185,#2183,easy,high,,,200k,bounty_hunter@stacker.news,???
 sutt,issue,#2185,#2183,easy,high,,,20k,bounty_hunter@stacker.news,???
+axelvyrn,advisory,GHSA-x2xp-x867-4jfc,,,,,100k,holonite@speed.app,???


### PR DESCRIPTION
## Description

Added the payout for [GHSA-x2xp-x867-4jfc](https://github.com/stackernews/stacker.news/security/advisories/GHSA-x2xp-x867-4jfc) to awards.csv as requested. 

Afaict, using advisory as the type and the GHSA id should not break our awards script but not sure.  