### PR TITLE
load new replies to comments on fetch more

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -67,7 +67,7 @@ async function comments (me, models, item, sort, cursor) {
   // XXX what a mess
   let comments
   if (me) {
-    const filter = ` AND ("Item"."invoiceActionState" IS NULL OR "Item"."invoiceActionState" = 'PAID' OR "Item"."userId" = ${me.id}) AND "Item".created_at <= '${decodedCursor.time.toISOString()}'::TIMESTAMP(3) `
+    const filter = ` AND ("Item"."invoiceActionState" IS NULL OR "Item"."invoiceActionState" = 'PAID' OR "Item"."userId" = ${me.id}) AND ("Item"."parentId" <> $1 OR "Item".created_at <= '${decodedCursor.time.toISOString()}'::TIMESTAMP(3)) `
     if (item.ncomments > FULL_COMMENTS_THRESHOLD) {
       const [{ item_comments_zaprank_with_me_limited: limitedComments }] = await models.$queryRawUnsafe(
         'SELECT item_comments_zaprank_with_me_limited($1::INTEGER, $2::INTEGER, $3::INTEGER, $4::INTEGER, $5::INTEGER, $6::INTEGER, $7::INTEGER, $8, $9)',
@@ -80,7 +80,7 @@ async function comments (me, models, item, sort, cursor) {
       comments = fullComments
     }
   } else {
-    const filter = ` AND ("Item"."invoiceActionState" IS NULL OR "Item"."invoiceActionState" = 'PAID') AND "Item".created_at <= '${decodedCursor.time.toISOString()}'::TIMESTAMP(3) `
+    const filter = ` AND ("Item"."invoiceActionState" IS NULL OR "Item"."invoiceActionState" = 'PAID') AND ("Item"."parentId" <> $1 OR "Item".created_at <= '${decodedCursor.time.toISOString()}'::TIMESTAMP(3)) `
     if (item.ncomments > FULL_COMMENTS_THRESHOLD) {
       const [{ item_comments_limited: limitedComments }] = await models.$queryRawUnsafe(
         'SELECT item_comments_limited($1::INTEGER, $2::INTEGER, $3::INTEGER, $4::INTEGER, $5::INTEGER, $6, $7)',


### PR DESCRIPTION
## Description

Fixes #2429 
Excludes descendants of a comment from being constrained by the given cursor time.

## Screenshots

https://github.com/user-attachments/assets/1c2b3499-52f1-42a8-a947-06a4125ea4ae


## Additional Context

I believe it’s not an issue for the descendants of a direct comment to not be time-constrained, as they are loaded by the parent comment, which already is.

## Checklist

**Are your changes backward compatible? Please answer below:**
n/a

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6, didn't get any duplicates, seems to work correctly on different posts and loading positions

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a