### PR TITLE
add devcontainer config for codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "sndev",
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "16gb",
+    "storage": "32gb"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-azuretools.vscode-containers"
+      ]
+    }
+  },
+  "containerEnv": {
+    "CPU_SHARES_IMPORTANT": "1024",
+    "CPU_SHARES_MODERATE": "512",
+    "CPU_SHARES_LOW": "128"
+  },
+  "postAttachCommand": "./scripts/setup-codespaces.sh && source .env.local && ./sndev start"
+}

--- a/.devcontainer/minimal/devcontainer.json
+++ b/.devcontainer/minimal/devcontainer.json
@@ -1,0 +1,22 @@
+{
+    "name": "sndev MINIMAL",
+    "hostRequirements": {
+      "cpus": 4,
+      "memory": "16gb",
+      "storage": "32gb"
+    },
+    "customizations": {
+      "vscode": {
+        "extensions": [
+          "ms-azuretools.vscode-containers"
+        ]
+      }
+    },
+    "containerEnv": {
+      "CPU_SHARES_IMPORTANT": "1024",
+      "CPU_SHARES_MODERATE": "512",
+      "CPU_SHARES_LOW": "128",
+      "COMPOSE_PROFILES": "minimal"
+    },
+    "postAttachCommand": "./scripts/setup-codespaces.sh && source .env.local && ./sndev start"
+  }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ You can run Stacker News on Github Codespaces
 #### Setup
 
 1. Open the repository on GitHub and click the **"Code"** button
