### PR TITLE
Twitter embeds for xcancel links

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -93,7 +93,7 @@ export function parseEmbedUrl (href) {
   if (!href) return null
 
   try {
-    const twitter = href.match(/^https?:\/\/(?:twitter|x)\.com\/(?:#!\/)?\w+\/status(?:es)?\/(?<id>\d+)/)
+    const twitter = href.match(/^https?:\/\/(?:twitter|x|xcancel)\.com\/(?:#!\/)?\w+\/status(?:es)?\/(?<id>\d+)/)
     if (twitter?.groups?.id) {
       return {
         provider: 'twitter',


### PR DESCRIPTION
## Description

This enables parsing of xcancel links to twitter embeds.

## Additional context

My bot will not reply to xcancel.com links with xcancel.com links though. So if somebody uses a xcancel.com link, we actually now basically just replace it with the x.com link 🤔

I can update it though.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

tbd

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no