### PR TITLE
Fix autoWithdraw settings schema

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -188,12 +188,6 @@ export function advSchema (args) {
   })
 }
 
-export const autowithdrawSchemaMembers = object({
-  autoWithdrawThreshold: intValidator.required('required').min(0, 'must be at least 0').max(10000, 'must be at most 10000').transform(Number),
-  autoWithdrawMaxFeePercent: floatValidator.required('required').min(0, 'must be at least 0').max(50, 'must not exceed 50').transform(Number),
-  autoWithdrawMaxFeeTotal: intValidator.required('required').min(0, 'must be at least 0').max(1_000, 'must not exceed 1000').transform(Number)
-})
-
 export const vaultEntrySchema = key => object({
   key: string().required('required').matches(key, `expected ${key}`),
   iv: string().required('required').hex().length(24, 'must be 24 characters long'),
@@ -475,9 +469,9 @@ export const settingsSchema = object().shape({
 }, [['tipRandomMax', 'tipRandomMin']])
 
 export const walletSettingsSchema = object({
-  autoWithdrawThreshold: intValidator.min(0, 'must be greater or equal to 0').required('required'),
-  autoWithdrawMaxFeePercent: floatValidator.min(0, 'must be greater or equal to 0').required('required'),
-  autoWithdrawMaxFeeTotal: intValidator.min(0, 'must be greater or equal to 0').required('required'),
+  autoWithdrawThreshold: intValidator.required('required').min(0, 'must be at least 0').max(10000, 'must be at most 10000').transform(Number),
+  autoWithdrawMaxFeePercent: floatValidator.required('required').min(0, 'must be at least 0').max(50, 'must not exceed 50').transform(Number),
+  autoWithdrawMaxFeeTotal: intValidator.required('required').min(0, 'must be at least 0').max(1_000, 'must not exceed 1000').transform(Number),
   receiveCreditsBelowSats: intValidator.min(0, 'must be greater or equal to 0').required('required'),
   sendCreditsBelowSats: intValidator.min(0, 'must be greater or equal to 0').required('required'),
   proxyReceive: boolean().required('required')


### PR DESCRIPTION
## Description

No bug encountered but `autoWithdrawSchemaMembers` wasn't used anywhere anymore but had more validation which I assume was added for a reason

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. saved settings

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no