### PR TITLE
Handle error property in NWC response

### DIFF
--- a/wallets/lib/protocols/nwc.js
+++ b/wallets/lib/protocols/nwc.js
@@ -45,7 +45,9 @@ export async function nwcTryRun (fun, { url }, { signal }) {
   const nostr = new Nostr()
   try {
     const nwc = await getNwc(nostr, url, { signal })
-    return await fun(nwc)
+    const res = await fun(nwc)
+    if (res.error) throw new Error(res.error)
+    return res
   } catch (e) {
     if (e.error) throw new Error(e.error.message || e.error.code)
     throw e


### PR DESCRIPTION
## Description

related to #2342 

If a NWC response includes an `error` property, this will now throw an error with the message set to it.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. Tested that attaching our local NWC send still works.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no