### PR TITLE
Fix fireworks not checking localStorage flag

### DIFF
--- a/components/fireworks.js
+++ b/components/fireworks.js
@@ -27,6 +27,8 @@ export function FireworksProvider ({ children }) {
   useEffect(() => {
     setContext({
       strike: () => {
+        const should = window.localStorage.getItem('lnAnimate') || 'yes'
+        if (should !== 'yes') return false
         cont?.addEmitter(
           {
             direction: 'top',


### PR DESCRIPTION
## Description

Fireworks didn't check if animations were disabled.

## Additional Context

- https://stacker.news/items/1022281?commentId=1022632
- you can merge just this to fix the bug or merge #2261 to fix the bug and refactor so it doesn't happen again

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. 

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no