### PR TITLE
Support when parameter in items with default sort

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -569,15 +569,16 @@ export default {
                       '"Item".outlawed = false',
                       '"Item".bio = false',
                       ad ? `"Item".id <> ${ad.id}` : '',
+                      whenClause(when || 'forever', 'Item'),
                       activeOrMine(me),
                       await filterClause(me, models, type),
                       subClause(sub, 3, 'Item', me, showNsfw),
                       muteClause(me))}
                     ORDER BY ${sub ? '"subHotScore"' : '"hotScore"'} DESC, "Item".msats DESC, "Item".id DESC
-                    OFFSET $1
-                    LIMIT $2`,
+                    OFFSET $3
+                    LIMIT $4`,
                 orderBy: `ORDER BY ${sub ? '"subHotScore"' : '"hotScore"'} DESC, "Item".msats DESC, "Item".id DESC`
-              }, decodedCursor.offset, limit, ...subArr)
+              }, ...whenRange(when, from, to || decodedCursor.time), decodedCursor.offset, limit, ...subArr)
               break
           }
           break


### PR DESCRIPTION
## Description

fixes https://github.com/stackernews/stacker.news/issues/2433

Use the when parameter for default sort, similarly as is already done for sort="top".

## Screenshots

## Additional Context

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

5, manually ran API queries without when and when='custom' and verified the results are within range, verified sort=top and sort=default return the same set of items (including using cursor with different limits), checked UI with hot/recent/random/top for defects.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Tested on desktop, dark mode only.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No
