### PR TITLE
Fix wallet_updated_at_trigger on wallet delete

### DIFF
--- a/prisma/migrations/20250804201438_fix_wallets_updated_at_trigger_on_delete/migration.sql
+++ b/prisma/migrations/20250804201438_fix_wallets_updated_at_trigger_on_delete/migration.sql
@@ -1,0 +1,23 @@
+-- fix trigger when wallet is deleted
+CREATE OR REPLACE FUNCTION wallet_updated_at_trigger() RETURNS TRIGGER AS $$
+DECLARE
+    user_id INT;
+BEGIN
+    IF TG_TABLE_NAME = 'WalletProtocol' THEN
+        SELECT w."userId" INTO user_id
+        FROM "Wallet" w
+        WHERE w.id = CASE
+            WHEN TG_OP = 'DELETE' THEN OLD."walletId"
+            ELSE NEW."walletId"
+        END;
+    ELSE
+        user_id := CASE WHEN TG_OP = 'DELETE' THEN OLD."userId" ELSE NEW."userId" END;
+    END IF;
+
+    UPDATE "users" u
+    SET "walletsUpdatedAt" = NOW()
+    WHERE u.id = user_id;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Description

When a wallet is deleted, we don't update `walletsUpdatedAt` as expected, because the wallet row is already deleted.

Instead of querying a deleted row, we can use `OLD."userId"` instead.

diff:

```diff
CREATE OR REPLACE FUNCTION wallet_updated_at_trigger() RETURNS TRIGGER AS $$
DECLARE
    user_id INT;
BEGIN
    IF TG_TABLE_NAME = 'WalletProtocol' THEN
        SELECT w."userId" INTO user_id
        FROM "Wallet" w
        WHERE w.id = CASE
            WHEN TG_OP = 'DELETE' THEN OLD."walletId"
            ELSE NEW."walletId"
        END;
    ELSE
-        SELECT w."userId" INTO user_id
-        FROM "Wallet" w
-        WHERE w.id = NEW.id;
+       user_id := CASE WHEN TG_OP = 'DELETE' THEN OLD."userId" ELSE NEW."userId" END;
    END IF;

    UPDATE "users" u
    SET "walletsUpdatedAt" = NOW()
    WHERE u.id = user_id;

    RETURN NULL;
END;
$$ LANGUAGE plpgsql;
```
## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`. Tested by deleting a wallet and seeing `walletsUpdatedAt` getting updated.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no