-2. Select the CodeSpaces tab and create a new codespace. (or configure with provided settings first)
+2. Select the Codespaces tab and create a new codespace. 
+   - You can also configure your codespace to run select services based on  `COMPOSE_PROFILES` as well as in a different region and machine type by clicking "..." and selecting "New with options...". Check [Modifying services](#modifying-services) for more information on `COMPOSE_PROFILES`
 3. Wait for the environment to set up (this may take several minutes the first time)
 4. Once ready, you'll see a terminal with the environment initialized
 
@@ -57,7 +58,7 @@ Access your running application at the URL shown in the forwarded ports panel (t
 
 #### Port Configuration
 
-⚠️ **Important**: For external access to work properly, you must set forwarded ports to **Public** in the Ports tab:
+⚠️ **Important**: For various internal services and external access to work properly, you must set forwarded ports to **Public** in the Ports tab:
 
 1. In your codespace, look for the "PORTS" tab in the bottom panel
 2. Click the lock icon to change visibility from "Private" to "Public"
@@ -384,7 +385,7 @@ We offer triage permissions to contributors after they've made a few contributio
 Contributors can get badges on their SN profiles by opening a pull request adding their SN nym to the [contributors.txt](/contributors.txt) file.
 
 ## What else you got
-We offer GitHub Codespaces support for cloud-based development! In the future we plan to offer more, like gratis github copilot subscriptions, reverse tunnels, and merch.
+In the future we plan to offer more, like gratis github copilot subscriptions, reverse tunnels, codespaces, and merch.
 
 If you'd like to see something added, please make a suggestion.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,33 @@ Go to [localhost:3000](http://localhost:3000).
 
 <br>
 
+### GitHub Codespaces
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/stackernews/stacker.news)
+
+You can run Stacker News on Github Codespaces
+
+#### Setup
+
+1. Open the repository on GitHub and click the **"Code"** button
+2. Select the CodeSpaces tab and create a new codespace. (or configure with provided settings first)
+3. Wait for the environment to set up (this may take several minutes the first time)
+4. Once ready, you'll see a terminal with the environment initialized
+
+#### Usage
+
+After the codespace is created, the development environment will be automatically set up and services started.
+
+Access your running application at the URL shown in the forwarded ports panel (typically `https://your-codespace-name-3000.app.github.dev`).
+
+#### Port Configuration
+
+⚠️ **Important**: For external access to work properly, you must set forwarded ports to **Public** in the Ports tab:
+
+1. In your codespace, look for the "PORTS" tab in the bottom panel
+2. Click the lock icon to change visibility from "Private" to "Public"
+<br>
+
 ## Usage
 
 Start the development environment
@@ -170,6 +197,7 @@ To add/remove DNS records you can now use `./sndev domains dns`. More on this [h
 # Table of Contents
 - [Getting started](#getting-started)
     - [Installation](#installation)
+        - [GitHub Codespaces](#github-codespaces)
     - [Usage](#usage)
         - [Modifying services](#modifying-services)
             - [Running specific services](#running-specific-services)
@@ -356,7 +384,7 @@ We offer triage permissions to contributors after they've made a few contributio
 Contributors can get badges on their SN profiles by opening a pull request adding their SN nym to the [contributors.txt](/contributors.txt) file.
 
 ## What else you got
-In the future we plan to offer more, like gratis github copilot subscriptions, reverse tunnels, codespaces, and merch.
+We offer GitHub Codespaces support for cloud-based development! In the future we plan to offer more, like gratis github copilot subscriptions, reverse tunnels, and merch.
 
 If you'd like to see something added, please make a suggestion.
 

--- a/scripts/setup-codespaces.sh
+++ b/scripts/setup-codespaces.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+if [ -z "$CODESPACE_NAME" ]; then
+  echo "Not in a Codespaces environment, skipping setup"
+  exit 0
+fi
+
+echo "Setting up Codespaces environment variables..."
+
+[ ! -f .env.local ] && touch .env.local && echo "Created .env.local" || echo ".env.local already exists, will preserve existing content"
+
+declare -A env_vars=(
+  ["NEXTAUTH_URL"]="https://${CODESPACE_NAME}-3000.app.github.dev/api/auth"
+  ["NEXT_PUBLIC_MEDIA_URL"]="https://${CODESPACE_NAME}-4566.app.github.dev/uploads"
+  ["LNAUTH_URL"]="https://${CODESPACE_NAME}-3000.app.github.dev/api/lnauth"
+  ["LNWITH_URL"]="https://${CODESPACE_NAME}-3000.app.github.dev/api/lnwith"
+  ["PUBLIC_URL"]="https://${CODESPACE_NAME}-3000.app.github.dev"
+  ["NEXT_PUBLIC_URL"]="https://${CODESPACE_NAME}-3000.app.github.dev"
+  ["NEXT_PUBLIC_IMGPROXY_URL"]="https://${CODESPACE_NAME}-3001.app.github.dev"
+  ["IMGPROXY_ALLOW_ORIGIN"]="https://${CODESPACE_NAME}-3000.app.github.dev"
+  ["NEXT_PUBLIC_MEDIA_DOMAIN"]="${CODESPACE_NAME}-4566.app.github.dev"
+)
+
+# Remove existing Codespaces-related entries to avoid duplicates
+for var in "${!env_vars[@]}"; do
+  sed -i.bak "/^${var}=/d" .env.local 2>/dev/null || true
+done
+
+# Add Codespaces environment variables
+echo "# Codespaces environment variables" >> .env.local
+for var in "${!env_vars[@]}"; do
+  echo "${var}=${env_vars[$var]}" >> .env.local
+  export "$var"="${env_vars[$var]}"
+done
+
+rm -f .env.local.bak 2>/dev/null || true

--- a/sndev
+++ b/sndev
@@ -534,12 +534,7 @@ DESCRIPTION
   This is automatically run when the Codespace is created.
 
 REQUIREMENTS
-  - Set GITHUB_TOKEN in Codespaces settings for NextAuth functionality
   - Set forwarded ports to 'Public' in the Ports tab for external access
-
-WARNING
-  Without GITHUB_TOKEN, authentication may fail. Without public ports,
-  external access to the application will be blocked.
 "
 
   echo "$help"

--- a/sndev
+++ b/sndev
@@ -39,6 +39,8 @@ docker__exec() {
 sndev__start() {
   shift
 
+
+
   if [ $# -eq 0 ]; then
     docker__compose up --build
     exit 0
@@ -481,6 +483,14 @@ sndev__login() {
   salt="202c90943c313b829e65e3f29164fb5dd7ea3370d7262c4159691c2f6493bb8b"
   # upsert user with nym and nym@sndev.team
   email="$1@sndev.team"
+
+  # Detect Codespaces and set the correct base URL
+  if [ -n "$CODESPACE_NAME" ]; then
+    BASE_URL="https://${CODESPACE_NAME}-3000.app.github.dev"
+  else
+    BASE_URL="http://localhost:3000"
+  fi
+
   docker__exec db psql -U sn -d stackernews -q <<EOF
     INSERT INTO users (name) VALUES ('$1') ON CONFLICT DO NOTHING;
     UPDATE users SET email = '$email', "emailHash" = encode(digest(LOWER('$email')||'$salt', 'sha256'), 'hex') WHERE name = '$1';
@@ -492,7 +502,7 @@ EOF
 
   echo
   echo "open url in browser"
-  echo "http://localhost:3000/api/auth/callback/email?token=SNDEV-TOKEN&email=$1%40sndev.team"
+  echo "$BASE_URL/api/auth/callback/email?token=SNDEV-TOKEN&email=$1%40sndev.team"
   echo
 }
 
@@ -502,6 +512,34 @@ login as a nym
 
 USAGE
   $ sndev login NYM
+"
+
+  echo "$help"
+}
+
+sndev__setup_codespaces() {
+  shift
+  ./scripts/setup-codespaces.sh
+}
+
+sndev__help_setup_codespaces() {
+  help="
+setup Codespaces environment variables
+
+USAGE
+  $ sndev setup_codespaces
+
+DESCRIPTION
+  Creates or updates .env.local with the correct URLs for GitHub Codespaces.
+  This is automatically run when the Codespace is created.
+
+REQUIREMENTS
+  - Set GITHUB_TOKEN in Codespaces settings for NextAuth functionality
+  - Set forwarded ports to 'Public' in the Ports tab for external access
+
+WARNING
+  Without GITHUB_TOKEN, authentication may fail. Without public ports,
+  external access to the application will be blocked.
 "
 
   echo "$help"
@@ -635,6 +673,9 @@ COMMANDS
   sn:
     login                 login as a nym
     set_balance           set the balance of a nym
+
+  codespaces:
+    setup_codespaces      setup environment for GitHub Codespaces
 
   lightning:
     fund                   pay a bolt11 for funding


### PR DESCRIPTION
## Description

Added .devcontainer a default & minimal configuration to support running the sndev environment in codespaces, added instructions in the README and modified login link so the hyperlink in the terminal can redirect to the correct container host link. Services are accessible via links in the VSCode tabs

closes #2209 

## Screenshots
Log in link
<img width="1325" alt="Screenshot 2025-06-25 at 09 40 37" src="https://github.com/user-attachments/assets/788420d7-6bd8-4716-99d4-c743f8e47a89" />

Logged in user
<img width="1239" alt="Screenshot 2025-06-25 at 09 40 19" src="https://github.com/user-attachments/assets/aed54398-31bc-467f-bfdd-81fdd7473f89" />

Codespaces config
<img width="929" alt="Screenshot 2025-06-25 at 09 51 02" src="https://github.com/user-attachments/assets/f9777047-05e7-4644-a8e1-639f3c99a94e" />

Ports Tab with links
<img width="1441" alt="Screenshot 2025-06-25 at 09 40 44" src="https://github.com/user-attachments/assets/e8659087-c33a-4148-b7c8-42bc7700add2" />

Lnbits
<img width="1412" alt="Screenshot 2025-06-25 at 09 41 03" src="https://github.com/user-attachments/assets/14a70fbc-28c3-4ec8-9beb-03f210abdb37" />

<img width="1241" alt="Screenshot 2025-06-25 at 09 42 24" src="https://github.com/user-attachments/assets/d86d8aec-b890-489d-bbae-6e8c485fc2b4" />



## Additional Context

The machines available for Github codespaces have limited compute & storage. Storage left after build & config is less than 10 GB. I customised the devcontainers to run using the highest available free tier machines.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**
