### PR TITLE
fix #2443: add parseYoutubeStart() to convert start times

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -78,6 +78,24 @@ export function parseInternalLinks (href) {
   return {}
 }
 
+export function parseYoutubeStart (t) {
+  // https://stackoverflow.com/questions/17379268/youtube-dropped-t-start-time-support-in-direct-url-and-embed-videos
+  // https://developers.google.com/youtube/player_parameters#start
+  let r = 0
+  const a = [{n:'h',v:3600},{n:'m',v:60},{n:'s',v:1}]
+  for (const j in a) {
+    const i = t.indexOf(a[j].n)
+    if (i >= 0) {
+      r += parseInt(t.substring(0, i)) * a[j].v
+      t = t.substring(i + 1)
+    }
+  }
+  if (t.length > 0) {
+    r += parseInt(t)
+  }
+  return r.toString()
+}
+
 export function parseEmbedUrl (href) {
   if (!href) return null
 
@@ -132,7 +150,7 @@ export function parseEmbedUrl (href) {
           id: searchParams.get('v'),
           meta: {
             href,
-            start: searchParams.get('t')
+            start: parseYoutubeStart(searchParams.get('t'))
           }
         }
       }
@@ -152,7 +170,7 @@ export function parseEmbedUrl (href) {
         id: pathname.slice(1), // remove leading slash
         meta: {
           href,
-          start: searchParams.get('t')
+          start: parseYoutubeStart(searchParams.get('t'))
         }
       }
     }

--- a/lib/url.js
+++ b/lib/url.js
@@ -81,19 +81,10 @@ export function parseInternalLinks (href) {
 export function parseYoutubeStart (t) {
   // https://stackoverflow.com/questions/17379268/youtube-dropped-t-start-time-support-in-direct-url-and-embed-videos
   // https://developers.google.com/youtube/player_parameters#start
-  if (!t) return null
+  if (!t || !t.match(/^([0-9]+[smh])+$/g)) return t
   let r = 0
-  const a = [{ n: 'h', v: 3600 }, { n: 'm', v: 60 }, { n: 's', v: 1 }]
-  for (const j in a) {
-    const i = t.indexOf(a[j].n)
-    if (i >= 0) {
-      r += parseInt(t.substring(0, i)) * a[j].v
-      t = t.substring(i + 1)
-    }
-  }
-  if (t.length > 0) {
-    r += parseInt(t)
-  }
+  for (const m of t.matchAll(/([0-9]+)([smh])/g))
+    r += parseInt(m[1]) * Math.pow(60, 'smh'.indexOf(m[2]))
   return r.toString()
 }
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -83,8 +83,9 @@ export function parseYoutubeStart (t) {
   // https://developers.google.com/youtube/player_parameters#start
   if (!t || !t.match(/^([0-9]+[smh])+$/g)) return t
   let r = 0
-  for (const m of t.matchAll(/([0-9]+)([smh])/g))
+  for (const m of t.matchAll(/([0-9]+)([smh])/g)) {
     r += parseInt(m[1]) * Math.pow(60, 'smh'.indexOf(m[2]))
+  }
   return r.toString()
 }
 

--- a/lib/url.js
+++ b/lib/url.js
@@ -81,6 +81,7 @@ export function parseInternalLinks (href) {
 export function parseYoutubeStart (t) {
   // https://stackoverflow.com/questions/17379268/youtube-dropped-t-start-time-support-in-direct-url-and-embed-videos
   // https://developers.google.com/youtube/player_parameters#start
+  if (!t) return null
   let r = 0
   const a = [{n:'h',v:3600},{n:'m',v:60},{n:'s',v:1}]
   for (const j in a) {

--- a/lib/url.js
+++ b/lib/url.js
@@ -83,7 +83,7 @@ export function parseYoutubeStart (t) {
   // https://developers.google.com/youtube/player_parameters#start
   if (!t) return null
   let r = 0
-  const a = [{n:'h',v:3600},{n:'m',v:60},{n:'s',v:1}]
+  const a = [{ n: 'h', v: 3600 }, { n: 'm', v: 60 }, { n: 's', v: 1 }]
   for (const j in a) {
     const i = t.indexOf(a[j].n)
     if (i >= 0) {


### PR DESCRIPTION
## Description

fixes https://github.com/stackernews/stacker.news/issues/2443

The start time is actually already passed to the embedded player verbatim.

But it seems Google have changed the accepted values. Now only an integer denoting seconds is accepted:

https://developers.google.com/youtube/player_parameters#start
https://stackoverflow.com/questions/17379268/youtube-dropped-t-start-time-support-in-direct-url-and-embed-videos

So, add a function parseYoutubeStart() which converts "2h30m10s" to "9010" etc.

## Screenshots

https://github.com/user-attachments/assets/148f39bb-789e-452b-b4ac-a42eb4e1c684

## Additional Context

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

8, I tested with multiple combinations (integers, hours, minutes, seconds)

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Tested on desktop (Firefox only), light and dark mode.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No
