### PR TITLE
Optional dmenu support in sndev

### DIFF
--- a/sndev
+++ b/sndev
@@ -39,14 +39,35 @@ docker__exec() {
 sndev__start() {
   shift
 
-
-
   if [ $# -eq 0 ]; then
-    docker__compose up --build
-    exit 0
+    if command -v dmenu > /dev/null 2>&1;  then
+      # use dmenu if installed to select a profile
+      profiles=$(sndev__dmenu_profile)
+      if [ -z "$profiles" ]; then
+        exit 1
+      fi
+      COMPOSE_PROFILES="$profiles" docker__compose up --build
+    else
+      docker__compose up --build
+    fi
+  else
+    docker__compose up "$@"
   fi
+}
 
-  docker__compose up "$@"
+sndev__dmenu_profile() {
+  # dmenu allows to select multiple profiles with CTRL+Enter
+  # in which case it will immediately write the selected profile to stdout
+  # so we loop over each line of the output and add each profile to an array
+  # to make sure we don't add duplicates
+  profiles="minimal payments wallets email search images capture"
+  selected=()
+  while read -r sel; do
+    if [[ ! " ${selected[*]} " =~ " ${sel} " ]]; then
+      selected+=("$sel")
+    fi
+  done < <(echo "$profiles" | tr ' ' '\n' | dmenu)
+  printf '%s,' "${selected[@]}" | sed 's/,$//'
 }
 
 sndev__help_start() {
@@ -180,7 +201,7 @@ sndev__delete() {
   printf "this deletes containers, volumes, and orphans - are you sure? [y/N] "
   read -r answer
   if [ "$answer" = "y" ]; then
-    docker__compose down --volumes --remove-orphans
+    COMPOSE_PROFILES="*" docker__compose down --volumes --remove-orphans
   else
     echo "delete cancelled"
   fi


### PR DESCRIPTION
# Description

IMO, one of the most annoying parts of `sndev` is how to select profiles. I switch between profiles a lot to avoid running containers that I don't need. So for example, when I don't need the wallets, I don't start the containers for them etc.

The standard way to select profiles is to define `COMPOSE_PROFILES` in .env.local. So to switch between them, you need to manually edit that file. I added this to the top of my file so I can just uncomment the line I need at the time:

```
COMPOSE_PROFILES=minimal
#COMPOSE_PROFILES=wallets,payments,minimal
#COMPOSE_PROFILES=payments,minimal
#COMPOSE_PROFILES=minimal,email
#COMPOSE_PROFILES=minimal,search
#COMPOSE_PROFILES=minimal,payments,images
#COMPOSE_PROFILES=minimal,payments,domains
```

(Is this also how you guys are switching between profiles?)

However, this was still annoying enough for me to look into how to use [`dmenu`](https://tools.suckless.org/dmenu/) for that, so I added optional support for it. If `dmenu` is installed, `sndev start` will now use it.

Here is me first selecting `minimal`, `payments` and `wallets`, then deleting all containers and then running only `minimal`:

https://github.com/user-attachments/assets/c6ff557e-724d-4c11-869f-5fca891c4e07

Additionally, `sndev delete` would only delete containers selected by `COMPOSE_PROFILES`. Every time it happened that `sndev delete` would not delete all containers because some weren't selected by `COMPOSE_PROFILES`, this was not what I wanted, so I think it's generally the case that `sndev delete` should ignore `COMPOSE_PROFILES` and just delete everything.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds dmenu-based COMPOSE_PROFILES selection to `sndev start` when no args, and ensures `sndev delete` removes all containers by setting `COMPOSE_PROFILES="*"`.
> 
> - **sndev**:
>   - **Profile selection**:
>     - `sndev__start`: When called without args, if `dmenu` is available, prompt to select one or more profiles and run `docker compose up --build` with `COMPOSE_PROFILES` set; otherwise default to previous behavior.
>     - New `sndev__dmenu_profile`: Presents predefined profiles via `dmenu` and returns a comma-separated list without duplicates.
>   - **Delete behavior**:
>     - `sndev__delete`: Uses `COMPOSE_PROFILES="*"` with `docker compose down --volumes --remove-orphans` to remove all containers regardless of selected profiles.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbc90b270a2b9e50951fb15db4df6bba02f9107c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->