### PR TITLE
Change order of tag and level in log message

### DIFF
--- a/styles/logger.module.css
+++ b/styles/logger.module.css
@@ -38,7 +38,7 @@
 .level {
     font-weight: bold;
     text-transform: uppercase;
-    min-width: 32px;
+    min-width: 30px;
 }
 
 .tag {

--- a/wallets/client/components/logger.js
+++ b/wallets/client/components/logger.js
@@ -99,8 +99,8 @@ export function LogMessage ({ tag, level, message, context, ts }) {
     <>
       <div className={styles.row} onClick={handleClick} style={style}>
         <TimeSince timestamp={ts} />
-        {tag !== null && <Tag tag={tag?.toLowerCase() ?? 'system'} />}
         <Level level={level} />
+        {tag !== null && <Tag tag={tag?.toLowerCase() ?? 'system'} />}
         <Message message={message} />
         {hasContext && <Indicator show={showContext} />}
       </div>


### PR DESCRIPTION
## Description

I think this looks better

## Screenshots

before:

<img width="1920" height="1080" alt="2025-09-09-230109_1920x1080_scrot" src="https://github.com/user-attachments/assets/d267558c-1897-4bbf-b613-e1fe97924f95" />

after:

<img width="1920" height="1080" alt="2025-09-09-230054_1920x1080_scrot" src="https://github.com/user-attachments/assets/04363272-51e1-46b5-a289-434e8ca41f93" />

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10` (if this breaks I'll ... idk)

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no