### PR TITLE
Fix GraphQL cannot represent bigint as integer

### DIFF
--- a/api/resolvers/upload.js
+++ b/api/resolvers/upload.js
@@ -6,7 +6,17 @@ import { msatsToSats } from '@/lib/format'
 export default {
   Query: {
     uploadFees: async (parent, { s3Keys }, { models, me }) => {
-      return uploadFees(s3Keys, { models, me })
+      const fees = await uploadFees(s3Keys, { models, me })
+      // GraphQL doesn't support bigint
+      return {
+        totalFees: Number(fees.totalFees),
+        totalFeesMsats: Number(fees.totalFeesMsats),
+        uploadFees: Number(fees.uploadFees),
+        uploadFeesMsats: Number(fees.uploadFeesMsats),
+        nUnpaid: Number(fees.nUnpaid),
+        bytesUnpaid: Number(fees.bytesUnpaid),
+        bytes24h: Number(fees.bytes24h)
+      }
     }
   },
   Mutation: {

--- a/api/resolvers/upload.js
+++ b/api/resolvers/upload.js
@@ -79,7 +79,7 @@ export async function uploadFees (s3Keys, { models, me }) {
   const uploadFees = BigInt(msatsToSats(uploadFeesMsats))
   const totalFeesMsats = BigInt(nUnpaid) * uploadFeesMsats
   const totalFees = BigInt(msatsToSats(totalFeesMsats))
-  return { bytes24h, bytesUnpaid, nUnpaid, uploadFees, totalFees, totalFeesMsats }
+  return { bytes24h, bytesUnpaid, nUnpaid, uploadFees, uploadFeesMsats, totalFees, totalFeesMsats }
 }
 
 export async function throwOnExpiredUploads (uploadIds, { tx }) {


### PR DESCRIPTION
## Description

reported by @Soxasora 

GraphQL does not support bigint so we have to cast upload fees to a number first

## Video

https://github.com/user-attachments/assets/01e42d9c-74e3-48f0-b27d-8449658d442f

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`, see video

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no