### PR TITLE
Fix draft gone if wallet prompt closed

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -39,6 +39,7 @@ import { useShowModal } from './modal'
 import dynamic from 'next/dynamic'
 import { useIsClient } from './use-client'
 import PageLoading from './page-loading'
+import { WalletPromptClosed } from '@/wallets/client/hooks'
 
 export class SessionRequiredError extends Error {
   constructor () {
@@ -1087,6 +1088,7 @@ export function Form ({
         await onSubmit(values, ...args)
       }
     } catch (err) {
+      if (err instanceof WalletPromptClosed) return
       console.log(err.message, err)
       toaster.danger(err.message ?? err.toString?.())
       return

--- a/components/use-item-submit.js
+++ b/components/use-item-submit.js
@@ -8,7 +8,7 @@ import { RETRY_PAID_ACTION } from '@/fragments/paidAction'
 import gql from 'graphql-tag'
 import { USER_ID } from '@/lib/constants'
 import { useMe } from './me'
-import { useWalletRecvPrompt, WalletPromptClosed } from '@/wallets/client/hooks'
+import { useWalletRecvPrompt } from '@/wallets/client/hooks'
 
 // this is intented to be compatible with upsert item mutations
 // so that it can be reused for all post types and comments and we don't have
@@ -27,12 +27,7 @@ export default function useItemSubmit (mutation,
 
   return useCallback(
     async ({ boost, crosspost, title, options, bounty, status, ...values }, { resetForm }) => {
-      try {
-        await walletPrompt()
-      } catch (err) {
-        if (err instanceof WalletPromptClosed) return
-        throw err
-      }
+      await walletPrompt()
 
       if (options) {
         // remove existing poll options since else they will be appended as duplicates


### PR DESCRIPTION
## Description

Since we didn't throw `WalletPromptClosed` but simply return, the form believed if the prompt was closed, the post or comment was submitted successfully and deleted the draft in localStorage.

This was only apparent when going to /wallets, because if we simply close the modal via the `x` button, we can still see the value in the text input, but the draft in localStorage is gone.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Drafts are no longer lost if we visit /wallets from the prompt or close the prompt ourselves.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no