### PR TITLE
Add flake.nix for Prisma CLI on NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+# Run `nix develop` to get a shell with the prisma CLI
+# reference: https://github.com/VanCoding/nix-prisma-utils
+
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    prisma-utils.url = "github:VanCoding/nix-prisma-utils";
+  };
+
+  outputs =
+    { nixpkgs, prisma-utils, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      prisma =
+        (prisma-utils.lib.prisma-factory {
+          inherit pkgs;
+          # just copy these hashes for now, and then change them when nix complains about the mismatch
+          prisma-fmt-hash = "sha256-atD5GZfmeU86mF1V6flAshxg4fFR2ews7EwaJWZZzbc=";
+          query-engine-hash = "sha256-8FTZaKmQCf9lrDQvkF5yWPeZ7TSVfFjTbjdbWWEHgq4=";
+          libquery-engine-hash = "sha256-USIdaum87ekGY6F6DaL/tKH0BAZvHBDK7zjmCLo//kM=";
+          schema-engine-hash = "sha256-k5MkxXViEqojbkkcW/4iBFNdfhb9PlMEF1M2dyhfOok=";
+        }).fromNpmLock
+          ./package-lock.json; # <--- path to our package-lock.json file that contains the version of prisma-engines
+    in
+    {
+      devShells.${system}.default = pkgs.mkShell {
+        env = prisma.env;
+        # or, you can use `shellHook` instead of `env` to load the same environment variables.
+        # shellHook = prisma.shellHook;
+      };
+    };
+}
+


### PR DESCRIPTION
## Description

Prisma does not provide pre-compiled client binaries. When you run `npx prisma migrate dev --create-only`, you therefore get this error:

```
$ npx prisma migrate dev --create-only
Warning Precompiled engine files are not available for nixos, please provide the paths via environment variables, see https://pris.ly/d/custom-engines
> Downloading Prisma engines for Node-API for linux-nixos [                    ] 0%Error: Failed to fetch sha256 checksum at https://binaries.prisma.sh/all_commits/06fc58a368dc7be9fbbbe894adf
8d445d208c284/linux-nixos/libquery_engine.so.node.gz.sha256 - 404 Not Found

If you need to ignore this error (e.g. in an offline environment), set the PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING environment variable to a truthy value.
Example: PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1
```

So far, I fixed this on my machine with a shell.nix but since I've upgraded to the nixos-25.05 channel, it broke.

I then found [nix-prisma-utils](https://github.com/VanCoding/nix-prisma-utils) and it worked for me.

I can now run `nix develop` and then run `npx prisma migrate dev`.

I should probably mention this somewhere in our README but I also think if somebody uses NixOS, they should be familiar enough with it to know what a flake.nix file means ?