### PR TITLE
Fix draft gone if wallet prompt closed

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -39,6 +39,7 @@ import { useShowModal } from './modal'
 import dynamic from 'next/dynamic'
 import { useIsClient } from './use-client'
 import PageLoading from './page-loading'
+import { WalletPromptClosed } from '@/wallets/client/hooks'
 
 export class SessionRequiredError extends Error {
   constructor () {
@@ -1087,6 +1088,7 @@ export function Form ({
         await onSubmit(values, ...args)
       }
     } catch (err) {
+      if (err instanceof WalletPromptClosed) return
       console.log(err.message, err)
       toaster.danger(err.message ?? err.toString?.())
       return

--- a/components/use-item-submit.js
+++ b/components/use-item-submit.js
@@ -8,7 +8,7 @@ import { RETRY_PAID_ACTION } from '@/fragments/paidAction'
 import gql from 'graphql-tag'
 import { USER_ID } from '@/lib/constants'
 import { useMe } from './me'
-import { useWalletRecvPrompt, WalletPromptClosed } from '@/wallets/client/hooks'
+import { useWalletRecvPrompt } from '@/wallets/client/hooks'
 
 // this is intented to be compatible with upsert item mutations
 // so that it can be reused for all post types and comments and we don't have
@@ -27,12 +27,7 @@ export default function useItemSubmit (mutation,
 
   return useCallback(
     async ({ boost, crosspost, title, options, bounty, status, ...values }, { resetForm }) => {
-      try {
-        await walletPrompt()
-      } catch (err) {
-        if (err instanceof WalletPromptClosed) return
-        throw err
-      }
+      await walletPrompt()
 
       if (options) {
         // remove existing poll options since else they will be appended as duplicates


### PR DESCRIPTION
reopens #2553 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Form submission now treats `WalletPromptClosed` as a no-op; local catch removed from `use-item-submit` to centralize handling.
> 
> - **Forms (`components/form.js`)**:
>   - Treat `WalletPromptClosed` errors as no-ops during `onSubmit`, avoiding toast/logging and early-returning.
> - **Item submit hook (`components/use-item-submit.js`)**:
>   - Remove `WalletPromptClosed` import and local try/catch; directly `await walletPrompt()` and rely on form-level handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13794c503c3e557fedf402abd7e148746c8cc237. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->