### PR TITLE
Fix wallets error handling order

### DIFF
--- a/wallets/client/context/hooks.js
+++ b/wallets/client/context/hooks.js
@@ -9,7 +9,7 @@ import {
   useWalletMigrationMutation, CryptoKeyRequiredError, useIsWrongKey
 } from '@/wallets/client/hooks'
 import { WalletConfigurationError } from '@/wallets/client/errors'
-import { SET_WALLETS, WRONG_KEY, KEY_MATCH, NO_KEY, useWalletsDispatch, WALLETS_QUERY_ERROR } from '@/wallets/client/context'
+import { SET_WALLETS, WRONG_KEY, KEY_MATCH, useWalletsDispatch, WALLETS_QUERY_ERROR, KEY_STORAGE_UNAVAILABLE } from '@/wallets/client/context'
 import { useIndexedDB } from '@/components/use-indexeddb'
 
 export function useServerWallets () {
@@ -110,7 +110,7 @@ export function useKeyInit () {
 
   useEffect(() => {
     if (typeof window.indexedDB === 'undefined') {
-      dispatch({ type: NO_KEY })
+      dispatch({ type: KEY_STORAGE_UNAVAILABLE })
     } else if (wrongKey) {
       dispatch({ type: WRONG_KEY })
     } else {

--- a/wallets/client/context/provider.js
+++ b/wallets/client/context/provider.js
@@ -1,5 +1,5 @@
 import { createContext, useContext, useReducer } from 'react'
-import walletsReducer, { Status } from './reducer'
+import walletsReducer from './reducer'
 import { useServerWallets, useKeyCheck, useAutomatedRetries, useKeyInit, useWalletMigration } from './hooks'
 import { WebLnProvider } from '@/wallets/lib/protocols/webln'
 
@@ -17,14 +17,14 @@ export function useTemplates () {
   return templates
 }
 
-export function useLoading () {
-  const { status } = useContext(WalletsContext)
-  return status === Status.LOADING_WALLETS
+export function useWalletsLoading () {
+  const { walletsLoading } = useContext(WalletsContext)
+  return walletsLoading
 }
 
-export function useStatus () {
-  const { status } = useContext(WalletsContext)
-  return status
+export function useWalletsError () {
+  const { walletsError } = useContext(WalletsContext)
+  return walletsError
 }
 
 export function useWalletsDispatch () {
@@ -41,13 +41,20 @@ export function useKeyHash () {
   return keyHash
 }
 
+export function useKeyError () {
+  const { keyError } = useContext(WalletsContext)
+  return keyError
+}
+
 export default function WalletsProvider ({ children }) {
   const [state, dispatch] = useReducer(walletsReducer, {
-    status: Status.LOADING_WALLETS,
     wallets: [],
+    walletsLoading: true,
+    walletsError: null,
     templates: [],
     key: null,
-    keyHash: null
+    keyHash: null,
+    keyError: null
   })
 
   return (

--- a/wallets/client/context/reducer.js
+++ b/wallets/client/context/reducer.js
@@ -1,12 +1,9 @@
 import { isTemplate, isWallet } from '@/wallets/lib/util'
 
-// states that dictate if we show a button or wallets on the wallets page
-export const Status = {
-  LOADING_WALLETS: 'LOADING_WALLETS',
-  NO_WALLETS: 'NO_WALLETS',
-  HAS_WALLETS: 'HAS_WALLETS',
-  PASSPHRASE_REQUIRED: 'PASSPHRASE_REQUIRED',
-  WALLETS_UNAVAILABLE: 'WALLETS_UNAVAILABLE'
+export const KeyStatus = {
+  KEY_MATCH: 'KEY_MATCH',
+  NO_KEY: 'NO_KEY',
+  WRONG_KEY: 'WRONG_KEY'
 }
 
 // wallet actions
@@ -14,7 +11,7 @@ export const SET_WALLETS = 'SET_WALLETS'
 export const SET_KEY = 'SET_KEY'
 export const WRONG_KEY = 'WRONG_KEY'
 export const KEY_MATCH = 'KEY_MATCH'
-export const NO_KEY = 'KEY_UNAVAILABLE'
+export const KEY_STORAGE_UNAVAILABLE = 'KEY_STORAGE_UNAVAILABLE'
 export const WALLETS_QUERY_ERROR = 'WALLETS_QUERY_ERROR'
 
 export default function reducer (state, action) {
@@ -28,7 +25,8 @@ export default function reducer (state, action) {
         .sort((a, b) => a.name.localeCompare(b.name))
       return {
         ...state,
-        status: transitionStatus(action, state, wallets.length > 0 ? Status.HAS_WALLETS : Status.NO_WALLETS),
+        walletsLoading: false,
+        walletsError: null,
         wallets,
         templates
       }
@@ -36,7 +34,8 @@ export default function reducer (state, action) {
     case WALLETS_QUERY_ERROR:
       return {
         ...state,
-        status: transitionStatus(action, state, action.error)
+        walletsLoading: false,
+        walletsError: action.error
       }
     case SET_KEY:
       return {
@@ -47,32 +46,19 @@ export default function reducer (state, action) {
     case WRONG_KEY:
       return {
         ...state,
-        status: transitionStatus(action, state, Status.PASSPHRASE_REQUIRED)
+        keyError: KeyStatus.WRONG_KEY
       }
     case KEY_MATCH:
       return {
         ...state,
-        status: transitionStatus(action, state, state.wallets.length > 0 ? Status.HAS_WALLETS : Status.NO_WALLETS)
+        keyError: null
       }
-    case NO_KEY:
+    case KEY_STORAGE_UNAVAILABLE:
       return {
         ...state,
-        status: transitionStatus(action, state, Status.WALLETS_UNAVAILABLE)
+        keyError: KeyStatus.KEY_STORAGE_UNAVAILABLE
       }
     default:
       return state
-  }
-}
-
-function transitionStatus ({ type }, { status: from }, to) {
-  switch (type) {
-    case SET_WALLETS: {
-      return (from instanceof Error || [Status.PASSPHRASE_REQUIRED, Status.WALLETS_UNAVAILABLE].includes(from)) ? from : to
-    }
-    case KEY_MATCH: {
-      return (from instanceof Error || from === Status.LOADING_WALLETS) ? from : to
-    }
-    default:
-      return to
   }
 }

--- a/wallets/client/hooks/indicator.js
+++ b/wallets/client/hooks/indicator.js
@@ -1,7 +1,7 @@
-import { useWallets, useLoading } from '@/wallets/client/context'
+import { useWallets, useWalletsLoading } from '@/wallets/client/context'
 
 export function useWalletIndicator () {
   const wallets = useWallets()
-  const loading = useLoading()
+  const loading = useWalletsLoading()
   return !loading && wallets.length === 0
 }

--- a/wallets/client/hooks/query.js
+++ b/wallets/client/hooks/query.js
@@ -32,7 +32,7 @@ import { timeoutSignal } from '@/lib/time'
 import { WALLET_SEND_PAYMENT_TIMEOUT_MS } from '@/lib/constants'
 import { useToast } from '@/components/toast'
 import { useMe } from '@/components/me'
-import { useWallets, useLoading as useWalletsLoading } from '@/wallets/client/context'
+import { useWallets, useWalletsLoading } from '@/wallets/client/context'
 
 export function useWalletsQuery () {
   const { me } = useMe()


### PR DESCRIPTION
## Description

I started to show any error during fetching or decrypting the wallets to the user in https://github.com/stackernews/stacker.news/pull/2284.

However, I didn't notice that this meant that this will block the prompt to unlock the wallets if the device has the wrong key since obviously, decryption will fail in that case (even though I wrote QA `10` :raised_eyebrow::see_no_evil:)

In #2282, I noticed that my design of handling different errors by figuring out the importance of errors thus which error could or couldn't overwrite another error didn't scale, but instead of acknowledging that the design was bad, I only refactored the code but kept the same design.

Now, I have a variable for each independent error we can have, and we decide during rendering which error we're going to show first.

So following the render order, we can now easily tell that we show states in the following order:

1. key storage unavailable
2. wrong key on device
3. error fetching wallets
4. error decrypting wallets
5. loading wallets
6. user has no wallets
7. user has wallets

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`11` :sweat_smile: 

I tested by manufacturing the errors from the bottom up.

1. Always return `loading: true` in `useWalletsQuery` → loading spinner forever
2. Error during decryption→ decryption error
3. Server throws error while fetching the wallets → failed to load wallets
5. Remove key → unlock wallets
6. key storage unavailable -> this device does not support storage of cryptographic keys via IndexedDB

see video:

https://github.com/user-attachments/assets/6ceb3adf-6c04-4eb3-81b3-cf8927fed100

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no
