### PR TITLE
Replace SimpleX group with Signal group

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -115,10 +115,10 @@ const ChatPopover = (
       </a>
       <span className='mx-2 text-muted'> \ </span>
       <a
-        href='https://simplex.chat/contact#/?v=1-2&smp=smp%3A%2F%2F6iIcWT_dF2zN_w5xzZEY7HI2Prbh3ldP07YTyDexPjE%3D%40smp10.simplex.im%2FebLYaEFGjsD3uK4fpE326c5QI1RZSxau%23%2F%3Fv%3D1-2%26dh%3DMCowBQYDK2VuAyEAV086Oj5yCsavWzIbRMCVuF6jq793Tt__rWvCec__viI%253D%26srv%3Drb2pbttocvnbrngnwziclp2f4ckjq65kebafws6g4hy22cdaiv5dwjqd.onion&data=%7B%22type%22%3A%22group%22%2C%22groupLinkId%22%3A%22cZwSGoQhyOUulzp7rwCdWQ%3D%3D%22%7D' className='nav-link p-0 d-inline-flex'
+        href='https://signal.group/#CjQKIEt57YiluJoTW3lZqaqAq6echCekEYFfg7eIua2X91nLEhA__6ALI9pkaY_McQqX0jm1' className='nav-link p-0 d-inline-flex'
         target='_blank' rel='noreferrer'
       >
-        simplex
+        signal
       </a>
     </Popover.Body>
   </Popover>


### PR DESCRIPTION
## Description

I don't check SimpleX a lot and when I check it, I see empty messages, or someone bumps a message because I didn't reply because I never received it. I already deleted the group, so can't share screenshots of what I mean anymore.

Signal is my preferred method of communication, and I think it's good to have a group so there is also a way to reach us for users who prefer that method. In theory, in a group, users can also give real-time support to each other. As long as we don't submit to BS as was the case with our TG group, it should be fine.

I think we should have just kicked the one guy that caused most of the trouble.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no