### PR TITLE
Fix live comments behavior on paginated and thread comments

### DIFF
--- a/components/show-new-comments.js
+++ b/components/show-new-comments.js
@@ -74,6 +74,10 @@ function traverseNewComments (client, item, onLevel, currentDepth, inSubtree) {
   // if we're at the depth limit, stop traversing, we've reached the bottom of the visible thread
   if (currentDepth >= COMMENT_DEPTH_LIMIT) return
 
+  // if the current item shows less comments than its nDirectComments, it's paginated
+  // we don't want to count/inject new comments in paginated items, as they shouldn't be visible
+  if (item.comments?.comments?.length < item.nDirectComments) return
+
   if (item.newComments && item.newComments.length > 0) {
     const dedupedNewComments = dedupeNewComments(item.newComments, item.comments?.comments)
 
@@ -161,8 +165,9 @@ export function ShowNewComments ({ topLevel, item, sort, depth = 0 }) {
   const client = useApolloClient()
   const ref = useRef(null)
 
-  // a thread is a top-level comment
-  const thread = item.path?.split('.').length === 2
+  // a thread comment is a parent comment that might have children
+  // when shown as full item (topLevel = true), we don't want to consider it a thread
+  const thread = item.path?.split('.').length === 2 && !topLevel
 
   // recurse through all new comments and their children
   // if the item is a thread, we also consider all of their existing children

--- a/components/use-live-comments.js
+++ b/components/use-live-comments.js
@@ -7,12 +7,13 @@ import { itemUpdateQuery, commentUpdateFragment, getLatestCommentCreatedAt } fro
 const POLL_INTERVAL = 1000 * 10 // 10 seconds
 
 // merge new comment into item's newComments
-// and prevent duplicates by checking if the comment is already in item's newComments
+// and prevent duplicates by checking if the comment is already in item's newComments or existing comments
 function mergeNewComment (item, newComment) {
   const existingNewComments = item.newComments || []
+  const existingComments = item.comments?.comments || []
 
-  // is the incoming new comment already in item's new comments?
-  if (existingNewComments.includes(newComment.id)) {
+  // is the incoming new comment already in item's new comments or existing comments?
+  if (existingNewComments.includes(newComment.id) || existingComments.some(comment => comment.id === newComment.id)) {
     return item
   }
 


### PR DESCRIPTION
## Description
Fixes #2333 

List of patches
- Don't show `show all new comments` button for thread comments in top level view
- Don't try to count/inject on paginated comments
- Show live comments dot on `view all x replies` button (for paginated comments)
- For showing just the dot, on new comments fetch dedupe them with already existing comments

## Screenshots


## Additional Context

`ViewAllReplies` has been merged with the `ReplyToAnotherPage` component as `ViewMoreReplies`, avoiding duplicate **live comments dot** code

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, QA on all comment states I could test

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a