### PR TITLE
Settings LNURL UI Update

### DIFF
--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -861,10 +861,28 @@ function AuthMethods ({ methods, apiKeyEnabled }) {
             : <div key={provider} className='mt-2'><EmailLinkForm callbackUrl='/settings' /></div>
         } else if (provider === 'lightning') {
           return (
+            <div key={provider} className="d-flex align-items-center mt-2">
             <QRLinkButton
               key={provider} provider={provider}
               status={methods[provider]} unlink={async () => await unlink(provider)}
             />
+            <Info className="ms-2">
+                      <ul>
+                        <li>
+                          This is an LNURL-auth. Not sure what it is? Check <a target="_blank" href="https://lightninglogin.live/learn">here</a>
+                        </li>
+                        <li>
+                          Linking your Lightning wallet allows you to quickly sign in and zap directly from your wallet.
+                        </li>
+                        <li>
+                          You can unlink your wallet at any time.
+                        </li>
+                        <li>
+                          <b>Tip:</b> Use a wallet that supports LNURL-auth for seamless experience. Check the list of <a target="_blank" href="https://github.com/lnurl/luds/blob/luds/README.md#lnurl-documents">supported wallets</a>
+                        </li>
+                      </ul>
+                    </Info>
+                  </div>
           )
         } else if (provider === 'nostr') {
           return <NostrLinkButton key='nostr' status={methods[provider]} unlink={async () => await unlink(provider)} />


### PR DESCRIPTION
## Description

Added a tooltip beside the Link Lightning button just like beside the Generate API key button (issue https://github.com/stackernews/stacker.news/issues/2198). It will tell the user about LNURL auth, a list of supported wallets and basic idea of what it is. ( as suggested in this [comment](https://github.com/stackernews/stacker.news/issues/2198#issuecomment-2926834820))

## Screenshots

N/A

## Additional Context

none

## Checklist

**Are your changes backwards compatible? Please answer below:**
yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
9 - it affects the settings UI

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
yes. checked from dev console.

**Did you introduce any new environment variables? If so, call them out explicitly here:**
none
