### PR TITLE
Use NWC lud16 parameter as initial value for lightning addresses

### DIFF
--- a/wallets/client/components/form/hooks.js
+++ b/wallets/client/components/form/hooks.js
@@ -90,6 +90,7 @@ export function useProtocolForm (protocol) {
     }
 
     if (protocol.name === 'LN_ADDR' && field.name === 'address' && lud16Domain && value) {
+      // remove domain part since we will append it automatically if lud16Domain is set
       value = value.split('@')[0]
     }
 

--- a/wallets/client/components/form/hooks.js
+++ b/wallets/client/components/form/hooks.js
@@ -89,7 +89,7 @@ export function useProtocolForm (protocol) {
       value = complementaryFormState?.config?.[field.name]
     }
 
-    if (field.name === 'address' && lud16Domain && value) {
+    if (protocol.name === 'LN_ADDR' && field.name === 'address' && lud16Domain && value) {
       value = value.split('@')[0]
     }
 

--- a/wallets/client/components/form/hooks.js
+++ b/wallets/client/components/form/hooks.js
@@ -51,14 +51,21 @@ export function useWalletProtocols () {
 export function useProtocol () {
   const { protocol, setProtocol } = useContext(WalletMultiStepFormContext)
   const protocols = useWalletProtocols()
+  const [lnAddrForm] = useProtocolForm({ name: 'LN_ADDR', send: false })
 
   useEffect(() => {
-    // when we move between send and receive, we need to make sure that we've selected a protocol
-    // that actually exists, so if the protocol is not found, we set it to the first protocol
+    // this makes sure that we've always selected a protocol (that exists) when moving between send and receive
     if (!protocol || !protocols.find(p => p.id === protocol.id)) {
-      setProtocol(protocols[0])
+      // we switch to the LN_ADDR protocol form if it exists and there's an initial value
+      // else we just select the first protocol.
+      const lnAddrProto = protocols.find(p => p.name === 'LN_ADDR')
+      if (lnAddrForm?.initial.address && lnAddrProto) {
+        setProtocol(lnAddrProto)
+      } else {
+        setProtocol(protocols[0])
+      }
     }
-  }, [protocol, protocols, setProtocol])
+  }, [protocol, protocols, setProtocol, lnAddrForm])
 
   // make sure we always have a protocol, even on first render before useEffect runs
   return useMemo(() => [protocol ?? protocols[0], setProtocol], [protocol, protocols, setProtocol])

--- a/wallets/lib/validate.js
+++ b/wallets/lib/validate.js
@@ -57,17 +57,11 @@ export function parseNwcUrl (walletConnectUrl) {
   // See https://stackoverflow.com/questions/56804936/how-does-only-numbers-in-url-resolve-to-a-domain
   // However, this seems to only get triggered if a wallet pubkey only contains digits so this is pretty improbable.
   const url = new URL(walletConnectUrl)
-  const params = {}
-  params.walletPubkey = url.host
-  const secret = url.searchParams.get('secret')
-  const relayUrls = url.searchParams.getAll('relay')
-  if (secret) {
-    params.secret = secret
+  return {
+    walletPubkey: url.host,
+    secret: url.searchParams.get('secret'),
+    relayUrls: url.searchParams.getAll('relay')
   }
-  if (relayUrls) {
-    params.relayUrls = relayUrls
-  }
-  return params
 }
 
 export const socketValidator = (msg = 'invalid socket') =>

--- a/wallets/lib/validate.js
+++ b/wallets/lib/validate.js
@@ -60,7 +60,8 @@ export function parseNwcUrl (walletConnectUrl) {
   return {
     walletPubkey: url.host,
     secret: url.searchParams.get('secret'),
-    relayUrls: url.searchParams.getAll('relay')
+    relayUrls: url.searchParams.getAll('relay'),
+    lud16: url.searchParams.get('lud16')
   }
 }
 


### PR DESCRIPTION
## Description

close #2560 based on #2563, #2562

If we're looking at a lightning address form and we previously entered a NWC send string, we now check if that string contains a `lud16` parameter and use it as the initial value.

The user still needs to explicitly save that lightning address.

**TODO**

- :white_check_mark: use lud16 parameter as default for lightning address
- :white_check_mark: automatically switch to ~first configured protocol~ lightning address if it has an initial value when moving to receive

ideally this default selection when switching to receive would be agnostic of lightning address and simply check all protocols if they have some initial value and then pick the first one, but that requires more changes. `useProtocolForm` would need to support returning the forms for multiple protocols.

- :white_check_mark: q&a

## Video

https://github.com/user-attachments/assets/c64fcd3c-88cb-4a1f-bd75-6c5beee5999b

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`, see video, also tested attaching LNbits send+receive

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no