### PR TITLE
Remove directReceive setting

### DIFF
--- a/api/paidAction/receive.js
+++ b/api/paidAction/receive.js
@@ -16,7 +16,6 @@ export async function getCost ({ msats }) {
 
 export async function getInvoiceablePeer (_, { me, models, cost, paymentMethod }) {
   if (paymentMethod === PAID_ACTION_PAYMENT_METHODS.P2P && !me?.proxyReceive) return null
-  if (paymentMethod === PAID_ACTION_PAYMENT_METHODS.DIRECT && !me?.directReceive) return null
 
   const wallets = await getInvoiceableWallets(me.id, { models })
   if (wallets.length === 0) {

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -208,6 +208,7 @@ export default gql`
     vaultKeyHash: String
     walletsUpdatedAt: Date
     proxyReceive: Boolean
+    directReceive: Boolean @deprecated
     receiveCreditsBelowSats: Int!
     sendCreditsBelowSats: Int!
   }

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -125,7 +125,6 @@ export default gql`
     wildWestMode: Boolean!
     withdrawMaxFeeDefault: Int!
     proxyReceive: Boolean
-    directReceive: Boolean
     receiveCreditsBelowSats: Int!
     sendCreditsBelowSats: Int!
   }
@@ -209,7 +208,6 @@ export default gql`
     vaultKeyHash: String
     walletsUpdatedAt: Date
     proxyReceive: Boolean
-    directReceive: Boolean
     receiveCreditsBelowSats: Int!
     sendCreditsBelowSats: Int!
   }

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -54,7 +54,6 @@ ${STREAK_FIELDS}
       vaultKeyHash
       walletsUpdatedAt
       proxyReceive
-      directReceive
     }
     optional {
       isContributor
@@ -117,7 +116,6 @@ export const SETTINGS_FIELDS = gql`
       }
       apiKeyEnabled
       proxyReceive
-      directReceive
       receiveCreditsBelowSats
       sendCreditsBelowSats
     }

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -160,7 +160,6 @@ export default function Settings ({ ssrData }) {
             hideIsContributor: settings?.hideIsContributor,
             noReferralLinks: settings?.noReferralLinks,
             proxyReceive: settings?.proxyReceive,
-            directReceive: settings?.directReceive,
             receiveCreditsBelowSats: settings?.receiveCreditsBelowSats,
             sendCreditsBelowSats: settings?.sendCreditsBelowSats
           }}
@@ -365,22 +364,6 @@ export default function Settings ({ ssrData }) {
               </div>
             }
             name='proxyReceive'
-            groupClassName='mb-0'
-          />
-          <Checkbox
-            label={
-              <div className='d-flex align-items-center'>directly deposit to attached wallets
-                <Info>
-                  <ul>
-                    <li>Directly deposit to your attached wallets if they cause your balance to exceed your auto-withdraw threshold</li>
-                    <li>Senders will be able to see your wallet's lightning node public key</li>
-                    <li>If 'proxy deposits' is also checked, it will take precedence and direct deposits will only be used as a fallback</li>
-                    <li>Because we can't determine if a payment succeeds, you won't be notified about direct deposits</li>
-                  </ul>
-                </Info>
-              </div>
-            }
-            name='directReceive'
             groupClassName='mb-0'
           />
           <Checkbox

--- a/prisma/migrations/20250614190749_remove_direct_receive_setting/migration.sql
+++ b/prisma/migrations/20250614190749_remove_direct_receive_setting/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `directReceive` on the `users` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "directReceive";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -148,7 +148,6 @@ model User {
   walletsUpdatedAt          DateTime?
   vaultEntries              VaultEntry[]         @relation("VaultEntries")
   proxyReceive              Boolean              @default(true)
-  directReceive             Boolean              @default(true)
   DirectPaymentReceived     DirectPayment[]      @relation("DirectPaymentReceived")
   DirectPaymentSent         DirectPayment[]      @relation("DirectPaymentSent")
   UserSubTrust              UserSubTrust[]


### PR DESCRIPTION
## Description

Close #2029 

This removes the `directReceive` setting because it currently unintentionally disabled the lightning address if  `directReceive` was not enabled and `proxyReceive` was not enabled or wrapping failed.

Since the original purpose of this setting was to disable buying credits, which is no longer possible since 5a8804de79ff8e004a74e52afc5ff4bf3e9ab3b3, this setting is no longer needed.

Now, if proxy was not enabled or wrapping failed, we always fallback to direct payments.

For the sake of keeping the product simple / simplifying it, I think we don't need to give stackers a dedicated setting to control if they want these fallbacks or not.

## Additional Context

I actually think we should never fallback to direct payments if the proxy was enabled.

If the proxy is enabled and we allow fallbacks, it's trivial to reveal the node pubkey by simply requesting an invoice for 1 sat in which case wrapping will almost always fail. This makes the proxy setting pretty useless imo. It gives a false sense of privacy.

Not having fallbacks comes at the cost of a higher chance of failed payments though.

But I also think it's easier to understand that if proxy is enabled, we _always_ and _only_ proxy (but it might fail due to fees), instead of having to explain that if wrapping fails, we will try without it and thus still reveal their node pubkey.

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. No more occurrences of `directReceive`.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no