### PR TITLE
Fix poll expiration clear button style

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1094,3 +1094,16 @@ div[contenteditable]:focus,
 .react-datepicker__year-text--in-range) {
   background-color: var(--bs-info) !important;
 }
+
+.react-datepicker__close-icon {
+  padding: 0rem 0.75rem !important;
+  align-items: center !important;
+  height: calc(100% - 3px) !important;
+
+  &::after {
+    content: "×" !important;
+    color: var(--theme-grey) !important;
+    font-size: 20px !important;
+    background: none !important;
+  }
+}


### PR DESCRIPTION
## Description

Fix style for the poll expiraton clear button, now better aligns with ui style. Inspiration from clear button from main search UI.

closes #2106 

## Screenshots

Dark Mode:
<img width="826" alt="Screenshot 2025-06-27 at 14 47 55" src="https://github.com/user-attachments/assets/21855026-4264-4c1f-831d-0fa93ab29dce" />

Dark Mode, mobile:
<img width="450" alt="Screenshot 2025-06-27 at 14 48 07" src="https://github.com/user-attachments/assets/390bc3eb-124b-4e3d-8131-48e789f8d108" />

Light Mode:
<img width="591" alt="Screenshot 2025-06-27 at 14 49 28" src="https://github.com/user-attachments/assets/e8625b7e-329c-4d7a-b99a-768f61beb620" />

Light Mode, mobile:
<img width="327" alt="Screenshot 2025-06-27 at 14 49 37" src="https://github.com/user-attachments/assets/c9c56b6a-3396-4399-b782-dcd1711f87a5" />


## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_

## Checklist

**Are your changes backward compatible? Please answer below:**
Y
_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Y

**Did you introduce any new environment variables? If so, call them out explicitly here:**
N
