### PR TITLE
Refactor issue extraction logic for proper award attribution

### DIFF
--- a/extend-awards.py
+++ b/extend-awards.py
@@ -16,14 +16,14 @@ def getIssue(n):
 	return j
 
 def findIssuesInPR(j):
-	p = re.compile('(#|https://github.com/stackernews/stacker.news/issues/)([0-9]+)')
+	closing_keywords = ['close', 'closes', 'closed', 'fix', 'fixes', 'fixed', 'resolve', 'resolves', 'resolved']
+	# Support both #123 and full URL
+	closing_pattern = re.compile(
+		r'(?i)\b(' + '|'.join(closing_keywords) + r')\s+(?:#|https://github\.com/stackernews/stacker\.news/issues/)(\d+)'
+	)
 	issues = set()
-	for m in p.finditer(j['title']):
-		issues.add(m.group(2))
-	if not 'body' in j or j['body'] is None:
-		return
-	for s in j['body'].split('\n'):
-		for m in p.finditer(s):
+	for text in [j.get('title', ''), j.get('body', '') or '']:
+		for m in closing_pattern.finditer(text):
 			issues.add(m.group(2))
 	return list(issues)
 


### PR DESCRIPTION
## Description
Closes #2276 

Refactors issue extraction in `findIssuesInPR` for extend-awards.py, where currently may lead to double attribution in awards.csv. Solution involves using keywords to find the actual closing attribution instead of merely mentioning the issue. PRs now should use the Github closing keywords: 
- close
- closes
- closed
- fix
- fixes
- fixed
- resolve
- resolves
- resolved

From Github docs: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

Original issue was spotted here: https://github.com/stackernews/stacker.news/pull/2266#discussion_r2190955990

## Screenshots

To test that functionality was fixed, I created a few test issues, https://github.com/brymut/stacker.news/issues, on my fork of this repo with the fixed `extend-awards.py` added to its main branch (so the Github Action can run). 

Then I created a test PR, closing issue 1 and just mentioning issue 2, and another PR only mentioning issue 2. 


Resulting awards.csv PR should then only have one 1 issue and 1 PR added to the list, because only one issue was attributed to be closed and only one PR actually closes it, the other only mentions it.



https://github.com/user-attachments/assets/44763ce2-cdb8-41ea-9ca8-99efcd23512c





## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_

## Checklist

**Are your changes backward compatible? Please answer below:**
Y

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
N/A

**Did you introduce any new environment variables? If so, call them out explicitly here:**
N
