### PR TITLE
Remove lightning address domain on paste

### DIFF
--- a/wallets/client/components/form/index.js
+++ b/wallets/client/components/form/index.js
@@ -230,9 +230,12 @@ function WalletProtocolFormField ({ type, ...props }) {
       onPaste = (e) => {
         e.preventDefault()
         const value = (e.clipboardData || window.clipboardData).getData('text')
-        if (value.endsWith(`@${lud16Domain}`)) {
-          formik.setFieldValue(props.name, value.slice(0, -`@${lud16Domain}`.length))
-        }
+        formik.setFieldValue(
+          props.name,
+          value.endsWith(`@${lud16Domain}`)
+            ? value.slice(0, -`@${lud16Domain}`.length)
+            : value
+        )
       }
     }
 

--- a/wallets/client/components/form/index.js
+++ b/wallets/client/components/form/index.js
@@ -14,6 +14,7 @@ import { TemplateLogsProvider, useTestSendPayment, useWalletLogger, useTestCreat
 import ArrowRight from '@/svgs/arrow-right-s-fill.svg'
 import InfoIcon from '@/svgs/information-fill.svg'
 import Link from 'next/link'
+import { useFormikContext } from 'formik'
 
 import { WalletMultiStepFormContextProvider, Step, useWallet, useWalletProtocols, useProtocol, useProtocolForm } from './hooks'
 import { Settings } from './settings'
@@ -186,6 +187,7 @@ function WalletProtocolFormNavigator () {
 function WalletProtocolFormField ({ type, ...props }) {
   const wallet = useWallet()
   const [protocol] = useProtocol()
+  const formik = useFormikContext()
 
   function transform ({ validate, encrypt, editable, help, share, ...props }) {
     const [upperHint, bottomHint] = Array.isArray(props.hint) ? props.hint : [null, props.hint]
@@ -221,13 +223,20 @@ function WalletProtocolFormField ({ type, ...props }) {
       </div>
     )
 
-    let append
+    let append, onPaste
     const lud16Domain = walletLud16Domain(wallet.name)
     if (props.name === 'address' && lud16Domain) {
       append = <InputGroup.Text className='text-monospace'>@{lud16Domain}</InputGroup.Text>
+      onPaste = (e) => {
+        e.preventDefault()
+        const value = (e.clipboardData || window.clipboardData).getData('text')
+        if (value.endsWith(`@${lud16Domain}`)) {
+          formik.setFieldValue(props.name, value.slice(0, -`@${lud16Domain}`.length))
+        }
+      }
     }
 
-    return { ...props, hint: bottomHint, label, readOnly, append }
+    return { ...props, hint: bottomHint, label, readOnly, append, onPaste }
   }
 
   switch (type) {

--- a/wallets/client/components/form/index.js
+++ b/wallets/client/components/form/index.js
@@ -221,17 +221,18 @@ function WalletProtocolFormField ({ type, ...props }) {
       </div>
     )
 
-    return { ...props, hint: bottomHint, label, readOnly }
+    let append
+    const lud16Domain = walletLud16Domain(wallet.name)
+    if (props.name === 'address' && lud16Domain) {
+      append = <InputGroup.Text className='text-monospace'>@{lud16Domain}</InputGroup.Text>
+    }
+
+    return { ...props, hint: bottomHint, label, readOnly, append }
   }
 
   switch (type) {
     case 'text': {
-      let append
-      const lud16Domain = walletLud16Domain(wallet.name)
-      if (props.name === 'address' && lud16Domain) {
-        append = <InputGroup.Text className='text-monospace'>@{lud16Domain}</InputGroup.Text>
-      }
-      return <Input {...transform(props)} append={append} />
+      return <Input {...transform(props)} />
     }
     case 'password':
       return <PasswordInput {...transform(props)} />


### PR DESCRIPTION
## Description

fix #2558 

This removes the lightning address domain if it matches with the one we would append automatically on paste, and only on paste.

## Video

https://github.com/user-attachments/assets/53556758-e5d8-4033-8cd8-d24529f66b38

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`9` see video

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no