### PR TITLE
Fix documentation for RECEIVE paid action

### DIFF
--- a/api/paidAction/README.md
+++ b/api/paidAction/README.md
@@ -103,7 +103,7 @@ stateDiagram-v2
 | donations         | x           |            | x           | x        | x          |             |              | x           |            |
 | update posts      | x           |            | x           |          | x          |             | x            | x           |            |
 | update comments   | x           |            | x           |          | x          |             | x            | x           |            |
-| receive           |             | x          |             |          | x          | x           | x            |             | x          |
+| receive           |             |            |             |          | x          | x           | x            |             | x          |
 | buy fee credits   |             |            | x           |          | x          |             |              | x           |            |
 | invite gift       | x           |            |             |          |            |             | x            | x           |            |
 


### PR DESCRIPTION
## Description

`OPTIMISTIC` as a payment method for `RECEIVE` was removed in 5a8804de.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no