### PR TITLE
Fix handleTouchMove not handling leaving elements

### DIFF
--- a/wallets/client/context/dnd.js
+++ b/wallets/client/context/dnd.js
@@ -123,14 +123,18 @@ export function useDndHandlers (index) {
       if (isTouchDragging) {
         // Find the element under the touch point
         const elementUnderTouch = document.elementFromPoint(touch.clientX, touch.clientY)
-        if (elementUnderTouch) {
-          const element = elementUnderTouch.closest('[data-index]')
-          if (element) {
-            const elementIndex = parseInt(element.dataset.index)
-            if (elementIndex !== index) {
-              dispatch({ type: DRAG_ENTER, index: elementIndex })
-            }
-          }
+        if (!elementUnderTouch) {
+          return dispatch({ type: DRAG_LEAVE })
+        }
+
+        const element = elementUnderTouch.closest('[data-index]')
+        if (!element) {
+          return dispatch({ type: DRAG_LEAVE })
+        }
+
+        const elementIndex = parseInt(element.dataset.index)
+        if (elementIndex !== index) {
+          dispatch({ type: DRAG_ENTER, index: elementIndex })
         }
       }
     }


### PR DESCRIPTION
## Description

somewhat related to #2322 

On mobile, we need to handle touch events, not mouse events.

This PR fixes not handling leaving an element while dragging via touch events.

This did not interfere with the functionality of changing priorities because we were handling entering an element fine; it was only a cosmetic issue.

## Video

https://github.com/user-attachments/assets/e9373ba1-3a56-42cb-ab81-0eaf39270dc7

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. See video and did some wild dragging around off-screen

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

theme not affected by my changes, but yes, DnD effects looks fine in light and dark mode

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no