### PR TITLE
Map lnAddr to correct wallet on save via prompt

### DIFF
--- a/wallets/client/hooks/prompt.js
+++ b/wallets/client/hooks/prompt.js
@@ -74,7 +74,7 @@ function LnAddrForm ({ onAttach }) {
   const initial = { address: '' }
 
   const onSubmit = useCallback(async ({ address }) => {
-    await upsert({ address })
+    await upsert(address)
     onAttach()
   }, [upsert, onAttach])
 

--- a/wallets/client/hooks/query.js
+++ b/wallets/client/hooks/query.js
@@ -31,14 +31,15 @@ import { gql, useApolloClient, useMutation, useQuery } from '@apollo/client'
 import { useDecryption, useEncryption, useSetKey, useWalletLoggerFactory, useWalletsUpdatedAt, WalletStatus } from '@/wallets/client/hooks'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
-  isEncryptedField, isTemplate, isWallet, protocolAvailable, protocolClientSchema, protocolLogName, reverseProtocolRelationName
+  isEncryptedField, isTemplate, isWallet, protocolAvailable, protocolClientSchema, protocolLogName, reverseProtocolRelationName,
+  walletLud16Domain
 } from '@/wallets/lib/util'
 import { protocolTestSendPayment } from '@/wallets/client/protocols'
 import { timeoutSignal } from '@/lib/time'
 import { WALLET_SEND_PAYMENT_TIMEOUT_MS } from '@/lib/constants'
 import { useToast } from '@/components/toast'
 import { useMe } from '@/components/me'
-import { useWallets, useWalletsLoading } from '@/wallets/client/context'
+import { useTemplates, useWallets, useWalletsLoading } from '@/wallets/client/context'
 import { requestPersistentStorage } from '@/components/use-indexeddb'
 
 export function useWalletsQuery () {
@@ -184,16 +185,29 @@ export function useWalletProtocolUpsert () {
 }
 
 export function useLightningAddressUpsert () {
-  const wallet = useMemo(() => ({ name: 'LN_ADDR', __typename: 'WalletTemplate' }), [])
   const protocol = useMemo(() => ({ name: 'LN_ADDR', send: false, __typename: 'WalletProtocolTemplate' }), [])
   const upsert = useWalletProtocolUpsert()
   const testCreateInvoice = useTestCreateInvoice(protocol)
+  const mapper = useLightningAddressToWalletMapper()
 
-  return useCallback(async (values) => {
-    // TODO(wallet-v2): parse domain from address input to use correct wallet template
-    await testCreateInvoice(values)
-    return await upsert(wallet, protocol, { ...values, enabled: true })
-  }, [testCreateInvoice, upsert, wallet, protocol])
+  return useCallback(async (address) => {
+    await testCreateInvoice({ address })
+    const wallet = mapper(address)
+    return await upsert(wallet, protocol, { address, enabled: true })
+  }, [testCreateInvoice, mapper, upsert, protocol])
+}
+
+function useLightningAddressToWalletMapper () {
+  const templates = useTemplates()
+  return useCallback((address) => {
+    return templates
+      .filter(t => t.protocols.some(p => p.name === 'LN_ADDR'))
+      .find(t => {
+        const domain = walletLud16Domain(t.name)
+        // the LN_ADDR wallet supports lightning addresses but does not have a domain because it's a generic wallet for any LN address
+        return domain && address.endsWith(domain)
+      }) ?? { name: 'LN_ADDR', __typename: 'WalletTemplate' }
+  }, [templates])
 }
 
 export function useWalletEncryptionUpdate () {


### PR DESCRIPTION
## Description

This resolves a TODO for attaching lightning addresses via the prompt. We're now mapping the address to the appropriate wallet if there is one and only use the generic lightning address wallet as a fallback.

## Video

https://github.com/user-attachments/assets/0be0afa1-2f83-4612-bb8b-a1979bb82723

## Additional Context

I assume this is the source of why we have a lot of LN_ADDR wallets even though most addresses in them are from a wallet we directly support.

I will create a follow-up PR to migrate these wallets to the correct wallet. This also helps with wallet statistics.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9`. Tested with npub.cash, blitz-wallet.com and patching the code to find no wallets to test the fallback.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no