### PR TITLE
Add zines to socials in footer

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -53,33 +53,43 @@ const RssPopover = (
 const SocialsPopover = (
   <Popover>
     <Popover.Body style={{ fontWeight: 500, fontSize: '.9rem' }}>
-      <a
-        href='https://njump.me/npub1jfujw6llhq7wuvu5detycdsq5v5yqf56sgrdq8wlgrryx2a2p09svwm0gx' className='nav-link p-0 d-inline-flex'
-        target='_blank' rel='noreferrer'
-      >
-        nostr
-      </a>
-      <span className='mx-2 text-muted'> \ </span>
-      <a
-        href='https://twitter.com/stacker_news' className='nav-link p-0 d-inline-flex'
-        target='_blank' rel='noreferrer'
-      >
-        twitter
-      </a>
-      <span className='mx-2 text-muted'> \ </span>
-      <a
-        href='https://www.youtube.com/@stackernews' className='nav-link p-0 d-inline-flex'
-        target='_blank' rel='noreferrer'
-      >
-        youtube
-      </a>
-      <span className='mx-2 text-muted'> \ </span>
-      <a
-        href='https://www.fountain.fm/show/Mg1AWuvkeZSFhsJZ3BW2' className='nav-link p-0 d-inline-flex'
-        target='_blank' rel='noreferrer'
-      >
-        pod
-      </a>
+      <div className='d-flex justify-content-center'>
+        <a
+          href='https://njump.me/npub1jfujw6llhq7wuvu5detycdsq5v5yqf56sgrdq8wlgrryx2a2p09svwm0gx' className='nav-link p-0 d-inline-flex'
+          target='_blank' rel='noreferrer'
+        >
+          nostr
+        </a>
+        <span className='mx-2 text-muted'> \ </span>
+        <a
+          href='https://twitter.com/stacker_news' className='nav-link p-0 d-inline-flex'
+          target='_blank' rel='noreferrer'
+        >
+          twitter
+        </a>
+        <span className='mx-2 text-muted'> \ </span>
+        <a
+          href='https://www.youtube.com/@stackernews' className='nav-link p-0 d-inline-flex'
+          target='_blank' rel='noreferrer'
+        >
+          youtube
+        </a>
+      </div>
+      <div className='d-flex justify-content-center'>
+        <a
+          href='https://www.fountain.fm/show/Mg1AWuvkeZSFhsJZ3BW2' className='nav-link p-0 d-inline-flex'
+          target='_blank' rel='noreferrer'
+        >
+          pod
+        </a>
+        <span className='mx-2 text-muted'> \ </span>
+        <a
+          href='https://www.plebpoet.com/zines.html' className='nav-link p-0 d-inline-flex'
+          target='_blank' rel='noreferrer'
+        >
+          zines
+        </a>
+      </div>
     </Popover.Body>
   </Popover>
 )


### PR DESCRIPTION
## Description

@janakelsay told me that @Soxasora had the idea to add a link to the zines in the footer.

While I discussed this idea with @janakelsay, we considered if we should link to a page on SN with all the PDFs and zaprite links, similar to how it's done [here](https://plebpoet.com/zines.html), but since:

- we don't deploy weekly
- the PDFs would bloat the repository
- it would be more work

I decided that it's easier for now to just link to her website.

## Screenshots

![2025-06-13-134035_1920x1080_scrot_001](https://github.com/user-attachments/assets/53c4cc3b-da80-431f-a44e-26645e0a0527)

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes, it's just a link

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. Link works!

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

nothing changed wrt light or dark mode

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no