### PR TITLE
Feature/sats filter

### DIFF
--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -102,6 +102,22 @@ async function sendUserNotification (userId, notification) {
     if (!userId) {
       throw new Error('user id is required')
     }
+
+    const user = await models.user.findUnique({ where: { id: userId } })
+    if (!user) return
+
+    if (user.satsFilter > 0 && notification.itemId) {
+      const item = await models.item.findUnique({
+        where: { id: notification.itemId },
+        select: { cost: true, boost: true, msats: true }
+      })
+      const sats = (item?.cost || 0) + (item?.boost || 0) + ((item?.msats || 0) / 1000)
+      if (sats < user.satsFilter) {
+        // respect satsFilter
+        return
+      }
+    }
+
     notification.data ??= {}
     if (notification.itemId) {
       // legacy Push API notificationclick event needs data.url as the navigate key is consumed by the browser
@@ -189,7 +205,7 @@ export async function notifyTerritorySubscribers ({ models, item }) {
     SELECT "userId" FROM "SubSubscription"
     WHERE "subName" = $1
     AND NOT EXISTS (SELECT 1 FROM "Mute" m WHERE m."muterId" = "SubSubscription"."userId" AND m."mutedId" = $2)
-    `, subName, Number(item.userId))
+    `, subName, Number(item.userId))  
 
     const author = await models.user.findUnique({ where: { id: item.userId } })
 
@@ -216,6 +232,7 @@ export async function notifyThreadSubscribers ({ models, item }) {
       SELECT DISTINCT "ThreadSubscription"."userId" FROM "ThreadSubscription"
       JOIN users ON users.id = "ThreadSubscription"."userId"
       JOIN "Reply" r ON "ThreadSubscription"."itemId" = r."ancestorId"
+      JOIN "Item" i ON i.id = r."itemId"
       WHERE r."itemId" = ${item.id}
       -- don't send notifications for own items
       AND r."userId" <> "ThreadSubscription"."userId"
@@ -251,6 +268,8 @@ export async function notifyItemParents ({ models, item }) {
       SELECT DISTINCT p."userId", i."userId" = p."userId" as "isDirect"
       FROM "Item" i
       JOIN "Item" p ON p.path @> i.path
+      JOIN users ON users.id = p."userId"
+      JOIN "Item" ri ON ri.id = ${Number(item.id)}::INTEGER
       WHERE i.id = ${Number(item.parentId)} and p."userId" <> ${Number(user.id)}
       AND NOT EXISTS (
         SELECT 1 FROM "Mute" m
@@ -260,6 +279,7 @@ export async function notifyItemParents ({ models, item }) {
         -- check that there is at least one parent subscribed to this thread
         SELECT 1 FROM "ThreadSubscription" ts WHERE p.id = ts."itemId" AND p."userId" = ts."userId"
       )`
+      
     await Promise.allSettled(
       parents.map(({ userId, isDirect }) => {
         return sendUserNotification(userId, {

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -205,7 +205,7 @@ export async function notifyTerritorySubscribers ({ models, item }) {
     SELECT "userId" FROM "SubSubscription"
     WHERE "subName" = $1
     AND NOT EXISTS (SELECT 1 FROM "Mute" m WHERE m."muterId" = "SubSubscription"."userId" AND m."mutedId" = $2)
-    `, subName, Number(item.userId))  
+    `, subName, Number(item.userId))
 
     const author = await models.user.findUnique({ where: { id: item.userId } })
 
@@ -232,7 +232,6 @@ export async function notifyThreadSubscribers ({ models, item }) {
       SELECT DISTINCT "ThreadSubscription"."userId" FROM "ThreadSubscription"
       JOIN users ON users.id = "ThreadSubscription"."userId"
       JOIN "Reply" r ON "ThreadSubscription"."itemId" = r."ancestorId"
-      JOIN "Item" i ON i.id = r."itemId"
       WHERE r."itemId" = ${item.id}
       -- don't send notifications for own items
       AND r."userId" <> "ThreadSubscription"."userId"
@@ -268,8 +267,6 @@ export async function notifyItemParents ({ models, item }) {
       SELECT DISTINCT p."userId", i."userId" = p."userId" as "isDirect"
       FROM "Item" i
       JOIN "Item" p ON p.path @> i.path
-      JOIN users ON users.id = p."userId"
-      JOIN "Item" ri ON ri.id = ${Number(item.id)}::INTEGER
       WHERE i.id = ${Number(item.parentId)} and p."userId" <> ${Number(user.id)}
       AND NOT EXISTS (
         SELECT 1 FROM "Mute" m
@@ -279,7 +276,6 @@ export async function notifyItemParents ({ models, item }) {
         -- check that there is at least one parent subscribed to this thread
         SELECT 1 FROM "ThreadSubscription" ts WHERE p.id = ts."itemId" AND p."userId" = ts."userId"
       )`
-      
     await Promise.allSettled(
       parents.map(({ userId, isDirect }) => {
         return sendUserNotification(userId, {


### PR DESCRIPTION
## Description
Closes #2438 
Introduces logic to suppress push notifications for users based on their satsFilter setting, preventing notifications for items below 0. The satsFilter is checked centrally under sendUserNotification since all notifications pass through it.

## Screenshots
N/A

## Additional Context
The working should be checked on phone, since I couldn't check it.
I could only provide a logical fix and tested through PC (windows).

## Checklist

**Are your changes backward compatible? Please answer below:**
yup

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8 (because did test only on PC and not phone)

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
N/A

**Did you introduce any new environment variables? If so, call them out explicitly here:**
none

**Did you use AI for this? If so, how much did it assist you?**

10% - Copilot helped me identify the possible files where the bug for this error might be since I am not still accustomed to the codebase. I filtered the files after that. No AI was used for coding purposes.