### PR TITLE
Fix missing type check in maxStreak resolver

### DIFF
--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -1133,7 +1133,8 @@ export default {
 
       const [{ max }] = await models.$queryRaw`
         SELECT MAX(COALESCE("endedAt"::date, (now() AT TIME ZONE 'America/Chicago')::date) - "startedAt"::date)
-        FROM "Streak" WHERE "userId" = ${user.id}`
+        FROM "Streak" WHERE "userId" = ${user.id}
+        AND type = 'COWBOY_HAT'`
       return max
     },
     isContributor: async (user, args, { me }) => {


### PR DESCRIPTION
## Description

Fix #2312

The `maxStreak` resolver was not checking the streak type.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Ran the query manually on the prod db, and it returns 48 for 0xbitcoiner as he expected.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no