### PR TITLE
fixing arrows in the carousel

### DIFF
--- a/components/carousel.module.css
+++ b/components/carousel.module.css
@@ -30,8 +30,16 @@ img.fullScreen {
     height: 100%;
 }
 
-div.fullScreenNav:hover > svg {
-    background-color: rgba(0, 0, 0, .5);
+div.fullScreenNav.navActive > svg {
+  background-color: rgba(0,0,0,0.60);
+  fill: rgba(255,255,255,0.95);
+  opacity: 1;
+}
+
+div.fullScreenNav.navIdle > svg {
+  background-color: rgba(0,0,0,0.28);
+  fill: rgba(255,255,255,0.75);
+  opacity: 0.85;
 }
 
 div.fullScreenNav  {
@@ -41,6 +49,8 @@ div.fullScreenNav  {
     height: 72px;
     display: flex;
     align-items: center;
+    opacity: 0.75;
+    transition: opacity 0.2s;
 }
 
 div.fullScreenNav.left {
@@ -53,9 +63,9 @@ div.fullScreenNav.right {
 
 div.fullScreenNav > svg {
     border-radius: 50%;
-    backdrop-filter: blur(4px);
-    background-color: rgba(0, 0, 0, 0.7);
+    background-color: rgba(0, 0, 0, 0.25);
     fill: white;
+    transition: background-color 0.2s, fill 0.2s;
     max-height: 34px;
     max-width: 34px;
     padding: 0.35rem;


### PR DESCRIPTION
## Description
fix #2500 
Added `navActive` state (`useState`) and `idleTimerRef`.
Introduced `getIdleTimer` and `bumpActivity` functions: each interaction makes the arrows opaque and restarts the timer;
when the timer expires, they become semi-transparent.

Called `bumpActivity`:

- on opening/index change
- on arrow click
- on mouse movement
- on touch
- on swipe
- on arrow keys

Added navActive and navIdle CSS classes with icon background/opacity/fill differences.
Cleaned up timers in unmount to avoid leaks.

## Screenshots

https://github.com/user-attachments/assets/8fa74360-f179-4d79-8b9b-877589a2e1d7


## Additional Context
opacity and IDLE_DELAY are customizable based on your preferences.
I set the delay to the following time: `IDLE_DELAY=2000` ms

## Checklist

**Are your changes backward compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6/10


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Tested mobile mode on chromium


**Did you introduce any new environment variables? If so, call them out explicitly here:**
NaN

**Did you use AI for this? If so, how much did it assist you?**
I used AI to find the files to edit, I did a manual search to figure out how to edit
