### PR TITLE
Add custom title rule for YouTube

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -28,8 +28,6 @@ import { verifyHmac } from './wallet'
 import { parse } from 'tldts'
 import { shuffleArray } from '@/lib/rand'
 
-metadataRuleSets.title.rules.unshift(['h1 > yt-formatted-string.ytd-watch-metadata', el => el.getAttribute('title')])
-
 function commentsOrderByClause (me, models, sort) {
   const sharedSortsArray = []
   sharedSortsArray.push('("Item"."pinId" IS NOT NULL) DESC')
@@ -597,7 +595,13 @@ export default {
         const response = await fetch(ensureProtocol(url), { redirect: 'follow' })
         const html = await response.text()
         const doc = domino.createWindow(html).document
-        const metadata = getMetadata(doc, url, { title: metadataRuleSets.title, publicationDate: publicationDateRuleSet })
+        const titleRuleSet = {
+          rules: [
+            ['h1 > yt-formatted-string.ytd-watch-metadata', el => el.getAttribute('title')],
+            ...metadataRuleSets.title.rules
+          ]
+        }
+        const metadata = getMetadata(doc, url, { title: titleRuleSet, publicationDate: publicationDateRuleSet })
         const dateHint = ` (${metadata.publicationDate?.getFullYear()})`
         const moreThanOneYearAgo = metadata.publicationDate && metadata.publicationDate < datePivot(new Date(), { years: -1 })
 


### PR DESCRIPTION
## Description

Not sure if this fixes #2164 but it's worth a try.

#2171 might not have fixed it because modifying an imported variable from an external library in-place might behave differently in prod.

See https://github.com/stackernews/stacker.news/pull/2171#discussion_r2188490093

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. It still fetches the YouTube title in dev.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no