### PR TITLE
Fix "true" passed instead of boolean for multiAuth

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -75,7 +75,7 @@ export default function Login ({ providers, callbackUrl, multiAuth, error, text,
   const [errorMessage, setErrorMessage] = useState(authErrorMessage(error, signin))
   const router = useRouter()
 
-  multiAuth = typeof multiAuth === 'string' ? multiAuth === 'true' : false
+  multiAuth = typeof multiAuth === 'string' ? multiAuth === 'true' : !!multiAuth
 
   // signup/signin awareness cookie
   useEffect(() => {


### PR DESCRIPTION
## Description

If you want to add a new account to switch to, the following warning is printed to the console:

> Warning: Received the string `true` for the boolean attribute `disabled`. Although this works, it will not work as expected if you pass the string "false". Did you mean disabled={true}?

This PR fixes this warning.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested if changing the type from string to boolean broke adding a new account, but no, still works as expected.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no