### PR TITLE
Fix QR code scan in dark mode

### DIFF
--- a/wallets/client/components/passphrase.js
+++ b/wallets/client/components/passphrase.js
@@ -15,7 +15,7 @@ export function Passphrase ({ passphrase }) {
       </p>
       <div className='d-flex justify-content-center'>
         <QRCodeSVG
-          className='h-auto mx-auto mw-100 my-3' size={256} value={passphrase}
+          className='h-auto mx-auto mw-100 my-3' size={256} value={passphrase} marginSize={1}
         />
       </div>
       <div


### PR DESCRIPTION
## Description

Related to #2288

This fixes scanning QR codes in dark mode because margin was missing.

The other places where `QRCodeSVG` is used do not include `marginSize` because they are wrapped with `<a>` tags with padding and white background.

## Screenshots

Before:

<img width="509" height="656" alt="2025-07-17-185333_509x656_scrot" src="https://github.com/user-attachments/assets/fcd56bd1-6687-4d75-8a4d-1a93c800cf9e" />

After:

<img width="508" height="655" alt="2025-07-17-185315_508x655_scrot" src="https://github.com/user-attachments/assets/cc9d041b-da06-4bbf-98e1-35e65a4ea2a0" />

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. Scanning works in dark and light mode now.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

yes, tested in light and dark mode, as mentioned in answer above

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no