### PR TITLE
Fix CLN container build on ARM

### DIFF
--- a/docker/cln/Dockerfile
+++ b/docker/cln/Dockerfile
@@ -1,8 +1,5 @@
 FROM polarlightning/clightning:24.11
 
-# make sure that wallet and identity is persisted across rebuilds.
-# server certificates contain stacker_lnd as a custom domain.
-# see https://docs.corelightning.org/docs/grpc#generating-custom-certificates-optional
-# since CLNRest in CLNv23.08 seems to use client certificates, they also contain stacker_lnd as a custom domain.
-# see https://github.com/ElementsProject/lightning/tree/v23.08/plugins/clnrest#configuration
+# make sure that wallet and identity is persisted across rebuilds
+# https://docs.corelightning.org/docs/grpc#generating-custom-certificates-optional
 COPY ["./hsm_secret", "./ca-key.pem", "./ca.pem", "./server-key.pem", "./server.pem", "./client-key.pem", "./client.pem", "/home/clightning/.lightning/regtest/"]

--- a/docker/cln/Dockerfile
+++ b/docker/cln/Dockerfile
@@ -1,13 +1,5 @@
 FROM polarlightning/clightning:24.11
 
-RUN apt-get update -y \
-  && apt-get install -y jq wget \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN wget https://raw.githubusercontent.com/ElementsProject/lightning/v23.08/plugins/clnrest/requirements.txt \
-  && pip install -r requirements.txt
-
 # make sure that wallet and identity is persisted across rebuilds.
 # server certificates contain stacker_lnd as a custom domain.
 # see https://docs.corelightning.org/docs/grpc#generating-custom-certificates-optional


### PR DESCRIPTION
## Description

I noticed we don't need to install the CLNRest plugin dependencies. [It's built-in since v23.08](https://docs.corelightning.org/docs/rest):

> CLNRest is a lightweight Rust-based built-in Core Lightning plugin (from v23.08) that transforms RPC calls into a REST service.

So we also shouldn't have needed this before #2475.

This should fix #2484 because it removes the failing command.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. Can still attach send and receive and pay

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no