### PR TITLE
Fix protocolId missing as dependency

### DIFF
--- a/wallets/client/hooks/logger.js
+++ b/wallets/client/hooks/logger.js
@@ -118,7 +118,7 @@ export function useWalletLogs (protocol, debug) {
     }, FAST_POLL_INTERVAL)
 
     return () => clearInterval(interval)
-  }, [fetchLogs, called, noFetch, debug])
+  }, [fetchLogs, protocolId, called, noFetch, debug])
 
   const loadMore = useCallback(async () => {
     const { data } = await fetchLogs({ variables: { protocolId, cursor, debug } })


### PR DESCRIPTION
## Description

This didn't cause any visible bugs because the wallet logs always remounted.

I am not sure why though, since `key={router.asPath}` is only passed to `<Form>`, not to `<WalletLogs>`:

https://github.com/stackernews/stacker.news/blob/cbc41c0d992c862bd9b0c292bbbee325e0fa9b15/wallets/client/components/forms.js#L188-L199

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

no visible bug, but it should never poll logs with a stale protocol

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no