### PR TITLE
Allow download of passphrase

### DIFF
--- a/wallets/client/components/passphrase.js
+++ b/wallets/client/components/passphrase.js
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useCallback } from 'react'
+import Button from 'react-bootstrap/Button'
 import { CopyButton } from '@/components/form'
 import styles from '@/styles/wallet.module.css'
 
@@ -7,7 +8,7 @@ export function Passphrase ({ passphrase }) {
   return (
     <>
       <p className='fw-bold line-height-md'>
-        Make sure to copy your passphrase now.
+        Make sure to save your passphrase now.
       </p>
       <p className='fw-bold line-height-md'>
         This is the only time we will show it to you.
@@ -23,9 +24,49 @@ export function Passphrase ({ passphrase }) {
           </div>
         ))}
       </div>
-      <div className='d-flex justify-content-end mt-3'>
+      <div className='d-flex justify-content-center mt-3 gap-2 align-items-center'>
         <CopyButton className='rounded' value={passphrase} variant='primary' />
+        <span className='text-muted'>or</span>
+        <DownloadButton passphrase={passphrase} />
       </div>
     </>
   )
+}
+
+export default function DownloadButton ({ passphrase }) {
+  const onClick = useCallback(() => {
+    const filename = 'stacker-news-passphrase.txt'
+    const value = `STACKER NEWS PASSPHRASE
+-----------------------
+
+Your passphrase to unlock your wallets on any device is:
+
+${passphrase}
+
+Please keep this passphrase safe and do not share it with anyone.
+`
+    download(filename, value)
+  }, [passphrase])
+
+  return (
+    <Button
+      className='rounded'
+      variant='primary'
+      onClick={onClick}
+    >
+      download
+    </Button>
+  )
+}
+
+function download (filename, value) {
+  const blob = new Blob([value], { type: 'text/plain' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
 }


### PR DESCRIPTION
## Description

This allows to download the passphrase instead of only copying it.

The file is named `stacker-news-passphrase.txt`. Example content:

```
STACKER NEWS PASSPHRASE
-----------------------

Your passphrase to unlock your wallets on any device is:

that lonely tooth economy trouble property boss album genre fury insane burden

Please keep this passphrase safe and do not share it with anyone.
```

## Screenshots

before:

<img width="518" height="411" alt="2025-09-28-183536_518x411_scrot" src="https://github.com/user-attachments/assets/5e031801-e579-4b9a-92fc-bc43c1d56748" />

after:

<img width="519" height="409" alt="2025-09-28-183445_519x409_scrot" src="https://github.com/user-attachments/assets/f066a2f1-eadc-4179-b900-d3b69fdb7dd8" />


## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. Clicking the button prompts me to save the file.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a button to download the wallet passphrase as a text file alongside the existing copy option.
> 
> - **Frontend (wallets)**:
>   - **Passphrase UI (`wallets/client/components/passphrase.js`)**:
>     - Add `DownloadButton` to save passphrase to `stacker-news-passphrase.txt` via Blob download.
>     - Update actions layout to centered with "or" separator; change prompt wording to "save" passphrase.
>     - Import `react-bootstrap/Button`, use `useCallback`, and add local `download` helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57210f748e4a43f3bb6907b1d164b7787fa5ad60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->