### PR TITLE
pass limit in nextCursorEncoded()

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -583,7 +583,7 @@ export default {
           break
       }
       return {
-        cursor: items.length === limit ? nextCursorEncoded(decodedCursor) : null,
+        cursor: items.length === limit ? nextCursorEncoded(decodedCursor, limit) : null,
         items,
         pins,
         ad

--- a/api/resolvers/search.js
+++ b/api/resolvers/search.js
@@ -168,7 +168,7 @@ export default {
       })
 
       return {
-        cursor: items.length === (limit || LIMIT) ? nextCursorEncoded(decodedCursor) : null,
+        cursor: items.length === limit ? nextCursorEncoded(decodedCursor, limit) : null,
         items
       }
     },


### PR DESCRIPTION
## Description

When a graphql API call is made like

{"operationName":"SubItems","variables":{"sort":"top","type":"all","limit":999}}

and there are more than 999 items, the call correctly returns 999 items, but the returned cursor is

{"offset":21,"time":"...}

because the default for the limit parameter is used:

lib/cursor.js:
export const LIMIT = 21
export function nextCursorEncoded (cursor, limit = LIMIT) {

This change passes the actual limit used to nextCursorEncoded().

## Screenshots

## Additional Context

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

1, no tests done.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

**Did you introduce any new environment variables? If so, call them out explicitly here:**
