### PR TITLE
Improve error messages on wrong permissions

### DIFF
--- a/wallets/client/errors.js
+++ b/wallets/client/errors.js
@@ -18,6 +18,7 @@ export class InvoiceExpiredError extends Error {
 export class WalletError extends Error {}
 export class WalletPaymentError extends WalletError {}
 export class WalletConfigurationError extends WalletError {}
+export class WalletValidationError extends WalletError {}
 
 export class WalletNotEnabledError extends WalletConfigurationError {
   constructor (name) {
@@ -98,5 +99,12 @@ export class WalletPaymentAggregateError extends WalletPaymentError {
       return acc
     }, []).filter(e => e instanceof WalletPaymentError)
     this.invoice = invoice
+  }
+}
+
+export class WalletPermissionsError extends WalletValidationError {
+  constructor (message) {
+    super('wrong permissions: ' + message)
+    this.name = 'WalletPermissionsError'
   }
 }

--- a/wallets/client/protocols/nwc.js
+++ b/wallets/client/protocols/nwc.js
@@ -1,4 +1,5 @@
 import { supportedMethods, nwcTryRun } from '@/wallets/lib/protocols/nwc'
+import { WalletPermissionsError } from '@/wallets/client/errors'
 
 export const name = 'NWC'
 
@@ -10,6 +11,6 @@ export async function sendPayment (bolt11, { url }, { signal }) {
 export async function testSendPayment ({ url }, { signal }) {
   const supported = await supportedMethods(url, { signal })
   if (!supported.includes('pay_invoice')) {
-    throw new Error('pay_invoice not supported')
+    throw new WalletPermissionsError('credentials do not allow spending')
   }
 }

--- a/wallets/server/protocols/nwc.js
+++ b/wallets/server/protocols/nwc.js
@@ -1,3 +1,4 @@
+import { WalletPermissionsError } from '@/wallets/client/errors'
 import { nwcTryRun, supportedMethods } from '@/wallets/lib/protocols/nwc'
 
 export const name = 'NWC'
@@ -16,13 +17,13 @@ export async function testCreateInvoice ({ url }, { signal }) {
   const supports = (method) => supported.includes(method)
 
   if (!supports('make_invoice')) {
-    throw new Error('make_invoice not supported')
+    throw new WalletPermissionsError('credentials do not allow receiving')
   }
 
   const mustNotSupport = ['pay_invoice', 'multi_pay_invoice', 'pay_keysend', 'multi_pay_keysend']
   for (const method of mustNotSupport) {
     if (supports(method)) {
-      throw new Error(`${method} must not be supported`)
+      throw new WalletPermissionsError('credentials allow spending')
     }
   }
 

--- a/wallets/server/resolvers/protocol.js
+++ b/wallets/server/resolvers/protocol.js
@@ -10,6 +10,7 @@ import { notifyNewStreak, notifyStreakLost } from '@/lib/webPush'
 import { decodeCursor, LIMIT, nextCursorEncoded } from '@/lib/cursor'
 import { logContextFromBolt11, walletLogger } from '@/wallets/server/logger'
 import { formatMsats } from '@/lib/format'
+import { WalletValidationError } from '@/wallets/client/errors'
 
 const WalletProtocolConfig = {
   __resolveType: config => config.__resolveType
@@ -87,6 +88,9 @@ export function testWalletProtocol (protocol) {
         WALLET_CREATE_INVOICE_TIMEOUT_MS
       )
     } catch (e) {
+      if (e instanceof WalletValidationError) {
+        throw new GqlInputError(e.message)
+      }
       throw new GqlInputError('failed to create invoice: ' + e.message)
     }
 


### PR DESCRIPTION
## Description

I don't think we need to show them the specific method that is failing validation. Just saying 'credentials allow spending' etc. should be enough context for a user to understand what's wrong.

## Screenshots

<img width="1920" height="1080" alt="2025-09-21-072803_1920x1080_scrot" src="https://github.com/user-attachments/assets/e024a6bd-db37-4dd6-8554-c804b8f0f8b5" />

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. Tested attaching send + receive with and without error

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no