### PR TITLE
Fix(npub): Do not parse npubs in links

### DIFF
--- a/lib/rehype-sn.js
+++ b/lib/rehype-sn.js
@@ -137,7 +137,7 @@ export default function rehypeSN (options = {}) {
         }
 
         // Handle Nostr IDs
-        if (node.type === 'text') {
+        if (node.type === 'text' && !(parent && parent.tagName === 'a')) {
           const newChildren = []
           let lastIndex = 0
           let match


### PR DESCRIPTION
## Description

Add check to prevent parsing of npubs in links.

closes #2252 

## Screenshots
Before fix
<img width="828" alt="Screenshot 2025-06-28 at 17 28 18" src="https://github.com/user-attachments/assets/6a4f3a94-34dc-4636-844d-1c8362a7377c" />

After fix
<img width="861" alt="Screenshot 2025-06-28 at 17 27 37" src="https://github.com/user-attachments/assets/d083d9c7-370d-4fe5-882c-a0348e046332" />

## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_

## Checklist

**Are your changes backward compatible? Please answer below:**
Y
_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**
N