### PR TITLE
Fix verification attempts not transactional

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -334,6 +334,7 @@ export const getAuthOptions = (req, res) => ({
           FROM (
             SELECT id FROM verification_requests
             WHERE identifier = ${identifier}
+            AND created_at > NOW() - INTERVAL '5 minutes'
             -- we need to find the most recent verification request for this email/identifier
             ORDER BY created_at DESC
             LIMIT 1


### PR DESCRIPTION
## Description

related to https://github.com/stackernews/stacker.news/pull/1818#discussion_r1940317181:

> Ideally, this code would not have any races at all, but it's a bit tricky because `identifier` isn't unique. We could wrap it all in a transaction and do an optimistic lock, or make it seriallizable, but our attempt limit is so low they won't get many more attempts anyway.

This uses `SELECT FOR UPDATE` with `$queryRaw` to make sure other tx will wait before reading the attempt count if there's already one tx in progress.

## Video

https://github.com/user-attachments/assets/3e945e2f-6f9c-4299-9c5d-e165e403d48e

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`, see video

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no