### PR TITLE
fix embed list bullet to render at top of embed

### DIFF
--- a/components/embed.js
+++ b/components/embed.js
@@ -125,19 +125,21 @@ const Embed = memo(function Embed ({ src, provider, id, meta, className, topLeve
   // This Twitter embed could use similar logic to the video embeds below
   if (provider === 'twitter') {
     return (
-      <div className={classNames(styles.twitterContainer, !show && styles.twitterContained, className)}>
-        <TwitterTweetEmbed
-          tweetId={id}
-          options={{ theme: darkMode ? 'dark' : 'light', width: topLevel ? '550px' : '350px' }}
-          key={darkMode ? '1' : '2'}
-          placeholder={<TweetSkeleton className={className} />}
-          onLoad={() => setOverflowing(true)}
-        />
-        {overflowing && !show &&
-          <Button size='lg' variant='info' className={styles.twitterShowFull} onClick={() => setShow(true)}>
-            show full tweet
-          </Button>}
-      </div>
+      <>
+        <div className={classNames(styles.twitterContainer, !show && styles.twitterContained, className)}>
+          <TwitterTweetEmbed
+            tweetId={id}
+            options={{ theme: darkMode ? 'dark' : 'light', width: topLevel ? '550px' : '350px' }}
+            key={darkMode ? '1' : '2'}
+            placeholder={<TweetSkeleton className={className} />}
+            onLoad={() => setOverflowing(true)}
+          />
+          {overflowing && !show &&
+            <Button size='lg' variant='info' className={styles.twitterShowFull} onClick={() => setShow(true)}>
+              show full tweet
+            </Button>}
+        </div>
+      </>
     )
   }
 

--- a/components/text.js
+++ b/components/text.js
@@ -138,7 +138,7 @@ export default memo(function Text ({ rel = UNKNOWN_LINK_REL, imgproxyUrls, child
       return <Link id={props.id} target='_blank' rel={rel} href={href}>{children}</Link>
     },
     img: TextMediaOrLink,
-    embed: Embed
+    embed: (props) => <Embed {...props} topLevel={topLevel} />
   }), [outlawed, rel, TextMediaOrLink, topLevel])
 
   const carousel = useCarousel()

--- a/components/text.module.css
+++ b/components/text.module.css
@@ -253,7 +253,7 @@
 }
 
 .text li > :is(.twitterContainer, .nostrContainer, .wavlakeWrapper, .spotifyWrapper, .onlyImages) {
-  display: inline-block;
+  display: inline-flex;
   vertical-align: top;
   width: 100%;
 }
@@ -263,6 +263,7 @@
   margin-top: 0;
   margin-bottom: 0rem;
   padding-left: 2rem;
+  max-width: calc(100% - 1rem);
 }
 
 .text ol ol,

--- a/components/text.module.css
+++ b/components/text.module.css
@@ -252,6 +252,11 @@
     margin-top: .25rem;
 }
 
+.text li > :is(.twitterContainer, .nostrContainer, .wavlakeWrapper, .spotifyWrapper) {
+  display: inline-block;
+  vertical-align: top;
+}
+
 .text ul,
 .text ol {
   margin-top: 0;

--- a/components/text.module.css
+++ b/components/text.module.css
@@ -252,9 +252,10 @@
     margin-top: .25rem;
 }
 
-.text li > :is(.twitterContainer, .nostrContainer, .wavlakeWrapper, .spotifyWrapper) {
+.text li > :is(.twitterContainer, .nostrContainer, .wavlakeWrapper, .spotifyWrapper, .onlyImages) {
   display: inline-block;
   vertical-align: top;
+  width: 100%;
 }
 
 .text ul,


### PR DESCRIPTION
## Description

Fix to make listed embeds in markdown render the bullets at the top of embeds rather that the bottom
closes #2204

Tested using:
```
- https://www.youtube.com/watch?v=TA5nwAKav6A&t=544s
- https://x.com/unusual_whales/status/1933171682505814096
- https://primal.net/e/nevent1qqsphjsyk2l8uw5y3jun0nyjp26efe8lc2glj9584gg8mmlg7d7nmugzrlygy
- https://wavlake.com/track/4f596f59-4dc3-4eb0-8ea7-a4bdf9d13585
- https://open.spotify.com/track/4LhRPmfYakIKSWWwGAFOPj?si=0s7pjVyJRCCaMKk9yZNWxA
- https://rumble.com/embed/v6nspz0/?pub=3dskgx
- https://peertube.tv/w/cU3WYY81yg3Hpz53aujv3k
- https://bitcointv.com/w/fZkPWnEgRTfrUGCCDDbRTv
- https://github.com/stackernews/stacker.news/issues/2204
```

## Screenshots

https://github.com/user-attachments/assets/152ed6eb-af84-4f52-8cfc-0f7ef6bfbd71



## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_

## Checklist

**Are your changes backwards compatible? Please answer below:**
Y

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**
No