### PR TITLE
navigator: also track new comments visible in viewport

### DIFF
--- a/components/use-comments-navigator.js
+++ b/components/use-comments-navigator.js
@@ -62,10 +62,6 @@ export function useCommentsNavigator () {
       window.requestAnimationFrame(() => {
         if (!commentRef?.current || !commentRef.current.isConnected) return
 
-        // don't track this new comment if it's visible in the viewport
-        const rect = commentRef.current.getBoundingClientRect()
-        if (rect.top >= 0 && rect.bottom <= window.innerHeight) return
-
         // dedupe
         const existing = commentRefs.current.some(item => item.ref.current === commentRef.current)
         if (existing) return


### PR DESCRIPTION
## Description

Removes the viewport check when tracking new comments with navigator.
I agree that the experience feels inconsistent, especially when the navigator becomes the main way someone navigates a comment thread.

## Checklist

**Are your changes backward compatible? Please answer below:**
n/a

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8, it was a plug-n-play check!

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a