### PR TITLE
Request persistent storage on wallet save

### DIFF
--- a/components/serviceworker.js
+++ b/components/serviceworker.js
@@ -102,10 +102,7 @@ export const ServiceWorkerProvider = ({ children }) => {
     }
     await subscribeToPushNotifications()
     // request persistent storage: https://web.dev/learn/pwa/offline-data#data_persistence
-    const persisted = await navigator?.storage?.persisted?.()
-    if (!persisted && navigator?.storage?.persist) {
-      return await navigator.storage.persist()
-    }
+    requestPersistentStorage()
   })
 
   useEffect(() => {

--- a/components/serviceworker.js
+++ b/components/serviceworker.js
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState, useCallback, useMemo } from 'react'
 import { Workbox } from 'workbox-window'
 import { gql, useMutation } from '@apollo/client'
+import { requestPersistentStorage } from './use-indexeddb'
 
 const applicationServerKey = process.env.NEXT_PUBLIC_VAPID_PUBKEY
 
@@ -79,6 +80,8 @@ export const ServiceWorkerProvider = ({ children }) => {
       action: STORE_SUBSCRIPTION,
       subscription: pushSubscription
     })
+    requestPersistentStorage()
+
     // send subscription to server
     const variables = {
       endpoint,
@@ -101,8 +104,6 @@ export const ServiceWorkerProvider = ({ children }) => {
       return await unsubscribeFromPushNotifications(pushSubscription)
     }
     await subscribeToPushNotifications()
-    // request persistent storage: https://web.dev/learn/pwa/offline-data#data_persistence
-    requestPersistentStorage()
   })
 
   useEffect(() => {

--- a/components/use-indexeddb.js
+++ b/components/use-indexeddb.js
@@ -129,6 +129,21 @@ async function _delete (dbName) {
   })
 }
 
+export async function requestPersistentStorage () {
+  try {
+    if (!('persisted' in navigator.storage) || !('persist' in navigator.storage)) {
+      throw new Error('persistent storage not supported')
+    }
+    const persisted = await navigator.storage.persisted()
+    if (!persisted) {
+      // browser might prompt the user to allow persistent storage
+      return await navigator.storage.persist()
+    }
+  } catch (err) {
+    console.error('failed to request persistent storage:', err)
+  }
+}
+
 class IndexedDBError extends Error {
   constructor (message) {
     super(message)

--- a/wallets/client/hooks/query.js
+++ b/wallets/client/hooks/query.js
@@ -33,6 +33,7 @@ import { WALLET_SEND_PAYMENT_TIMEOUT_MS } from '@/lib/constants'
 import { useToast } from '@/components/toast'
 import { useMe } from '@/components/me'
 import { useWallets, useWalletsLoading } from '@/wallets/client/context'
+import { requestPersistentStorage } from '@/components/use-indexeddb'
 
 export function useWalletsQuery () {
   const { me } = useMe()
@@ -188,6 +189,8 @@ export function useWalletProtocolUpsert (wallet, protocol) {
       logger.error(err.message)
       throw err
     }
+
+    requestPersistentStorage()
 
     return updatedWallet
   }, [wallet, protocol, logger, testSendPayment, encryptConfig, mutate])


### PR DESCRIPTION
## Description

We were only requesting persistent storage on push subscription toggle.

We now also do on wallet save, and instead of on toggle, we now save on push subscription save.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested wallet save and subscribing to push subscriptions.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no