### PR TITLE
Remove unused forceWaitForPayment

### DIFF
--- a/components/use-paid-mutation.js
+++ b/components/use-paid-mutation.js
@@ -10,8 +10,7 @@ import { useWalletPayment } from '@/wallets/client/hooks'
 this is just like useMutation with a few changes:
 1. pays an invoice returned by the mutation
 2. takes an onPaid and onPayError callback, and additional options for payment behavior
-  - namely forceWaitForPayment which will always wait for the invoice to be paid
-  - and persistOnNavigate which will keep the invoice in the cache after navigation
+  - persistOnNavigate which will keep the invoice in the cache after navigation
 3. onCompleted behaves a little differently, but analogously to useMutation, ie clientside side effects
   of completion can still rely on it
   a. it's called before the invoice is paid for optimistic updates
@@ -77,7 +76,7 @@ export function usePaidMutation (mutation,
 
     // use the most inner callbacks/options if they exist
     const {
-      onPaid, onPayError, forceWaitForPayment, persistOnNavigate,
+      onPaid, onPayError, persistOnNavigate,
       update, waitFor = inv => inv?.actionState === 'PAID', updateOnFallback
     } = { ...options, ...innerOptions }
     const ourOnCompleted = innerOnCompleted || onCompleted
@@ -107,7 +106,7 @@ export function usePaidMutation (mutation,
       })
 
       // should we wait for the invoice to be paid?
-      if (response?.paymentMethod === 'OPTIMISTIC' && !forceWaitForPayment) {
+      if (response?.paymentMethod === 'OPTIMISTIC') {
         // onCompleted is called before the invoice is paid for optimistic updates
         ourOnCompleted?.(data)
         // don't wait to pay the invoice


### PR DESCRIPTION
## Description

Afaict, `forceWaitForPayment` is never passed as a payment behavior option, so it's always `undefined`, so `!forceWaitForPayment` is always true, so we can remove it from the `&&` condition.

I tried to find if it was ever used using `git log -G "forceWaitForPayment"`:

```
$ g l -G "forceWaitForPayment"
9f06fd65 UX latency enhancements for paid actions (#1434)
79f0df17 improve pessimistic paid actions by letting the server perform actions and settle invoice on `HELD`  (#1253)
ca11ac9f backend payment optimism (#1195)
```

but in all these commits, it is not used afaict.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`1`. non-custodial zaps still work

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no