### PR TITLE
Fix CommentsViewAt coalesce fallbacks

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -181,7 +181,7 @@ export async function itemQueryWithMeta ({ me, models, query, orderBy = '' }, ..
         "ThreadSubscription"."itemId" IS NOT NULL AS "meSubscription", "ItemForward"."itemId" IS NOT NULL AS "meForward",
         to_jsonb("Sub".*) || jsonb_build_object('meMuteSub', "MuteSub"."userId" IS NOT NULL)
         || jsonb_build_object('meSubscription', "SubSubscription"."userId" IS NOT NULL) as sub,
-        COALESCE("CommentsViewAt"."last_viewed_at", "Item"."created_at") as "meCommentsViewedAt"
+        COALESCE("CommentsViewAt"."last_viewed_at", "Item"."lastCommentAt", "Item"."created_at") as "meCommentsViewedAt"
       FROM (
         ${query}
       ) "Item"


### PR DESCRIPTION
## Description

Fixes `meCommentsViewedAt` fallbacks following this coalesce order:
`"CommentsViewAt"."last_viewed_at" -> "Item"."lastCommentAt" -> "Item"."created_at"`

## Screenshots

## Additional Context

Didn't think of it since dev seed has `lastCommentAt` null

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6, shouldn't kill anything

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a