### PR TITLE
fixing line numbers on error traces in development

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -57,7 +57,8 @@ module.exports = withPlausibleProxy()({
   },
   compress: false,
   experimental: {
-    scrollRestoration: true
+    scrollRestoration: true,
+    serverSourceMaps: true
   },
   reactStrictMode: true,
   productionBrowserSourceMaps: true,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "NODE_OPTIONS='--trace-warnings' next dev",
+    "dev": "NODE_OPTIONS='--trace-warnings --enable-source-maps' next dev",
     "build": "next build",
     "migrate": "prisma migrate deploy",
     "start": "NODE_OPTIONS='--trace-warnings --max-old-space-size=4096 --max-semi-space-size=128' next start -p $PORT --keepAliveTimeout 120000",


### PR DESCRIPTION
## Description
fix #2361

Changes Made:

in `package.json` (dev script):

Added `NODE_OPTIONS='--trace-warnings --enable-source-maps'` to the dev script.

Why: Enables Node to use source maps generated by Next, so that server-side stack traces in development report correct file and line numbers.

in `next.config.js`:

Activated `experimental.serverSourceMaps: true`.
Why: serverSourceMaps causes server-side space for Node to read;

Before/After Behavior:

Before: Error traces in dev showed "wrong" lines or bundle/transpiled references.
After: Traces show the original source with correct line/column (verified with the test in zap.js).
Operational Notes

The app's logical paths have been left unchanged, only the debug/build configuration.


## Screenshots

https://github.com/user-attachments/assets/bd9b7cee-1d88-4884-96db-6904cb0e8568


https://github.com/user-attachments/assets/1a182b47-8d48-4e47-adb9-0e4b51fcecba

## Additional Context
You can also add --enable-source-maps to the start script if you want server-side mapped stacks in local production; this is not required.

I also tested the changes by forcing errors in:
Client component (dev)
Server component / server actions
API Routes / Route Handlers
getServerSideProps
getStaticProps (build-time)
Middleware/Edge (if used)
Dynamic import/chunk
Worker (tsx)
Jest

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_
all good
## Checklist

**Are your changes backward compatible? Please answer below:**yes

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**7


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**n/a


**Did you introduce any new environment variables? If so, call them out explicitly here:**n/a
