### PR TITLE
Fix Force favicon refresh with cache-busting for notification state (Safari compatibility)

### DIFF
--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -413,8 +413,10 @@ export function AnonDropdown ({ path }) {
   useEffect(() => {
     if (!window.localStorage.getItem('striked')) {
       const to = setTimeout(() => {
-        strike()
-        window.localStorage.setItem('striked', 'yep')
+        const striked = strike()
+        if (striked) {
+          window.localStorage.setItem('striked', 'yep')
+        }
       }, randInRange(3000, 10000))
       return () => clearTimeout(to)
     }

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -420,7 +420,8 @@ export function AnonDropdown ({ path }) {
 
   useEffect(() => {
     if (!window.localStorage.getItem('striked')) {
-      const striked = strike()
+      const to = setTimeout(() => {
+        const striked = strike()
         if (striked) {
           window.localStorage.setItem('striked', 'yep')
         }

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -15,7 +15,7 @@ import { useServiceWorker } from '../serviceworker'
 import { signOut } from 'next-auth/react'
 import Badges from '../badge'
 import { randInRange } from '../../lib/rand'
-import { useLightning } from '../lightning'
+import { useFireworks } from '../fireworks'
 import LightningIcon from '../../svgs/bolt.svg'
 import SearchIcon from '../../svgs/search-line.svg'
 import classNames from 'classnames'
@@ -408,7 +408,7 @@ export function LoginButtons ({ handleClose }) {
 }
 
 export function AnonDropdown ({ path }) {
-  const strike = useLightning()
+  const strike = useFireworks()
 
   useEffect(() => {
     if (!window.localStorage.getItem('striked')) {

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -15,7 +15,7 @@ import { useServiceWorker } from '../serviceworker'
 import { signOut } from 'next-auth/react'
 import Badges from '../badge'
 import { randInRange } from '../../lib/rand'
-import { useLightning } from '../lightning'
+import { useFireworks } from '../fireworks'
 import LightningIcon from '../../svgs/bolt.svg'
 import SearchIcon from '../../svgs/search-line.svg'
 import classNames from 'classnames'
@@ -418,13 +418,15 @@ export function LoginButtons ({ handleClose }) {
 }
 
 export function AnonDropdown ({ path }) {
-  const strike = useLightning()
+  const strike = useFireworks()
 
   useEffect(() => {
     if (!window.localStorage.getItem('striked')) {
       const to = setTimeout(() => {
-        strike()
-        window.localStorage.setItem('striked', 'yep')
+        const striked = strike()
+        if (striked) {
+          window.localStorage.setItem('striked', 'yep')
+        }
       }, randInRange(3000, 10000))
       return () => clearTimeout(to)
     }

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -15,7 +15,7 @@ import { useServiceWorker } from '../serviceworker'
 import { signOut } from 'next-auth/react'
 import Badges from '../badge'
 import { randInRange } from '../../lib/rand'
-import { useFireworks } from '../fireworks'
+import { useLightning } from '../lightning'
 import LightningIcon from '../../svgs/bolt.svg'
 import SearchIcon from '../../svgs/search-line.svg'
 import classNames from 'classnames'
@@ -121,8 +121,26 @@ export function NavSelect ({ sub: subName, className, size }) {
 export function NavNotifications ({ className }) {
   const hasNewNotes = useHasNewNotes()
 
+  // Dynamically update favicon to avoid browser caching issues (esp. Safari)
+  useEffect(() => {
+    const setFavicon = (href) => {
+      // Remove all existing favicon link tags
+      const links = document.querySelectorAll('link[rel="icon"], link[rel="shortcut icon"]')
+      links.forEach(link => link.parentNode.removeChild(link))
+      // Create new favicon link with cache-busting query
+      const link = document.createElement('link')
+      link.rel = 'shortcut icon'
+      link.type = 'image/png'
+      // Add a cache-busting query string to force reload in Safari
+      link.href = href + '?v=' + Date.now()
+      document.head.appendChild(link)
+    }
+    setFavicon(hasNewNotes ? '/favicon-notify.png' : '/favicon.png')
+  }, [hasNewNotes])
+
   return (
     <>
+      {/* fallback for SSR, but will be replaced on client by useEffect */}
       <Head>
         <link rel='shortcut icon' href={hasNewNotes ? '/favicon-notify.png' : '/favicon.png'} />
       </Head>
@@ -400,15 +418,13 @@ export function LoginButtons ({ handleClose }) {
 }
 
 export function AnonDropdown ({ path }) {
-  const strike = useFireworks()
+  const strike = useLightning()
 
   useEffect(() => {
     if (!window.localStorage.getItem('striked')) {
       const to = setTimeout(() => {
-        const striked = strike()
-        if (striked) {
-          window.localStorage.setItem('striked', 'yep')
-        }
+        strike()
+        window.localStorage.setItem('striked', 'yep')
       }, randInRange(3000, 10000))
       return () => clearTimeout(to)
     }

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -420,9 +420,10 @@ export function AnonDropdown ({ path }) {
 
   useEffect(() => {
     if (!window.localStorage.getItem('striked')) {
-      const to = setTimeout(() => {
-        strike()
-        window.localStorage.setItem('striked', 'yep')
+      const striked = strike()
+        if (striked) {
+          window.localStorage.setItem('striked', 'yep')
+        }
       }, randInRange(3000, 10000))
       return () => clearTimeout(to)
     }


### PR DESCRIPTION
## Description

Closes https://github.com/stackernews/stacker.news/issues/2256
Changed the favicon URL each time (by appending a query string `?v=timestamp`), which can force Safari to reload the favicon each time the notification state changes. This increases the likelihood that Safari and other browsers will reload the favicon immediately.

## Screenshots
not really applicable but still I clicked before and after screenshots for unread notifs thrice, while the tabs were bookmarked
![Screenshot 2025-07-06 171744](https://github.com/user-attachments/assets/2c0e182d-52b5-4980-a652-fbdd7b4043e8)

![Screenshot 2025-07-06 172000](https://github.com/user-attachments/assets/fe879f21-658a-4154-b12e-40551d2538b9)
## Additional Context

When I had an unread notification, I bookmarked the tab while it was unread and of course it saved the icon with the red square. Then I reloaded the site and read the notif, this updated both the bookmarked icon and the actual one. Next 5 times I refreshed the site at different time intervals; there was no error.

## Checklist

**Are your changes backward compatible? Please answer below:**
yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
9

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
none