### PR TITLE
short cirtuit out of live comment query if possible

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -749,7 +749,7 @@ export default {
           FROM "Item"
           -- comments can be nested, so we need to get all comments that are descendants of the root
           ${whereClause(
-            '"Item".path <@ (SELECT path FROM "Item" WHERE id = $1)',
+            '"Item".path <@ (SELECT path FROM "Item" WHERE id = $1 AND "Item"."lastCommentAt" > $2)',
             activeOrMine(me),
             '"Item"."created_at" > $2'
           )}


### PR DESCRIPTION
there's no pressing need to do this, but if the query planner is behaving, this should prevent unnecessary index scans when we know an item does not have new comments (`path <@ NULL` always evaluates to false).

afaict this shouldn't have any adverse effects.