### PR TITLE
Replace text-wrap with white-space because of better support

### DIFF
--- a/styles/logger.module.css
+++ b/styles/logger.module.css
@@ -30,7 +30,7 @@
 }
 
 .timestamp {
-    text-wrap: nowrap;
+    white-space: nowrap;
     min-width: 20px;
     text-align: right;
 }


### PR DESCRIPTION
## Description

[`text-wrap`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-wrap) is newly available, [`white-space`](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) is widely available

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no