### PR TITLE
Don't wrap base64 cert output

### DIFF
--- a/sndev
+++ b/sndev
@@ -536,7 +536,7 @@ sndev__cert() {
     echo "no CERTDIR label found for $1"
     exit 1
   fi
-  docker__exec $1 cat $certdir/tls.cert | base64
+  docker__exec $1 cat $certdir/tls.cert | base64 -w0
 }
 
 sndev__help_cert() {


### PR DESCRIPTION
## Description

When you run `sndev cert lnd`, the output contains new lines. I had to always remove them manually with `tr -d '\n'` before I could pipe the output into my clipboard via `xclip`.

I noticed that `base64` has the option to not wrap lines via `-w0`. Now I can pipe the output of `sndev cert lnd` into `xclip` and save the LND wallet.

## Additional Context

I used https://www.shellcheck.net/ to make sure `base64 -w0` is POSIX compliant and I think it is because I did not see this error:

> ^-- SC2039: In POSIX sh, [[ ]] is undefined.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no