### PR TITLE
auto show: use textarea as anchor and 

### DIFF
--- a/components/preserve-scroll.js
+++ b/components/preserve-scroll.js
@@ -59,7 +59,7 @@ export default function preserveScroll (callback) {
         const refMoved = newRefTop - refTop
 
         // if the anchor ref moved, we need to scroll to the new position
-        if (refMoved !== 0) {
+        if (refMoved > 0) {
           window.scrollTo({
             // some browsers don't respond well to fractional scroll position, so we round up the new position to the nearest integer
             top: scrollTop + Math.ceil(refMoved),

--- a/components/preserve-scroll.js
+++ b/components/preserve-scroll.js
@@ -51,8 +51,11 @@ export default function preserveScroll (callback) {
     window.requestAnimationFrame(() => {
       if (!anchorRef) return
 
+      // bail if user scrolled manually
+      if (window.scrollY !== scrollTop) return
+
       // get the new position of the anchor ref along with the new scroll position
-      const newRefTop = anchorRef ? anchorRef.getBoundingClientRect().top + window.scrollY : window.scrollY
+      const newRefTop = anchorRef.getBoundingClientRect().top + window.scrollY
       // has the anchor ref moved?
       const refMoved = newRefTop - refTop
 

--- a/components/preserve-scroll.js
+++ b/components/preserve-scroll.js
@@ -8,35 +8,65 @@ export default function preserveScroll (callback) {
     return
   }
 
-  // get a reference element at the center of the viewport to track if content is added above it
-  const ref = document.elementFromPoint(window.innerWidth / 2, window.innerHeight / 2)
-  const refTop = ref ? ref.getBoundingClientRect().top + scrollTop : scrollTop
+  // check if a ref element is in the viewport
+  const isElementInViewport = (element) => {
+    if (!element?.getBoundingClientRect) return false
+
+    const rect = element.getBoundingClientRect()
+    return (
+      rect.bottom > 0 &&
+      rect.right > 0 &&
+      rect.top < window.innerHeight &&
+      rect.left < window.innerWidth
+    )
+  }
+
+  // pick a textarea element to use as anchor ref, if any
+  const selectTextarea = () => {
+    // pick the focused textarea, if any
+    const active = document.activeElement
+    if (active && active.tagName === 'TEXTAREA' && isElementInViewport(active)) {
+      return active
+    }
+
+    // if no textarea is focused, check if there are any in the viewport
+    const textareas = document.querySelectorAll('textarea')
+    for (const textarea of textareas) {
+      if (isElementInViewport(textarea)) {
+        return textarea
+      }
+    }
+
+    return null
+  }
+
+  // if no textarea is found, use the center of the viewport as fallback anchor
+  const anchorRef = selectTextarea() || document.elementFromPoint(window.innerWidth / 2, window.innerHeight / 2)
+  const refTop = anchorRef ? anchorRef.getBoundingClientRect().top + scrollTop : scrollTop
 
   // observe the document for changes in height
   const observer = new window.MutationObserver(() => {
-    // request animation frame to ensure the DOM is updated
+    cleanup()
+
+    // double rAF to ensure the DOM is updated - textareas are rendered on the next tick
     window.requestAnimationFrame(() => {
-      // we can't proceed if we couldn't find a traceable reference element
-      if (!ref) {
-        cleanup()
-        return
-      }
+      window.requestAnimationFrame(() => {
+        if (!anchorRef) return
 
-      // get the new position of the reference element along with the new scroll position
-      const newRefTop = ref ? ref.getBoundingClientRect().top + window.scrollY : window.scrollY
-      // has the reference element moved?
-      const refMoved = newRefTop - refTop
+        // get the new position of the anchor ref along with the new scroll position
+        const newRefTop = anchorRef ? anchorRef.getBoundingClientRect().top + window.scrollY : window.scrollY
+        // has the anchor ref moved?
+        const refMoved = newRefTop - refTop
 
-      // if the reference element moved, we need to scroll to the new position
-      if (refMoved > 0) {
-        window.scrollTo({
-          // some browsers don't respond well to fractional scroll position, so we round up the new position to the nearest integer
-          top: scrollTop + Math.ceil(refMoved),
-          behavior: 'instant'
-        })
-      }
-
-      cleanup()
+        // if the anchor ref moved, we need to scroll to the new position
+        if (refMoved !== 0) {
+          window.scrollTo({
+            // some browsers don't respond well to fractional scroll position, so we round up the new position to the nearest integer
+            top: scrollTop + Math.ceil(refMoved),
+            behavior: 'instant'
+          })
+        }
+      })
     })
   })
 

--- a/components/preserve-scroll.js
+++ b/components/preserve-scroll.js
@@ -44,40 +44,26 @@ export default function preserveScroll (callback) {
   const anchorRef = selectTextarea() || document.elementFromPoint(window.innerWidth / 2, window.innerHeight / 2)
   const refTop = anchorRef ? anchorRef.getBoundingClientRect().top + scrollTop : scrollTop
 
-  // observe the document for changes in height
-  const observer = new window.MutationObserver(() => {
-    cleanup()
+  callback()
 
-    // double rAF to ensure the DOM is updated - textareas are rendered on the next tick
+  // double rAF to ensure the DOM is updated - textareas are rendered on the next tick
+  window.requestAnimationFrame(() => {
     window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => {
-        if (!anchorRef) return
+      if (!anchorRef) return
 
-        // get the new position of the anchor ref along with the new scroll position
-        const newRefTop = anchorRef ? anchorRef.getBoundingClientRect().top + window.scrollY : window.scrollY
-        // has the anchor ref moved?
-        const refMoved = newRefTop - refTop
+      // get the new position of the anchor ref along with the new scroll position
+      const newRefTop = anchorRef ? anchorRef.getBoundingClientRect().top + window.scrollY : window.scrollY
+      // has the anchor ref moved?
+      const refMoved = newRefTop - refTop
 
-        // if the anchor ref moved, we need to scroll to the new position
-        if (refMoved > 0) {
-          window.scrollTo({
-            // some browsers don't respond well to fractional scroll position, so we round up the new position to the nearest integer
-            top: scrollTop + Math.ceil(refMoved),
-            behavior: 'instant'
-          })
-        }
-      })
+      // if the anchor ref moved, we need to scroll to the new position
+      if (refMoved > 0) {
+        window.scrollTo({
+          // some browsers don't respond well to fractional scroll position, so we round up the new position to the nearest integer
+          top: scrollTop + Math.ceil(refMoved),
+          behavior: 'instant'
+        })
+      }
     })
   })
-
-  const timeout = setTimeout(() => cleanup(), 1000) // fallback
-
-  function cleanup () {
-    clearTimeout(timeout)
-    observer.disconnect()
-  }
-
-  observer.observe(document.body, { childList: true, subtree: true })
-
-  callback()
 }


### PR DESCRIPTION
## Description

Reopens #2407 
If in the viewport we have a textarea, `preserveScroll` will use it as the anchor element to determine if something has moved.
If multiple textareas are present in the viewport, the focused one is preferred, otherwise the first in the tree will be picked as anchor.

#### Jitteriness
Also removes the `MutationObserver` used to get calculations on the most updated DOM. It was a precautionary measure that got obsolete by using two RAFs for the textarea anchor support.
Scroll preservation now also bails when there's some form of scrolling happening, avoiding jittery scrolling.

## Screenshots

Textarea is the preferred anchor element, with fallback

https://github.com/user-attachments/assets/4eec08c5-d2ee-4292-81b8-e790078e8888

<sup>incredibly fumbled on the compression settings</sup>

Difference between MutationObserver and two RAFs



## Additional Context

This required an additional layer of `requestAnimationFrame`: some browsers may have their own anonymous content, like text extensions and such, deferring textarea/input renders.

It still fallbacks to picking a ref at the middle of the viewport in absence of textareas

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, Brave, Safari, Chrome

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a