### PR TITLE
feat: Add support for scheduled posts

### DIFF
--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -3,6 +3,7 @@ import { notifyItemMention, notifyItemParents, notifyMention, notifyTerritorySub
 import { getItemMentions, getMentions, performBotBehavior } from './lib/item'
 import { msatsToSats, satsToMsats } from '@/lib/format'
 import { GqlInputError } from '@/lib/error'
+import { getScheduleAt } from '@/lib/item'
 
 export const anonable = true
 
@@ -96,6 +97,10 @@ export async function perform (args, context) {
   const mentions = await getMentions(args, context)
   const itemMentions = await getItemMentions(args, context)
 
+  // Check if this is a scheduled post
+  const scheduleAt = getScheduleAt(data.text)
+  const isScheduled = !!scheduleAt
+
   // start with median vote
   if (me) {
     const [row] = await tx.$queryRaw`SELECT
@@ -112,6 +117,8 @@ export async function perform (args, context) {
     ...data,
     ...invoiceData,
     boost,
+    isScheduled,
+    scheduledAt: scheduleAt,
     threadSubscriptions: {
       createMany: {
         data: [

--- a/api/paidAction/lib/item.js
+++ b/api/paidAction/lib/item.js
@@ -1,5 +1,5 @@
 import { USER_ID } from '@/lib/constants'
-import { deleteReminders, getDeleteAt, getRemindAt } from '@/lib/item'
+import { deleteReminders, getDeleteAt, getRemindAt, getScheduleAt } from '@/lib/item'
 import { parseInternalLinks } from '@/lib/url'
 
 export async function getMentions ({ text }, { me, tx }) {
@@ -46,13 +46,18 @@ export const getItemMentions = async ({ text }, { me, tx }) => {
 }
 
 export async function performBotBehavior ({ text, id }, { me, tx }) {
-  // delete any existing deleteItem or reminder jobs for this item
+  // delete any existing deleteItem, reminder, or publishScheduledPost jobs for this item
   const userId = me?.id || USER_ID.anon
   id = Number(id)
   await tx.$queryRaw`
     DELETE FROM pgboss.job
-    WHERE name = 'deleteItem'
+    WHERE (name = 'deleteItem' OR name = 'publishScheduledPost')
     AND data->>'id' = ${id}::TEXT
+    AND state <> 'completed'`
+  await tx.$queryRaw`
+    DELETE FROM pgboss.job
+    WHERE name = 'publishScheduledPost'
+    AND data->>'itemId' = ${id}::TEXT
     AND state <> 'completed'`
   await deleteReminders({ id, userId, models: tx })
 
@@ -84,6 +89,31 @@ export async function performBotBehavior ({ text, id }, { me, tx }) {
           remindAt
         }
       })
+    }
+
+    const scheduleAt = getScheduleAt(text)
+    if (scheduleAt) {
+      // For new items, scheduling info is set during creation
+      // For updates, we need to update the item
+      const existingItem = await tx.item.findUnique({ where: { id: Number(id) } })
+      if (existingItem && !existingItem.isScheduled) {
+        await tx.item.update({
+          where: { id: Number(id) },
+          data: {
+            isScheduled: true,
+            scheduledAt: scheduleAt
+          }
+        })
+      }
+
+      // Schedule the job to publish the post
+      await tx.$queryRaw`
+        INSERT INTO pgboss.job (name, data, startafter, keepuntil)
+        VALUES (
+          'publishScheduledPost',
+          jsonb_build_object('itemId', ${id}::INTEGER),
+          ${scheduleAt}::TIMESTAMP WITH TIME ZONE,
+          ${scheduleAt}::TIMESTAMP WITH TIME ZONE + interval '1 minute')`
     }
   }
 }

--- a/api/resolvers/search.js
+++ b/api/resolvers/search.js
@@ -1,6 +1,6 @@
 import { decodeCursor, LIMIT, nextCursorEncoded } from '@/lib/cursor'
 import { whenToFrom } from '@/lib/time'
-import { getItem, itemQueryWithMeta, SELECT } from './item'
+import { getItem, itemQueryWithMeta, SELECT, scheduledOrMine } from './item'
 import { parse } from 'tldts'
 
 function queryParts (q) {
@@ -163,7 +163,8 @@ export default {
           WITH r(id, rank) AS (VALUES ${values})
           ${SELECT}, rank
           FROM "Item"
-          JOIN r ON "Item".id = r.id`,
+          JOIN r ON "Item".id = r.id
+          WHERE ${scheduledOrMine(me)}`,
         orderBy: 'ORDER BY rank ASC'
       })
 
@@ -501,7 +502,8 @@ export default {
           WITH r(id, rank) AS (VALUES ${values})
           ${SELECT}, rank
           FROM "Item"
-          JOIN r ON "Item".id = r.id`,
+          JOIN r ON "Item".id = r.id
+          WHERE ${scheduledOrMine(me)}`,
         orderBy: 'ORDER BY rank ASC, msats DESC'
       })).map((item, i) => {
         const e = sitems.body.hits.hits[i]

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -11,6 +11,7 @@ export default gql`
     auctionPosition(sub: String, id: ID, boost: Int): Int!
     boostPosition(sub: String, id: ID, boost: Int): BoostPositions!
     itemRepetition(parentId: ID): Int!
+    scheduledItems(cursor: String, limit: Limit): Items
   }
 
   type BoostPositions {
@@ -63,6 +64,8 @@ export default gql`
     act(id: ID!, sats: Int, act: String, hasSendWallet: Boolean): ItemActPaidAction!
     pollVote(id: ID!): PollVotePaidAction!
     toggleOutlaw(id: ID!): Item!
+    cancelScheduledPost(id: ID!): Item!
+    publishScheduledPostNow(id: ID!): Item!
   }
 
   type PollVoteResult {
@@ -112,6 +115,8 @@ export default gql`
     deletedAt: Date
     deleteScheduledAt: Date
     reminderScheduledAt: Date
+    scheduledAt: Date
+    isScheduled: Boolean!
     title: String
     searchTitle: String
     url: String

--- a/fragments/paidAction.js
+++ b/fragments/paidAction.js
@@ -23,6 +23,8 @@ const ITEM_PAID_ACTION_FIELDS = gql`
       id
       deleteScheduledAt
       reminderScheduledAt
+      scheduledAt
+      isScheduled
       ...CommentFields
       comments {
         comments {
@@ -39,6 +41,8 @@ const ITEM_PAID_ACTION_FIELDS_NO_CHILD_COMMENTS = gql`
       id
       deleteScheduledAt
       reminderScheduledAt
+      scheduledAt
+      isScheduled
       ...CommentFields
     }
   }
@@ -151,6 +155,8 @@ export const UPSERT_DISCUSSION = gql`
         id
         deleteScheduledAt
         reminderScheduledAt
+        scheduledAt
+        isScheduled
       }
       ...PaidActionFields
     }
@@ -168,6 +174,8 @@ export const UPSERT_JOB = gql`
         id
         deleteScheduledAt
         reminderScheduledAt
+        scheduledAt
+        isScheduled
       }
       ...PaidActionFields
     }
