### PR TITLE
Fix missing check for pay_invoice for NWC recv

### DIFF
--- a/wallets/server/protocols/nwc.js
+++ b/wallets/server/protocols/nwc.js
@@ -1,4 +1,4 @@
-import { nwcTryRun } from '@/wallets/lib/protocols/nwc'
+import { nwcTryRun, supportedMethods } from '@/wallets/lib/protocols/nwc'
 
 export const name = 'NWC'
 
@@ -12,6 +12,20 @@ export async function createInvoice ({ msats, description, expiry }, { url }, { 
 }
 
 export async function testCreateInvoice ({ url }, { signal }) {
+  const supported = await supportedMethods(url, { signal })
+  const supports = (method) => supported.includes(method)
+
+  if (!supports('make_invoice')) {
+    throw new Error('make_invoice not supported')
+  }
+
+  const mustNotSupport = ['pay_invoice', 'multi_pay_invoice', 'pay_keysend', 'multi_pay_keysend']
+  for (const method of mustNotSupport) {
+    if (supports(method)) {
+      throw new Error(`${method} must not be supported`)
+    }
+  }
+
   return await createInvoice(
     { msats: 1000, description: 'SN test invoice', expiry: 1 },
     { url },


### PR DESCRIPTION
## Description

In #2169, I forgot to copy the existing validation for NWC receive to the new code.

**This means we didn't check that `pay_invoice` is not supported.**

## Additional Context

I downloaded a CSV file for all currently saved NWC receive protocols to check if any of them do support `pay_invoice`. Then we should delete them.

I also went through the diff of #2169 to check if I forgot that for other protocols, too, but I didn't. But most of them didn't even include a way to test if payments are not supported (see LNbits, Phoenixd).

This could be fixed via #1341. Instead of only testing if a payment is possible, we can do the same when attaching a receive wallet to make sure it's not possible (we always cancel the HODL invoice).

## Checklist

**Are your changes backward compatible? Please answer below:**

yes, but we have to manually delete any existing NWC wallet for receiving that supports payments

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. Attaching NWC send for NWC receive fails now. Attaching NWC receive for NWC receive still works.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no