### PR TITLE
fixing magic code input error

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -1451,6 +1451,7 @@ export function MultiInput ({
   onChange, autoFocus, hideError, inputType = 'text',
   ...props
 }) {
+  const formik = useFormikContext()
   const [inputs, setInputs] = useState(new Array(length).fill(''))
   const inputRefs = useRef(new Array(length).fill(null))
   const [, meta, helpers] = useField({ name })
@@ -1549,7 +1550,7 @@ export function MultiInput ({
         ))}
       </div>
       <div>
-        {hideError && meta.touched && meta.error && ( // custom error message is showed if hideError is true
+        {hideError && formik.submitCount > 0 && meta.touched && meta.error && ( // custom error message is showed if hideError is true
           <BootstrapForm.Control.Feedback type='invalid' className='d-block'>
             {meta.error}
           </BootstrapForm.Control.Feedback>


### PR DESCRIPTION
## Description

fix #2511 

I modified `form.js`

`MultiInput` now uses `useFormikContext()` to read `submitCount`.
The logic for displaying the aggregate error has been changed: the error is only shown if there has been at least one attempt to submit, using the condition `formik.submitCount > 0` along with `meta.touched && meta.error`.

## Screenshots

https://github.com/user-attachments/assets/61defbe1-f294-4fd9-a149-3e6a9b4ea29d

## Additional Context

The error appears only after the first submission with an incomplete/incorrect code; while typing the 6 digits it is not shown.
After the first failed submission, errors like "required" and "must be 6 alphanumeric characters" will display with the same behavior as before. If this isn't correct, I'll make the necessary changes.

## Checklist

**Are your changes backward compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7/10


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:** 
NaN


**Did you introduce any new environment variables? If so, call them out explicitly here:** 
NaN


**Did you use AI for this? If so, how much did it assist you?**
I didn't use AI for this, all manual research.