@@ -183,6 +191,8 @@ export const UPSERT_LINK = gql`
         id
         deleteScheduledAt
         reminderScheduledAt
+        scheduledAt
+        isScheduled
       }
       ...PaidActionFields
     }
@@ -200,6 +210,8 @@ export const UPSERT_POLL = gql`
         id
         deleteScheduledAt
         reminderScheduledAt
+        scheduledAt
+        isScheduled
       }
       ...PaidActionFields
     }
@@ -215,6 +227,8 @@ export const UPSERT_BOUNTY = gql`
         id
         deleteScheduledAt
         reminderScheduledAt
+        scheduledAt
+        isScheduled
       }
       ...PaidActionFields
     }

--- a/lib/item.js
+++ b/lib/item.js
@@ -21,7 +21,13 @@ const reminderPattern = /\B@remindme\s+in\s+(\d+)\s+(second|minute|hour|day|week
 
 const reminderMentionPattern = /\B@remindme/i
 
+const schedulePattern = /\B@schedule\s+in\s+(\d+)\s+(second|minute|hour|day|week|month|year)s?/gi
+
+const scheduleMentionPattern = /\B@schedule/i
+
 export const hasDeleteMention = (text) => deleteMentionPattern.test(text ?? '')
+
+export const hasScheduleMention = (text) => scheduleMentionPattern.test(text ?? '')
 
 export const getDeleteCommand = (text) => {
   if (!text) return false
@@ -60,6 +66,24 @@ export const getReminderCommand = (text) => {
 }
 
 export const hasReminderCommand = (text) => !!getReminderCommand(text)
+
+export const getScheduleCommand = (text) => {
+  if (!text) return false
+  const matches = [...text.matchAll(schedulePattern)]
+  const commands = matches?.map(match => ({ number: parseInt(match[1]), unit: match[2] }))
+  return commands.length ? commands[commands.length - 1] : undefined
+}
+
+export const getScheduleAt = (text) => {
+  const command = getScheduleCommand(text)
+  if (command) {
+    const { number, unit } = command
+    return datePivot(new Date(), { [`${unit}s`]: number })
+  }
+  return null
+}
+
+export const hasScheduleCommand = (text) => !!getScheduleCommand(text)
 
 export const deleteItemByAuthor = async ({ models, id, item }) => {
   if (!item) {

--- a/prisma/migrations/20250611000000_scheduled_posts/migration.sql
+++ b/prisma/migrations/20250611000000_scheduled_posts/migration.sql
@@ -1,0 +1,274 @@
+-- Add fields for scheduled posts to the Item model
+ALTER TABLE "Item" ADD COLUMN "scheduledAt" TIMESTAMP(3);
+ALTER TABLE "Item" ADD COLUMN "isScheduled" BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Create indexes for efficient querying of scheduled posts
+CREATE INDEX "Item_scheduledAt_idx" ON "Item"("scheduledAt");
+CREATE INDEX "Item_isScheduled_idx" ON "Item"("isScheduled");
+CREATE INDEX "Item_isScheduled_scheduledAt_idx" ON "Item"("isScheduled", "scheduledAt");
+
+-- Update stored functions to filter out scheduled posts from comments for non-owners
+
+CREATE OR REPLACE FUNCTION item_comments_zaprank_with_me_limited(
+    _item_id int, _global_seed int, _me_id int, _limit int, _offset int, _grandchild_limit int,
+    _level int, _where text, _order_by text)
+  RETURNS jsonb
+  LANGUAGE plpgsql VOLATILE PARALLEL SAFE AS
+$$
+DECLARE
+    result  jsonb;
+BEGIN
+    IF _level < 1 THEN
+        RETURN '[]'::jsonb;
+    END IF;
+
+    EXECUTE 'CREATE TEMP TABLE IF NOT EXISTS t_item ON COMMIT DROP AS '
+    || 'WITH RECURSIVE base AS ( '
+    || '    (SELECT "Item".*, 1 as level, ROW_NUMBER() OVER () as rn '
+    || '    FROM "Item" '
+    || '    LEFT JOIN hot_score_view g(id, "hotScore", "subHotScore") ON g.id = "Item".id '
+    || '    WHERE "Item"."parentId" = $1 '
+    || '    AND ("Item"."isScheduled" = false OR "Item"."userId" = $3) '
+    ||      _order_by || ' '
+    || '    LIMIT $4 '
+    || '    OFFSET $5) '
+    || '    UNION ALL '
+    || '    (SELECT "Item".*, b.level + 1, ROW_NUMBER() OVER (PARTITION BY "Item"."parentId" ' || _order_by || ') as rn '
+    || '    FROM "Item" '
+    || '    JOIN base b ON "Item"."parentId" = b.id '
+    || '    LEFT JOIN hot_score_view g(id, "hotScore", "subHotScore") ON g.id = "Item".id '
+    || '    WHERE b.level < $7 AND (b.level = 1 OR b.rn <= $6) '
+    || '    AND ("Item"."isScheduled" = false OR "Item"."userId" = $3)) '
+    || ') '
+    || 'SELECT "Item".*, '
+    || '    "Item".created_at at time zone ''UTC'' AS "createdAt", '
+    || '    "Item".updated_at at time zone ''UTC'' AS "updatedAt", '
+    || '    "Item"."invoicePaidAt" at time zone ''UTC'' AS "invoicePaidAtUTC", '
+    || '    to_jsonb(users.*) || jsonb_build_object(''meMute'', "Mute"."mutedId" IS NOT NULL) AS user, '
+    || '    COALESCE("ItemAct"."meMsats", 0) AS "meMsats", '
+    || '    COALESCE("ItemAct"."mePendingMsats", 0) as "mePendingMsats", '
+    || '    COALESCE("ItemAct"."meDontLikeMsats", 0) AS "meDontLikeMsats", '
+    || '    COALESCE("ItemAct"."meMcredits", 0) AS "meMcredits", '
+    || '    COALESCE("ItemAct"."mePendingMcredits", 0) as "mePendingMcredits", '
+    || '    "Bookmark"."itemId" IS NOT NULL AS "meBookmark", '
+    || '    "ThreadSubscription"."itemId" IS NOT NULL AS "meSubscription", '
+    || '    g.hot_score AS "hotScore", g.sub_hot_score AS "subHotScore" '
+    || 'FROM base "Item" '
+    || 'JOIN users ON users.id = "Item"."userId" '
+    || '    LEFT JOIN "Mute" ON "Mute"."muterId" = $3 AND "Mute"."mutedId" = "Item"."userId" '
+    || '    LEFT JOIN "Bookmark" ON "Bookmark"."userId" = $3 AND "Bookmark"."itemId" = "Item".id '
+    || '    LEFT JOIN "ThreadSubscription" ON "ThreadSubscription"."userId" = $3 AND "ThreadSubscription"."itemId" = "Item".id '
+    || '    LEFT JOIN hot_score_view g ON g.id = "Item".id '
+    || 'LEFT JOIN LATERAL ( '
+    || '    SELECT "itemId", '
+    || '        sum("ItemAct".msats) FILTER (WHERE "invoiceActionState" IS DISTINCT FROM ''FAILED'' AND "InvoiceForward".id IS NOT NULL AND (act = ''FEE'' OR act = ''TIP'')) AS "meMsats", '
+    || '        sum("ItemAct".msats) FILTER (WHERE "invoiceActionState" IS DISTINCT FROM ''FAILED'' AND "InvoiceForward".id IS NULL AND (act = ''FEE'' OR act = ''TIP'')) AS "meMcredits", '
+    || '        sum("ItemAct".msats) FILTER (WHERE "invoiceActionState" IS NOT DISTINCT FROM ''PENDING'' AND "InvoiceForward".id IS NOT NULL AND (act = ''FEE'' OR act = ''TIP'')) AS "mePendingMsats", '
+    || '        sum("ItemAct".msats) FILTER (WHERE "invoiceActionState" IS NOT DISTINCT FROM ''PENDING'' AND "InvoiceForward".id IS NULL AND (act = ''FEE'' OR act = ''TIP'')) AS "mePendingMcredits", '
+    || '        sum("ItemAct".msats) FILTER (WHERE "invoiceActionState" IS DISTINCT FROM ''FAILED'' AND act = ''DONT_LIKE_THIS'') AS "meDontLikeMsats" '
+    || '    FROM "ItemAct" '
+    || '    LEFT JOIN "Invoice" ON "Invoice".id = "ItemAct"."invoiceId" '
+    || '    LEFT JOIN "InvoiceForward" ON "InvoiceForward"."invoiceId" = "Invoice"."id" '
+    || '    WHERE "ItemAct"."userId" = $3 '
+    || '    AND "ItemAct"."itemId" = "Item".id '
+    || '    GROUP BY "ItemAct"."itemId" '
+    || ') "ItemAct" ON true '
+    || 'WHERE ("Item".level = 1 OR "Item".rn <= $6 - "Item".level + 2) ' || _where || ' '
+    USING _item_id, _global_seed, _me_id, _limit, _offset, _grandchild_limit, _level, _where, _order_by;
+
+    EXECUTE ''
+        || 'SELECT COALESCE(jsonb_agg(sub), ''[]''::jsonb) AS comments '
+        || 'FROM  ( '
+        || '    SELECT "Item".*, item_comments_zaprank_with_me_limited("Item".id, $2, $3, $4, $5, $6, $7 - 1, $8, $9) AS comments '
+        || '    FROM t_item "Item" '
+        || '    WHERE  "Item"."parentId" = $1 '
+        ||      _order_by
+        || ' ) sub '
+    INTO result
+    USING _item_id, _global_seed, _me_id, _limit, _offset, _grandchild_limit, _level, _where, _order_by;
+
+    RETURN result;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION item_comments_zaprank_with_me(_item_id int, _global_seed int, _me_id int, _level int, _where text, _order_by text)
+  RETURNS jsonb
+  LANGUAGE plpgsql VOLATILE PARALLEL SAFE AS
+$$
+DECLARE
+    result  jsonb;
+BEGIN
+    IF _level < 1 THEN
+        RETURN '[]'::jsonb;
+    END IF;
+
+    EXECUTE 'CREATE TEMP TABLE IF NOT EXISTS t_item ON COMMIT DROP AS '
+    || 'WITH RECURSIVE base AS ( '
+    || '    (SELECT "Item".*, 1 as level '
+    || '    FROM "Item" '
+    || '    LEFT JOIN hot_score_view g(id, "hotScore", "subHotScore") ON g.id = "Item".id '
+    || '    WHERE "Item"."parentId" = $1 '
+    || '    AND ("Item"."isScheduled" = false OR "Item"."userId" = $3) '
+    ||      _order_by || ') '
+    || '    UNION ALL '
+    || '    (SELECT "Item".*, b.level + 1 '
+    || '    FROM "Item" '
+    || '    JOIN base b ON "Item"."parentId" = b.id '
+    || '    LEFT JOIN hot_score_view g(id, "hotScore", "subHotScore") ON g.id = "Item".id '
+    || '    WHERE b.level < $2 '
+    || '    AND ("Item"."isScheduled" = false OR "Item"."userId" = $3)) '
+    || ') '
+    || 'SELECT "Item".*, '
+    || '    "Item".created_at at time zone ''UTC'' AS "createdAt", '
+    || '    "Item".updated_at at time zone ''UTC'' AS "updatedAt", '
+    || '    "Item"."invoicePaidAt" at time zone ''UTC'' AS "invoicePaidAtUTC", '
+    || '    to_jsonb(users.*) || jsonb_build_object(''meMute'', "Mute"."mutedId" IS NOT NULL) AS user, '
+    || '    COALESCE("ItemAct"."meMsats", 0) AS "meMsats", '
+    || '    COALESCE("ItemAct"."mePendingMsats", 0) as "mePendingMsats", '
+    || '    COALESCE("ItemAct"."meDontLikeMsats", 0) AS "meDontLikeMsats", '
+    || '    COALESCE("ItemAct"."meMcredits", 0) AS "meMcredits", '
+    || '    COALESCE("ItemAct"."mePendingMcredits", 0) as "mePendingMcredits", '
+    || '    "Bookmark"."itemId" IS NOT NULL AS "meBookmark", '
+    || '    "ThreadSubscription"."itemId" IS NOT NULL AS "meSubscription", '
+    || '    g.hot_score AS "hotScore", g.sub_hot_score AS "subHotScore" '
+    || 'FROM base "Item" '
+    || 'JOIN users ON users.id = "Item"."userId" '
+    || '    LEFT JOIN "Mute" ON "Mute"."muterId" = $3 AND "Mute"."mutedId" = "Item"."userId" '
+    || '    LEFT JOIN "Bookmark" ON "Bookmark"."userId" = $3 AND "Bookmark"."itemId" = "Item".id '
+    || '    LEFT JOIN "ThreadSubscription" ON "ThreadSubscription"."userId" = $3 AND "ThreadSubscription"."itemId" = "Item".id '
+    || '    LEFT JOIN hot_score_view g ON g.id = "Item".id '
+    || 'LEFT JOIN LATERAL ( '
+    || '    SELECT "itemId", '
+    || '        sum("ItemAct".msats) FILTER (WHERE "invoiceActionState" IS DISTINCT FROM ''FAILED'' AND "InvoiceForward".id IS NOT NULL AND (act = ''FEE'' OR act = ''TIP'')) AS "meMsats", '
+    || '        sum("ItemAct".msats) FILTER (WHERE "invoiceActionState" IS DISTINCT FROM ''FAILED'' AND "InvoiceForward".id IS NULL AND (act = ''FEE'' OR act = ''TIP'')) AS "meMcredits", '
+    || '        sum("ItemAct".msats) FILTER (WHERE "invoiceActionState" IS NOT DISTINCT FROM ''PENDING'' AND "InvoiceForward".id IS NOT NULL AND (act = ''FEE'' OR act = ''TIP'')) AS "mePendingMsats", '
+    || '        sum("ItemAct".msats) FILTER (WHERE "invoiceActionState" IS NOT DISTINCT FROM ''PENDING'' AND "InvoiceForward".id IS NULL AND (act = ''FEE'' OR act = ''TIP'')) AS "mePendingMcredits", '
+    || '        sum("ItemAct".msats) FILTER (WHERE "invoiceActionState" IS DISTINCT FROM ''FAILED'' AND act = ''DONT_LIKE_THIS'') AS "meDontLikeMsats" '
+    || '    FROM "ItemAct" '
+    || '    LEFT JOIN "Invoice" ON "Invoice".id = "ItemAct"."invoiceId" '
+    || '    LEFT JOIN "InvoiceForward" ON "InvoiceForward"."invoiceId" = "Invoice"."id" '
+    || '    WHERE "ItemAct"."userId" = $3 '
+    || '    AND "ItemAct"."itemId" = "Item".id '
+    || '    GROUP BY "ItemAct"."itemId" '
+    || ') "ItemAct" ON true '
+    || _where || ' '
+    USING _item_id, _level, _me_id, _global_seed, _where, _order_by;
+
+    EXECUTE ''
+        || 'SELECT COALESCE(jsonb_agg(sub), ''[]''::jsonb) AS comments '
+        || 'FROM  ( '
+        || '    SELECT "Item".*, item_comments_zaprank_with_me("Item".id, $6, $5, $2 - 1, $3, $4) AS comments '
+        || '    FROM t_item "Item" '
+        || '    WHERE  "Item"."parentId" = $1 '
+        ||      _order_by
+        || ' ) sub '
+    INTO result
+    USING _item_id, _level, _where, _order_by, _me_id, _global_seed;
+
+    RETURN result;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION item_comments(_item_id int, _level int, _where text, _order_by text)
+  RETURNS jsonb
+  LANGUAGE plpgsql VOLATILE PARALLEL SAFE AS
+$$
+DECLARE
+    result  jsonb;
+BEGIN
+    IF _level < 1 THEN
+        RETURN '[]'::jsonb;
+    END IF;
+
+    EXECUTE 'CREATE TEMP TABLE IF NOT EXISTS t_item ON COMMIT DROP AS '
+    || 'WITH RECURSIVE base AS ( '
+    || '    (SELECT "Item".*, 1 as level '
+    || '    FROM "Item" '
+    || '    WHERE "Item"."parentId" = $1 '
+    || '    AND "Item"."isScheduled" = false '
+    ||      _order_by || ') '
+    || '    UNION ALL '
+    || '    (SELECT "Item".*, b.level + 1 '
+    || '    FROM "Item" '
+    || '    JOIN base b ON "Item"."parentId" = b.id '
+    || '    WHERE b.level < $2 '
+    || '    AND "Item"."isScheduled" = false) '
+    || ') '
+    || 'SELECT "Item".*, '
+    || '    "Item".created_at at time zone ''UTC'' AS "createdAt", '
+    || '    "Item".updated_at at time zone ''UTC'' AS "updatedAt", '
+    || '    "Item"."invoicePaidAt" at time zone ''UTC'' AS "invoicePaidAtUTC", '
+    || '    to_jsonb(users.*) AS user '
+    || 'FROM base "Item" '
+    || 'JOIN users ON users.id = "Item"."userId" '
+    || _where || ' '
+    USING _item_id, _level, _where, _order_by;
+
+    EXECUTE ''
+        || 'SELECT COALESCE(jsonb_agg(sub), ''[]''::jsonb) AS comments '
+        || 'FROM  ( '
+        || '    SELECT "Item".*, item_comments("Item".id, $2 - 1, $3, $4) AS comments '
+        || '    FROM t_item "Item" '
+        || '    WHERE  "Item"."parentId" = $1 '
+        ||      _order_by
+        || ' ) sub '
+    INTO result
+    USING _item_id, _level, _where, _order_by;
+
+    RETURN result;
+END
+$$;
+
+CREATE OR REPLACE FUNCTION item_comments_limited(
+    _item_id int, _limit int, _offset int, _grandchild_limit int,
+    _level int, _where text, _order_by text)
+  RETURNS jsonb
+  LANGUAGE plpgsql VOLATILE PARALLEL SAFE AS
+$$
+DECLARE
+    result  jsonb;
+BEGIN
+    IF _level < 1 THEN
+        RETURN '[]'::jsonb;
+    END IF;
+
+    EXECUTE 'CREATE TEMP TABLE IF NOT EXISTS t_item ON COMMIT DROP AS '
+    || 'WITH RECURSIVE base AS ( '
+    || '    (SELECT "Item".*, 1 as level, ROW_NUMBER() OVER () as rn '
+    || '    FROM "Item" '
+    || '    WHERE "Item"."parentId" = $1 '
+    || '    AND "Item"."isScheduled" = false '
+    ||      _order_by || ' '
+    || '    LIMIT $2 '
+    || '    OFFSET $3) '
+    || '    UNION ALL '
+    || '    (SELECT "Item".*, b.level + 1, ROW_NUMBER() OVER (PARTITION BY "Item"."parentId" ' || _order_by || ') as rn '
+    || '    FROM "Item" '
+    || '    JOIN base b ON "Item"."parentId" = b.id '
+    || '    WHERE b.level < $5 AND (b.level = 1 OR b.rn <= $4) '
+    || '    AND "Item"."isScheduled" = false) '
+    || ') '
+    || 'SELECT "Item".*, '
+    || '    "Item".created_at at time zone ''UTC'' AS "createdAt", '
+    || '    "Item".updated_at at time zone ''UTC'' AS "updatedAt", '
+    || '    "Item"."invoicePaidAt" at time zone ''UTC'' AS "invoicePaidAtUTC", '
+    || '    to_jsonb(users.*) AS user '
+    || 'FROM base "Item" '
+    || 'JOIN users ON users.id = "Item"."userId" '
+    || 'WHERE ("Item".level = 1 OR "Item".rn <= $4 - "Item".level + 2) ' || _where || ' '
+    USING _item_id, _limit, _offset, _grandchild_limit, _level, _where, _order_by;
+
+    EXECUTE ''
+        || 'SELECT COALESCE(jsonb_agg(sub), ''[]''::jsonb) AS comments '
+        || 'FROM  ( '
+        || '    SELECT "Item".*, item_comments_limited("Item".id, $2, $3, $4, $5 - 1, $6, $7) AS comments '
+        || '    FROM t_item "Item" '
+        || '    WHERE  "Item"."parentId" = $1 '
+        ||      _order_by
+        || ' ) sub '
+    INTO result
+    USING _item_id, _limit, _offset, _grandchild_limit, _level, _where, _order_by;
+
+    RETURN result;
+END
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -563,6 +563,8 @@ model Item {
   bio                  Boolean               @default(false)
   freebie              Boolean               @default(false)
   deletedAt            DateTime?
+  scheduledAt          DateTime?
+  isScheduled          Boolean               @default(false)
   otsFile              Bytes?
   otsHash              String?
   imgproxyUrls         Json?
@@ -629,6 +631,9 @@ model Item {
   @@index([url])
   @@index([boost])
   @@index([invoicePaidAt])
+  @@index([scheduledAt])
+  @@index([isScheduled])
+  @@index([isScheduled, scheduledAt])
 }
 
 // we use this to denormalize a user's aggregated interactions (zaps) with an item

--- a/worker/index.js
+++ b/worker/index.js
@@ -38,6 +38,7 @@ import { expireBoost } from './expireBoost'
 import { payingActionConfirmed, payingActionFailed } from './payingAction'
 import { autoDropBolt11s } from './autoDropBolt11'
 import { postToSocial } from './socialPoster'
+import { publishScheduledPost, schedulePostSideEffects } from './publishScheduledPosts'
 
 // WebSocket polyfill
 import ws from 'isomorphic-ws'
@@ -144,6 +145,8 @@ async function work () {
   await boss.work('reminder', jobWrapper(remindUser))
   await boss.work('thisDay', jobWrapper(thisDay))
   await boss.work('socialPoster', jobWrapper(postToSocial))
+  await boss.work('publishScheduledPost', jobWrapper(publishScheduledPost))
+  await boss.work('schedulePostSideEffects', jobWrapper(schedulePostSideEffects))
   await boss.work('checkWallet', jobWrapper(checkWallet))
 
   console.log('working jobs')

--- a/worker/publishScheduledPosts.js
+++ b/worker/publishScheduledPosts.js
@@ -1,0 +1,77 @@
+import { notifyItemMention, notifyItemParents, notifyMention, notifyTerritorySubscribers, notifyUserSubscribers, notifyThreadSubscribers } from '@/lib/webPush'
+
+export async function publishScheduledPost ({ data: { itemId }, models, lnd }) {
+  console.log('publishing scheduled post', itemId)
+
+  const item = await models.item.findUnique({
+    where: { id: itemId },
+    include: {
+      user: true,
+      mentions: true,
+      itemReferrers: { include: { refereeItem: true } }
+    }
+  })
+
+  if (!item || !item.isScheduled || item.deletedAt) {
+    console.log('item not found, not scheduled, or deleted', itemId)
+    return
+  }
+
+  const publishTime = new Date()
+
+  // Update the item to be published with new timestamp
+  await models.item.update({
+    where: { id: itemId },
+    data: {
+      isScheduled: false,
+      scheduledAt: null,
+      createdAt: publishTime,
+      updatedAt: publishTime
+    }
+  })
+
+  // Refresh any cached views or materialized data that might reference this item
+  await models.$executeRaw`REFRESH MATERIALIZED VIEW CONCURRENTLY hot_score_view`
+
+  // Queue side effects
+  await models.$executeRaw`
+    INSERT INTO pgboss.job (name, data, startafter)
+    VALUES ('schedulePostSideEffects', jsonb_build_object('itemId', ${itemId}::INTEGER), now())`
+
+  console.log('published scheduled post with new timestamp', itemId, publishTime)
+}
+
+export async function schedulePostSideEffects ({ data: { itemId }, models }) {
+  const item = await models.item.findFirst({
+    where: { id: itemId },
+    include: {
+      mentions: true,
+      itemReferrers: { include: { refereeItem: true } },
+      user: true
+    }
+  })
+
+  if (!item) {
+    console.log('item not found for side effects', itemId)
+    return
+  }
+
+  // Send notifications for scheduled posts that are now published
+  if (item.parentId) {
+    notifyItemParents({ item, models }).catch(console.error)
+    notifyThreadSubscribers({ models, item }).catch(console.error)
+  }
+
+  for (const { userId } of item.mentions) {
+    notifyMention({ models, item, userId }).catch(console.error)
+  }
+
+  for (const { refereeItem } of item.itemReferrers) {
+    notifyItemMention({ models, referrerItem: item, refereeItem }).catch(console.error)
+  }
+
+  notifyUserSubscribers({ models, item }).catch(console.error)
+  notifyTerritorySubscribers({ models, item }).catch(console.error)
+
+  console.log('completed side effects for scheduled post', itemId)
+}


### PR DESCRIPTION
## Description

This PR implements scheduled posts functionality, allowing users to schedule content for future publication using the `@schedule in X time` syntax.

Closes https://github.com/stackernews/stacker.news/issues/740

**Core Features:**
- `@schedule in X time` command parsing (supports seconds, minutes, hours, days, weeks, months, years)
- Database schema extensions: `scheduledAt` and `isScheduled` fields on Item model
- Background job processing via pg-boss for automated publishing at scheduled time
- GraphQL mutations for managing scheduled posts: `cancelScheduledPost`, `publishScheduledPostNow`
- `scheduledItems` query for users to view their scheduled content

**Technical Implementation:**
- **Backend:** Extended item creation/update flows to detect schedule commands and set scheduling metadata
- **Database:** Added indexes for efficient querying of scheduled posts and updated stored procedures to filter scheduled posts from public view (visible only to owners)
- **Worker:** New `publishScheduledPost` and `schedulePostSideEffects` job handlers for automated publishing and notification processing
- **Security:** Scheduled posts are hidden from public feeds until published, visible only to the author
- **GraphQL:** Extended schema with new fields and mutations, updated fragments to include scheduling data

**User Experience:**
- Posts with `@schedule in 2 hours` syntax are automatically scheduled
- Scheduled posts maintain all original functionality (mentions, notifications, etc.) when published
- Clean separation between scheduled and published content in all queries

## Screenshots

![anon_view](https://github.com/user-attachments/assets/2374d7ae-7fc1-4979-98c5-c793795d489a)

Note that anon users can see that this account has 6 total items but only 5 are listed (one scheduled post not shown but counted).

## Checklist

**Are your changes backwards compatible? Please answer below:**

Yes. The implementation is fully backwards compatible:
- New database fields use default values (`isScheduled: false`)
- All existing queries continue to work unchanged
- No breaking changes to existing API contracts
- Schedule commands are optional and don't affect normal posting flow

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

8/10. Comprehensive testing includes:
- Schedule command parsing with various time formats
- Item is not visible for other users or anons.
- The post becomes visible when the scheduling time is due.


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

N/A - This is a backend-only implementation.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No new environment variables introduced. The feature uses existing pg-boss infrastructure and database connections.

## TODO

Figure out a way to refresh the item's “created at” time that's cached by Apollo and does not get updated even after the scheduled publishing happens. Any ideas?