### PR TITLE
Better explain passphrase reset

### DIFF
--- a/wallets/client/hooks/passphrase.js
+++ b/wallets/client/hooks/passphrase.js
@@ -148,9 +148,36 @@ export function usePassphrasePrompt () {
       <p className='line-height-md mt-3'>
         Enter your passphrase to decrypt your wallets on this device.
       </p>
-      <p className='line-height-md'>
-        {showPassphrase && 'The passphrase reveal button is above your wallets on the original device.'}
-      </p>
+      <AccordianItem
+        className='line-height-md text-white my-3'
+        header='Where can I find my passphrase?'
+        body={
+          showPassphrase
+            ? (
+              <>
+                <p>
+                  Your passphrase was generated on the device where you first created your wallets. To find it:
+                </p>
+                <ol>
+                  <li>Go to your wallets on that original device</li>
+                  <li>Look above your list of wallets</li>
+                  <li>Click the 'passphrase' button to reveal it</li>
+                </ol>
+                <p>
+                  Make sure to store your passphrase somewhere safe — you'll need to enter it on any device you want to access your wallets like this one.
+                </p>
+              </>
+              )
+            : (
+              <>
+                <p>
+                  We have already shown you your passphrase so we cannot show it to you again, sorry.
+                  Please check your password manager or other locations where you may have stored your passphrase.
+                </p>
+              </>
+              )
+        }
+      />
       <AccordianItem
         className='line-height-md text-white my-3'
         header='I lost my passphrase. What should I do?'


### PR DESCRIPTION
## Description

This should clarify some things about passphrase reset.

related to cases like https://stacker.news/items/1259012

## Screenshots

before:

<img width="300" height="534" alt="localhost_3000_wallets(iPhone SE) (2)" src="https://github.com/user-attachments/assets/12c660d8-475a-4929-9823-617c6faee7eb" />

after:

<img width="300" height="534" alt="localhost_3000_wallets(iPhone SE)" src="https://github.com/user-attachments/assets/46088a76-5a98-4668-9978-fbb09071f6d2" />

<img width="300" height="534" alt="localhost_3000_wallets(iPhone SE) (1)" src="https://github.com/user-attachments/assets/8c5a8ed4-93be-41e2-a91a-91038332dc6e" />

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`, it's just UI, no logic

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

it helped me with the text

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances the wallet decryption prompt with accordion help explaining where to find the passphrase and what happens on reset, with minor layout tweaks.
> 
> - **Frontend**
>   - **Wallet decryption prompt (`wallets/client/hooks/passphrase.js`)**:
>     - Replace static help text with two `AccordianItem` sections:
>       - “Where can I find my passphrase?” (conditional content if `showPassphrase` is available).
>       - “I lost my passphrase. What should I do?” explaining reset issues a new passphrase and deletes sending credentials.
>     - Minor UI tweak: add `className='mt-3'` to `Form`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17a4c52421527d2af2fd81073730269a05c0bd19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->