### PR TITLE
Remove unused injected amount param

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -1068,15 +1068,14 @@ export function Form ({
     })
   }, [storageKeyPrefix])
 
-  const onSubmitInner = useCallback(async ({ amount, ...values }, ...args) => {
-    const variables = { amount, ...values }
+  const onSubmitInner = useCallback(async (values, ...args) => {
     if (requireSession && !me) {
       throw new SessionRequiredError()
     }
 
     try {
       if (onSubmit) {
-        await onSubmit(variables, ...args)
+        await onSubmit(values, ...args)
       }
     } catch (err) {
       console.log(err.message, err)


### PR DESCRIPTION
## Description

I noticed—a while ago actually—that every form submission included an `amount` parameter.

For example, when you search for something, the URL contains an useless `amount` parameter: https://stacker.news/search?amount=&q=asdf

I now looked into this because of #2169 and noticed it's a relict of #1194 where I introduced the `usePayment` hook.

This hook no longer exists. We now handle payments with `usePaidMutation`.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`. I searched for `name='amount'` to find all places where the `amount` param is used in a form.

That's the case for zaps, boost, buying credits, withdrawals and donations. I tested all of them.

The change also makes clear that nothing actually changes except that we don't include an useless, undefined `amount`  param to every form submission.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no