### PR TITLE
Fix missing custom expiry for phoenixd invoices

### DIFF
--- a/wallets/server/protocols/phoenixd.js
+++ b/wallets/server/protocols/phoenixd.js
@@ -20,6 +20,7 @@ export async function createInvoice (
   const body = new URLSearchParams()
   body.append('description', description)
   body.append('amountSat', msatsToSats(msats))
+  body.append('expirySeconds', Math.ceil(expiry / 1000))
 
   const hostname = url.replace(/^https?:\/\//, '').replace(/\/+$/, '')
   const agent = getAgent({ hostname })


### PR DESCRIPTION
## Description

Phoenixd supports custom expiry but we weren't passing it.

Using `Math.ceil()` so when we divide 1 by 1000, it's 1, not 0, and not sure what 0 means. I decoded such a lightning invoice with https://lightningdecoder.com/ and for Expire Time, it only showed two dashes.
## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no