### PR TITLE
Use WindowClient.navigate() instead of service worker message

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -60,14 +60,6 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
     router.events.on('routeChangeComplete', nprogressDone)
     router.events.on('routeChangeError', nprogressDone)
 
-    const handleServiceWorkerMessage = (event) => {
-      if (event.data?.type === 'navigate') {
-        router.push(event.data.url)
-      }
-    }
-
-    navigator.serviceWorker?.addEventListener('message', handleServiceWorkerMessage)
-
     if (!props?.apollo) return
     // HACK: 'cause there's no way to tell Next to skip SSR
     // So every page load, we modify the route in browser history
@@ -90,7 +82,6 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
       router.events.off('routeChangeStart', nprogressStart)
       router.events.off('routeChangeComplete', nprogressDone)
       router.events.off('routeChangeError', nprogressDone)
-      navigator.serviceWorker?.removeEventListener('message', handleServiceWorkerMessage)
     }
   }, [router.asPath, props?.apollo, shouldShowProgressBar])
 

--- a/sw/index.js
+++ b/sw/index.js
@@ -123,13 +123,7 @@ self.addEventListener('notificationclick', function (event) {
         .then(clients => {
           if (clients.length > 0) {
             const client = clients[0]
-            return client.focus()
-              .then(() => {
-                return client.postMessage({
-                  type: 'navigate',
-                  url
-                })
-              })
+            return client.focus().then(() => client.navigate(url))
           } else {
             return self.clients.openWindow(url)
           }


### PR DESCRIPTION
## Description

**Update 9/11**

Okay, finally tested this to a satisfactory degree and I'm quite confident this native solution to navigate to links works at least as well as the existing solution with `postMessage`.

This doesn't mean it works well, but I saw no difference between both implementations and I would prefer this one because it uses native APIs. 

That it doesn't use client-side routing is negligible imo. The possibly slight increase in navigation speed shouldn't be worth a theoretically less reliable implementation.

Contrary to what @cursor mentioned [below](https://github.com/stackernews/stacker.news/pull/2294#pullrequestreview-3031430061), [`WindowClient.navigate()` actually has pretty good support across browsers](https://developer.mozilla.org/en-US/docs/Web/API/WindowClient/navigate#browser_compatibility).

---

fix #2293 

I noticed that [`self.clients.matchAll()`](https://developer.mozilla.org/en-US/docs/Web/API/Clients/matchAll) actually returns [`WindowClient`](https://developer.mozilla.org/en-US/docs/Web/API/WindowClient) instances and they do have a [`navigate()`](https://developer.mozilla.org/en-US/docs/Web/API/WindowClient/navigate) function.

## Video

This video is running the code in this PR. The code on `master` behaves in the same way: it hangs for a good few seconds before it navigates. I assume it's related to the dev build + slow SSH tunnel (TCP meltdown) which also probably causes the slow cold PWA starts.

https://github.com/user-attachments/assets/6e02005a-dd9d-4f88-88d1-764ec15a8c3f

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`, see video

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no