### PR TITLE
Remove NWC receive for Coinos

### DIFF
--- a/prisma/migrations/20250920162959_remove_coinos_nwc_receive/migration.sql
+++ b/prisma/migrations/20250920162959_remove_coinos_nwc_receive/migration.sql
@@ -1,0 +1,1 @@
+UPDATE "WalletTemplate" SET "recvProtocols" = array_remove("recvProtocols", 'NWC') WHERE name = 'COINOS';


### PR DESCRIPTION
## Description

Coinos does not support creating receive-only NWC connections.

I also checked the database, there aren't any rows in the `WalletProtocol` table for NWC receive with Coinos.

## Screenshot

<img width="1920" height="1080" alt="2025-09-20-183804_1920x1080_scrot" src="https://github.com/user-attachments/assets/03829d80-fa14-4a0a-a9b9-be722793e168" />

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

tbd

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no