### PR TITLE
Fix comments not shown if all are from us and pending

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -54,7 +54,8 @@ function commentsOrderByClause (me, models, sort) {
 async function comments (me, models, item, sort, cursor) {
   const orderBy = commentsOrderByClause(me, models, sort)
 
-  if (item.nDirectComments === 0) {
+  // if we're logged in, there might be pending comments from us we want to show but weren't counted
+  if (!me && item.nDirectComments === 0) {
     return {
       comments: [],
       cursor: null
@@ -1240,7 +1241,8 @@ export default {
         return item.comments
       }
 
-      if (item.ncomments === 0) {
+      // if we're logged in, there might be pending comments from us we want to show but weren't counted
+      if (!me && item.ncomments === 0) {
         return {
           comments: [],
           cursor: null


### PR DESCRIPTION
## Description

fix #2499

#2499 really only happens when there are only pending comments from us.

I can't say much about the performance impact of this fix, since I don't really understand why it was needed in the first place :grimacing: If there are no comments, why was it expensive to fetch them? And why is it more expensive for anon iiuc?

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`6`. Tested that pending comments from us show up now

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no