### PR TITLE
Fix carousel dropdown

### DIFF
--- a/components/carousel.js
+++ b/components/carousel.js
@@ -53,11 +53,18 @@ function useArrowKeys ({ moveLeft, moveRight }) {
   }, [onKeyDown])
 }
 
-function Carousel ({ close, mediaArr, src }) {
+function Carousel ({ close, mediaArr, src, setOptions }) {
   const [index, setIndex] = useState(mediaArr.findIndex(([key]) => key === src))
   const [currentSrc, canGoLeft, canGoRight] = useMemo(() => {
     return [mediaArr[index][0], index > 0, index < mediaArr.length - 1]
   }, [mediaArr, index])
+
+  useEffect(() => {
+    if (index === -1) return
+    setOptions({
+      overflow: <CarouselOverflow {...mediaArr[index][1]} />
+    })
+  }, [index, mediaArr, setOptions])
 
   const moveLeft = useCallback(() => {
     setIndex(i => Math.max(0, i - 1))
@@ -108,8 +115,8 @@ export function CarouselProvider ({ children }) {
   const showModal = useShowModal()
 
   const showCarousel = useCallback(({ src }) => {
-    showModal((close) => {
-      return <Carousel close={close} mediaArr={Array.from(media.current.entries())} src={src} />
+    showModal((close, setOptions) => {
+      return <Carousel close={close} mediaArr={Array.from(media.current.entries())} src={src} setOptions={setOptions} />
     }, {
       fullScreen: true,
       overflow: <CarouselOverflow {...media.current.get(src)} />


### PR DESCRIPTION
## Description

I noticed that @brymut fixed something in #2262 that we haven't even noticed yet.

The `... > view original` is never updated while we move around in the carousel, so clicking on `view original` always opens the image with which we entered the carousel. This PR fixes this.

Seems like this has always been a problem. In #1425, I did pass `setOptions` to `<Carousel>` but never used it, so I removed it in #2325 today.

I set @brymut as the author of the commit so rewards go to him.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Dropdown is now properly updated while moving around in the carousel

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no