### PR TITLE
Use SSR for wallets

### DIFF
--- a/pages/wallets/[...slug].js
+++ b/pages/wallets/[...slug].js
@@ -1,20 +1,16 @@
 import { getGetServerSideProps } from '@/api/ssrApollo'
 import { WalletForms as WalletFormsComponent } from '@/wallets/client/components'
+import { WALLET } from '@/wallets/client/fragments'
+import { useDecryptedWallet } from '@/wallets/client/hooks'
 import { unurlify } from '@/wallets/lib/util'
-import { useParams } from 'next/navigation'
 
-export const getServerSideProps = getGetServerSideProps({ authRequired: true })
+const variablesFunc = params => {
+  const id = Number(params.slug[0])
+  return !Number.isNaN(id) ? { id } : { name: unurlify(params.slug[0]) }
+}
+export const getServerSideProps = getGetServerSideProps({ query: WALLET, variables: variablesFunc, authRequired: true })
 
-export default function WalletForms () {
-  const params = useParams()
-  const walletName = unurlify(params.slug[0])
-
-  // if the wallet name is a number, we are showing a configured wallet
-  // otherwise, we are showing a template
-  const isNumber = !Number.isNaN(Number(walletName))
-  if (isNumber) {
-    return <WalletFormsComponent id={Number(walletName)} />
-  }
-
-  return <WalletFormsComponent name={walletName} />
+export default function WalletForms ({ ssrData }) {
+  const decryptedWallet = useDecryptedWallet(ssrData?.wallet)
+  return <WalletFormsComponent wallet={decryptedWallet ?? ssrData?.wallet} />
 }

--- a/pages/wallets/[...slug].js
+++ b/pages/wallets/[...slug].js
@@ -16,6 +16,10 @@ export const getServerSideProps = getGetServerSideProps({ query: WALLET, variabl
 export default function WalletForms ({ ssrData }) {
   const router = useRouter()
   const variables = variablesFunc(router.query)
+  // this will print the following warning in the console:
+  //   Warning: fragment with name WalletTemplateFields already exists.
+  //   graphql-tag enforces all fragment names across your application to be unique
+  // this is not a problem because the warning is only meant to avoid overwriting fragments but we're reusing it
   const { data, refetch } = useQuery(WALLET, { variables })
   const dat = useData(data, ssrData)
 

--- a/pages/wallets/[...slug].js
+++ b/pages/wallets/[...slug].js
@@ -16,9 +16,9 @@ export const getServerSideProps = getGetServerSideProps({ query: WALLET, variabl
 export default function WalletForms ({ ssrData }) {
   const router = useRouter()
   const variables = variablesFunc(router.query)
-  const { data } = useQuery(WALLET, { variables })
+  const { data, refetch } = useQuery(WALLET, { variables })
   const dat = useData(data, ssrData)
 
   const decryptedWallet = useDecryptedWallet(dat?.wallet)
-  return <WalletFormsComponent wallet={decryptedWallet ?? dat?.wallet} />
+  return <WalletFormsComponent wallet={decryptedWallet ?? dat?.wallet} refetch={refetch} />
 }

--- a/pages/wallets/[...slug].js
+++ b/pages/wallets/[...slug].js
@@ -1,8 +1,11 @@
 import { getGetServerSideProps } from '@/api/ssrApollo'
+import { useData } from '@/components/use-data'
 import { WalletForms as WalletFormsComponent } from '@/wallets/client/components'
 import { WALLET } from '@/wallets/client/fragments'
 import { useDecryptedWallet } from '@/wallets/client/hooks'
 import { unurlify } from '@/wallets/lib/util'
+import { useQuery } from '@apollo/client'
+import { useRouter } from 'next/router'
 
 const variablesFunc = params => {
   const id = Number(params.slug[0])
@@ -11,6 +14,11 @@ const variablesFunc = params => {
 export const getServerSideProps = getGetServerSideProps({ query: WALLET, variables: variablesFunc, authRequired: true })
 
 export default function WalletForms ({ ssrData }) {
-  const decryptedWallet = useDecryptedWallet(ssrData?.wallet)
-  return <WalletFormsComponent wallet={decryptedWallet ?? ssrData?.wallet} />
+  const router = useRouter()
+  const variables = variablesFunc(router.query)
+  const { data } = useQuery(WALLET, { variables })
+  const dat = useData(data, ssrData)
+
+  const decryptedWallet = useDecryptedWallet(dat?.wallet)
+  return <WalletFormsComponent wallet={decryptedWallet ?? dat?.wallet} />
 }

--- a/pages/wallets/[...slug].js
+++ b/pages/wallets/[...slug].js
@@ -24,5 +24,10 @@ export default function WalletForms ({ ssrData }) {
   const dat = useData(data, ssrData)
 
   const decryptedWallet = useDecryptedWallet(dat?.wallet)
-  return <WalletFormsComponent wallet={decryptedWallet ?? dat?.wallet} refetch={refetch} />
+  const wallet = decryptedWallet ?? ssrData?.wallet
+  if (!wallet) {
+    return null
+  }
+
+  return <WalletFormsComponent wallet={wallet} refetch={refetch} />
 }

--- a/wallets/client/components/card.js
+++ b/wallets/client/components/card.js
@@ -7,7 +7,7 @@ import Link from 'next/link'
 import RecvIcon from '@/svgs/arrow-left-down-line.svg'
 import SendIcon from '@/svgs/arrow-right-up-line.svg'
 import DragIcon from '@/svgs/draggable.svg'
-import { useWalletImage, useWalletSupport, useWalletStatus, WalletStatus } from '@/wallets/client/hooks'
+import { useWalletImage, useWalletSupport, useWalletStatus, WalletStatus, useProtocolTemplates } from '@/wallets/client/hooks'
 import { isWallet, urlify, walletDisplayName } from '@/wallets/lib/util'
 import { Draggable } from '@/wallets/client/components'
 
@@ -56,8 +56,14 @@ export function WalletCard ({ wallet, draggable = false, index, ...props }) {
 
 function WalletLink ({ wallet, children }) {
   const support = useWalletSupport(wallet)
-  const sendRecvParam = support.send ? 'send' : 'receive'
-  const href = '/wallets' + (isWallet(wallet) ? `/${wallet.id}` : `/${urlify(wallet.name)}`) + `/${sendRecvParam}`
+  const protocols = useProtocolTemplates(wallet)
+  const firstSend = protocols.find(p => p.send)
+  const firstRecv = protocols.find(p => !p.send)
+
+  let href = '/wallets'
+  href += isWallet(wallet) ? `/${wallet.id}` : `/${urlify(wallet.name)}`
+  href += support.send ? `/send/${urlify(firstSend.name)}` : `/receive/${urlify(firstRecv.name)}`
+
   return <Link href={href}>{children}</Link>
 }
 

--- a/wallets/client/components/forms.js
+++ b/wallets/client/components/forms.js
@@ -116,7 +116,8 @@ function WalletProtocolSelector () {
 
   useEffect(() => {
     if (!selected && protocols.length > 0) {
-      router.replace(`/${path}/${urlify(protocols[0].name)}`, null, { shallow: true })
+      // TODO: why does this need shallow: false since SSR?
+      router.replace(`/${path}/${urlify(protocols[0].name)}`, null, { shallow: false })
     }
   }, [path])
 

--- a/wallets/client/components/forms.js
+++ b/wallets/client/components/forms.js
@@ -9,7 +9,7 @@ import styles from '@/styles/wallet.module.css'
 import navStyles from '@/styles/nav.module.css'
 import { Checkbox, Form, Input, PasswordInput, SubmitButton } from '@/components/form'
 import CancelButton from '@/components/cancel-button'
-import { useWalletProtocolUpsert, useWalletProtocolRemove, useWalletQuery, TemplateLogsProvider } from '@/wallets/client/hooks'
+import { useWalletProtocolUpsert, useWalletProtocolRemove, TemplateLogsProvider } from '@/wallets/client/hooks'
 import { useToast } from '@/components/toast'
 import Text from '@/components/text'
 import Info from '@/components/info'
@@ -17,10 +17,9 @@ import classNames from 'classnames'
 
 const WalletFormsContext = createContext()
 
-export function WalletForms ({ id, name }) {
-  // TODO(wallet-v2): handle loading and error states
-  const { data, refetch } = useWalletQuery({ name, id })
-  const wallet = data?.wallet
+export function WalletForms ({ wallet }) {
+  const router = useRouter()
+  const refetch = useCallback(() => router.refresh(), [router])
 
   return (
     <WalletLayout>

--- a/wallets/client/components/forms.js
+++ b/wallets/client/components/forms.js
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useMemo, createContext, useContext } from 'react'
+import { useCallback, useMemo, createContext, useContext } from 'react'
 import { Button, InputGroup, Nav } from 'react-bootstrap'
 import Link from 'next/link'
 import { useParams, usePathname } from 'next/navigation'
@@ -9,7 +9,7 @@ import styles from '@/styles/wallet.module.css'
 import navStyles from '@/styles/nav.module.css'
 import { Checkbox, Form, Input, PasswordInput, SubmitButton } from '@/components/form'
 import CancelButton from '@/components/cancel-button'
-import { useWalletProtocolUpsert, useWalletProtocolRemove, TemplateLogsProvider } from '@/wallets/client/hooks'
+import { useWalletProtocolUpsert, useWalletProtocolRemove, useProtocolTemplates, TemplateLogsProvider } from '@/wallets/client/hooks'
 import { useToast } from '@/components/toast'
 import Text from '@/components/text'
 import Info from '@/components/info'
@@ -77,8 +77,13 @@ function WalletFormSelector () {
 }
 
 function WalletSendRecvSelector () {
+  const wallet = useWallet()
   const path = useWalletPathname()
+  const protocols = useProtocolTemplates(wallet)
   const selected = useSendRecvParam()
+
+  const firstSend = protocols.find(p => p.send)
+  const firstRecv = protocols.find(p => !p.send)
 
   // TODO(wallet-v2): if you click a nav link again, it will update the URL
   //   but not run the effect again to select the first protocol by default
@@ -89,12 +94,12 @@ function WalletSendRecvSelector () {
       activeKey={selected}
     >
       <Nav.Item>
-        <Link href={`/${path}/send`} passHref legacyBehavior replace>
+        <Link href={`/${path}/send${firstSend ? `/${urlify(firstSend.name)}` : ''}`} passHref legacyBehavior replace>
           <Nav.Link className='ps-3' eventKey='send'>SEND</Nav.Link>
         </Link>
       </Nav.Item>
       <Nav.Item>
-        <Link href={`/${path}/receive`} passHref legacyBehavior replace>
+        <Link href={`/${path}/receive${firstRecv ? `/${urlify(firstRecv.name)}` : ''}`} passHref legacyBehavior replace>
           <Nav.Link className='ps-3' eventKey='receive'>RECEIVE</Nav.Link>
         </Link>
       </Nav.Item>
@@ -105,18 +110,11 @@ function WalletSendRecvSelector () {
 function WalletProtocolSelector () {
   const walletPath = useWalletPathname()
   const sendRecvParam = useSendRecvParam()
+  const selected = useWalletProtocolParam()
   const path = `${walletPath}/${sendRecvParam}`
 
-  const protocols = useWalletProtocols()
-  const selected = useWalletProtocolParam()
-  const router = useRouter()
-
-  useEffect(() => {
-    if (!selected && protocols.length > 0) {
-      // TODO: why does this need shallow: false since SSR?
-      router.replace(`/${path}/${urlify(protocols[0].name)}`, null, { shallow: false })
-    }
-  }, [path])
+  const wallet = useWallet()
+  const protocols = useProtocolTemplates(wallet).filter(p => sendRecvParam === 'send' ? p.send : !p.send)
 
   if (protocols.length === 0) {
     // TODO(wallet-v2): let user know how to request support if the wallet actually does support sending
@@ -176,7 +174,7 @@ function WalletProtocolForm () {
       return
     }
     // we just created a new user wallet from a template
-    router.replace(`/wallets/${upsert.id}/${sendRecvParam}`, null, { shallow: true })
+    router.replace(`/wallets/${upsert.id}/${sendRecvParam}/${urlify(protocol.name)}`, null, { shallow: true })
     toaster.success('wallet attached', { persistOnNavigate: true })
   }, [upsertWalletProtocol, toaster, wallet, router])
 
@@ -298,17 +296,6 @@ function useWalletProtocolParam () {
   const name = params.slug[2]
   // returns only :protocol in /wallets/:name/:send/:protocol
   return name ? unurlify(name) : null
-}
-
-function useWalletProtocols () {
-  const wallet = useWallet()
-  const sendRecvParam = useSendRecvParam()
-  if (!sendRecvParam) return []
-
-  const protocolFilter = p => sendRecvParam === 'send' ? p.send : !p.send
-  return isWallet(wallet)
-    ? wallet.template.protocols.filter(protocolFilter)
-    : wallet.protocols.filter(protocolFilter)
 }
 
 function useSelectedProtocol () {

--- a/wallets/client/components/forms.js
+++ b/wallets/client/components/forms.js
@@ -17,10 +17,7 @@ import classNames from 'classnames'
 
 const WalletFormsContext = createContext()
 
-export function WalletForms ({ wallet }) {
-  const router = useRouter()
-  const refetch = useCallback(() => router.refresh(), [router])
-
+export function WalletForms ({ wallet, refetch }) {
   return (
     <WalletLayout>
       <div className={styles.form}>

--- a/wallets/client/hooks/query.js
+++ b/wallets/client/hooks/query.js
@@ -1,5 +1,4 @@
 import {
-  WALLET,
   UPSERT_WALLET_RECEIVE_BLINK,
   UPSERT_WALLET_RECEIVE_CLN_REST,
   UPSERT_WALLET_RECEIVE_LIGHTNING_ADDRESS,
@@ -123,31 +122,6 @@ function useRefetchOnChange (refetch) {
 
     refetch()
   }, [refetch, me?.id, walletsUpdatedAt])
-}
-
-export function useWalletQuery ({ id, name }) {
-  const { me } = useMe()
-  const query = useQuery(WALLET, { variables: { id, name }, skip: !me })
-  const [wallet, setWallet] = useState(null)
-
-  const { decryptWallet, ready } = useWalletDecryption()
-
-  useEffect(() => {
-    if (!query.data?.wallet || !ready) return
-    decryptWallet(query.data?.wallet)
-      .then(protocolCheck)
-      .then(undoFieldAlias)
-      .then(wallet => setWallet(wallet))
-      .catch(err => {
-        console.error('failed to decrypt wallet:', err)
-      })
-  }, [query.data, decryptWallet, ready])
-
-  return useMemo(() => ({
-    ...query,
-    loading: !wallet,
-    data: wallet ? { wallet } : null
-  }), [query, wallet])
 }
 
 export function useDecryptedWallet (wallet) {

--- a/wallets/client/hooks/query.js
+++ b/wallets/client/hooks/query.js
@@ -150,6 +150,24 @@ export function useWalletQuery ({ id, name }) {
   }), [query, wallet])
 }
 
+export function useDecryptedWallet (wallet) {
+  const { decryptWallet, ready } = useWalletDecryption()
+  const [decryptedWallet, setDecryptedWallet] = useState(undoFieldAlias(wallet))
+
+  useEffect(() => {
+    if (!ready || !wallet) return
+    decryptWallet(wallet)
+      .then(protocolCheck)
+      .then(undoFieldAlias)
+      .then(wallet => setDecryptedWallet(wallet))
+      .catch(err => {
+        console.error('failed to decrypt wallet:', err)
+      })
+  }, [decryptWallet, wallet, ready])
+
+  return decryptedWallet
+}
+
 export function useWalletProtocolUpsert (wallet, protocol) {
   const mutation = getWalletProtocolUpsertMutation(protocol)
   const [mutate] = useMutation(mutation)

--- a/wallets/client/hooks/query.js
+++ b/wallets/client/hooks/query.js
@@ -143,7 +143,7 @@ function server2Client (wallet) {
     return { id, ...wallet, template: { name: templateId, ...template } }
   }
 
-  return undoFieldAlias(checkProtocolAvailability(wallet))
+  return wallet ? undoFieldAlias(checkProtocolAvailability(wallet)) : wallet
 }
 
 export function useWalletProtocolUpsert (wallet, protocol) {

--- a/wallets/client/hooks/wallet.js
+++ b/wallets/client/hooks/wallet.js
@@ -53,3 +53,9 @@ export function useWalletsUpdatedAt () {
   const { me } = useMe()
   return me?.privates?.walletsUpdatedAt
 }
+
+export function useProtocolTemplates (wallet) {
+  return useMemo(() => {
+    return isWallet(wallet) ? wallet.template.protocols : wallet.protocols
+  }, [wallet])
+}

--- a/wallets/lib/util.js
+++ b/wallets/lib/util.js
@@ -1,6 +1,7 @@
 import * as yup from 'yup'
 import wallets from '@/wallets/lib/wallets.json'
 import protocols from '@/wallets/lib/protocols'
+import { SSR } from '@/lib/constants'
 
 function walletJson (name) {
   return wallets.find(wallet => wallet.name === name)
@@ -88,7 +89,7 @@ export function protocolFields ({ name, send }) {
 export function protocolAvailable ({ name, send }) {
   const { isAvailable } = protocol({ name, send })
 
-  if (typeof isAvailable === 'function') {
+  if (!SSR && typeof isAvailable === 'function') {
     return isAvailable()
   }
 

--- a/wallets/server/resolvers/wallet.js
+++ b/wallets/server/resolvers/wallet.js
@@ -96,6 +96,8 @@ async function wallet (parent, { id, name }, { me, models }) {
         protocols: true
       }
     })
+    if (!wallet) throw new GqlInputError('wallet not found')
+
     return mapWalletResolveTypes(wallet)
   }
 


### PR DESCRIPTION
## Description

This enables SSR for wallet configuration pages.

Before, we showed an empty page while the client fetched a wallet, see videos.

If a wallet didn't exist, the page would stay empty.

Now, the page is rendered on the server with input fields that require decryption being empty until decryption finishes and we correctly show a 404 page if a wallet wasn't found.

## Additional context

1. /wallets doesn't use SSR because we fetch the wallets in the background for zaps, not specifically for that page. The loading indicator is also good because it avoids showing the wallets before we checked if they need to unlock their wallets first.

1. There's a warning from `graphql-tag` now for the `WALLET` query:

> Warning: fragment with name WalletTemplateFields already exists.
graphql-tag enforces all fragment names across your application to be unique; read more about
this in the docs: http://dev.apollodata.com/core/fragments.html#unique-names

I think we can ignore it because the warning exists to avoid overwriting fragments, but we're reusing the same fragment.

However, not sure why this warning didn't show before. We have already been reusing the same fragment twice in the `WALLET` query via `USER_WALLET_FIELDS` and `WALLET_TEMPLATE_FIELDS` in `WALLET_OR_TEMPLATE_FIELDS`. Both `USER_WALLET_FIELDS` and `WALLET_TEMPLATE_FIELDS` define the (identical) `WalletTemplateFields` fragment.

## Video

before:

https://github.com/user-attachments/assets/eaa1196f-f62b-4f57-ac16-f0bf7462717b

after:

https://github.com/user-attachments/assets/75677657-7270-426f-9b20-39c9648bdfce

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`. Tested attaching and editing wallets, and reloading each wallet page to trigger SSR

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no