### PR TITLE
Embeds with load timeout

### DIFF
--- a/components/text.module.css
+++ b/components/text.module.css
@@ -385,12 +385,29 @@
     padding: .75rem 1rem;
 }
 
-.tweetsSkeleton {
+.tweetsSkeleton, .embedLoadingError {
     display: flex;
     flex-flow: row wrap;
     max-width: 350px;
     width: 100%;
     padding-right: 12px;
+}
+
+.embedLoadingErrorMessage {
+    justify-content: center;
+    display: flex;
+    flex-direction: column;
+    border-radius: 0.4rem;
+    height: 150px;
+    padding: 1.5rem;
+    background-color: var(--theme-commentBg);
+}
+
+.embedLoadingErrorMessage svg {
+    width: 24px;
+    height: 24px;
+    margin-bottom: 1rem;
+    margin-left: -0.15rem;
 }
 
 .topLevel .tweetsSkeleton, :global(.topLevel) .tweetsSkeleton {


### PR DESCRIPTION
## Description

[Reported on SN](https://stacker.news/items/1238514/r/sox?commentId=1238818)
Adds a load timeout to embeds, replacing the faulty embed with an error component that links to the source.

## Video
e.g. njump is offline and after 15 seconds we replace the embed with the error component

https://github.com/user-attachments/assets/7e7227f1-4e66-43ed-b37d-e87fc97e4152


## Additional Context

This has been back ported from #2501 
Applied aggressive memoization best practices to avoid unnecessary re-renders.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6, all embeds work the same and load correctly, but the error component has only been tested with the reported URL.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
Used agent mode to apply the `useLoadTimeout` hook, mainly because of laziness since it was a matter of copy and paste.
Used ask mode to compare opinions on memoization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a load-timeout mechanism to all embeds with an error fallback UI, refactoring embeds into memoized components and improving dark mode handling.
> 
> - **Embeds**:
>   - Introduce `LoadingError` fallback UI with link to source; used when an embed fails to load.
>   - Refactor into memoized components: `TwitterEmbed`, `NostrEmbed`, `YouTubeEmbed`, `RumbleEmbed`, `PeerTubeEmbed`, `WavlakeEmbed`, `SpotifyEmbed`.
>   - `NostrEmbed`: postMessage-based dark mode updates; height sync retained; improved cleanup and dependency handling.
>   - `YouTubeEmbed`: memoized options; handles `onReady`/`onError` to clear timeout.
>   - `TwitterEmbed`: preserves skeleton/“show full” UI; clears timeout on load.
>   - `SpotifyEmbed`: memoized URL normalization; uses Spotify IFrame API and load timeout.
> - **Infrastructure**:
>   - Add `useLoadTimeout` hook (default 15s) to detect `iframe`/embed load or error; clears listeners/timeouts appropriately.
>   - Main `Embed` component now routes by `provider` and shows `LoadingError` on failure.
> - **Styles**:
>   - Add `.embedLoadingError` and `.embedLoadingErrorMessage` styles (icon, layout, theme-aware background).
>   - Share layout with `.tweetsSkeleton`; minor container/style tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d910202f739f8aa37e3aa99b188b9924826dda5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->