### PR TITLE
/wallets/debug: fix getDate is not a function

### DIFF
--- a/wallets/client/components/debug.js
+++ b/wallets/client/components/debug.js
@@ -50,15 +50,15 @@ export function WalletDebugSettings () {
       <div className='text-end'>{remoteKeyHash ? shortHash(remoteKeyHash) : 'unknown'}</div>
       <div className='text-nowrap'>device key update:</div>
       <div className='text-end' suppressHydrationWarning>
-        {localKeyUpdatedAt ? `${timeSince(new Date(localKeyUpdatedAt))} ago` : 'unknown'}
+        {localKeyUpdatedAt ? `${timeSince(new Date(localKeyUpdatedAt))}` : 'unknown'}
       </div>
       <div className='text-nowrap'>server key update:</div>
       <div className='text-end' suppressHydrationWarning>
-        {remoteKeyHashUpdatedAt ? `${timeSince(new Date(remoteKeyHashUpdatedAt))} ago` : 'unknown'}
+        {remoteKeyHashUpdatedAt ? `${timeSince(new Date(remoteKeyHashUpdatedAt))}` : 'unknown'}
       </div>
       <div className='text-nowrap'>wallet update:</div>
       <div className='text-end' suppressHydrationWarning>
-        {walletsUpdatedAt ? `${timeSince(new Date(walletsUpdatedAt))} ago` : 'unknown'}
+        {walletsUpdatedAt ? `${timeSince(new Date(walletsUpdatedAt))}` : 'unknown'}
       </div>
       <div className='text-nowrap'>diagnostics:</div>
       {/* not using Formik here because we want to submit immediately on change */}

--- a/wallets/client/components/debug.js
+++ b/wallets/client/components/debug.js
@@ -50,15 +50,15 @@ export function WalletDebugSettings () {
       <div className='text-end'>{remoteKeyHash ? shortHash(remoteKeyHash) : 'unknown'}</div>
       <div className='text-nowrap'>device key update:</div>
       <div className='text-end' suppressHydrationWarning>
-        {localKeyUpdatedAt ? `${timeSince(localKeyUpdatedAt)} ago` : 'unknown'}
+        {localKeyUpdatedAt ? `${timeSince(new Date(localKeyUpdatedAt))} ago` : 'unknown'}
       </div>
       <div className='text-nowrap'>server key update:</div>
       <div className='text-end' suppressHydrationWarning>
-        {remoteKeyHashUpdatedAt ? `${timeSince(new Date(remoteKeyHashUpdatedAt).getTime())} ago` : 'unknown'}
+        {remoteKeyHashUpdatedAt ? `${timeSince(new Date(remoteKeyHashUpdatedAt))} ago` : 'unknown'}
       </div>
       <div className='text-nowrap'>wallet update:</div>
       <div className='text-end' suppressHydrationWarning>
-        {walletsUpdatedAt ? `${timeSince(new Date(walletsUpdatedAt).getTime())} ago` : 'unknown'}
+        {walletsUpdatedAt ? `${timeSince(new Date(walletsUpdatedAt))} ago` : 'unknown'}
       </div>
       <div className='text-nowrap'>diagnostics:</div>
       {/* not using Formik here because we want to submit immediately on change */}

--- a/wallets/client/components/debug.js
+++ b/wallets/client/components/debug.js
@@ -50,15 +50,15 @@ export function WalletDebugSettings () {
       <div className='text-end'>{remoteKeyHash ? shortHash(remoteKeyHash) : 'unknown'}</div>
       <div className='text-nowrap'>device key update:</div>
       <div className='text-end' suppressHydrationWarning>
-        {localKeyUpdatedAt ? `${timeSince(new Date(localKeyUpdatedAt))}` : 'unknown'}
+        {localKeyUpdatedAt ? timeSince(new Date(localKeyUpdatedAt)) : 'unknown'}
       </div>
       <div className='text-nowrap'>server key update:</div>
       <div className='text-end' suppressHydrationWarning>
-        {remoteKeyHashUpdatedAt ? `${timeSince(new Date(remoteKeyHashUpdatedAt))}` : 'unknown'}
+        {remoteKeyHashUpdatedAt ? timeSince(new Date(remoteKeyHashUpdatedAt)) : 'unknown'}
       </div>
       <div className='text-nowrap'>wallet update:</div>
       <div className='text-end' suppressHydrationWarning>
-        {walletsUpdatedAt ? `${timeSince(new Date(walletsUpdatedAt))}` : 'unknown'}
+        {walletsUpdatedAt ? timeSince(new Date(walletsUpdatedAt)) : 'unknown'}
       </div>
       <div className='text-nowrap'>diagnostics:</div>
       {/* not using Formik here because we want to submit immediately on change */}


### PR DESCRIPTION
## Description

If the local key was updated more than one day ago, the `timeSince` function will call `getDate` on a number.

I also removed the 'ago' suffix because in that case, `timeSince` will not return a relative time but a date like '27 Jul'.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. Input to `timeSince` is now always a date

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no