### PR TITLE
Fix error message if no route found

### DIFF
--- a/api/lnd/index.js
+++ b/api/lnd/index.js
@@ -60,17 +60,11 @@ export async function estimateRouteFee ({ lnd, destination, tokens, mtokens, req
       timeout
     }, (err, res) => {
       if (err) {
-        if (res?.failure_reason) {
-          reject(new Error(`Unable to estimate route: ${res.failure_reason}`))
-        } else {
-          reject(err)
-        }
-        return
+        return reject(err)
       }
 
-      if (res.routing_fee_msat < 0 || res.time_lock_delay <= 0) {
-        reject(new Error('Unable to estimate route, excessive values: ' + JSON.stringify(res)))
-        return
+      if (res.failure_reason !== 'FAILURE_REASON_NONE' || res.routing_fee_msat < 0 || res.time_lock_delay <= 0) {
+        return reject(new Error(`Unable to estimate route: ${res.failure_reason}`))
       }
 
       resolve({


### PR DESCRIPTION
## Description

We currently log the following:

> failed to wrap invoice: Unable to estimate route, excessive values: {"routing_fee_msat":"0","time_lock_delay":"0","failure_reason":"FAILURE_REASON_NO_ROUTE"}

The code tried to use `res.failure_reason` if it exists, but it didn't reach that line because `err` is apparently not set.

This PR fixes this.

Will lookup the source code of `lnd.router.estimateRouteFee` to make sure errors are handled properly.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested wrapping via p2p zaps

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no