### PR TITLE
Fix module not found if new package added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,6 @@ WORKDIR /app
 
 EXPOSE 3000
 
-# install dependencies inside the image for prod
 COPY package.json package-lock.json ./
 RUN npm ci --legacy-peer-deps --loglevel verbose
 


### PR DESCRIPTION
## Description

I noticed that if someone adds a new package via `npm install`, it will update their local node_modules, which is then mounted and the app will run.

But if someone then pulls the new package.json and runs `sndev start`, `npm ci` only runs during image build since #2498, but then we override the node_modules/ generated by this call with the node_modules/ from the host machine because of the mounted volume and thus the app will not run because it won't find the new package.

I considered [excluding the host node_modules via an anonymous volume](https://stackoverflow.com/questions/29181032/add-a-volume-to-docker-but-exclude-a-sub-folder) but this breaks the worker (it actually never runs `npm ci` but fully depends on installing dependencies while mounted), requires using `-V` with `docker-compose up` to renew anonymous volumes and might have other unknown issues.

Simply running `npm ci` again before all runs is the simplest solution and is also basically what we've been doing for a long time.

Added some comments to make it less confusing why we're doing this.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. this fixes the issue I had: my node_modules/ were in a state where it was missing `@shocknet/clink-sdk` even though it's in package.json (because of switching branches etc. I assume) and after rebasing on master with #2498, the app didn't find the module anymore

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no