### PR TITLE
Fix clear new comments on route change

### DIFF
--- a/components/comment.js
+++ b/components/comment.js
@@ -156,6 +156,27 @@ export default function Comment ({
     }
   }, [item.id, rootLastCommentAt])
 
+  useEffect(() => {
+    // clear new comments when navigating away
+    const eraseNewComments = () => {
+      if (item.newComments?.length > 0) {
+        cache.writeFragment({
+          id: `Item:${item.id}`,
+          fragment: gql`
+            fragment NewComments on Item {
+              newComments
+            }`,
+          data: {
+            newComments: []
+          }
+        })
+      }
+    }
+
+    router.events.on('routeChangeStart', eraseNewComments)
+    return () => router.events.off('routeChangeStart', eraseNewComments)
+  }, [item.id, item.newComments, cache, router.events])
+
   const bottomedOut = depth === COMMENT_DEPTH_LIMIT || (item.comments?.comments.length === 0 && item.nDirectComments > 0)
   // Don't show OP badge when anon user comments on anon user posts
   const op = root.user.name === item.user.name && Number(item.user.id) !== USER_ID.anon

--- a/components/comment.js
+++ b/components/comment.js
@@ -261,7 +261,7 @@ export default function Comment ({
       </div>
       {collapse !== 'yep' && (
         bottomedOut
-          ? <div className={styles.children}><div className={classNames(styles.comment, 'mt-3')}><ReplyOnAnotherPage item={item} cache={cache} /></div></div>
+          ? <div className={styles.children}><div className={classNames(styles.comment, 'mt-3')}><ReplyOnAnotherPage item={item} /></div></div>
           : (
             <div className={styles.children}>
               {item.outlawed && !me?.privates?.wildWestMode
@@ -306,9 +306,10 @@ export function ViewAllReplies ({ id, nshown, nhas }) {
   )
 }
 
-function ReplyOnAnotherPage ({ item, cache }) {
+function ReplyOnAnotherPage ({ item }) {
   const root = useRoot()
   const rootId = commentSubTreeRootId(item, root)
+  const { cache } = useApolloClient()
 
   let text = 'reply on another page'
   if (item.ncomments > 0) {


### PR DESCRIPTION
## Description

Fixes bottomed out comments retaining their `newComments` field by clearing it on route change.

## Screenshots

https://github.com/user-attachments/assets/abb64564-1bcf-4142-b089-2a599531fae1

## Additional Context

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7, on route changes, only items that have the newComments array populated are being cleared


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a