### PR TITLE
Change layout in wallet prompt

### DIFF
--- a/wallets/client/hooks/prompt.js
+++ b/wallets/client/hooks/prompt.js
@@ -127,12 +127,12 @@ function SkipForm ({ onSkip }) {
   return (
     <Form
       initial={{ dontShowAgain: false }}
-      className='d-flex justify-content-between align-items-center mt-3'
+      className='d-flex align-items-center mt-3'
       onSubmit={onSubmit}
       schema={schema}
     >
-      <Checkbox label="don't show again" name='dontShowAgain' groupClassName='mb-0' />
       <Button type='submit' variant='secondary' size='sm'>skip</Button>
+      <Checkbox label="don't show again" name='dontShowAgain' groupClassName='mb-0 ms-3' />
     </Form>
   )
 }


### PR DESCRIPTION
## Description

I think the checkbox is currently too easy to miss. It's also a modifier of skipping, so it should also be closer to the skip button because of that and come after the skip button.

## Screenshots

before:

<img width="300" height="534" alt="localhost_3000_~bitcoin_post_type=link(iPhone SE) (1)" src="https://github.com/user-attachments/assets/128d71b8-a9cb-4a06-9fa6-d01b425dcfe0" />

after:

<img width="300" height="534" alt="localhost_3000_~bitcoin_post_type=link(iPhone SE)" src="https://github.com/user-attachments/assets/461d4232-8d2a-4387-971c-936c9fb5f48c" />

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. No functionality changed

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no