### PR TITLE
Fix input type of url for NWC receive

### DIFF
--- a/wallets/lib/protocols/nwc.js
+++ b/wallets/lib/protocols/nwc.js
@@ -32,7 +32,7 @@ export default [
         name: 'url',
         label: 'url',
         placeholder: 'nostr+walletconnect://',
-        type: 'text',
+        type: 'password',
         required: true,
         validate: nwcUrlValidator()
       }


### PR DESCRIPTION
## Description

Even though receive credentials are not encrypted, we still use the password type for them, but we weren't for NWC receive.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. Just changing the type of the input

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no