### PR TITLE
fix link to /daily in CCinfo loads forever

### DIFF
--- a/components/info/cc.js
+++ b/components/info/cc.js
@@ -13,7 +13,7 @@ export default function CCInfo (props) {
           <ul>
             <li>if the zap is small and you don't have a direct channel to SN, the routing fee may exceed SN's 3% max fee</li>
             <li>check your <Link href='/wallets/logs'>wallet logs</Link> for clues</li>
-            <li>if you have questions about the errors in your wallet logs, mention the error in the <a href='/daily'>saloon</a></li>
+            <li>if you have questions about the errors in your wallet logs, mention the error in the <Link href='/api/daily'>saloon</Link></li>
           </ul>
         </li>
         <li>some zaps might be smaller than your configured receiving dust limit

--- a/components/info/cc.js
+++ b/components/info/cc.js
@@ -13,7 +13,7 @@ export default function CCInfo (props) {
           <ul>
             <li>if the zap is small and you don't have a direct channel to SN, the routing fee may exceed SN's 3% max fee</li>
             <li>check your <Link href='/wallets/logs'>wallet logs</Link> for clues</li>
-            <li>if you have questions about the errors in your wallet logs, mention the error in the <Link href='/daily'>saloon</Link></li>
+            <li>if you have questions about the errors in your wallet logs, mention the error in the <a href='/daily'>saloon</a></li>
           </ul>
         </li>
         <li>some zaps might be smaller than your configured receiving dust limit


### PR DESCRIPTION
## Description

fixes #2370 using standard navigation with `<a>` tag 

## Screenshots
![2025-08-02 02-44-26](https://github.com/user-attachments/assets/d9999583-d35a-4cbb-bc50-74d09948846a)

## Additional Context
`api/daily` redirect breaks NextJS rewrite rules in client side navigation.

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_
everything good

## Checklist

**Are your changes backward compatible? Please answer below:**
yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**
