### PR TITLE
Fix pull-to-refresh can trigger on unexpected scroll positions

### DIFF
--- a/components/pull-to-refresh.js
+++ b/components/pull-to-refresh.js
@@ -17,6 +17,13 @@ export default function PullToRefresh ({ children, className }) {
     setIsPWA(androidPWA || iosPWA)
   }
 
+  const clearPullDistance = () => {
+    setPullDistance(0)
+    document.body.style.marginTop = '0px'
+    touchStartY.current = 0
+    touchEndY.current = 0
+  }
+
   useEffect(checkPWA, [])
 
   const handleTouchStart = useCallback((e) => {
@@ -28,6 +35,13 @@ export default function PullToRefresh ({ children, className }) {
   const handleTouchMove = useCallback((e) => {
     if (touchStartY.current === 0) return
     if (!isPWA) return
+
+    // if we're not at the top of the page after the touch start, reset the pull distance
+    if (window.scrollY > 0) {
+      clearPullDistance()
+      return
+    }
+
     touchEndY.current = e.touches[0].clientY
     const distance = touchEndY.current - touchStartY.current
     setPullDistance(distance)
@@ -39,10 +53,7 @@ export default function PullToRefresh ({ children, className }) {
     if (touchEndY.current - touchStartY.current > REFRESH_THRESHOLD) {
       router.push(router.asPath)
     }
-    setPullDistance(0)
-    document.body.style.marginTop = '0px'
-    touchStartY.current = 0
-    touchEndY.current = 0
+    clearPullDistance()
   }, [router])
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Navigator #2377 exacerbated unexpected triggers to pull-to-refresh by emitting `touchStart` on `scrollY === 0`, but navigator scrolls between `touchStart` and `touchMove`, causing `touchMove` to think we're still at the top

Other autoscrolls can cause this as the scroll position can change between touch events, so we need to continuously validate our assumptions during the touch events, not just at the start.

## Screenshots
n/a

## Additional Context
n/a

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8, everything works at it should

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a