### PR TITLE
Fix missing catch on IDB open in key init

### DIFF
--- a/wallets/client/context/hooks.js
+++ b/wallets/client/context/hooks.js
@@ -129,8 +129,12 @@ export function useKeyInit () {
     let db
 
     async function openDb () {
-      db = await open()
-      setDb(db)
+      try {
+        db = await open()
+        setDb(db)
+      } catch (err) {
+        console.error('failed to open indexeddb:', err)
+      }
     }
     openDb()
 


### PR DESCRIPTION
## Description

Not sure if this is related to the bugs stackers have reported, but we should definitely catch if IndexedDB failed to open here.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no