### PR TITLE
removing free comments

### DIFF
--- a/api/paidAction/itemCreate.js
+++ b/api/paidAction/itemCreate.js
@@ -49,10 +49,10 @@ export async function getCost ({ subName, parentId, uploadIds, boost = 0, bio },
           FROM upload_fees(${me?.id || USER_ID.anon}::INTEGER, ${uploadIds}::INTEGER[]))
       + ${satsToMsats(boost)}::INTEGER as cost`
 
-  // sub allows freebies (or is a bio or a comment), cost is less than baseCost, not anon,
+  // sub allows freebies (bio), cost is less than baseCost, not anon,
   // cost must be greater than user's balance, and user has not disabled freebies
-  const freebie = (parentId || bio) && cost <= baseCost && !!me &&
-    me?.msats < cost && !me?.disableFreebies && me?.mcredits < cost
+  const freebie = bio && cost <= baseCost && !!me &&
+    me?.msats < cost && me?.mcredits < cost
 
   return freebie ? BigInt(0) : BigInt(cost)
 }

--- a/components/fee-button.js
+++ b/components/fee-button.js
@@ -14,7 +14,7 @@ import { SubmitButton } from './form'
 
 const FeeButtonContext = createContext()
 
-export function postCommentBaseLineItems ({ baseCost = 1, comment = false, me }) {
+export function postCommentBaseLineItems ({ baseCost = 1, comment = false, bio = false, me }) {
   const anonCharge = me
     ? {}
     : {
@@ -28,10 +28,10 @@ export function postCommentBaseLineItems ({ baseCost = 1, comment = false, me })
   return {
     baseCost: {
       term: baseCost,
-      label: `${comment ? 'comment' : 'post'} cost`,
+      label: `${bio ? 'bio' : (comment ? 'comment' : 'post')} cost`,
       op: '_',
       modifier: (cost) => cost + baseCost,
-      allowFreebies: comment
+      allowFreebies: bio
     },
     ...anonCharge
   }


### PR DESCRIPTION
## Description
fix issue #2278 
removed the ability to make free comments, limiting the freebies function to bios only

## Screenshots

https://github.com/user-attachments/assets/ab7ceab4-7e9c-4bd7-ba2b-fa354560a2d0

## Additional Context
I have not completely removed the free comment logic (even from databases and other functions) to let you test the change

changes in `api/paidAction/itemCreate.js` : an action is now considered a "freebie" only if it's a bio, not comments. The condition that checked whether the user had disabled freebies has also been removed, to potentially remove the logic.

changes in `components/fee-button.js` : The feature now also accepts a bio parameter. The label has been updated to display "bio cost," "comment cost," or "post cost" depending on the content type. The logic for freebies has been changed to `allowFreebies: bio`, meaning they are only allowed for bios.

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_
all good

## Checklist

**Are your changes backward compatible? Please answer below:**
y

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**7


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**
