### PR TITLE
feat(territory): Founder disable territory deletes

### DIFF
--- a/api/typeDefs/sub.js
+++ b/api/typeDefs/sub.js
@@ -22,7 +22,7 @@ export default gql`
       replyCost: Int!,
       postTypes: [String!]!,
       billingType: String!, billingAutoRenew: Boolean!,
-      moderated: Boolean!, nsfw: Boolean!): SubPaidAction!
+      moderated: Boolean!, nsfw: Boolean!, disableDeletion: Boolean!): SubPaidAction!
     paySub(name: String!): SubPaidAction!
     toggleMuteSub(name: String!): Boolean!
     toggleSubSubscription(name: String!): Boolean!
@@ -30,7 +30,7 @@ export default gql`
     unarchiveTerritory(name: String!, desc: String, baseCost: Int!,
       replyCost: Int!, postTypes: [String!]!,
       billingType: String!, billingAutoRenew: Boolean!,
-      moderated: Boolean!, nsfw: Boolean!): SubPaidAction!
+      moderated: Boolean!, nsfw: Boolean!, disableDeletion: Boolean!): SubPaidAction!
   }
 
   type Sub {
@@ -55,6 +55,7 @@ export default gql`
     moderatedCount: Int!
     meMuteSub: Boolean!
     nsfw: Boolean!
+    disableDeletion: Boolean!
     nposts(when: String, from: String, to: String): Int!
     ncomments(when: String, from: String, to: String): Int!
     meSubscription: Boolean!

--- a/components/delete.js
+++ b/components/delete.js
@@ -7,7 +7,7 @@ import Dropdown from 'react-bootstrap/Dropdown'
 import { useShowModal } from './modal'
 import { useToast } from './toast'
 
-export default function Delete ({ itemId, children, onDelete, type = 'post' }) {
+export default function Delete ({ itemId, children, onDelete, type = 'post', founder = false }) {
   const showModal = useShowModal()
 
   const [deleteItem] = useMutation(
@@ -43,6 +43,7 @@ export default function Delete ({ itemId, children, onDelete, type = 'post' }) {
           return (
             <DeleteConfirm
               type={type}
+              founder={founder}
               onConfirm={async () => {
                 const { error } = await deleteItem({ variables: { id: itemId } })
                 if (error) {
@@ -62,25 +63,31 @@ export default function Delete ({ itemId, children, onDelete, type = 'post' }) {
   )
 }
 
-export function DeleteConfirm ({ onConfirm, type }) {
+export function DeleteConfirm ({ onConfirm, type, founder }) {
   const [error, setError] = useState()
   const toaster = useToast()
 
   return (
     <>
       {error && <Alert variant='danger' onClose={() => setError(undefined)} dismissible>{error}</Alert>}
-      <p className='fw-bolder'>Are you sure? This is a gone forever kind of delete.</p>
+      <p className='fw-bolder'>
+        {founder
+          ? `Are you sure? This will permanently delete this ${type.toLowerCase()} as the territory founder.`
+          : 'Are you sure? This is a gone forever kind of delete.'}
+      </p>
       <div className='d-flex justify-content-end'>
         <Button
           variant='danger' onClick={async () => {
             try {
               await onConfirm()
-              toaster.success(`deleted ${type.toLowerCase()}`)
+              toaster.success(founder
+                ? `deleted ${type.toLowerCase()} as founder`
+                : `deleted ${type.toLowerCase()}`)
             } catch (e) {
               setError(e.message || e)
             }
           }}
-        >delete
+        >{founder ? 'delete as founder' : 'delete'}
         </Button>
       </div>
     </>
@@ -88,10 +95,11 @@ export function DeleteConfirm ({ onConfirm, type }) {
 }
 
 export function DeleteDropdownItem (props) {
+  const { founder } = props || {}
   return (
     <Delete {...props}>
       <Dropdown.Item>
-        delete
+        {founder ? 'delete as founder' : 'delete'}
       </Dropdown.Item>
     </Delete>
   )

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -223,9 +223,27 @@ export default function ItemInfo ({
                   <PinSubDropdownItem item={item} />
                 </>}
               {item.mine && !item.position && !item.deletedAt && !item.bio &&
+                (!sub?.disableDeletion || (me && sub?.userId === Number(me.id))) &&
+                  <>
+                    <hr className='dropdown-divider' />
+                    <DeleteDropdownItem
+                      itemId={item.id}
+                      type={item.title ? 'post' : 'comment'}
+                      founder={sub?.disableDeletion && me && sub?.userId === Number(me.id)}
+                    />
+                  </>}
+              {item.mine && !item.position && !item.deletedAt && !item.bio && sub?.disableDeletion &&
+                me && sub?.userId !== Number(me.id) &&
+                  <>
+                    <hr className='dropdown-divider' />
+                    <Dropdown.Item disabled className='text-muted'>
+                      delete disabled by territory founder
+                    </Dropdown.Item>
+                  </>}
+              {!item.mine && sub?.disableDeletion && me && sub?.userId === Number(me.id) &&
                 <>
                   <hr className='dropdown-divider' />
-                  <DeleteDropdownItem itemId={item.id} type={item.title ? 'post' : 'comment'} />
+                  <DeleteDropdownItem itemId={item.id} type={item.title ? 'post' : 'comment'} founder />
                 </>}
               {me && !item.mine &&
                 <>

--- a/components/post.js
+++ b/components/post.js
@@ -111,7 +111,10 @@ export function PostForm ({ type, sub, children }) {
           size='medium'
           sub={sub?.name}
           info={sub && <TerritoryInfo sub={sub} includeLink />}
-          hint={sub?.moderated && 'this territory is moderated'}
+          hint={[
+            sub?.moderated && 'this territory is moderated',
+            sub?.disableDeletion && 'this territory has deletion disabled'
+          ].filter(Boolean).join(' and ')}
         />
         <div>
           {postButtons}
@@ -177,7 +180,10 @@ export default function Post ({ sub }) {
             size='medium'
             label='territory'
             info={sub && <TerritoryInfo sub={sub} includeLink />}
-            hint={sub?.moderated && 'this territory is moderated'}
+            hint={[
+              sub?.moderated && 'this territory is moderated',
+              sub?.disableDeletion && 'this territory has deletion disabled'
+            ].filter(Boolean).join(' and ')}
           />}
       </PostForm>
     </>

--- a/components/reply.js
+++ b/components/reply.js
@@ -186,7 +186,10 @@ export default forwardRef(function Reply ({
                 required
                 appendValue={quote}
                 placeholder={placeholder}
-                hint={sub?.moderated && 'this territory is moderated'}
+                hint={[
+                  sub?.moderated && 'this territory is moderated',
+                  sub?.disableDeletion && 'this territory has deletion disabled'
+                ].filter(Boolean).join(' and ')}
               />
               <ItemButtonBar createText='reply' hasCancel={false} />
             </Form>

--- a/components/territory-form.js
+++ b/components/territory-form.js
@@ -96,6 +96,7 @@ export default function TerritoryForm ({ sub }) {
           billingType: sub?.billingType || 'MONTHLY',
           billingAutoRenew: sub?.billingAutoRenew || false,
           moderated: sub?.moderated || false,
+          disableDeletion: sub?.disableDeletion || false,
           nsfw: sub?.nsfw || false
         }}
         schema={schema}
@@ -256,6 +257,24 @@ export default function TerritoryForm ({ sub }) {
                   </div>
           }
                 name='moderated'
+                groupClassName='ms-1'
+              />
+              <BootstrapForm.Label>deletion control</BootstrapForm.Label>
+              <Checkbox
+                inline
+                label={
+                  <div className='d-flex align-items-center'>disable post deletion
+                    <Info>
+                      <ol>
+                        <li>Only territory founders can delete posts and comments</li>
+                        <li>Authors cannot delete their own content</li>
+                        <li>Delete bot commands will be ignored</li>
+                        <li>Your territory will get a <Badge bg='warning'>no deletion</Badge> badge</li>
+                      </ol>
+                    </Info>
+                  </div>
+                }
+                name='disableDeletion'
                 groupClassName='ms-1'
               />
               <BootstrapForm.Label>nsfw</BootstrapForm.Label>

--- a/components/territory-header.js
+++ b/components/territory-header.js
@@ -32,6 +32,7 @@ export function TerritoryDetails ({ sub, children }) {
           {sub.name}
           {sub.status === 'STOPPED' && <Badge className='ms-2' bg='danger'>archived</Badge>}
           {(sub.moderated || sub.moderatedCount > 0) && <Badge className='ms-2' bg='secondary'>moderated{sub.moderatedCount > 0 && ` ${sub.moderatedCount}`}</Badge>}
+          {sub.disableDeletion && <Badge className='ms-2' bg='warning'>no deletion</Badge>}
           {(sub.nsfw) && <Badge className='ms-2' bg='secondary'>nsfw</Badge>}
         </small>
       }

--- a/fragments/comments.js
+++ b/fragments/comments.js
@@ -121,6 +121,7 @@ export const COMMENTS_ITEM_EXT_FIELDS = gql`
         name
         userId
         moderated
+        disableDeletion
         meMuteSub
       }
       user {

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -32,6 +32,7 @@ export const ITEM_FIELDS = gql`
       name
       userId
       moderated
+      disableDeletion
       meMuteSub
       meSubscription
       nsfw
@@ -110,6 +111,7 @@ export const ITEM_FULL_FIELDS = gql`
         name
         userId
         moderated
+        disableDeletion
         meMuteSub
         meSubscription
         replyCost

--- a/fragments/paidAction.js
+++ b/fragments/paidAction.js
@@ -265,10 +265,10 @@ export const UPSERT_SUB = gql`
   ${PAID_ACTION}
   mutation upsertSub($oldName: String, $name: String!, $desc: String, $baseCost: Int!,
     $replyCost: Int!, $postTypes: [String!]!, $billingType: String!,
-    $billingAutoRenew: Boolean!, $moderated: Boolean!, $nsfw: Boolean!) {
+    $billingAutoRenew: Boolean!, $moderated: Boolean!, $nsfw: Boolean!, $disableDeletion: Boolean!) {
       upsertSub(oldName: $oldName, name: $name, desc: $desc, baseCost: $baseCost,
         replyCost: $replyCost, postTypes: $postTypes, billingType: $billingType,
-        billingAutoRenew: $billingAutoRenew, moderated: $moderated, nsfw: $nsfw) {
+        billingAutoRenew: $billingAutoRenew, moderated: $moderated, nsfw: $nsfw, disableDeletion: $disableDeletion) {
       result {
         name
       }
@@ -280,10 +280,10 @@ export const UNARCHIVE_TERRITORY = gql`
   ${PAID_ACTION}
   mutation unarchiveTerritory($name: String!, $desc: String, $baseCost: Int!,
     $replyCost: Int!, $postTypes: [String!]!, $billingType: String!,
-    $billingAutoRenew: Boolean!, $moderated: Boolean!, $nsfw: Boolean!) {
+    $billingAutoRenew: Boolean!, $moderated: Boolean!, $nsfw: Boolean!, $disableDeletion: Boolean!) {
       unarchiveTerritory(name: $name, desc: $desc, baseCost: $baseCost,
         replyCost: $replyCost, postTypes: $postTypes, billingType: $billingType,
-        billingAutoRenew: $billingAutoRenew, moderated: $moderated, nsfw: $nsfw) {
+        billingAutoRenew: $billingAutoRenew, moderated: $moderated, nsfw: $nsfw, disableDeletion: $disableDeletion) {
       result {
         name
       }

--- a/fragments/subs.js
+++ b/fragments/subs.js
@@ -34,6 +34,7 @@ export const SUB_FIELDS = gql`
     meMuteSub
     meSubscription
     nsfw
+    disableDeletion
   }`
 
 export const SUB_FULL_FIELDS = gql`

--- a/lib/item.js
+++ b/lib/item.js
@@ -61,20 +61,32 @@ export const getReminderCommand = (text) => {
 
 export const hasReminderCommand = (text) => !!getReminderCommand(text)
 
-export const deleteItemByAuthor = async ({ models, id, item }) => {
+export const deleteItemByAuthor = async ({ models, id, item, founderOnly = false }) => {
   if (!item) {
-    item = await models.item.findUnique({ where: { id: Number(id) } })
+    item = await models.item.findUnique({
+      where: { id: Number(id) },
+      include: { sub: true }
+    })
   }
   if (!item) {
     console.log('attempted to delete an item that does not exist', id)
     return
   }
   const updateData = { deletedAt: new Date() }
-  if (item.text) {
-    updateData.text = '*deleted by author*'
-  }
-  if (item.title) {
-    updateData.title = 'deleted by author'
+  if (founderOnly) {
+    if (item.text) {
+      updateData.text = '*deleted by territory founder*'
+    }
+    if (item.title) {
+      updateData.title = 'deleted by territory founder'
+    }
+  } else {
+    if (item.text) {
+      updateData.text = '*deleted by author*'
+    }
+    if (item.title) {
+      updateData.title = 'deleted by author'
+    }
   }
   if (item.url) {
     updateData.url = null

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -325,6 +325,7 @@ export function territorySchema (args) {
       .max(100000, 'must be at most 100k'),
     postTypes: array().of(string().oneOf(POST_TYPES)).min(1, 'must support at least one post type'),
     billingType: string().required('required').oneOf(TERRITORY_BILLING_TYPES, 'required'),
+    disableDeletion: boolean(),
     nsfw: boolean()
   })
 }

--- a/prisma/migrations/20250903190049_disable_delete/migration.sql
+++ b/prisma/migrations/20250903190049_disable_delete/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Sub" ADD COLUMN     "disableDeletion" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -689,6 +689,7 @@ model Sub {
   moderated        Boolean     @default(false)
   moderatedCount   Int         @default(0)
   nsfw             Boolean     @default(false)
+  disableDeletion  Boolean     @default(false)
 
   parent            Sub?                @relation("ParentChildren", fields: [parentName], references: [name])
   children          Sub[]               @relation("ParentChildren")


### PR DESCRIPTION
## Description

Closes #709 

Feat to let territory founders disable posts & comment deletes. Also disables bot deletes

## Screenshots


https://github.com/user-attachments/assets/c7680a41-050e-40a7-91f1-ea983f351c2e



## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_

## Checklist

**Are your changes backward compatible? Please answer below:**
Y
_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
9

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Y

**Did you introduce any new environment variables? If so, call them out explicitly here:**
N