### PR TITLE
Strict chronological ordering for sort=recent

### DIFF
--- a/api/resolvers/search.js
+++ b/api/resolvers/search.js
@@ -455,7 +455,7 @@ export default {
 
       const searchRequest = {
         index: process.env.OPENSEARCH_INDEX,
-        size: LIMIT,
+        size: sort === 'recent' ? 2 * LIMIT : LIMIT,
         _source: {
           excludes: [
             'text',
@@ -525,7 +525,7 @@ export default {
       })
 
       return {
-        cursor: items.length === LIMIT ? nextCursorEncoded(decodedCursor) : null,
+        cursor: items.length === LIMIT && sort !== 'recent' ? nextCursorEncoded(decodedCursor) : null,
         items
       }
     }


### PR DESCRIPTION
## Description

Closes https://github.com/stackernews/stacker.news/issues/2017

Implements strict chronological ordering when `sort=recent`, while maintaining retrieval of relevant results.

## Screenshots

Before: 

<img width="1512" height="982" alt="Screenshot 2025-09-16 at 6 30 35 PM" src="https://github.com/user-attachments/assets/909fa0aa-7b94-44b4-a70e-72a576a75b7d" />

After:

<img width="1512" height="982" alt="Screenshot 2025-09-16 at 10 51 10 PM" src="https://github.com/user-attachments/assets/82ac0025-7c25-480a-a7c5-3ed40afcb49d" />


## Additional Context

Trying to balance relevance with strict chronological ordering was tricky, so I went with a compromise solution.  Return only the first page of `2 * LIMIT` most relevant results (with relevance scored according to both semantic relevance and recency), and strictly order those results chronologically.

I went with this approach for the following reasons:

- Users report usually being able to find what they're looking for, which suggests that current relevancy metrics are working (https://stacker.news/items/928640)
- However, users expect strict chronological ordering when sorting by recent (https://stacker.news/items/1222373?commentId=1222765)

The compromise solution is therefore to use relevancy metrics to find the top K most relevant (which includes a recency bias already), and then strictly sorting the K results by date.  This meets the user's expectations of strict chronological sorting while still making sure the top most relevant results are included in the first page of results.

Note that with this approach, I turned off pagination for `sort=recent`. Only one page of the `2 * LIMIT` most relevant results is shown. It's difficult to get full chronological sorting across pages due to how pagination works in the current search function.  (We want OpenSearch to get the top K most relevant results, but that also results in OpenSearch ranking the results by relevance rather than by date. The current pagination approach uses an offset in the OpenSearch query itself, so to get fully chronological pagination while also maintaining a relevancy criteria requires a major rewrite of the pagination approach just for `sort=recent`.  I think the one page of results approach was the best compromise.)

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

8.  

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

n/a

**Did you use AI for this? If so, how much did it assist you?**

I mainly used AI as a thought partner and as an alternative to googling for OpenSearch syntax and functionality. I asked AI to suggest where to make the edits, but I made the ultimate changes on my own.  AI was helpful in getting me started, but its suggestions were ultimately not that helpful because it suggested some janky approaches to dealing with the pagination issues.
