### PR TITLE
Allow testing of magic code with sndev

### DIFF
--- a/pages/email.js
+++ b/pages/email.js
@@ -17,7 +17,13 @@ export default function Email () {
 
   useEffect(() => {
     setSignin(!!cookie.parse(document.cookie).signin)
-    setCallback(JSON.parse(window.sessionStorage.getItem('callback')))
+    setCallback(
+      JSON.parse(window.sessionStorage.getItem('callback')) ?? (
+        // allow testing during development with `sndev login test_email_login`
+        process.env.NODE_ENV === 'development'
+          ? { email: 'test_email_login@sndev.team', callbackUrl: process.env.NEXT_PUBLIC_URL }
+          : null
+      ))
   }, [])
 
   // build and push the final callback URL

--- a/sndev
+++ b/sndev
@@ -476,13 +476,15 @@ sndev__login() {
     sndev__help_login
     exit 1
   fi
-  # hardcode token for which is the hex digest of the sha256 of
-  # "SNDEV-TOKEN3_0W_PhDRZVanbeJsZZGIEljexkKoGbL6qGIqSwTjjI"
-  # next-auth concats the token with the secret from env and then sha256's it
-  token="d5fce54babffcb070c39f78d947761fd9ec37647fafcecb9734a3085a78e5c5e"
-  salt="202c90943c313b829e65e3f29164fb5dd7ea3370d7262c4159691c2f6493bb8b"
-  # upsert user with nym and nym@sndev.team
+
+  nym="$1"
   email="$1@sndev.team"
+
+  # next-auth concats the token with the secret from env and then sha256's it
+  token="sndev1"
+  secret="3_0W_PhDRZVanbeJsZZGIEljexkKoGbL6qGIqSwTjjI" # NEXT_AUTH_SECRET
+  token_hash=$(echo -n "${token}${secret}" | sha256sum | cut -d' ' -f1)
+  salt="202c90943c313b829e65e3f29164fb5dd7ea3370d7262c4159691c2f6493bb8b"
 
   # Detect Codespaces and set the correct base URL
   if [ -n "$CODESPACE_NAME" ]; then
@@ -492,18 +494,21 @@ sndev__login() {
   fi
 
   docker__exec db psql -U sn -d stackernews -q <<EOF
-    INSERT INTO users (name) VALUES ('$1') ON CONFLICT DO NOTHING;
-    UPDATE users SET email = '$email', "emailHash" = encode(digest(LOWER('$email')||'$salt', 'sha256'), 'hex') WHERE name = '$1';
+    INSERT INTO users (name) VALUES ('$nym') ON CONFLICT DO NOTHING;
+    UPDATE users SET email = '$email', "emailHash" = encode(digest(LOWER('$email')||'$salt', 'sha256'), 'hex') WHERE name = '$nym';
     INSERT INTO verification_requests (identifier, token, expires)
-      VALUES ('$email', '$token', NOW() + INTERVAL '1 day')
+      VALUES ('$email', '$token_hash', NOW() + INTERVAL '1 day')
       ON CONFLICT (token) DO UPDATE
       SET identifier = '$email', expires = NOW() + INTERVAL '1 day';
 EOF
 
   echo
   echo "open url in browser"
-  echo "$BASE_URL/api/auth/callback/email?token=SNDEV-TOKEN&email=$1%40sndev.team"
-  echo
+  echo "$BASE_URL/api/auth/callback/email?token=$token&email=${email//@/%40}"
+  if [ "$nym" == "test_email_login" ]; then
+    echo
+    echo "or go to $BASE_URL/email and enter $token as the token"
+  fi
 }
 
 sndev__help_login() {


### PR DESCRIPTION
## Description

With these changes, one can test the magic login code via `sndev login test_email_login`.

If the correct nym is used, it will print this:

```
$ sndev login test_email_login

open url in browser
http://localhost:3000/api/auth/callback/email?token=sndev1&email=test_email_login%40sndev.team

or go to http://localhost:3000/email and enter sndev1 as the token
```

As mentioned, you can then go to /email and enter sndev1 to login.

## Additional context

all these `process.env.NODE_ENV` checks in our code are quite ugly, we should put a constant like `IS_DEV` or `IS_PROD` into lib/constants and use that

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. Only affects `sndev`

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no