### PR TITLE
fix(Comment): Remove scroll to top when changing comment sort order.

### DIFF
--- a/components/item-full.js
+++ b/components/item-full.js
@@ -25,7 +25,6 @@ import { UNKNOWN_LINK_REL } from '@/lib/constants'
 import classNames from 'classnames'
 import { CarouselProvider } from './carousel'
 import Embed from './embed'
-import { useRouter } from 'next/router'
 import useCommentsView from './use-comments-view'
 
 function BioItem ({ item, handleClick }) {
@@ -169,9 +168,6 @@ export default function ItemFull ({ item, fetchMoreComments, bio, rank, ...props
     markItemViewed(item)
   }, [item.id, markItemViewed])
 
-  const router = useRouter()
-  const carouselKey = `${item.id}-${router.query?.sort || 'default'}`
-
   return (
     <>
       {rank
@@ -181,7 +177,7 @@ export default function ItemFull ({ item, fetchMoreComments, bio, rank, ...props
           </div>)
         : <div />}
       <RootProvider root={item.root || item}>
-        <CarouselProvider key={carouselKey}>
+        <CarouselProvider key={item.id}>
           {item.parentId
             ? <Comment topLevel item={item} replyOpen includeParent noComments {...props} />
             : (


### PR DESCRIPTION
## Description

fix #2555 
Prevent scroll to top because of the CarouselProvider getting unmounted.
Rationale: https://github.com/stackernews/stacker.news/issues/2555#issuecomment-3316089617

## Screenshots

## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_

## Checklist

**Are your changes backward compatible? Please answer below:**
Y

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Y

**Did you introduce any new environment variables? If so, call them out explicitly here:**
N

**Did you use AI for this? If so, how much did it assist you?**
N
