### PR TITLE
Fix anon check in Apollo Client during SSR

### DIFF
--- a/api/ssrApollo.js
+++ b/api/ssrApollo.js
@@ -15,7 +15,7 @@ import { getServerSession } from 'next-auth/next'
 import { getAuthOptions } from '@/pages/api/auth/[...nextauth]'
 import { NOFOLLOW_LIMIT } from '@/lib/constants'
 import { satsToMsats } from '@/lib/format'
-import { MULTI_AUTH_ANON, MULTI_AUTH_LIST } from '@/lib/auth'
+import { MULTI_AUTH_ANON, MULTI_AUTH_POINTER } from '@/lib/auth'
 
 export default async function getSSRApolloClient ({ req, res, me = null }) {
   const session = req && await getServerSession(req, res, getAuthOptions(req))
@@ -156,7 +156,7 @@ export function getGetServerSideProps (
 
     // required to redirect to /signup on page reload
     // if we switched to anon and authentication is required
-    if (req.cookies[MULTI_AUTH_LIST] === MULTI_AUTH_ANON) {
+    if (req.cookies[MULTI_AUTH_POINTER] === MULTI_AUTH_ANON) {
       me = null
     }
 


### PR DESCRIPTION
## Description

Was just going through all branches that I have locally and found this fix that I apparently never pushed, lol.

This fixes showing the logged in user during SSR instead of anon if we switched to it:

https://github.com/user-attachments/assets/e905be56-a654-4e55-bdbf-52a233dc23ed

## Additional context

There's probably a better way to do this, like making `getServerSession` aware of this so it would not return a session in the first place.

But I think I have more important things to do right now than refactoring code related to multi auth (again).

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`, see video

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no