### PR TITLE
Fix spacing if no badges

### DIFF
--- a/components/badge.js
+++ b/components/badge.js
@@ -46,6 +46,8 @@ export default function Badges ({ user, badge, className = 'ms-1', badgeClassNam
     })
   }
 
+  if (badges.length === 0) return null
+
   return (
     <span className={className}>
       {badges.map(({ icon, overlayText, sizeDelta }, i) => (


### PR DESCRIPTION
before:

<img width="437" height="92" alt="2025-07-31-231947_437x92_scrot" src="https://github.com/user-attachments/assets/7013f39b-b7b6-43e0-b489-b0f7066a66dd" />

after:

<img width="429" height="96" alt="2025-07-31-232002_429x96_scrot" src="https://github.com/user-attachments/assets/ea0fec53-4537-4cae-857d-22401d1da5ad" />