### PR TITLE
Fix unique constraint hit during territory unarchive

### DIFF
--- a/api/paidAction/territoryUnarchive.js
+++ b/api/paidAction/territoryUnarchive.js
@@ -78,9 +78,16 @@ export async function perform ({ name, invoiceId, ...data }, { me, cost, tx }) {
     }
   })
 
-  await tx.userSubTrust.createMany({
-    data: initialTrust({ name: updatedSub.name, userId: updatedSub.userId })
-  })
+  const trust = initialTrust({ name: updatedSub.name, userId: updatedSub.userId })
+  for (const t of trust) {
+    await tx.userSubTrust.upsert({
+      where: {
+        userId_subName: { userId: t.userId, subName: t.subName }
+      },
+      update: t,
+      create: t
+    })
+  }
 
   return updatedSub
 }


### PR DESCRIPTION
## Description

fix #2244

Since Prisma does not support bulk upserts (https://github.com/prisma/prisma/issues/4134), we now upsert the trust of the seeds and the new owner individually, as suggested in [this comment](https://github.com/prisma/prisma/discussions/22688#discussioncomment-8159528).

**However, I wonder if it was intentional to not reset or change the trust of the previous owner in some way**.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested that this now does what the previous code intended to do. It inserts or updates the corresponding rows for the initial trust in a territory.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no