### PR TITLE
Fix count of viewed comments of a post

### DIFF
--- a/components/item-info.js
+++ b/components/item-info.js
@@ -110,7 +110,7 @@ export default function ItemInfo ({
         </>}
       <Link
         href={`/items/${item.id}`} onClick={(e) => {
-          const viewedAt = commentsViewedAt(item)
+          const viewedAt = commentsViewedAt(item.id)
           if (viewedAt) {
             e.preventDefault()
             router.push(

--- a/components/item.js
+++ b/components/item.js
@@ -29,7 +29,7 @@ import { useShowModal } from './modal'
 import { BoostHelp } from './adv-post-form'
 
 function onItemClick (e, router, item) {
-  const viewedAt = commentsViewedAt(item)
+  const viewedAt = commentsViewedAt(item.id)
   if (viewedAt) {
     e.preventDefault()
     if (e.ctrlKey || e.metaKey) {

--- a/lib/new-comments.js
+++ b/lib/new-comments.js
@@ -12,8 +12,8 @@ export function commentsViewedAt (item) {
   return Number(window.localStorage.getItem(`${COMMENTS_VIEW_PREFIX}:${item.id}`))
 }
 
-export function commentsViewedNum (item) {
-  return Number(window.localStorage.getItem(`${COMMENTS_NUM_PREFIX}:${item.id}`))
+export function commentsViewedNum (itemId) {
+  return Number(window.localStorage.getItem(`${COMMENTS_NUM_PREFIX}:${itemId}`))
 }
 
 export function commentsViewedAfterComment (rootId, createdAt) {
@@ -24,7 +24,7 @@ export function commentsViewedAfterComment (rootId, createdAt) {
 export function newComments (item) {
   if (!item.parentId) {
     const viewedAt = commentsViewedAt(item)
-    const viewNum = commentsViewedNum(item)
+    const viewNum = commentsViewedNum(item.id)
 
     if (viewedAt && viewNum) {
       return viewedAt < new Date(item.lastCommentAt).getTime() || viewNum < item.ncomments

--- a/lib/new-comments.js
+++ b/lib/new-comments.js
@@ -11,7 +11,7 @@ export function commentsViewed (item) {
 export function commentsViewedAfterComment (rootId, createdAt) {
   window.localStorage.setItem(`${COMMENTS_VIEW_PREFIX}:${rootId}`, new Date(createdAt).getTime())
   const existingRootComments = window.localStorage.getItem(`${COMMENTS_NUM_PREFIX}:${rootId}`) || 0
-  window.localStorage.setItem(`${COMMENTS_NUM_PREFIX}:${rootId}`, existingRootComments + 1)
+  window.localStorage.setItem(`${COMMENTS_NUM_PREFIX}:${rootId}`, Number(existingRootComments) + 1)
 }
 
 export function commentsViewedAt (item) {

--- a/lib/new-comments.js
+++ b/lib/new-comments.js
@@ -8,20 +8,23 @@ export function commentsViewed (item) {
   }
 }
 
-export function commentsViewedAfterComment (rootId, createdAt) {
-  window.localStorage.setItem(`${COMMENTS_VIEW_PREFIX}:${rootId}`, new Date(createdAt).getTime())
-  const existingRootComments = window.localStorage.getItem(`${COMMENTS_NUM_PREFIX}:${rootId}`) || 0
-  window.localStorage.setItem(`${COMMENTS_NUM_PREFIX}:${rootId}`, Number(existingRootComments) + 1)
+export function commentsViewedAt (item) {
+  return Number(window.localStorage.getItem(`${COMMENTS_VIEW_PREFIX}:${item.id}`))
 }
 
-export function commentsViewedAt (item) {
-  return window.localStorage.getItem(`${COMMENTS_VIEW_PREFIX}:${item.id}`)
+export function commentsViewedNum (item) {
+  return Number(window.localStorage.getItem(`${COMMENTS_NUM_PREFIX}:${item.id}`))
+}
+
+export function commentsViewedAfterComment (rootId, createdAt) {
+  window.localStorage.setItem(`${COMMENTS_VIEW_PREFIX}:${rootId}`, new Date(createdAt).getTime())
+  window.localStorage.setItem(`${COMMENTS_NUM_PREFIX}:${rootId}`, commentsViewedNum(rootId) + 1)
 }
 
 export function newComments (item) {
   if (!item.parentId) {
     const viewedAt = commentsViewedAt(item)
-    const viewNum = window.localStorage.getItem(`${COMMENTS_NUM_PREFIX}:${item.id}`)
+    const viewNum = commentsViewedNum(item)
 
     if (viewedAt && viewNum) {
       return viewedAt < new Date(item.lastCommentAt).getTime() || viewNum < item.ncomments

--- a/lib/new-comments.js
+++ b/lib/new-comments.js
@@ -8,8 +8,8 @@ export function commentsViewed (item) {
   }
 }
 
-export function commentsViewedAt (item) {
-  return Number(window.localStorage.getItem(`${COMMENTS_VIEW_PREFIX}:${item.id}`))
+export function commentsViewedAt (itemId) {
+  return Number(window.localStorage.getItem(`${COMMENTS_VIEW_PREFIX}:${itemId}`))
 }
 
 export function commentsViewedNum (itemId) {
@@ -23,7 +23,7 @@ export function commentsViewedAfterComment (rootId, createdAt) {
 
 export function newComments (item) {
   if (!item.parentId) {
-    const viewedAt = commentsViewedAt(item)
+    const viewedAt = commentsViewedAt(item.id)
     const viewNum = commentsViewedNum(item.id)
 
     if (viewedAt && viewNum) {


### PR DESCRIPTION
## Description

When we reply to a post, we update the count of comments we’ve viewed in that post to avoid seeing the new comment indicator on our own replies.
But instead of counting, we're actually concatenating strings with what we retrieve in the local storage.

This PR parses `commentsViewNum` as Number, allowing real counts.

## Screenshots

3 replies gets saved as `111` (as 3 times +1)
<img width="313" height="29" alt="image" src="https://github.com/user-attachments/assets/123032d1-1a6c-4cf4-9e3a-a14d81e0cad4" />


## Additional Context

This actually **still worked anyway**, because to search for new comments we do (other than checking the time) `commentsViewedNum < item.ncomments`. So `6 + 1` would do `61` instead of `7`, and the comparison would  still give the expected behavior.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7, tested where it pertains

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a