### PR TITLE
Improve image detection

### DIFF
--- a/worker/imgproxy.js
+++ b/worker/imgproxy.js
@@ -33,7 +33,7 @@ const imageUrlMatchers = [
 const exclude = [
   u => u.protocol !== 'https:',
   u => u.host.endsWith('.onion') || u.host.endsWith('.b32.ip') || u.host.endsWith('.loki'),
-  u => ['twitter.com', 'x.com', 'nitter.it', 'nitter.at'].some(h => h === u.host),
+  u => ['twitter.com', 'x.com', 'nitter.it', 'nitter.at', 'xcancel.com'].some(h => h === u.host),
   u => u.host === 'stacker.news',
   u => u.host === 'news.ycombinator.com',
   u => u.host === 'www.youtube.com' || u.host === 'youtu.be',

--- a/worker/imgproxy.js
+++ b/worker/imgproxy.js
@@ -31,7 +31,7 @@ const imageUrlMatchers = [
   u => u.host === 'i.imgur.com'
 ]
 const exclude = [
-  u => u.protocol === 'mailto:',
+  u => u.protocol !== 'https:',
   u => u.host.endsWith('.onion') || u.host.endsWith('.b32.ip') || u.host.endsWith('.loki'),
   u => ['twitter.com', 'x.com', 'nitter.it', 'nitter.at'].some(h => h === u.host),
   u => u.host === 'stacker.news',


### PR DESCRIPTION
## Description

Any image link should be HTTPS and xcancel.com links are not images.

The clients checks them all the time (and might even be triggering 429 Too Many Requests for the client IP if there are too many on a page). This PR doesn't fix that; these are just easy improvements to our list of definitely-not-image hosts.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

I did not test, only made sure that `new URL("https://xcancel.com).protocol` returns `https:`, so looks good to me

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no