### PR TITLE
Fix check wallet job runs twice

### DIFF
--- a/prisma/migrations/20250616140427_fix_check_wallet_runs_twice/migration.sql
+++ b/prisma/migrations/20250616140427_fix_check_wallet_runs_twice/migration.sql
@@ -1,0 +1,21 @@
+-- fix that trigger also runs when the wallet JSONB column is updated
+-- https://github.com/stackernews/stacker.news/issues/2234
+
+CREATE OR REPLACE FUNCTION check_wallet_trigger() RETURNS TRIGGER AS $$
+DECLARE
+    user_id INTEGER;
+BEGIN
+    IF TG_OP = 'UPDATE' AND OLD.wallet != NEW.wallet THEN
+        -- the trigger that updates the wallet JSONB column triggered this trigger
+        RETURN NULL;
+    END IF;
+
+    -- if TG_OP is DELETE, then NEW.userId is NULL
+    user_id := CASE WHEN TG_OP = 'DELETE' THEN OLD."userId" ELSE NEW."userId" END;
+
+    INSERT INTO pgboss.job (name, data, retrylimit, startafter, keepuntil)
+    VALUES ('checkWallet', jsonb_build_object('userId', user_id), 21, now(), now() + interval '5 minutes');
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Description

Fix #2234 

## Additional context

This is not the best fix because it works by assuming knowledge that the other trigger exists.

However, I tried to fix this by attaching the trigger to the child tables (`WalletNWC` etc.) but on detach, I couldn't get the trigger to fire in a way that the trigger would still find the user. This is the trigger I used:

```sql
CREATE OR REPLACE FUNCTION check_wallet_trigger() RETURNS TRIGGER AS $$
DECLARE
    user_id INTEGER;
BEGIN
    SELECT "userId" INTO user_id
    FROM "Wallet"
    WHERE id = CASE WHEN TG_OP = 'DELETE' THEN OLD."walletId" ELSE NEW."walletId" END;

    INSERT INTO pgboss.job (name, data, retrylimit, startafter, keepuntil)
    VALUES ('checkWallet', jsonb_build_object('userId', user_id), 21, now(), now() + interval '5 minutes');

    RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
END;
$$ LANGUAGE plpgsql;

CREATE OR REPLACE TRIGGER check_wallet_trigger
BEFORE INSERT OR UPDATE OR DELETE ON "WalletLNbits"
FOR EACH ROW EXECUTE PROCEDURE check_wallet_trigger();
```

So I am proposing this hack as a fix. ¯\\\_(ツ)\_/¯

This will change anyway during #2169 

## Checklist

**Are your changes backwards compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested with LNbits send+recv, enabling, disabling, detaching. Gun and horses appear and disappear as expected and only one job is inserted, unlike before.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no