### PR TITLE
Remove unused keyCheck hook

### DIFF
--- a/wallets/client/context/hooks.js
+++ b/wallets/client/context/hooks.js
@@ -28,9 +28,6 @@ export function useServerWallets () {
   }, [query])
 }
 
-export function useKeyCheck () {
-}
-
 export function useAutomatedRetries () {
   const waitForWalletPayment = useWalletPayment()
   const invoiceHelper = useInvoice()

--- a/wallets/client/context/provider.js
+++ b/wallets/client/context/provider.js
@@ -1,6 +1,6 @@
 import { createContext, useContext, useReducer } from 'react'
 import walletsReducer from './reducer'
-import { useServerWallets, useKeyCheck, useAutomatedRetries, useKeyInit, useWalletMigration } from './hooks'
+import { useServerWallets, useAutomatedRetries, useKeyInit, useWalletMigration } from './hooks'
 import { WebLnProvider } from '@/wallets/lib/protocols/webln'
 
 // https://react.dev/learn/scaling-up-with-reducer-and-context
@@ -78,7 +78,6 @@ export default function WalletsProvider ({ children }) {
 
 function WalletHooks ({ children }) {
   useServerWallets()
-  useKeyCheck()
   useAutomatedRetries()
   useKeyInit()
 


### PR DESCRIPTION
This hook wasn't used because what it was supposed to do was moved to `useIsWrongKey` and `useKeyInit`
