### PR TITLE
Improve CSS for lists in modals

### DIFF
--- a/components/adv-post-form.js
+++ b/components/adv-post-form.js
@@ -32,7 +32,7 @@ const FormStatus = {
 
 export function BoostHelp () {
   return (
-    <ol style={{ lineHeight: 1.25 }}>
+    <ol>
       <li>Boost ranks items higher based on the amount</li>
       <li>The highest boost in a territory over the last 30 days is pinned to the top of the territory</li>
       <li>The highest boost across all territories over the last 30 days is pinned to the top of the homepage</li>

--- a/components/info/cc.js
+++ b/components/info/cc.js
@@ -5,7 +5,7 @@ export default function CCInfo (props) {
   return (
     <Info {...props}>
       <h6>Why am I getting cowboy credits?</h6>
-      <ul className='line-height-md'>
+      <ul>
         <li>to receive sats, you must attach an <Link href='/wallets'>external receiving wallet</Link></li>
         <li>zappers may have chosen to send you CCs instead of sats</li>
         <li>if the zaps are split on a post, recipients will receive CCs regardless of their configured receiving wallet</li>

--- a/components/info/reward-sats.js
+++ b/components/info/reward-sats.js
@@ -5,7 +5,7 @@ export default function RewardSatsInfo (props) {
   return (
     <Info {...props}>
       <h6>Where did my sats come from?</h6>
-      <ul className='line-height-md'>
+      <ul>
         <li>you may have sats from before <Link href='/items/835465'>SN went not-custodial</Link></li>
         <li>sats also come from <Link href='/rewards'>daily rewards</Link> and territory revenue
           <ul>

--- a/components/job-form.js
+++ b/components/job-form.js
@@ -114,7 +114,7 @@ export default function JobForm ({ item, sub }) {
           label={
             <div className='d-flex align-items-center'>boost
               <Info>
-                <ol className='line-height-md'>
+                <ol>
                   <li>Boost ranks jobs higher based on the amount</li>
                   <li>The minimum boost is {numWithUnits(BOOST_MIN, { abbreviate: false })}</li>
                   <li>Boost must be divisible by {numWithUnits(BOOST_MULT, { abbreviate: false })}</li>

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -322,6 +322,10 @@ svg {
   padding: 0;
   background-color: transparent;
 }
+.modal-body li {
+  line-height: 1.25;
+  margin-top: 0.5rem;
+}
 .modal-close.fullscreen {
   padding: 1.25rem;
 }


### PR DESCRIPTION
## Description

We used to use `line-height` to control gaps between list items. However, `line-height` controls the gap between _lines_, not only list items.

So I think we should actually use a small `line-height` within a list item and use margins between them.

This is relevant for the boost info, see screenshots.

## Screenshots

before:

_everything tight together:_

<img width="513" height="447" alt="2025-08-29-235203_513x447_scrot" src="https://github.com/user-attachments/assets/67780a78-bcbf-457c-9b21-89440d13ce88" />

_stays the same:_

<img width="516" height="366" alt="2025-08-29-235237_516x366_scrot" src="https://github.com/user-attachments/assets/a71dfa9d-d2a4-4d7b-bfbc-1f83963b052c" />

_everything less tight together, but no distinct gaps between lines or (nested) items:_

<img width="515" height="534" alt="2025-08-29-235927_515x534_scrot" src="https://github.com/user-attachments/assets/5e9df92c-c28f-4aa7-99ea-6251f1116473" />

after:

_closer lines, more gaps between list items:_

<img width="516" height="528" alt="2025-08-29-234619_516x528_scrot" src="https://github.com/user-attachments/assets/ee82f693-c9c4-4ec7-b195-c118131ec26a" />

_unchanged_

<img width="512" height="364" alt="2025-08-29-234636_512x364_scrot" src="https://github.com/user-attachments/assets/a36b445a-ec6a-4ffa-baf1-a174bb16d050" />

_closer lines, more gaps between list items:_

<img width="517" height="535" alt="2025-08-29-235856_517x535_scrot" src="https://github.com/user-attachments/assets/7773829b-6e3c-4269-b529-16c8af569b9b" />


## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`, see screenshots. Searched for `<Info>` to remove and test obsolete inline CSS to control `line-height` of `ul` or `ol` elements. 

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no