### PR TITLE
Only allow https: for links

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -258,7 +258,7 @@ export function linkSchema (args) {
   return object({
     title: titleValidator,
     text: textValidator(MAX_POST_TEXT_LENGTH),
-    url: string().url().required('required'),
+    url: string().https().required('required'),
     ...advPostSchemaMembers(args),
     ...subSelectSchemaMembers(args)
   }).test({


### PR DESCRIPTION
## Description

fix #2424 

I think limiting links to https: should be okay. [Here](https://en.wikipedia.org/wiki/List_of_URI_schemes) is the list of official URI schemes and I don't think we need any of them except https.

However, this now _requires_ https: in the front. Before, no scheme was required, so `stacker.news` was a valid input. Now, it has to be `https://stacker.news`.

I am not sure if this is a UX problem. Browsers copy URLs with the scheme and I assume that's how most links are shared, and not by manually typing them etc.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`.  intent: no longer works but https: does

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no