### PR TITLE
Fix favicon misclearing by navigator

### DIFF
--- a/components/use-comments-navigator.js
+++ b/components/use-comments-navigator.js
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useRef, useState, startTransition, createContext, useContext } from 'react'
 import styles from './comment.module.css'
-import { useRouter } from 'next/router'
 import LongPressable from './long-pressable'
 import { useFavicon } from './favicon'
 
@@ -28,7 +27,6 @@ export function useCommentsNavigatorContext () {
 }
 
 export function useCommentsNavigator () {
-  const router = useRouter()
   const { setHasNewComments } = useFavicon()
   const [commentCount, setCommentCount] = useState(0)
   // refs in ref to not re-render on tracking
@@ -161,11 +159,10 @@ export function useCommentsNavigator () {
     navigatorRef.current = { trackNewComment, untrackNewComment, scrollToComment, clearCommentRefs }
   }
 
-  // clear the navigator on route changes
+  // clear the navigator on unmount
   useEffect(() => {
-    router.events.on('routeChangeStart', clearCommentRefs)
-    return () => router.events.off('routeChangeStart', clearCommentRefs)
-  }, [clearCommentRefs, router.events])
+    return () => clearCommentRefs()
+  }, [clearCommentRefs])
 
   return { navigator: navigatorRef.current, commentCount }
 }


### PR DESCRIPTION
## Description

Fixes favicon getting miscleared by route change events.

## Screenshots
n/a

## Additional Context

The problem was that route change events triggered a navigator clear on first load, setting the `hasNewComments` state to `false`. I didn't think about it at all at first, because comments were getting tracked anyway... but they were getting tracked anyway because `requestAnimationFrame` delays the tracking action `after` that first wrong clear.

In few words: on first load, route change events triggers a navigator clear

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**
