### PR TITLE
Fix old key overwrites new key

### DIFF
--- a/wallets/client/context/hooks.js
+++ b/wallets/client/context/hooks.js
@@ -152,16 +152,11 @@ export function useKeyInit () {
       try {
         // TODO(wallet-v2): remove migration code
         //   and delete the old IndexedDB after wallet v2 has been released for some time
-        const oldKeyAndHash = await loadOldKey()
-        if (oldKeyAndHash) {
-          // return key found in old db and save it to new db
-          await setKey(oldKeyAndHash)
-          return
-        }
 
-        // create random key before opening transaction in case we need it
-        // and because we can't run async code in a transaction because it will close the transaction
+        // load old key and create random key before opening transaction in case we need them
+        // because we can't run async code in a transaction because it will close the transaction
         // see https://javascript.info/indexeddb#transactions-autocommit
+        const oldKeyAndHash = await loadOldKey()
         const { key: randomKey, hash: randomHash } = await generateRandomKey()
 
         // run read and write in one transaction to avoid race conditions
@@ -177,6 +172,11 @@ export function useKeyInit () {
             if (read.result) {
               // return key+hash found in db
               return resolve(read.result)
+            }
+
+            if (oldKeyAndHash) {
+              // return key+hash found in old db
+              return resolve(oldKeyAndHash)
             }
 
             // no key found, write and return generated random key


### PR DESCRIPTION
## Description

We were always using the old key to decrypt wallets if it was found. 

This means that if device sync was enabled before #2169, the existing key could decrypt the migrated wallets.

However, when the passphrase is shown, we encrypt the wallets with a new key. Same is true on passphrase reset.

But on page load, we will still load the old key instead of the new key so the 'unlock wallets' prompt is shown.

This PR fixes this by only loading the old key if a new key was not found.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. We now always use the new key if it exists. If not but old key exists, we use that. Else we generate a new key.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no