### PR TITLE
Remove unused createInvoice mutation

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -5,16 +5,15 @@ import {
 import crypto, { timingSafeEqual } from 'crypto'
 import { decodeCursor, LIMIT, nextCursorEncoded } from '@/lib/cursor'
 import { SELECT, itemQueryWithMeta } from './item'
-import { formatMsats, msatsToSats, msatsToSatsDecimal, satsToMsats } from '@/lib/format'
+import { formatMsats, msatsToSats, msatsToSatsDecimal } from '@/lib/format'
 import {
   USER_ID, INVOICE_RETENTION_DAYS,
-  PAID_ACTION_PAYMENT_METHODS,
   WALLET_CREATE_INVOICE_TIMEOUT_MS,
   WALLET_RETRY_AFTER_MS,
   WALLET_RETRY_BEFORE_MS,
   WALLET_MAX_RETRIES
 } from '@/lib/constants'
-import { amountSchema, validateSchema, withdrawlSchema, lnAddrSchema } from '@/lib/validate'
+import { validateSchema, withdrawlSchema, lnAddrSchema } from '@/lib/validate'
 import assertGofacYourself from './ofac'
 import assertApiKeyNotPermitted from './apiKey'
 import { bolt11Tags } from '@/lib/bolt11'
@@ -475,20 +474,6 @@ const resolvers = {
     __resolveType: invoiceOrDirect => invoiceOrDirect.__resolveType
   },
   Mutation: {
-    createInvoice: async (parent, { amount }, { me, models, lnd, headers }) => {
-      await validateSchema(amountSchema, { amount })
-      await assertGofacYourself({ models, headers })
-
-      const { invoice, paymentMethod } = await performPaidAction('RECEIVE', {
-        msats: satsToMsats(amount)
-      }, { models, lnd, me })
-
-      return {
-        ...invoice,
-        __resolveType:
-          paymentMethod === PAID_ACTION_PAYMENT_METHODS.DIRECT ? 'Direct' : 'Invoice'
-      }
-    },
     createWithdrawl: createWithdrawal,
     sendToLnAddr,
     cancelInvoice: async (parent, { hash, hmac, userCancel }, { me, models, lnd, boss }) => {

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -74,7 +74,6 @@ const typeDefs = `
   }
 
   extend type Mutation {
-    createInvoice(amount: Int!): InvoiceOrDirect!
     createWithdrawl(invoice: String!, maxFee: Int!): Withdrawl!
     sendToLnAddr(addr: String!, amount: Int!, maxFee: Int!, comment: String, identifier: Boolean, name: String, email: String): Withdrawl!
     cancelInvoice(hash: String!, hmac: String, userCancel: Boolean): Invoice!


### PR DESCRIPTION
## Description

While looking into #2029, I noticed that the `createInvoice` mutation is not used anywhere afaict.

I searched for `mutation create`, but could not find a mutation that calls `createInvoice`.

I then used `git log -S "mutation createInvoice"` and found that the mutation that would call this function was removed in 146b6027 (see pages/withdraw.js).

This makes sense, because that commit also introduced the `buyCredits` mutation; essentially replacing the `createInvoice` mutation.

So I am pretty confident this mutation is indeed no longer used anywhere.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. Code builds and tested buying credits. Not sure what else to test.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no