### PR TITLE
feat(Satistics): Add option to filter by earn

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -221,6 +221,17 @@ const resolvers = {
         )
       }
 
+      if (!include.has('stacked') && include.has('earn')) {
+        queries.push(
+          `(SELECT
+              min("Earn".id) as id, created_at as "createdAt",
+              sum(msats) as msats, 'earn' as type, NULL::JSONB AS other
+            FROM "Earn"
+            WHERE "Earn"."userId" = $1 AND "Earn".created_at <= $2
+            GROUP BY "userId", created_at)`
+        )
+      }
+
       if (include.has('spent')) {
         queries.push(
           `(SELECT "Item".id, MAX("ItemAct".created_at) as "createdAt", sum("ItemAct".msats) as msats,

--- a/components/form.js
+++ b/components/form.js
@@ -999,12 +999,13 @@ export function VariableInput ({ label, groupClassName, name, hint, max, min, re
 
 export function Checkbox ({
   children, label, groupClassName, type = 'checkbox',
-  hiddenLabel, extra, handleChange, inline, disabled, ...props
+  hiddenLabel, extra, handleChange, inline, disabled, indeterminate, ...props
 }) {
   // React treats radios and checkbox inputs differently other input types, select, and textarea.
   // Formik does this too! When you specify `type` to useField(), it will
   // return the correct bag of props for you
   const [field, meta, helpers] = useField({ ...props, type })
+  const inputRef = useRef(null)
   return (
     <FormGroup className={groupClassName}>
       {hiddenLabel && <BootstrapForm.Label className='invisible'>{label}</BootstrapForm.Label>}
@@ -1014,6 +1015,10 @@ export function Checkbox ({
       >
         <BootstrapForm.Check.Input
           isInvalid={meta.touched && meta.error}
+          ref={el => {
+            inputRef.current = el
+            if (el) el.indeterminate = !!indeterminate
+          }}
           {...field} {...props} disabled={disabled} type={type} onChange={(e) => {
             field.onChange(e)
             handleChange && handleChange(e.target.checked, helpers.setValue)

--- a/pages/satistics/index.js
+++ b/pages/satistics/index.js
@@ -234,6 +234,7 @@ export default function Satistics ({ ssrData }) {
             invoice: included('invoice'),
             withdrawal: included('withdrawal'),
             stacked: included('stacked'),
+            earn: included('earn'),
             spent: included('spent')
           }}
         >
@@ -251,7 +252,13 @@ export default function Satistics ({ ssrData }) {
             <Checkbox
               label='stacked' name='stacked' inline
               checked={included('stacked')}
+              indeterminate={!included('stacked') && included('earn')}
               handleChange={c => filterRoutePush('stacked', c)}
+            />
+            <Checkbox
+              label='earn' name='earn' inline
+              checked={included('earn')}
+              handleChange={c => filterRoutePush('earn', c)}
             />
             <Checkbox
               label='spent' name='spent' inline


### PR DESCRIPTION
## Description
closes #685

Added filtering option by "earn", added an indeterminate state on "stacked" to rep that its a subcategory of it.

## Screenshots


https://github.com/user-attachments/assets/8df40027-e608-4542-8f2e-530740cd09e1



## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_

## Checklist

**Are your changes backward compatible? Please answer below:**
Y

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
9

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Y

**Did you introduce any new environment variables? If so, call them out explicitly here:**
N

**Did you use AI for this? If so, how much did it assist you?**
Y, to come up with the SQL query otherwise came up with the rest of the solution.