### PR TITLE
Only run npm ci during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ EXPOSE 3000
 
 COPY package.json package-lock.json ./
 RUN npm ci --legacy-peer-deps --loglevel verbose
-CMD ["sh","-c","npm install --loglevel verbose --legacy-peer-deps && npx prisma migrate dev && npm run dev"]
+CMD ["sh","-c","npx prisma migrate dev && npm run dev"]


### PR DESCRIPTION
## Description

`npm ci` is meant for deployments. It's more secure because it will never touch package.json or package-lock.json:

<img width="821" height="519" alt="2025-09-09-020436_821x519_scrot" src="https://github.com/user-attachments/assets/45ad658c-bb53-4d9a-9f1d-f46952744afd" />

-- https://docs.npmjs.com/cli/v11/commands/npm-ci

I think most companies that got hit today weren't using `npm ci` because they automatically updated to the next (minor) version via `npm install`.

[Here](https://news.ycombinator.com/item?id=45172015)'s a HN commenter with the same thought process:

> I'm a little confused on one of the excerpts from your article.
>
>> Our package-lock.json specified the stable version 1.3.2 or newer, so it installed the latest version 1.3.3
>
> As far as I've always understood, the lockfile always specifies one single, locked version for each dependency, and even provides the URL to the tarball of that version. You can define "x version or newer" in the package.json file, but if it updates to a new patch version it's updating the lockfile with it. The npm docs suggest this is the case as well: https://arc.net/l/quote/cdigautx
>
> And with that, packages usually shouldn't be getting updated in your CI pipeline.
>
> Am I mistaken on how npm(/yarn/pnpm) lockfiles work?

The thread seems to agree that `npm ci` should be used.

## Additional context

- I see no use of `npm install` or `npm ci` on startup because package.json and package-lock.json can never change after the build of an image. They are copied into it during the build. So for them to change, we need to build the image again. The `COPY` line will run again when there's a cache miss (which happens when one of the input files change).

- This should also increase the speed of getting the app up and running because it doesn't run `npm install` every time.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. ran `sndev start`, added a new line to package.json, ran it again and saw that `npm ci` runs again because of a cache miss in the previous line.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no