### PR TITLE
Fix comments view tracking

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -181,7 +181,7 @@ export async function itemQueryWithMeta ({ me, models, query, orderBy = '' }, ..
         "ThreadSubscription"."itemId" IS NOT NULL AS "meSubscription", "ItemForward"."itemId" IS NOT NULL AS "meForward",
         to_jsonb("Sub".*) || jsonb_build_object('meMuteSub', "MuteSub"."userId" IS NOT NULL)
         || jsonb_build_object('meSubscription', "SubSubscription"."userId" IS NOT NULL) as sub,
-        COALESCE("CommentsViewAt"."last_viewed_at", "Item"."lastCommentAt", "Item"."created_at") as "meCommentsViewedAt"
+        "CommentsViewAt"."last_viewed_at" as "meCommentsViewedAt"
       FROM (
         ${query}
       ) "Item"

--- a/components/comment.js
+++ b/components/comment.js
@@ -162,15 +162,15 @@ export default function Comment ({
 
     const itemCreatedAt = new Date(item.createdAt).getTime()
 
-    const rootViewedAt = new Date(root.meCommentsViewedAt).getTime()
+    const meViewedAt = new Date(root.meCommentsViewedAt).getTime()
+    const viewedAt = me?.id ? meViewedAt : router.query.commentsViewedAt
+
+    const isNewComment = viewedAt && itemCreatedAt > viewedAt
+    // injected comments are new regardless of me or anon view time
     const rootLast = new Date(root.lastCommentAt || root.createdAt).getTime()
-    // it's a new comment if it was created after the last comment was viewed
-    const isNewComment = me?.id && rootViewedAt
-      ? itemCreatedAt > rootViewedAt
-      // anon fallback is based on the commentsViewedAt query param or the last comment createdAt
-      : ((router.query.commentsViewedAt && itemCreatedAt > router.query.commentsViewedAt) ||
-        (itemCreatedAt > rootLast))
-    if (!isNewComment) return
+    const isNewInjectedComment = item.injected && itemCreatedAt > (meViewedAt || rootLast)
+
+    if (!isNewComment && !isNewInjectedComment) return
 
     if (item.injected) {
       // newly injected comments (item.injected) have to use a different class to outline every new comment

--- a/components/item-full.js
+++ b/components/item-full.js
@@ -163,7 +163,7 @@ function ItemText ({ item }) {
 
 export default function ItemFull ({ item, fetchMoreComments, bio, rank, ...props }) {
   // no cache update here because we need to preserve the initial value
-  const { markItemViewed } = useCommentsView({ itemId: item.id, updateCache: false })
+  const { markItemViewed } = useCommentsView(item.id, { updateCache: false })
 
   useEffect(() => {
     markItemViewed(item)

--- a/components/item-full.js
+++ b/components/item-full.js
@@ -11,7 +11,6 @@ import { useMe } from './me'
 import Button from 'react-bootstrap/Button'
 import { useEffect } from 'react'
 import Poll from './poll'
-import { commentsViewed } from '@/lib/new-comments'
 import Related from './related'
 import PastBounties from './past-bounties'
 import Check from '@/svgs/check-double-line.svg'
@@ -27,8 +26,7 @@ import classNames from 'classnames'
 import { CarouselProvider } from './carousel'
 import Embed from './embed'
 import { useRouter } from 'next/router'
-import { useMutation } from '@apollo/client'
-import { UPDATE_ITEM_USER_VIEW } from '@/fragments/items'
+import useCommentsView from './use-comments-view'
 
 function BioItem ({ item, handleClick }) {
   const { me } = useMe()
@@ -164,25 +162,12 @@ function ItemText ({ item }) {
 }
 
 export default function ItemFull ({ item, fetchMoreComments, bio, rank, ...props }) {
-  const { me } = useMe()
   // no cache update here because we need to preserve the initial value
-  const [updateCommentsViewAt] = useMutation(UPDATE_ITEM_USER_VIEW)
+  const { markItemViewed } = useCommentsView({ updateCache: false })
 
   useEffect(() => {
-    if (item.parentId) return
-    // local comments viewed (anon fallback)
-    if (!me?.id) return commentsViewed(item)
-
-    const last = new Date(item.lastCommentAt || item.createdAt)
-    const viewedAt = new Date(item.meCommentsViewedAt)
-
-    if (viewedAt.getTime() >= last.getTime()) return
-
-    // me server comments viewed
-    updateCommentsViewAt({
-      variables: { id: item.id, meCommentsViewedAt: last }
-    })
-  }, [item.id, item.lastCommentAt, item.createdAt, item.meCommentsViewedAt, me?.id])
+    markItemViewed(item)
+  }, [item.id, markItemViewed])
 
   const router = useRouter()
   const carouselKey = `${item.id}-${router.query?.sort || 'default'}`

--- a/components/item-full.js
+++ b/components/item-full.js
@@ -163,10 +163,10 @@ function ItemText ({ item }) {
 
 export default function ItemFull ({ item, fetchMoreComments, bio, rank, ...props }) {
   // no cache update here because we need to preserve the initial value
-  const { markItemViewed } = useCommentsView({ updateCache: false })
+  const { markItemViewed } = useCommentsView({ item, updateCache: false })
 
   useEffect(() => {
-    markItemViewed(item)
+    markItemViewed()
   }, [item.id, markItemViewed])
 
   const router = useRouter()

--- a/components/item-full.js
+++ b/components/item-full.js
@@ -163,10 +163,10 @@ function ItemText ({ item }) {
 
 export default function ItemFull ({ item, fetchMoreComments, bio, rank, ...props }) {
   // no cache update here because we need to preserve the initial value
-  const { markItemViewed } = useCommentsView({ item, updateCache: false })
+  const { markItemViewed } = useCommentsView({ itemId: item.id, updateCache: false })
 
   useEffect(() => {
-    markItemViewed()
+    markItemViewed(item)
   }, [item.id, markItemViewed])
 
   const router = useRouter()

--- a/components/reply.js
+++ b/components/reply.js
@@ -30,7 +30,7 @@ export default forwardRef(function Reply ({
   const showModal = useShowModal()
   const root = useRoot()
   const sub = item?.sub || root?.sub
-  const { markCommentViewedAt } = useCommentsView()
+  const { markCommentViewedAt } = useCommentsView(root.id)
 
   useEffect(() => {
     if (replyOpen || quote || !!window.localStorage.getItem('reply-' + parentId + '-' + 'text')) {

--- a/components/reply.js
+++ b/components/reply.js
@@ -30,7 +30,7 @@ export default forwardRef(function Reply ({
   const showModal = useShowModal()
   const root = useRoot()
   const sub = item?.sub || root?.sub
-  const { markCommentViewedAt } = useCommentsView({ item })
+  const { markCommentViewedAt } = useCommentsView()
 
   useEffect(() => {
     if (replyOpen || quote || !!window.localStorage.getItem('reply-' + parentId + '-' + 'text')) {

--- a/components/reply.js
+++ b/components/reply.js
@@ -1,11 +1,9 @@
 import { Form, MarkdownInput } from '@/components/form'
 import styles from './reply.module.css'
 import { COMMENTS } from '@/fragments/comments'
-import { UPDATE_ITEM_USER_VIEW } from '@/fragments/items'
 import { useMe } from './me'
 import { forwardRef, useCallback, useEffect, useState, useRef, useMemo } from 'react'
 import { FeeButtonProvider, postCommentBaseLineItems, postCommentUseRemoteLineItems } from './fee-button'
-import { commentsViewedAfterComment } from '@/lib/new-comments'
 import { commentSchema } from '@/lib/validate'
 import { ItemButtonBar } from './post'
 import { useShowModal } from './modal'
@@ -15,7 +13,7 @@ import { CREATE_COMMENT } from '@/fragments/paidAction'
 import useItemSubmit from './use-item-submit'
 import gql from 'graphql-tag'
 import { updateAncestorsCommentCount } from '@/lib/comments'
-import { useMutation } from '@apollo/client'
+import useCommentsView from './use-comments-view'
 
 export default forwardRef(function Reply ({
   item,
@@ -32,14 +30,7 @@ export default forwardRef(function Reply ({
   const showModal = useShowModal()
   const root = useRoot()
   const sub = item?.sub || root?.sub
-  const [updateCommentsViewAt] = useMutation(UPDATE_ITEM_USER_VIEW, {
-    update (cache, { data: { updateCommentsViewAt } }) {
-      cache.modify({
-        id: `Item:${root?.id}`,
-        fields: { meCommentsViewedAt: () => updateCommentsViewAt }
-      })
-    }
-  })
+  const { markCommentViewedAt } = useCommentsView({ item })
 
   useEffect(() => {
     if (replyOpen || quote || !!window.localStorage.getItem('reply-' + parentId + '-' + 'text')) {
@@ -97,14 +88,7 @@ export default forwardRef(function Reply ({
 
         // so that we don't see indicator for our own comments, we record this comments as the latest time
         // but we also have record num comments, in case someone else commented when we did
-        const rootId = ancestors[0]
-        if (me?.id) {
-          // server-tracked view
-          updateCommentsViewAt({ variables: { id: rootId, meCommentsViewedAt: result.createdAt } })
-        } else {
-          // anon fallback
-          commentsViewedAfterComment(rootId, result.createdAt)
-        }
+        markCommentViewedAt(result.createdAt, { ncomments: 1 })
       }
     },
     onSuccessfulSubmit: (data, { resetForm }) => {

--- a/components/use-comments-view.js
+++ b/components/use-comments-view.js
@@ -1,0 +1,53 @@
+import { useMutation } from '@apollo/client'
+import { useCallback } from 'react'
+import { UPDATE_ITEM_USER_VIEW } from '@/fragments/items'
+import { commentsViewedAfterComment, commentsViewed, newComments } from '@/lib/new-comments'
+import { useMe } from './me'
+import { useRoot } from './root'
+
+export default function useCommentsView ({ updateCache = true } = {}) {
+  const { me } = useMe()
+  const root = useRoot()
+
+  const [updateCommentsViewAt] = useMutation(UPDATE_ITEM_USER_VIEW, updateCache && {
+    update (cache, { data: { updateCommentsViewAt } }) {
+      cache.modify({
+        id: `Item:${root.id}`,
+        fields: { meCommentsViewedAt: () => updateCommentsViewAt }
+      })
+    }
+  })
+
+  const updateViewTimestamp = useCallback((id, timestamp, anonFallbackFn) => {
+    if (me?.id) {
+      updateCommentsViewAt({ variables: { id, meCommentsViewedAt: timestamp } })
+    } else {
+      anonFallbackFn()
+    }
+  }, [me?.id, updateCommentsViewAt])
+
+  // update meCommentsViewedAt on comment injection
+  const markCommentViewedAt = useCallback((latest, { rootId, ncomments } = {}) => {
+    const id = rootId || root.id
+    updateViewTimestamp(
+      id,
+      latest,
+      () => commentsViewedAfterComment(id, latest, ncomments)
+    )
+  }, [me?.id, root?.id, updateViewTimestamp])
+
+  // update meCommentsViewedAt on item view
+  const markItemViewed = useCallback(item => {
+    if (!newComments(item)) return
+    const { lastCommentAt, createdAt } = item
+    const latest = new Date(lastCommentAt || createdAt)
+
+    updateViewTimestamp(
+      item.id,
+      latest,
+      () => commentsViewed(item)
+    )
+  }, [me?.id, updateViewTimestamp])
+
+  return { markCommentViewedAt, markItemViewed }
+}

--- a/components/use-comments-view.js
+++ b/components/use-comments-view.js
@@ -23,7 +23,7 @@ export default function useCommentsView ({ item, updateCache = true } = {}) {
     }
   })
 
-  const updateViewTimestamp = useCallback((id, timestamp, anonFallbackFn) => {
+  const updateViewedAt = useCallback((id, timestamp, anonFallbackFn) => {
     if (me?.id) {
       updateCommentsViewAt({ variables: { id, meCommentsViewedAt: timestamp } })
     } else {
@@ -33,24 +33,24 @@ export default function useCommentsView ({ item, updateCache = true } = {}) {
 
   // update meCommentsViewedAt on comment injection
   const markCommentViewedAt = useCallback((latest, { ncomments } = {}) => {
-    updateViewTimestamp(
+    updateViewedAt(
       itemId,
       latest,
       () => commentsViewedAfterComment(itemId, latest, ncomments)
     )
-  }, [itemId, updateViewTimestamp])
+  }, [itemId, updateViewedAt])
 
   // update meCommentsViewedAt on item view
   const markItemViewed = useCallback((latest) => {
     if (!item || (item?.meCommentsViewedAt && !newComments(item))) return
     const newLatest = new Date(latest || item?.lastCommentAt)
 
-    updateViewTimestamp(
+    updateViewedAt(
       itemId,
       newLatest,
       () => commentsViewed(item)
     )
-  }, [item, itemId, updateViewTimestamp])
+  }, [item, itemId, updateViewedAt])
 
   return { markCommentViewedAt, markItemViewed }
 }

--- a/components/use-comments-view.js
+++ b/components/use-comments-view.js
@@ -26,32 +26,30 @@ export default function useCommentsView ({ item, updateCache = true } = {}) {
     } else {
       anonFallbackFn()
     }
-  }, [me?.id, updateCommentsViewAt, updateCache])
+  }, [me?.id, updateCommentsViewAt])
 
   // update meCommentsViewedAt on comment injection
-  const markCommentViewedAt = useCallback((latest, { rootId, ncomments } = {}) => {
-    const id = rootId || root.id
+  const markCommentViewedAt = useCallback((latest, { ncomments } = {}) => {
+    const id = item?.id || root?.id
 
     updateViewTimestamp(
       id,
       latest,
       () => commentsViewedAfterComment(id, latest, ncomments)
     )
-  }, [root?.id, updateViewTimestamp, updateCache])
+  }, [item?.id, root?.id, updateViewTimestamp])
 
   // update meCommentsViewedAt on item view
   const markItemViewed = useCallback(() => {
-    if (item.meCommentsViewedAt && !newComments(item)) return
-
-    const { lastCommentAt } = item
-    const latest = new Date(lastCommentAt)
+    if (item?.meCommentsViewedAt && !newComments(item)) return
+    const latest = new Date(item?.lastCommentAt)
 
     updateViewTimestamp(
-      item.id,
+      item?.id,
       latest,
       () => commentsViewed(item)
     )
-  }, [updateViewTimestamp, updateCache])
+  }, [item?.id, root?.id, updateViewTimestamp])
 
   return { markCommentViewedAt, markItemViewed }
 }

--- a/components/use-comments-view.js
+++ b/components/use-comments-view.js
@@ -39,7 +39,8 @@ export default function useCommentsView ({ itemId, updateCache = true } = {}) {
   // update meCommentsViewedAt on item view
   const markItemViewed = useCallback((item, latest) => {
     if (!item || (item?.meCommentsViewedAt && !newComments(item))) return
-    const newLatest = new Date(latest || item?.lastCommentAt)
+    const lastAt = latest || item?.lastCommentAt || item?.createdAt
+    const newLatest = new Date(lastAt)
 
     updateViewedAt(newLatest, () => commentsViewed(item))
   }, [updateViewedAt])

--- a/components/use-comments-view.js
+++ b/components/use-comments-view.js
@@ -3,19 +3,16 @@ import { useCallback } from 'react'
 import { UPDATE_ITEM_USER_VIEW } from '@/fragments/items'
 import { commentsViewedAfterComment, commentsViewed, newComments } from '@/lib/new-comments'
 import { useMe } from './me'
-import { useRoot } from './root'
 
-export default function useCommentsView ({ itemId, updateCache = true } = {}) {
+export default function useCommentsView (itemId, { updateCache = true } = {}) {
   const { me } = useMe()
-  const root = useRoot()
-  const id = itemId || root?.id
 
   const [updateCommentsViewAt] = useMutation(UPDATE_ITEM_USER_VIEW, {
     update (cache, { data: { updateCommentsViewAt } }) {
-      if (!updateCache || !id) return
+      if (!updateCache || !itemId) return
 
       cache.modify({
-        id: `Item:${id}`,
+        id: `Item:${itemId}`,
         fields: { meCommentsViewedAt: () => updateCommentsViewAt }
       })
     }
@@ -23,22 +20,22 @@ export default function useCommentsView ({ itemId, updateCache = true } = {}) {
 
   const updateViewedAt = useCallback((latest, anonFallbackFn) => {
     if (me?.id) {
-      updateCommentsViewAt({ variables: { id, meCommentsViewedAt: latest } })
+      updateCommentsViewAt({ variables: { id: Number(itemId), meCommentsViewedAt: latest } })
     } else {
       anonFallbackFn()
     }
-  }, [me?.id, id, updateCommentsViewAt])
+  }, [me?.id, itemId, updateCommentsViewAt])
 
   // update meCommentsViewedAt on comment injection
   const markCommentViewedAt = useCallback((latest, { ncomments } = {}) => {
     if (!latest) return
 
-    updateViewedAt(latest, () => commentsViewedAfterComment(id, latest, ncomments))
-  }, [id, updateViewedAt])
+    updateViewedAt(latest, () => commentsViewedAfterComment(itemId, latest, ncomments))
+  }, [itemId, updateViewedAt])
 
   // update meCommentsViewedAt on item view
   const markItemViewed = useCallback((item, latest) => {
-    if (!item || (item?.meCommentsViewedAt && !newComments(item))) return
+    if (!item || item.parentId || (item?.meCommentsViewedAt && !newComments(item))) return
     const lastAt = latest || item?.lastCommentAt || item?.createdAt
     const newLatest = new Date(lastAt)
 

--- a/components/use-live-comments.js
+++ b/components/use-live-comments.js
@@ -88,7 +88,7 @@ function cacheNewComments (cache, latest, topLevelId, newComments, sort) {
 export default function useLiveComments (topLevelId, after, sort) {
   const latestKey = `liveCommentsLatest:${topLevelId}`
   const { cache } = useApolloClient()
-  const { markCommentViewedAt } = useCommentsView()
+  const { markCommentViewedAt } = useCommentsView({ itemId: topLevelId })
   const [disableLiveComments] = useLiveCommentsToggle()
   const [latest, setLatest] = useState(after)
   const [initialized, setInitialized] = useState(false)

--- a/components/use-live-comments.js
+++ b/components/use-live-comments.js
@@ -88,7 +88,7 @@ function cacheNewComments (cache, latest, topLevelId, newComments, sort) {
 export default function useLiveComments (topLevelId, after, sort) {
   const latestKey = `liveCommentsLatest:${topLevelId}`
   const { cache } = useApolloClient()
-  const { markCommentViewedAt } = useCommentsView({ itemId: topLevelId })
+  const { markCommentViewedAt } = useCommentsView(topLevelId)
   const [disableLiveComments] = useLiveCommentsToggle()
   const [latest, setLatest] = useState(after)
   const [initialized, setInitialized] = useState(false)

--- a/components/use-live-comments.js
+++ b/components/use-live-comments.js
@@ -10,7 +10,6 @@ import {
   updateAncestorsCommentCount,
   calculateDepth
 } from '../lib/comments'
-import { useRoot } from './root'
 
 const POLL_INTERVAL = 1000 * 5 // 5 seconds
 
@@ -89,7 +88,6 @@ function cacheNewComments (cache, latest, topLevelId, newComments, sort) {
 export default function useLiveComments (topLevelId, after, sort) {
   const latestKey = `liveCommentsLatest:${topLevelId}`
   const { cache } = useApolloClient()
-  const root = useRoot()
   const { markCommentViewedAt } = useCommentsView()
   const [disableLiveComments] = useLiveCommentsToggle()
   const [latest, setLatest] = useState(after)
@@ -137,7 +135,7 @@ export default function useLiveComments (topLevelId, after, sort) {
         window.sessionStorage.setItem(latestKey, injectedLatest)
       }
     }
-  }, [data, cache, topLevelId, root.id, sort, latest, markCommentViewedAt])
+  }, [data, cache, topLevelId, sort, latest, markCommentViewedAt])
 }
 
 const STORAGE_KEY = 'disableLiveComments'


### PR DESCRIPTION
## Description

Fixes items not being tracked server-side because `meCommentsViewedAt` would always be up-to-date.
Fixes outlining conditions for logged-in and anon users.
Backports the `useCommentsView` hook from #2462

## Screenshots
This video showcases an item that was never visited (no outlines), and what happens when we start tracking it.
Also showcases a correctly working outlining.

https://github.com/user-attachments/assets/c10ff4b5-b6a7-4a03-bb10-bb4f0a310eba

## Additional Context

Coalescing wasn't the greatest of ideas considering that the purpose of `CommentsViewAt` should be personal tracking.

## Checklist

**Are your changes backward compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, iterative QA

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a