### PR TITLE
Only update status if protocolId is set

### DIFF
--- a/wallets/server/logger.js
+++ b/wallets/server/logger.js
@@ -16,7 +16,7 @@ export function walletLogger ({
     const createdAt = context?.createdAt ?? new Date()
     delete context?.createdAt
 
-    const updateStatus = ['OK', 'ERROR', 'WARNING'].includes(level) && (invoiceId || withdrawalId || context.bolt11 || context?.updateStatus)
+    const updateStatus = protocolId && ['OK', 'ERROR', 'WARNING'].includes(level) && (invoiceId || withdrawalId || context.bolt11 || context?.updateStatus)
     delete context?.updateStatus
 
     try {


### PR DESCRIPTION
## Description

@cursor mentioned this in https://github.com/stackernews/stacker.news/pull/2307#pullrequestreview-3040260608.

We should only run the status update of a protocol while logging when we actually have a protocol id.

It can currently never happen that `updateStatus` is true without a protocol id also set, but it's good to make sure.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. Protocol status still gets updated. 

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no