### PR TITLE
Allow 0 and otherwise empty forwards

### DIFF
--- a/lib/form.js
+++ b/lib/form.js
@@ -10,7 +10,12 @@ export const normalizeForwards = (forward) => {
   if (!Array.isArray(forward)) {
     return undefined
   }
-  return forward.filter(fwd => fwd.nym || fwd.user?.name).map(fwd => ({ nym: fwd.nym ?? fwd.user?.name, pct: Number(fwd.pct) }))
+  // Convert to normalized objects and filter out entries with no recipient
+  // and entries with a zero/invalid percentage. Users sometimes type '0'
+  // to mean blank; treat those as empty and drop them before sending to the server.
+  return forward
+    .map(fwd => ({ nym: fwd.nym ?? fwd.user?.name, pct: Number(fwd.pct) }))
+    .filter(fwd => fwd.nym && Number.isFinite(fwd.pct) && fwd.pct > 0)
 }
 
 export const toastUpsertSuccessMessages = (toaster, upsertResponseData, dataKey, itemText) => {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -146,12 +146,20 @@ export function advPostSchemaMembers ({ me, existingBoost = 0, ...args }) {
             },
             message: 'cannot forward to yourself'
           }),
-        pct: intValidator.required('must specify a percentage').min(1, 'percentage must be at least 1').max(100, 'percentage must not exceed 100')
+        pct: intValidator.required('must specify a percentage').max(100, 'percentage must not exceed 100')
       }))
       .compact((v) => !v.nym && !v.pct)
       .test({
         name: 'sum',
-        test: forwards => forwards ? forwards.map(fwd => Number(fwd.pct)).reduce((sum, cur) => sum + cur, 0) <= 100 : true,
+        test: forwards => {
+          if (!forwards) return true
+          const pcts = forwards.map(fwd => {
+            const s = typeof fwd.pct === 'string' ? fwd.pct.trim() : fwd.pct
+            return s === '' ? NaN : parseFloat(s)
+          })
+          if (!pcts.every(Number.isFinite)) return true
+          return pcts.reduce((sum, cur) => sum + cur, 0) <= 100
+        },
         message: 'the total forward percentage exceeds 100%'
       })
       .test({


### PR DESCRIPTION
## Description

fix #2271 

Made client and server changes to handle forward recipients more robustly:

`form.js:` normalize forwards before sending the mutation. Converts `pct` to Number and filters out entries that have no recipient (`nym`) or have non-finite or non-positive percentages. This lets the browser accept 0 or empty input while preventing blank/zero forwards from being sent to the server.

`validate.js:` adjusted the forwards schema so server-side validation remains strict but more precise:

## Additional Context

Only fully empty forward objects (no `nym` and no `pct`) are compacted away.
The total-sum check now skips when any `pct` is non-finite so that field-level validators (e.g. `required`) produce the specific error the user should see (instead of a confusing "sum exceeds 100%" message).


## Screenshots


https://github.com/user-attachments/assets/e1e060e6-e8d7-4820-b984-5d85b82e14e7



## Checklist

**Are your changes backward compatible? Please answer below:**
yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7/10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**nan


**Did you introduce any new environment variables? If so, call them out explicitly here:**nan
