### PR TITLE
wallet logger fixes

### DIFF
--- a/wallets/server/logger.js
+++ b/wallets/server/logger.js
@@ -14,6 +14,7 @@ export function walletLogger ({
     // since logs are created asynchronously and thus might get inserted out of order
     // however, millisecond precision is not always enough ...
     const createdAt = context?.createdAt ?? new Date()
+    delete context?.createdAt
 
     const updateStatus = ['OK', 'ERROR', 'WARNING'].includes(level) && (invoiceId || withdrawalId || context.bolt11 || context?.updateStatus)
     delete context?.updateStatus

--- a/wallets/server/resolvers/protocol.js
+++ b/wallets/server/resolvers/protocol.js
@@ -19,7 +19,7 @@ const WalletLogEntry = {
   context: async ({ level, context, invoice, withdrawal }, args, { me }) => {
     const isError = ['error', 'warn'].includes(level.toLowerCase())
 
-    if (withdrawal) {
+    if (withdrawal && me?.id === withdrawal.userId) {
       return {
         ...await logContextFromBolt11(withdrawal.bolt11),
         ...(withdrawal.preimage ? { preimage: withdrawal.preimage } : {}),

--- a/wallets/server/resolvers/protocol.js
+++ b/wallets/server/resolvers/protocol.js
@@ -16,16 +16,19 @@ const WalletProtocolConfig = {
 }
 
 const WalletLogEntry = {
-  context: async ({ level, context, withdrawal }) => {
+  context: async ({ level, context, invoice, withdrawal }, args, { me }) => {
     const isError = ['error', 'warn'].includes(level.toLowerCase())
 
-    // never return invoice as context because it might leak sensitive sender details
     if (withdrawal) {
       return {
         ...await logContextFromBolt11(withdrawal.bolt11),
         ...(withdrawal.preimage ? { preimage: withdrawal.preimage } : {}),
         ...(isError ? { max_fee: formatMsats(withdrawal.msatsFeePaying) } : {})
       }
+    }
+
+    if (invoice && me?.id === invoice.userId) {
+      return await logContextFromBolt11(invoice.bolt11)
     }
 
     return context


### PR DESCRIPTION
## Description

1. Logs by the client include `createdAt` in the context object, but they weren't meant to literally be included in the logger context, but simply as a timestamp for the message itself.

2. Removed `WalletLogEntry` field resolver duplicate that wasn't used. The one that is used is in wallets/server/resolvers/protocol.js.

3. Invoice was not included in the context for `sending payment` or `payment sent` log messages. If the invoice belongs to the user, it's safe to show. It will also show up in satistics.

4. Make sure we only show withdrawals that belong to the user, even though there's no case where we would create a log message for someone and link to the withdrawal of someone else.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. `sending payment` or `payment sent` log messages now include invoice in context. `createdAt` of the log message itself no longer shows up in there.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no