### PR TITLE
Define all CSS for tab navigation in nav.module.css

### DIFF
--- a/pages/satistics/index.js
+++ b/pages/satistics/index.js
@@ -17,7 +17,7 @@ import ItemJob from '@/components/item-job'
 import PageLoading from '@/components/page-loading'
 import PayerData from '@/components/payer-data'
 import { Badge } from 'react-bootstrap'
-import navStyles from '../settings/settings.module.css'
+import navStyles from '@/styles/nav.module.css'
 import classNames from 'classnames'
 
 export const getServerSideProps = getGetServerSideProps({ query: WALLET_HISTORY, authRequired: true })

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -28,7 +28,7 @@ import { useMe } from '@/components/me'
 import { INVOICE_RETENTION_DAYS, ZAP_UNDO_DELAY_MS } from '@/lib/constants'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 import { useField } from 'formik'
-import styles from './settings.module.css'
+import styles from '@/styles/nav.module.css'
 import { AuthBanner } from '@/components/banners'
 
 export const getServerSideProps = getGetServerSideProps({ query: SETTINGS, authRequired: true })

--- a/styles/nav.module.css
+++ b/styles/nav.module.css
@@ -12,8 +12,3 @@
 .nav :global .active {
     border-bottom: 2px solid var(--bs-primary);
 }
-
-.alert {
-    color: var(--bs-danger);
-    margin-bottom: 10px;
-}

--- a/styles/wallet.module.css
+++ b/styles/wallet.module.css
@@ -93,16 +93,6 @@
   margin-left: 0.5rem;
 }
 
-.nav {
-  justify-content: center;
-  font-size: 110%;
-  gap: 0 0.5rem;
-}
-
-.nav :global .active {
-  border-bottom: 2px solid var(--bs-primary);
-}
-
 .form {
   display: flex;
   justify-content: center;

--- a/wallets/client/components/forms.js
+++ b/wallets/client/components/forms.js
@@ -6,6 +6,8 @@ import { useRouter } from 'next/router'
 import { WalletLayout, WalletLayoutHeader, WalletLayoutImageOrName, WalletLogs } from '@/wallets/client/components'
 import { protocolDisplayName, protocolFields, protocolClientSchema, unurlify, urlify, isWallet, isTemplate, walletLud16Domain } from '@/wallets/lib/util'
 import styles from '@/styles/wallet.module.css'
+import navStyles from '@/styles/nav.module.css'
+import classNames from 'classnames'
 import { Checkbox, Form, Input, PasswordInput, SubmitButton } from '@/components/form'
 import CancelButton from '@/components/cancel-button'
 import { useWalletProtocolUpsert, useWalletProtocolRemove, useWalletQuery, TemplateLogsProvider } from '@/wallets/client/hooks'
@@ -87,17 +89,17 @@ function WalletSendRecvSelector () {
   return (
     <Nav
       key={path}
-      className={styles.nav}
+      className={classNames(navStyles.nav, 'justify-content-center')}
       activeKey={selected}
     >
       <Nav.Item>
         <Link href={`/${path}/send`} passHref legacyBehavior replace>
-          <Nav.Link eventKey='send'>SEND</Nav.Link>
+          <Nav.Link className='ps-3' eventKey='send'>SEND</Nav.Link>
         </Link>
       </Nav.Item>
       <Nav.Item>
         <Link href={`/${path}/receive`} passHref legacyBehavior replace>
-          <Nav.Link eventKey='receive'>RECEIVE</Nav.Link>
+          <Nav.Link className='ps-3' eventKey='receive'>RECEIVE</Nav.Link>
         </Link>
       </Nav.Item>
     </Nav>
@@ -131,7 +133,7 @@ function WalletProtocolSelector () {
   return (
     <Nav
       key={path}
-      className={`${styles.nav} justify-content-start mt-3 mb-3`}
+      className={classNames(navStyles.nav, 'mt-0')}
       activeKey={selected}
     >
       {


### PR DESCRIPTION
## Description

- put all CSS for tab navigation in nav.module.css
- remove left padding from protocol tabs to be consistent with tabs in settings and satistics (see screenshots)
- add some top padding to SEND and RECEIVE tabs

## Screenshots

before:

<img width="300" height="534" alt="localhost_3000_wallets_alby_receive_nwc(iPhone SE)" src="https://github.com/user-attachments/assets/522b9212-992b-40c3-ab4c-f7a7cc176772" />

after:

<img width="300" height="534" alt="localhost_3000_wallets_alby_receive_nwc(iPhone SE) (1)" src="https://github.com/user-attachments/assets/2670e5d4-b243-4558-8602-ed0a9b354789" />

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`. Only found tab navigation in settings, satistics and wallets

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no