### PR TITLE
Delete Pending requests on switch account / logout

### DIFF
--- a/components/account.js
+++ b/components/account.js
@@ -11,6 +11,7 @@ import { cookieOptions, MULTI_AUTH_ANON, MULTI_AUTH_LIST, MULTI_AUTH_POINTER } f
 const b64Decode = str => Buffer.from(str, 'base64').toString('utf-8')
 
 export const nextAccount = async () => {
+  if (typeof window !== 'undefined') window.logoutInProgress = true
   const { status } = await fetch('/api/next-account', { credentials: 'include' })
   // if status is 302, this means the server was able to switch us to the next available account
   return status === 302
@@ -69,7 +70,7 @@ const AccountListRow = ({ account, selected, ...props }) => {
   const onClick = async (e) => {
     // prevent navigation
     e.preventDefault()
-
+    if (typeof window !== 'undefined') window.logoutInProgress = true
     // update pointer cookie
     const options = cookieOptions({ httpOnly: false })
     const anon = account.id === USER_ID.anon

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -305,7 +305,9 @@ function LogoutObstacle ({ onClose }) {
               router.reload()
               return
             }
-
+            window.logoutInProgress = true
+            document.cookie = 'next-auth.session-token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
+            document.cookie = 'multi_auth.user-id=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
             // order is important because we need to be logged in to delete push subscription on server
             const pushSubscription = await swRegistration?.pushManager.getSubscription()
             if (pushSubscription) {

--- a/components/nav/common.js
+++ b/components/nav/common.js
@@ -22,6 +22,7 @@ import { useWalletIndicator } from '@/wallets/client/hooks'
 import SwitchAccountList, { nextAccount, useAccounts } from '@/components/account'
 import { useShowModal } from '@/components/modal'
 import { numWithUnits } from '@/lib/format'
+import { clearAuthCookies } from '@/lib/auth'
 
 export function Brand ({ className }) {
   return (
@@ -306,8 +307,7 @@ function LogoutObstacle ({ onClose }) {
               return
             }
             window.logoutInProgress = true
-            document.cookie = 'next-auth.session-token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
-            document.cookie = 'multi_auth.user-id=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT'
+            clearAuthCookies()
             // order is important because we need to be logged in to delete push subscription on server
             const pushSubscription = await swRegistration?.pushManager.getSubscription()
             if (pushSubscription) {

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -4,6 +4,7 @@ import { decodeCursor, LIMIT } from './cursor'
 import { COMMENTS_LIMIT, SSR } from './constants'
 import { RetryLink } from '@apollo/client/link/retry'
 import { isMutationOperation, isQueryOperation } from '@apollo/client/utilities'
+import { setContext } from '@apollo/client/link/context'
 
 function isFirstPage (cursor, existingThings, limit = LIMIT) {
   if (cursor) {
@@ -46,8 +47,19 @@ const retryLink = new RetryLink({
 })
 
 function getClient (uri) {
+  const authContextLink = setContext((_, { headers }) => {
+    if (SSR) return { headers }
+    if (typeof window !== 'undefined' && window.logoutInProgress) {
+      const newHeaders = { ...headers }
+      delete newHeaders.authorization
+      delete newHeaders.cookie
+      return { headers: newHeaders }
+    }
+    return { headers }
+  })
   const link = from([
     retryLink,
+    authContextLink,
     split(
       // batch zaps if wallet is enabled so they can be executed serially in a single request
       operation => operation.operationName === 'act' && operation.variables.act === 'TIP' && operation.getContext().batch,

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -35,6 +35,12 @@ export const cookieOptions = (args) => ({
   ...args
 })
 
+export const clearAuthCookies = () => {
+  const expiredDate = 'Thu, 01 Jan 1970 00:00:00 GMT'
+  document.cookie = `${SESSION_COOKIE}=; path=/; expires=${expiredDate}`
+  document.cookie = `${MULTI_AUTH_POINTER}=; path=/; expires=${expiredDate}`
+}
+
 export function setMultiAuthCookies (req, res, { id, jwt, name, photoId }) {
   const httpOnlyOptions = cookieOptions()
   const jsOptions = { ...httpOnlyOptions, httpOnly: false }


### PR DESCRIPTION
## Description

fix #2366 

Fixed race condition:

- Added Apollo Client context link that strips authentication headers from requests when window.logoutInProgress flag is true
- Set logout flag immediately before logout/account switch operations to invalidate auth context for pending requests
- Created reusable clearAuthCookies() helper function in auth.js using existing cookie constants
- Added immediate client-side cookie invalidation during logout process using centralized cookie management

_A clear and concise description of what you changed and why._

## Screenshots

## Additional Context

Uses Apollo Client's setContext link for clean request interception, clearAuthCookies() function can be reused for other logout scenarios

## Checklist

**Are your changes backward compatible? Please answer below:**
Yes


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8/10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
NaN

**Did you introduce any new environment variables? If so, call them out explicitly here:**
NaN

**Did you use AI for this? If so, how much did it assist you?**
I used AI to locate interested files and to test the implementations