### PR TITLE
refactor: convert WebLnProvider into hook

### DIFF
--- a/wallets/client/hooks/global.js
+++ b/wallets/client/hooks/global.js
@@ -16,7 +16,7 @@ import { useMe } from '@/components/me'
 import { useIndexedDB } from '@/components/use-indexeddb'
 import { FAILED_INVOICES } from '@/fragments/invoice'
 import { isTemplate, isWallet } from '@/wallets/lib/util'
-import { WebLnProvider } from '@/wallets/lib/protocols/webln'
+import { useWeblnEvents } from '@/wallets/lib/protocols/webln'
 import { useWalletsQuery } from '@/wallets/client/hooks/query'
 import { useWalletPayment } from '@/wallets/client/hooks/payment'
 import { useGenerateRandomKey, useSetKey, useIsWrongKey, useDeleteOldDb } from '@/wallets/client/hooks/crypto'
@@ -87,9 +87,7 @@ export function WalletsProvider ({ children }) {
     <WalletsContext.Provider value={state}>
       <WalletsDispatchContext.Provider value={dispatch}>
         <WalletHooks>
-          <WebLnProvider>
-            {children}
-          </WebLnProvider>
+          {children}
         </WalletHooks>
       </WalletsDispatchContext.Provider>
     </WalletsContext.Provider>
@@ -101,6 +99,7 @@ function WalletHooks ({ children }) {
   useAutomatedRetries()
   useKeyInit()
   useDeleteLocalWallets()
+  useWeblnEvents()
 
   return children
 }

--- a/wallets/lib/protocols/webln.js
+++ b/wallets/lib/protocols/webln.js
@@ -12,7 +12,10 @@ export default {
   isAvailable: () => window?.weblnEnabled
 }
 
-export function WebLnProvider ({ children }) {
+// this hook is used to check if the lightning browser extension is still enabled
+// in which case we will also not attempt to use WebLN
+// for payments using the `isAvailable` function above
+export function useWeblnEvents () {
   useEffect(() => {
     const onEnable = () => {
       window.weblnEnabled = true
@@ -33,6 +36,4 @@ export function WebLnProvider ({ children }) {
       window.removeEventListener('webln:disabled', onDisable)
     }
   }, [])
-
-  return children
 }


### PR DESCRIPTION
## Description

Instead of using a component that only uses `useEffect` to hook into WebLN events from the browser extension, we can just call `useEffect` in a custom hook like we already do for other hooks.

## Additional context

~This is targeting the `wallets` branch instead of `master`, because the changes here depend on the changes in `wallets` that have not been merged yet into `master` (#2572).~

~I did not want to port the code back to `master` since it's not that important so I'd rather just not have to resolve a conflict later.~

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. WebLN wallet still disabled when lightning browser extension is disabled 

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Convert the `WebLnProvider` component into a `useWeblnEvents` hook and wire it into global wallet hooks, removing the provider wrapper.
> 
> - **Wallets (client)**:
>   - Replace `WebLnProvider` usage in `wallets/client/hooks/global.js` with `useWeblnEvents()` inside `WalletHooks`, removing the provider wrapper around children.
> - **WebLN protocol**:
>   - Convert component `WebLnProvider` to hook `useWeblnEvents` in `wallets/lib/protocols/webln.js` to manage `webln:enabled/disabled` events and set `window.weblnEnabled` for `isAvailable`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1614dd9f777625bb4b11a72ac10031f2d25d55e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->