### PR TITLE
Preload HSTS

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -128,7 +128,7 @@ export function middleware (request) {
   // more useful headers
   resp.headers.set('X-Content-Type-Options', 'nosniff')
   resp.headers.set('Referrer-Policy', 'origin-when-cross-origin')
-  resp.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
+  resp.headers.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload')
 
   return resp
 }


### PR DESCRIPTION
## Description

Fix for [GHSA-x2xp-x867-4jfc](https://github.com/stackernews/stacker.news/security/advisories/GHSA-x2xp-x867-4jfc)

I assume that every subdomain of stacker.news is served over HTTPS. If that is not the case, we should not preload HSTS and thus close this PR.

If that is the case, we can merge this PR and then once it is deployed, I will submit stacker.news to the HSTS preload list via https://hstspreload.org/.
