### PR TITLE
Use touch-action: pan-y to fix DnD vs scroll

### DIFF
--- a/styles/dnd.module.css
+++ b/styles/dnd.module.css
@@ -18,7 +18,7 @@
 @media (max-width: 768px) {
   .draggable {
     /* https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action */
-    touch-action: none;
+    touch-action: pan-y;
     user-select: none;
     -webkit-user-select: none;
     -moz-user-select: none;

--- a/wallets/client/context/dnd.js
+++ b/wallets/client/context/dnd.js
@@ -123,14 +123,18 @@ export function useDndHandlers (index) {
       if (isTouchDragging) {
         // Find the element under the touch point
         const elementUnderTouch = document.elementFromPoint(touch.clientX, touch.clientY)
-        if (elementUnderTouch) {
-          const element = elementUnderTouch.closest('[data-index]')
-          if (element) {
-            const elementIndex = parseInt(element.dataset.index)
-            if (elementIndex !== index) {
-              dispatch({ type: DRAG_ENTER, index: elementIndex })
-            }
-          }
+        if (!elementUnderTouch) {
+          return dispatch({ type: DRAG_LEAVE })
+        }
+
+        const element = elementUnderTouch.closest('[data-index]')
+        if (!element) {
+          return dispatch({ type: DRAG_LEAVE })
+        }
+
+        const elementIndex = parseInt(element.dataset.index)
+        if (elementIndex !== index) {
+          dispatch({ type: DRAG_ENTER, index: elementIndex })
         }
       }
     }


### PR DESCRIPTION
## Description

fix #2322 based on #2347

Setting [`touch-action`](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action) to `none` prevented panning (scrolling). Using `touch-action: pan-y` allows vertical scrolling.

It's not perfect, because when you start with scrolling vertically, you can still scroll horizontally and unexpectedly trigger DnD, see video. 

However, by observing my own scrolling behavior on mobile, I assume that in the general case, people don't follow-up vertical movements to scroll with horizontal movements, so they won't run into this.

So I think this is a pretty simple fix for #2322 that covers 99% of the cases.

DnD is more annoying to use now if you don't know that scrolling horizontally first prevents the annoying scrolling while dragging :sweat_smile: 

## Video

before:

https://github.com/user-attachments/assets/461d16cd-5c48-4b33-8b63-cd82ab832f32

after:

https://github.com/user-attachments/assets/7d9044dc-0174-497e-ae29-115305b0a97b

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`, see video.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no