### PR TITLE
Remove unused onPaid for RECEIVE paid action

### DIFF
--- a/api/paidAction/receive.js
+++ b/api/paidAction/receive.js
@@ -54,24 +54,6 @@ export async function describe ({ description }, { me, cost, paymentMethod, sybi
   return description ?? `SN: ${me?.name ?? ''} receives ${numWithUnits(msatsToSats(cost - fee))}`
 }
 
-export async function onPaid ({ invoice }, { tx }) {
-  if (!invoice) {
-    throw new Error('invoice is required')
-  }
-
-  // P2P lnurlp does not need to update the user's balance
-  if (invoice?.invoiceForward) return
-
-  await tx.user.update({
-    where: { id: invoice.userId },
-    data: {
-      mcredits: {
-        increment: invoice.msatsReceived
-      }
-    }
-  })
-}
-
 export async function nonCriticalSideEffects ({ invoice }, { models }) {
   await notifyDeposit(invoice.userId, invoice)
   await models.$executeRaw`


### PR DESCRIPTION
## Description

This function can be removed because it will never do anything when called.

It does not do anything for wrapped invoices, and it will never get called for direct payments (since we don't know when the invoice was paid).

These are the only two payment methods for the `RECEIVE` paid action since 5a8804d.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. Paid a wrapped invoice and a direct invoice returned via LNURLp and saw no errors in the worker.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no