### PR TITLE
fix: push notificationclick event not triggered

### DIFF
--- a/sw/index.js
+++ b/sw/index.js
@@ -93,11 +93,7 @@ self.addEventListener('push', function (event) {
     )
   }
 
-  event.waitUntil(
-    self.registration.showNotification(payload.title, payload.options)
-      .then(() => self.registration.getNotifications())
-      .then(notifications => self.navigator.setAppBadge?.(notifications.length))
-  )
+  event.waitUntil(self.registration.showNotification(payload.title, payload.options))
 })
 
 self.addEventListener('notificationclick', function (event) {

--- a/sw/index.js
+++ b/sw/index.js
@@ -99,11 +99,10 @@ self.addEventListener('push', function (event) {
 self.addEventListener('notificationclick', function (event) {
   event.notification.close()
 
-  const promises = []
   const url = event.notification.data?.url
   if (url) {
     // First try to find and focus an existing client before opening a new window
-    promises.push(
+    event.waitUntil(
       self.clients.matchAll({ type: 'window', includeUncontrolled: true })
         .then(clients => {
           if (clients.length > 0) {
@@ -121,22 +120,6 @@ self.addEventListener('notificationclick', function (event) {
         })
     )
   }
-
-  promises.push(
-    self.registration.getNotifications()
-      .then(notifications => self.navigator.setAppBadge?.(notifications.length))
-  )
-
-  event.waitUntil(Promise.all(promises))
-})
-
-// not supported by iOS
-// see https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/notificationclose_event
-self.addEventListener('notificationclose', function (event) {
-  event.waitUntil(
-    self.registration.getNotifications()
-      .then(notifications => self.navigator.setAppBadge?.(notifications.length))
-  )
 })
 
 self.addEventListener('pushsubscriptionchange', function (event) {


### PR DESCRIPTION
## Description

**drafted for evaluation**

~~Potentially fixes #2293~~ Fixes notificationclick event from not being dispatched

Theory:
 - Sequentially updating the app badge count after showing a push notification (extending the event time), caused the notification to be shown out-of-time, potentially causing `notificationclick` to not trigger because the browser wouldn't trust the notification.

This PR removes the support for app badge counts, to be re-instated in the near future.

## Screenshots

https://github.com/user-attachments/assets/12097cc0-37fb-4b3d-95c1-1431252f340b

## Additional Context

I still think that app badge counts can be safely implemented, before showing a notification, we just need to do it manually.
Sketch:

```javascript
const { tag } = payload
if (getNotifications({ tag }.length === 0) {
  setAppBadge + 1
}
```

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, tested in local with Chrome and Safari, tested via HTTPS on iOS

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a