### PR TITLE
Fix navigator not clearing on Item navigation

### DIFF
--- a/pages/items/[id]/index.js
+++ b/pages/items/[id]/index.js
@@ -26,7 +26,7 @@ export default function Item ({ ssrData }) {
   }
 
   return (
-    <CommentsNavigatorProvider>
+    <CommentsNavigatorProvider key={item.id}>
       <Layout sub={sub} item={item}>
         <ItemFull item={item} fetchMoreComments={fetchMoreComments} />
       </Layout>


### PR DESCRIPTION
## Description

Fixes stale navigator on item navigation by giving a key (`item.id`) to the navigator provider, triggering an effective unmount also when the item ID has changed.

## Screenshots

https://github.com/user-attachments/assets/293a2eb3-d884-4db6-9dd3-1e6db02881aa



## Additional Context

I fixed this during iterative QA with route change events, but overall I think it's better to continue with simple unmounting logic and just give a key to the provider to cause an unmount.

## Checklist

**Are your changes backward compatible? Please answer below:**
n/a

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, tried on threads that links to a subtree

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a