### PR TITLE
fix #2392: make subs return meSubscription

### DIFF
--- a/api/resolvers/sub.js
+++ b/api/resolvers/sub.js
@@ -59,7 +59,7 @@ export default {
           FROM "Sub"
           LEFT JOIN "SubSubscription" ss ON "Sub".name = ss."subName" AND ss."userId" = ${me.id}::INTEGER
           LEFT JOIN "MuteSub" ON "Sub".name = "MuteSub"."subName" AND "MuteSub"."userId" = ${me.id}::INTEGER
-          WHERE status <> 'STOPPED' ${showNsfw ? '' : 'AND "Sub"."nsfw" = FALSE'}
+          WHERE status <> 'STOPPED' ${showNsfw ? Prisma.empty : Prisma.sql`AND "Sub"."nsfw" = FALSE`}
           GROUP BY "Sub".name, ss."userId", "MuteSub"."userId"
           ORDER BY "Sub".name ASC
         `


### PR DESCRIPTION
## Description

fix #2392 

I noticed that operation Subs always returned meSubscription false, that seems to be the source of the problem.

Depending on the sequence the client calls Subs and SubItems (which returns proper meSubscription), the client gets a false meSubscription.

Switching between hot and top is such a sequence where hot ends up with just a Subs call at the end.

_A clear and concise description of what you changed and why._

Hence, extend subs to return meSubscription using a LEFT JOIN like seen similarly.

## Screenshots

https://github.com/user-attachments/assets/b4c7087d-d849-4b84-b463-f4c14dac9fba

## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_

Should subs return more fields from SubSubcription, like it does with MuteSub.*?

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

3, I reproduced the problem, made the change, verified it resolves the problem (see video above). Didn't try to test other cases where Subs is called.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Tested on desktop (Firefox only), only dark mode.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No
