### PR TITLE
Remove unreachable code

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -987,7 +987,7 @@ export async function createWithdrawal (parent, { invoice, maxFee }, { me, model
   return await performPayingAction({ bolt11: invoice, maxFee, walletId: wallet?.id }, { me, models, lnd })
 }
 
-export async function sendToLnAddr (parent, { addr, amount, maxFee, comment, ...payer },
+async function sendToLnAddr (parent, { addr, amount, maxFee, comment, ...payer },
   { me, models, lnd, headers }) {
   if (!me) {
     throw new GqlAuthenticationError()
@@ -1005,7 +1005,7 @@ export async function sendToLnAddr (parent, { addr, amount, maxFee, comment, ...
   return await createWithdrawal(parent, { invoice: res.pr, maxFee }, { me, models, lnd, headers })
 }
 
-export async function fetchLnAddrInvoice (
+async function fetchLnAddrInvoice (
   { addr, amount, maxFee, comment, ...payer },
   { me, models, lnd }) {
   const options = await lnAddrOptions(addr)


### PR DESCRIPTION
## Description

`fetchLnAddrInvoice` is only ever called in `sendToLnAddr`.

So there's no code that passes `autoWithdraw: true`, so the code block I removed was unreachable because `autoWithdraw` was always false.

I also think we don't need to fix that because we already validate that stackers can't configure a @stacker.news lightning address as a wallet and that's also not already the case:

```sql
SELECT address from "WalletLightningAddress" where address LIKE '%stacker.news';
(0 rows)
```

I also removed the `export` keyword because the functions also weren't imported anywhere else.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`5`. Did not test, I just looked at the code and that the code still builds (-> no broken imports).

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no