### PR TITLE
fix(Item): fix ranking by invoicePaidAt instead of created_at

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -247,7 +247,7 @@ export const whereClause = (...clauses) => {
 }
 
 function whenClause (when, table) {
-  return `"${table}".created_at <= $2 and "${table}".created_at >= $1`
+  return `COALESCE("${table}"."invoicePaidAt", "${table}".created_at) <= $2 and COALESCE("${table}"."invoicePaidAt", "${table}".created_at) >= $1`
 }
 
 export const activeOrMine = (me) => {
@@ -433,7 +433,7 @@ export default {
               ${SELECT}
               ${relationClause(type)}
               ${whereClause(
-                '"Item".created_at <= $1',
+                'COALESCE("Item"."invoicePaidAt", "Item".created_at) <= $1',
                 '"Item"."deletedAt" IS NULL',
                 subClause(sub, 4, subClauseTable(type), me, showNsfw),
                 activeOrMine(me),


### PR DESCRIPTION
## Description

Factor in invoicePaidAt instead of just created_at when ranking posts. 

## Screenshots
To test, I recreated the post details from https://stacker.news/items/1246127 on a test post. And checked that the post appears as expected. 
<img width="1281" height="407" alt="Screenshot 2025-10-06 at 16 35 02" src="https://github.com/user-attachments/assets/aa0ff391-b214-47b4-bf42-180a753adfa8" />



## Checklist

**Are your changes backward compatible? Please answer below:**
Yes
_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**
N

**Did you use AI for this? If so, how much did it assist you?**
N