### PR TITLE
Add another example to question about backward compatibility

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ _Was anything unclear during your work on this PR? Anything we should definitely
 
 **Are your changes backward compatible? Please answer below:**
 
-_For example, a change is not backward compatible if you removed a GraphQL field._
+_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
 
 **On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
 


### PR DESCRIPTION
I dropped a database column in #2230, but didn't notice that old Prisma clients would still try to query this column.

For the future, we can just add a comment to the columns in the Prisma schema columns that we want to remove in a follow-up PR.