### PR TITLE
Fix autoprefixer warning

### DIFF
--- a/styles/nav.module.css
+++ b/styles/nav.module.css
@@ -6,7 +6,7 @@
     scrollbar-width: thin;
     padding-bottom: 0.5rem;
     margin: 1rem 0;
-    justify-content: start;
+    justify-content: flex-start;
     font-size: 110%;
     gap: 0 0.5rem;
 }


### PR DESCRIPTION
## Description

Fixes this warning in the browser console:

```
./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[7].oneOf[9].use[1]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[7].oneOf[9].use[2]!./styles/nav.module.css
Warning

(9:5) autoprefixer: start value has mixed support, consider using flex-start instead

Import trace for requested module:
./node_modules/next/dist/build/webpack/loaders/css-loader/src/index.js??ruleSet[1].rules[7].oneOf[9].use[1]!./node_modules/next/dist/build/webpack/loaders/postcss-loader/src/index.js??ruleSet[1].rules[7].oneOf[9].use[2]!./styles/nav.module.css
./styles/nav.module.css
./wallets/client/components/forms.js
./wallets/client/components/index.js
./wallets/client/hooks/crypto.js
./wallets/client/hooks/index.js
./components/use-paid-mutation.js
```

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no