### PR TITLE
Delete NWC plaintext credentials that allow payments

### DIFF
--- a/prisma/migrations/20250910153121_delete_nwc_recv_with_payments/migration.sql
+++ b/prisma/migrations/20250910153121_delete_nwc_recv_with_payments/migration.sql
@@ -10,7 +10,7 @@ WHERE id IN (
         158,
         166
     )
-)
+);
 
 -- delete wallets that now have no protocols
 DELETE FROM "Wallet"

--- a/prisma/migrations/20250910153121_delete_nwc_recv_with_payments/migration.sql
+++ b/prisma/migrations/20250910153121_delete_nwc_recv_with_payments/migration.sql
@@ -1,9 +1,18 @@
-DELETE FROM "WalletRecvNWC"
-WHERE "id" IN (
-    7,
-    67,
-    140,
-    157,
-    158,
-    166
-);
+WITH deleted_protocols AS (
+    DELETE FROM "WalletProtocol"
+    WHERE id IN (
+        SELECT "protocolId" FROM "WalletRecvNWC"
+        WHERE id IN (
+            7,
+            67,
+            140,
+            157,
+            158,
+            166
+        )
+    )
+    RETURNING "walletId"
+)
+DELETE FROM "Wallet"
+WHERE id IN (SELECT "walletId" FROM deleted_protocols)
+AND NOT EXISTS (SELECT 1 FROM "WalletProtocol" WHERE "walletId" = "Wallet"."id");

--- a/prisma/migrations/20250910153121_delete_nwc_recv_with_payments/migration.sql
+++ b/prisma/migrations/20250910153121_delete_nwc_recv_with_payments/migration.sql
@@ -1,18 +1,17 @@
-WITH deleted_protocols AS (
-    DELETE FROM "WalletProtocol"
+-- delete protocols that have accidentally been saved in plaintext with permissions to spend
+DELETE FROM "WalletProtocol"
+WHERE id IN (
+    SELECT "protocolId" FROM "WalletRecvNWC"
     WHERE id IN (
-        SELECT "protocolId" FROM "WalletRecvNWC"
-        WHERE id IN (
-            7,
-            67,
-            140,
-            157,
-            158,
-            166
-        )
+        7,
+        67,
+        140,
+        157,
+        158,
+        166
     )
-    RETURNING "walletId"
 )
+
+-- delete wallets that now have no protocols
 DELETE FROM "Wallet"
-WHERE id IN (SELECT "walletId" FROM deleted_protocols)
-AND NOT EXISTS (SELECT 1 FROM "WalletProtocol" WHERE "walletId" = "Wallet"."id");
+WHERE NOT EXISTS (SELECT 1 FROM "WalletProtocol" WHERE "walletId" = "Wallet"."id");

--- a/prisma/migrations/20250910153121_delete_nwc_recv_with_payments/migration.sql
+++ b/prisma/migrations/20250910153121_delete_nwc_recv_with_payments/migration.sql
@@ -15,3 +15,5 @@ WHERE id IN (
 -- delete wallets that now have no protocols
 DELETE FROM "Wallet"
 WHERE NOT EXISTS (SELECT 1 FROM "WalletProtocol" WHERE "walletId" = "Wallet"."id");
+
+-- badges will not be updated but that's okay, not important enough for the effort

--- a/prisma/migrations/20250910153121_delete_nwc_recv_with_payments/migration.sql
+++ b/prisma/migrations/20250910153121_delete_nwc_recv_with_payments/migration.sql
@@ -1,0 +1,9 @@
+DELETE FROM "WalletRecvNWC"
+WHERE "id" IN (
+    7,
+    67,
+    140,
+    157,
+    158,
+    166
+);


### PR DESCRIPTION
## Description

**Final comment**

This will delete wallets that are now empty but **it will not update badges by ending streaks**. I think that's okay. Instead of accidentally inserting something wrong into the `Streak` table, a simple wallet save by the stacker will bring their badges to the correct state (if it ended up being wrong)

---

As mentioned in #2365, we should delete the NWC credentials that have been saved in plaintext with any method that supports paying.

To automate this, I added basic nip47 support to `nak` in https://github.com/fiatjaf/nak/pull/78 today.

<details>
<summary>Steps</summary>

Steps to find the IDs we should delete:

1. Download CSV of this query from metabase:

```sql
SELECT id, url FROM "WalletRecvNWC";
```

2. Build my fork of `nak` with nip47 support

```
$ git clone git@github.com:ekzyis/nak
$ cd nak
$ git checkout nip47
$ go build .
```

3. Run this command:

```
$ cat nwc_recv.csv | tail -n+2 | awk -F, '{print $2}' | xargs -tn1 ./nak nwc get_info --url 2>&1 | tee nwc_recv_info.txt
```

4. Print all NWC urls with `pay_invoice` support:

```
$ awk 'NR%2==1{printf "%s ", $0; next} {print}' nwc_recv_info.txt | grep pay_invoice | awk -F' ' '{print $5}' | tr -d "'"
```

5. Lookup corresponding id in nwc_recv.csv 

</details>

I will run these steps again after we deployed #2365.

## Additional Context

<details>
<summary>statistics</summary>

Sanity check: 167 matches number of rows in `WalletRecvNWC`

```
$ awk 'NR%2==1{printf "%s ", $0; next} {print}' exclude/nwc_recv_info.txt | wc -l
167
```

How many `get_info` timeouts after 10s? 95 (will run them again with bigger timeouts)

```
$ awk 'NR%2==1{printf "%s ", $0; next} {print}' exclude/nwc_recv_info.txt | grep timeout | wc -l
95
```

How many with `pay_invoice` support? 6

```
$ awk 'NR%2==1{printf "%s ", $0; next} {print}' exclude/nwc_recv_info.txt | grep pay_invoice | wc -l
6
```

How many failed because of nip04 vs nip44? 1 (I only added nip44 support)

</details>

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`. Tested with a wallet that only has one protocol that should get deleted (wallet gets deleted, too) and wallet that has one protocol remaining (wallet does not get deleted)

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no