### PR TITLE
Fix missing dependency in snow callback

### DIFF
--- a/components/animation/snow.js
+++ b/components/animation/snow.js
@@ -21,7 +21,7 @@ export const SnowProvider = ({ children }) => {
     }
     setStartIndex(i % MAX_FLAKES)
     setFlakes(newFlakes)
-  }, [setFlakes, startIndex])
+  }, [flakes, startIndex])
 
   return (
     <SnowContext.Provider value={snow}>


### PR DESCRIPTION
fix https://github.com/stackernews/stacker.news/pull/2261#pullrequestreview-2995064996

(state setters function have a stable identity so they don't need to be included as a dependency)
