### PR TITLE
fix wrong URL on Reply on another page

### DIFF
--- a/components/comment.js
+++ b/components/comment.js
@@ -318,7 +318,7 @@ export function ViewMoreReplies ({ item, navigateRoot = false }) {
   const root = useRoot()
   const id = navigateRoot ? commentSubTreeRootId(item, root) : item.id
 
-  const href = `/items/${id}` + (navigateRoot ? '' : `?commentId=${item.id}`)
+  const href = `/items/${id}` + (navigateRoot ? `?commentId=${item.id}` : '')
 
   const text = navigateRoot && item.ncomments === 0
     ? 'reply on another page'

--- a/components/comment.js
+++ b/components/comment.js
@@ -280,7 +280,7 @@ export default function Comment ({
       </div>
       {collapse !== 'yep' && (
         bottomedOut
-          ? <div className={styles.children}><div className={classNames(styles.comment, 'mt-3 pb-2')}><ViewMoreReplies item={item} navigateRoot /></div></div>
+          ? <div className={styles.children}><div className={classNames(styles.comment, 'mt-3 pb-2')}><ViewMoreReplies item={item} threadContext /></div></div>
           : (
             <div className={styles.children}>
               {item.outlawed && !me?.privates?.wildWestMode
@@ -314,13 +314,15 @@ export default function Comment ({
   )
 }
 
-export function ViewMoreReplies ({ item, navigateRoot = false }) {
+export function ViewMoreReplies ({ item, threadContext = false }) {
   const root = useRoot()
-  const id = navigateRoot ? commentSubTreeRootId(item, root) : item.id
+  const id = threadContext ? commentSubTreeRootId(item, root) : item.id
 
-  const href = `/items/${id}` + (navigateRoot ? `?commentId=${item.id}` : '')
+  // if threadContext is true, we travel to some comments before the current comment, focusing on the comment itself
+  // otherwise, we directly navigate to the comment
+  const href = `/items/${id}` + (threadContext ? `?commentId=${item.id}` : '')
 
-  const text = navigateRoot && item.ncomments === 0
+  const text = threadContext && item.ncomments === 0
     ? 'reply on another page'
     : `view all ${item.ncomments} replies`
 


### PR DESCRIPTION
## Description

Fixes #2409 
After merging together the bottomed out and pagination link buttons, I wrongly deleted the `commentId` param that scrolls the user to the correct comment.
This PR re-instates the correct URL.

## Screenshots
n/a

## Additional Context
n/a

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
9, scrolls to the correct comment

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a