### PR TITLE
fix cancel on edit

### DIFF
--- a/components/comment-edit.js
+++ b/components/comment-edit.js
@@ -37,6 +37,7 @@ export default function CommentEdit ({ comment, editThreshold, onSuccess, onCanc
           }}
           schema={commentSchema}
           onSubmit={onSubmit}
+          storageKeyPrefix={`comment-edit-${comment.id}`}
         >
           <MarkdownInput
             name='text'

--- a/components/comment.js
+++ b/components/comment.js
@@ -28,6 +28,8 @@ import LinkToContext from './link-to-context'
 import Boost from './boost-button'
 import { gql, useApolloClient } from '@apollo/client'
 import classNames from 'classnames'
+import { useShowModal } from './modal'
+import { CancelWorkConfirm } from './confirm-modal'
 
 function Parent ({ item, rootText }) {
   const root = useRoot()
@@ -100,6 +102,7 @@ export default function Comment ({
   rootText, noComments, noReply, truncate, depth, pin, setDisableRetry, disableRetry,
   navigator
 }) {
+  const showModal = useShowModal()
   const [edit, setEdit] = useState()
   const { me } = useMe()
   const isHiddenFreebie = me?.privates?.satsFilter !== 0 && !item.mine && item.freebie && !item.freedFreebie
@@ -246,7 +249,26 @@ export default function Comment ({
                     </>
                   }
                   edit={edit}
-                  toggleEdit={e => { setEdit(!edit) }}
+                  toggleEdit={e => {
+                    if (edit) {
+                      const editText = window.localStorage.getItem(`comment-edit-${item.id}-text`)
+                      if (editText?.trim() && editText.trim() !== item.text.trim()) {
+                        showModal(onClose => (
+                          <CancelWorkConfirm
+                            onConfirm={() => {
+                              window.localStorage.removeItem(`comment-edit-${item.id}-text`)
+                              setEdit(false)
+                            }}
+                            onClose={onClose}
+                          />
+                        ))
+                      } else {
+                        setEdit(false)
+                      }
+                    } else {
+                      setEdit(true)
+                    }
+                  }}
                   editText={edit ? 'cancel' : 'edit'}
                 />}
 

--- a/components/comment.js
+++ b/components/comment.js
@@ -252,7 +252,7 @@ export default function Comment ({
                   toggleEdit={e => {
                     if (edit) {
                       const editText = window.localStorage.getItem(`comment-edit-${item.id}-text`)
-                      if (editText?.trim() && editText.trim() !== item.text.trim()) {
+                      if (editText && editText.trim() !== item.text.trim()) {
                         showModal(onClose => (
                           <CancelWorkConfirm
                             onConfirm={() => {

--- a/components/confirm-modal.js
+++ b/components/confirm-modal.js
@@ -1,0 +1,50 @@
+import Button from 'react-bootstrap/Button'
+
+export default function ConfirmModal ({
+  onConfirm,
+  message = 'Are you sure?',
+  confirmText = 'yep',
+  confirmVariant = 'info',
+  onClose
+}) {
+  return (
+    <>
+      <p className='fw-bolder'>{message}</p>
+      <div className='d-flex justify-content-end'>
+        <Button
+          variant={confirmVariant}
+          onClick={() => {
+            onConfirm()
+            onClose()
+          }}
+        >
+          {confirmText}
+        </Button>
+      </div>
+    </>
+  )
+}
+
+export function CancelWorkConfirm ({ onConfirm, onClose }) {
+  return (
+    <ConfirmModal
+      message='Are you sure? You will lose your work'
+      confirmText='yes'
+      confirmVariant='danger'
+      onConfirm={onConfirm}
+      onClose={onClose}
+    />
+  )
+}
+
+export function DeleteConfirm ({ onConfirm, onClose, type = 'item' }) {
+  return (
+    <ConfirmModal
+      message='Are you sure? This is a gone forever kind of delete.'
+      confirmText='delete'
+      confirmVariant='danger'
+      onConfirm={onConfirm}
+      onClose={onClose}
+    />
+  )
+}

--- a/components/confirm-modal.js
+++ b/components/confirm-modal.js
@@ -36,15 +36,3 @@ export function CancelWorkConfirm ({ onConfirm, onClose }) {
     />
   )
 }
-
-export function DeleteConfirm ({ onConfirm, onClose, type = 'item' }) {
-  return (
-    <ConfirmModal
-      message='Are you sure? This is a gone forever kind of delete.'
-      confirmText='delete'
-      confirmVariant='danger'
-      onConfirm={onConfirm}
-      onClose={onClose}
-    />
-  )
-}

--- a/components/reply.js
+++ b/components/reply.js
@@ -6,7 +6,7 @@ import { FeeButtonProvider, postCommentBaseLineItems, postCommentUseRemoteLineIt
 import { commentSchema } from '@/lib/validate'
 import { ItemButtonBar } from './post'
 import { useShowModal } from './modal'
-import { Button } from 'react-bootstrap'
+import { CancelWorkConfirm } from './confirm-modal'
 import { useRoot } from './root'
 import { CREATE_COMMENT } from '@/fragments/paidAction'
 import { injectComment } from '@/lib/comments'
@@ -99,18 +99,10 @@ export default forwardRef(function Reply ({
                   const text = window.localStorage.getItem('reply-' + parentId + '-' + 'text')
                   if (text?.trim()) {
                     showModal(onClose => (
-                      <>
-                        <p className='fw-bolder'>Are you sure? You will lose your work</p>
-                        <div className='d-flex justify-content-end'>
-                          <Button
-                            variant='info' onClick={() => {
-                              onCancel()
-                              onClose()
-                            }}
-                          >yep
-                          </Button>
-                        </div>
-                      </>
+                      <CancelWorkConfirm
+                        onConfirm={onCancel}
+                        onClose={onClose}
+                      />
                     ))
                   } else {
                     onCancel()


### PR DESCRIPTION
## Description

fix #2568 

Implemented confirmation prompt when canceling comment edit.

- Created reusable `ConfirmModal` component with presets for different confirmation types.
- Added confirmation modal logic to `comment.js eoggleEdit `function that checks for unsaved changes in `localStorage`.
- Updated both` comment.js` and `reply.js` to use the new reusable component.
- Added `storageKeyPrefix` to `comment-edit.js` to properly track form changes

## Screenshots

https://github.com/user-attachments/assets/6c2ceda3-10e7-4dc1-9608-bc8029538f51


## Additional Context

The implementation follows the exact same pattern used in `reply.js` to maintain consistency.
the confirmation logic is handled at the parent component level `comment.js` 
This implementation *DOES NOT* fix the multi-tab problem highlighted by @adlai, a broader refactor of the editing system would be needed, which goes beyond the scope of this issue.

## Checklist

**Are your changes backward compatible? Please answer below:**
Yes


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7/10


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
NaN


**Did you introduce any new environment variables? If so, call them out explicitly here:**
No


**Did you use AI for this? If so, how much did it assist you?**
I used AI to analyze the existing codebase and find interested files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c4b2bd637618ddf40491e985d6f156c69a958d68. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->