### PR TITLE
fix: reload highlighter when language is available

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -276,7 +276,8 @@ function Code ({ node, inline, className, children, style, ...props }) {
         loading: () => <CodeSkeleton className={className} {...props}>{children}</CodeSkeleton>
       }),
       import('react-syntax-highlighter/dist/cjs/styles/hljs/atom-one-dark').then(mod => mod.default)
-    ]), [className, props, children]
+    // className is necessary to re-compute language
+    ]), [className]
   )
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Fixes #2600 
Adds the `language` dependency to the `useEffect` that dynamically loads the highlighter, triggering a reload of the highlighter once `language` is available.
Also memoizes the `language` computation and persists the `loadHighlighter` function across re-renders to avoid extra work.

## Screenshots

https://github.com/user-attachments/assets/e01f3572-26e6-434a-ae91-a4d6b32ddab6

## Additional Context

n/a

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8, it works correctly on the given text.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reloads the syntax highlighter when `language` becomes available/changes, memoizes `language`, and adds safe cleanup to avoid setting state after unmount.
> 
> - **Code rendering (`components/text.js` > `Code`)**:
>   - Memoizes `language` from `className` via `useMemo` and updates `loadHighlighter` dependency to `[className]`.
>   - Updates `useEffect` dependencies to `[inline, language, loadHighlighter]`; early-returns for `inline` and `math`.
>   - Adds abort/cleanup guard to prevent state updates after unmount while loading highlighter.
>   - Minor refactor: uses loaded `Highlighter` and sets theme once loaded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ceabd84022b353ea53be18c50e33ee3985973605. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->