### PR TITLE
Allow 0 pct forwards to pass only in the client

### DIFF
--- a/components/adv-post-form.js
+++ b/components/adv-post-form.js
@@ -282,7 +282,7 @@ export default function AdvPostForm ({ children, item, sub, storageKeyPrefix }) 
                     name={`forward[${index}].pct`}
                     type='number'
                     step={5}
-                    min={1}
+                    min={0}
                     max={100}
                     append={<InputGroup.Text className='text-monospace'>%</InputGroup.Text>}
                     groupClassName={`${styles.percent} mb-0`}

--- a/lib/form.js
+++ b/lib/form.js
@@ -2,7 +2,7 @@ import { hasDeleteMention, hasReminderMention } from './item'
 
 /**
  * Normalize an array of forwards by converting the pct from a string to a number
- * Also extracts nym from nested user object, if necessary
+ * Also extracts nym from nested user object, if necessary and removes 0 pct fowards
  * @param {*} forward Array of forward objects ({nym?: string, pct: string, user?: { name: string } })
  * @returns normalized array, or undefined if not provided
  */
@@ -10,7 +10,7 @@ export const normalizeForwards = (forward) => {
   if (!Array.isArray(forward)) {
     return undefined
   }
-  return forward.filter(fwd => fwd.nym || fwd.user?.name).map(fwd => ({ nym: fwd.nym ?? fwd.user?.name, pct: Number(fwd.pct) }))
+  return forward.filter(fwd => (fwd.nym || fwd.user?.name) && Number(fwd.pct) > 0).map(fwd => ({ nym: fwd.nym ?? fwd.user?.name, pct: Number(fwd.pct) }))
 }
 
 export const toastUpsertSuccessMessages = (toaster, upsertResponseData, dataKey, itemText) => {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -146,7 +146,7 @@ export function advPostSchemaMembers ({ me, existingBoost = 0, ...args }) {
             },
             message: 'cannot forward to yourself'
           }),
-        pct: intValidator.required('must specify a percentage').min(1, 'percentage must be at least 1').max(100, 'percentage must not exceed 100')
+        pct: intValidator.required('must specify a percentage').min(0, 'percentage must be at least 0').max(100, 'percentage must not exceed 100')
       }))
       .compact((v) => !v.nym && !v.pct)
       .test({


### PR DESCRIPTION
## Description

_A clear and concise description of what you changed and why._

The client validation is changed to allow 0 by:

-  Changing the minimum allowed input to zero({min=0} in AdvPostForm component
-  Modifying the form validation in lib/validate.js to allow a minimum of 0

To only allow 0 to only pass the client:

-  The forwards are validated  to be > 0  when  _normalizeForwards_ is called before mutuation in [use-item-submit.js](https://github.com/stackernews/stacker.news/blob/master/components/use-item-submit.js#L62). _normalizeForwards_  filters to remove forwards with 0 as pct.

## Screenshots

<img width="922" height="542" alt="Allow-0-pct-client-forwards" src="https://github.com/user-attachments/assets/ade9a2b4-4364-49ed-b1a8-45d54c4cd59a" />

## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_
No

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

Only form validation and is changed when forwards are normalized.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No
