### PR TITLE
Fix progress line not connecting if there's only one

### DIFF
--- a/components/multi-step-form.js
+++ b/components/multi-step-form.js
@@ -53,11 +53,12 @@ export function MultiStepForm ({ children, initial, steps }) {
 
 function Progress () {
   const steps = useSteps()
+  const maxSteps = useMaxSteps()
   const stepIndex = useStepIndex()
 
   const style = (index) => {
     switch (index) {
-      case 0: return { marginLeft: '-5px', marginRight: '-13px' }
+      case 0: return maxSteps === 2 ? { marginLeft: '-13px', marginRight: '-15px' } : { marginLeft: '-5px', marginRight: '-13px' }
       case 1: return { marginLeft: '-13px', marginRight: '-15px' }
       default: return {}
     }


### PR DESCRIPTION
before:

<img width="300" height="534" alt="localhost_3000_wallets_blitz_step=receive(iPhone SE)" src="https://github.com/user-attachments/assets/971fbd2d-834f-4651-bf6f-b6d6ddb91ae4" />

after:

<img width="300" height="534" alt="localhost_3000_wallets_blitz_step=receive(iPhone SE) (1)" src="https://github.com/user-attachments/assets/2cf3cdf4-861b-4d49-a580-a59fcbf70468" />
