### PR TITLE
Sats per Big Mac

### DIFF
--- a/api/resolvers/price.js
+++ b/api/resolvers/price.js
@@ -18,10 +18,42 @@ const getPrice = cachedFetcher(async function fetchPrice (fiat = 'USD') {
   keyGenerator: (fiat = 'USD') => fiat
 })
 
+const getBigMacPrice = cachedFetcher(async function fetchBigMacPrice () {
+  const csvUrl = 'https://raw.githubusercontent.com/TheEconomist/big-mac-data/master/output-data/big-mac-raw-index.csv'
+  try {
+    const res = await fetch(csvUrl)
+    const csvText = await res.text()
+    const lines = csvText.split('\n')
+    const usaEntries = lines
+      .filter(line => line.includes(',USA,USD,'))
+      .map(line => {
+        const cols = line.split(',')
+        return {
+          date: cols[0],
+          price: parseFloat(cols[4])
+        }
+      })
+      .filter(entry => !isNaN(entry.price))
+      .sort((a, b) => new Date(b.date) - new Date(a.date))
+    return usaEntries[0]?.price || 5.79
+  } catch (err) {
+    console.error('Big Mac price fetch error:', err)
+    return 5.79
+  }
+}, {
+  maxSize: 1,
+  cacheExpiry: 24 * 60 * 60 * 1000,
+  forceRefreshThreshold: 0,
+  keyGenerator: () => 'bigmac-usd'
+})
+
 export default {
   Query: {
     price: async (parent, { fiatCurrency }, ctx) => {
       return await getPrice(fiatCurrency) || -1
+    },
+    bigMacPrice: async () => {
+      return await getBigMacPrice() || 5.79
     }
   }
 }

--- a/api/typeDefs/price.js
+++ b/api/typeDefs/price.js
@@ -3,5 +3,6 @@ import { gql } from 'graphql-tag'
 export default gql`
   extend type Query {
     price(fiatCurrency: String): Float
+    bigMacPrice: Float
   }
 `

--- a/components/nav/price-carousel.js
+++ b/components/nav/price-carousel.js
@@ -9,7 +9,8 @@ const carousel = [
   '1btc',
   'blockHeight',
   'chainFee',
-  'halving'
+  'halving',
+  'bigmac'
 ]
 
 export const PriceCarouselContext = createContext({

--- a/components/price.js
+++ b/components/price.js
@@ -12,7 +12,8 @@ import { usePriceCarousel } from './nav/price-carousel'
 
 export const PriceContext = React.createContext({
   price: null,
-  fiatSymbol: null
+  fiatSymbol: null,
+  bigMacPrice: null
 })
 
 export function usePrice () {
@@ -34,8 +35,9 @@ export function PriceProvider ({ price, children }) {
 
   const contextValue = useMemo(() => ({
     price: data?.price || price,
-    fiatSymbol: CURRENCY_SYMBOLS[fiatCurrency] || '$'
-  }), [data?.price, price, me?.privates?.fiatCurrency])
+    fiatSymbol: CURRENCY_SYMBOLS[fiatCurrency] || '$',
+    bigMacPrice: data?.bigMacPrice || 5.79
+  }), [data?.price, data?.bigMacPrice, price, me?.privates?.fiatCurrency])
 
   return (
     <PriceContext.Provider value={contextValue}>
@@ -56,7 +58,7 @@ function AccessibleButton ({ id, description, children, ...props }) {
 export default function Price ({ className }) {
   const [selection, handleClick] = usePriceCarousel()
 
-  const { price, fiatSymbol } = usePrice()
+  const { price, fiatSymbol, bigMacPrice } = usePrice()
   const { height: blockHeight, halving } = useBlockHeight()
   const { fee: chainFee } = useChainFee()
 
@@ -102,6 +104,15 @@ export default function Price ({ className }) {
     return (
       <AccessibleButton id='chainFee-hint' description='Show time until halving' className={compClassName} onClick={handleClick} variant='link'>
         {chainFee} sat/vB
+      </AccessibleButton>
+    )
+  }
+
+  if (selection === 'bigmac') {
+    if (!price || price < 0 || !bigMacPrice) return null
+    return (
+      <AccessibleButton id='bigmac-hint' description='Show satoshis per Big Mac' className={compClassName} onClick={handleClick} variant='link'>
+        {fixedDecimal(Math.round((bigMacPrice / price) * 100000000), 0)} sats/Big Mac
       </AccessibleButton>
     )
   }

--- a/fragments/price.js
+++ b/fragments/price.js
@@ -3,4 +3,5 @@ import { gql } from '@apollo/client'
 export const PRICE = gql`
   query price($fiatCurrency: String) {
     price(fiatCurrency: $fiatCurrency)
+    bigMacPrice
   }`


### PR DESCRIPTION
## Description

adding requested feature in #2502

Added a new "Big Mac Index" ticker to the price carousel that displays how many satoshis are needed to buy a Big Mac;

- Added `'bigmac'` to price carousel rotation
- Creating a new `GraphQL` resolver that fetches Big Mac prices from [The Economist's official GitHub repository](https://raw.githubusercontent.com/TheEconomist/big-mac-data/master/output-data/big-mac-raw-index.csv)
- Implemented proper caching (24 hours for Big Mac data, 1 minute for Bitcoin prices)

## Screenshots

<img width="933" height="93" alt="Istantanea_2025-09-16_10-16-43" src="https://github.com/user-attachments/assets/7162cc63-d141-4e8b-832b-454713354d73" />

---

<img width="400" height="865" alt="489962047-b8a30ca7-dda5-4b4c-baea-01b54b409fe3" src="https://github.com/user-attachments/assets/79a202f5-914c-447a-9490-40262bdb50db" />

---

<img width="400" height="865" alt="489962082-92bc5c3c-93da-4aa9-aac6-eb744b7a4b78" src="https://github.com/user-attachments/assets/b9cae700-b6cc-4f86-899e-dadc3a52eddd" />

## Additional Context

The data is cached for 24 hours since Big Mac prices don't change frequently. The feature includes robust error handling with fallback to the last known Big Mac price ($5.79) if the external data source is unavailable. Used existing `cachedFetcher` pattern for data fetching


## Checklist

**Are your changes backward compatible? Please answer below:**
yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8/10


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
yes


**Did you introduce any new environment variables? If so, call them out explicitly here:**
NaN

**Did you use AI for this? If so, how much did it assist you?**
i did use ai just to understand the context and do research about big mac prices