### PR TITLE
Refactor authorization with schema directives

### DIFF
--- a/api/directives/auth.js
+++ b/api/directives/auth.js
@@ -1,0 +1,57 @@
+import gql from 'graphql-tag'
+import { defaultFieldResolver } from 'graphql'
+import { getDirective, MapperKind, mapSchema } from '@graphql-tools/utils'
+import { GqlAuthorizationError } from '@/lib/error'
+
+const DIRECTIVE_NAME = 'auth'
+
+export const typeDef = gql`
+    directive @${DIRECTIVE_NAME}(allow: [Role!]!) on FIELD_DEFINITION
+    enum Role {
+        ADMIN
+        OWNER
+        USER
+    }
+`
+
+export function apply (schema) {
+  return mapSchema(schema, {
+    [MapperKind.OBJECT_FIELD]: fieldConfig => {
+      const upperDirective = getDirective(schema, fieldConfig, DIRECTIVE_NAME)?.[0]
+      if (upperDirective) {
+        const { resolve = defaultFieldResolver } = fieldConfig
+        const { allow } = upperDirective
+        return {
+          ...fieldConfig,
+          resolve: async function (parent, args, context, info) {
+            checkFieldPermissions(allow, parent, args, context, info)
+            return await resolve(parent, args, context, info)
+          }
+        }
+      }
+    }
+  })
+}
+
+function checkFieldPermissions (allow, parent, args, { me }, { parentType }) {
+  // TODO: should admin users always have access to all fields?
+
+  if (allow.indexOf('OWNER') >= 0) {
+    if (!me) {
+      throw new GqlAuthorizationError('you must be logged in to access this field')
+    }
+
+    switch (parentType.name) {
+      case 'User':
+        if (me.id !== parent.id) {
+          throw new GqlAuthorizationError('you must be the owner to access this field')
+        }
+        break
+      default:
+        // we could just try the userId column and not care about the type
+        // but we want to be explicit and throw on unexpected types instead
+        // to catch potential issues in our authorization layer fast
+        throw new GqlAuthorizationError('failed to check owner: unknown type')
+    }
+  }
+}

--- a/api/directives/index.js
+++ b/api/directives/index.js
@@ -1,0 +1,14 @@
+import { makeExecutableSchema } from '@graphql-tools/schema'
+
+import * as upper from './upper'
+import * as auth from './auth'
+
+const DIRECTIVES = [upper, auth]
+
+export function makeExecutableSchemaWithDirectives (typeDefs, resolvers) {
+  const schema = makeExecutableSchema({
+    typeDefs: [...typeDefs, ...DIRECTIVES.map(({ typeDef }) => typeDef)],
+    resolvers
+  })
+  return DIRECTIVES.reduce((acc, directive) => directive.apply(acc), schema)
+}

--- a/api/directives/upper.js
+++ b/api/directives/upper.js
@@ -1,0 +1,30 @@
+import gql from 'graphql-tag'
+import { defaultFieldResolver } from 'graphql'
+import { getDirective, MapperKind, mapSchema } from '@graphql-tools/utils'
+
+/** Example schema directive that uppercases the value of the field before returning it to the client */
+
+const DIRECTIVE_NAME = 'upper'
+
+export const typeDef = gql`directive @${DIRECTIVE_NAME} on FIELD_DEFINITION`
+
+export function apply (schema) {
+  return mapSchema(schema, {
+    [MapperKind.OBJECT_FIELD]: fieldConfig => {
+      const upperDirective = getDirective(schema, fieldConfig, DIRECTIVE_NAME)?.[0]
+      if (upperDirective) {
+        const { resolve = defaultFieldResolver } = fieldConfig
+        return {
+          ...fieldConfig,
+          resolve: async function (parent, args, context, info) {
+            const result = await resolve(parent, args, context, info)
+            if (typeof result === 'string') {
+              return result.toUpperCase()
+            }
+            return result
+          }
+        }
+      }
+    }
+  })
+}

--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -936,10 +936,6 @@ export default {
 
   User: {
     privates: async (user, args, { me, models }) => {
-      if (!me || me.id !== user.id) {
-        return null
-      }
-
       return user
     },
     optional: user => user,

--- a/api/ssrApollo.js
+++ b/api/ssrApollo.js
@@ -1,8 +1,6 @@
 import { ApolloClient, InMemoryCache } from '@apollo/client'
 import { SchemaLink } from '@apollo/client/link/schema'
-import { makeExecutableSchema } from '@graphql-tools/schema'
-import resolvers from './resolvers'
-import typeDefs from './typeDefs'
+import { schema } from '@/pages/api/graphql'
 import models from './models'
 import { print } from 'graphql'
 import lnd from './lnd'
@@ -22,10 +20,7 @@ export default async function getSSRApolloClient ({ req, res, me = null }) {
   const client = new ApolloClient({
     ssrMode: true,
     link: new SchemaLink({
-      schema: makeExecutableSchema({
-        typeDefs,
-        resolvers
-      }),
+      schema,
       context: {
         models,
         me: session

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -79,7 +79,7 @@ export default gql`
     proportion: Float
 
     optional: UserOptional!
-    privates: UserPrivates
+    privates: UserPrivates @auth(allow: [OWNER])
 
     meMute: Boolean!
     meSubscriptionPosts: Boolean!

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -1,18 +1,20 @@
 import { ApolloServer } from '@apollo/server'
 import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default'
 import { startServerAndCreateNextHandler } from '@as-integrations/next'
-import resolvers from '@/api/resolvers'
 import models from '@/api/models'
 import lnd from '@/api/lnd'
 import typeDefs from '@/api/typeDefs'
+import { makeExecutableSchemaWithDirectives } from '@/api/directives'
+import resolvers from '@/api/resolvers'
 import { getServerSession } from 'next-auth/next'
 import { getAuthOptions } from './auth/[...nextauth]'
 import search from '@/api/search'
 import { multiAuthMiddleware } from '@/lib/auth'
 
+export const schema = makeExecutableSchemaWithDirectives(typeDefs, resolvers)
+
 const apolloServer = new ApolloServer({
-  typeDefs,
-  resolvers,
+  schema,
   introspection: true,
   allowBatchedHttpRequests: true,
   plugins: [{

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -1,4 +1,5 @@
 import { ApolloServer } from '@apollo/server'
+import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default'
 import { startServerAndCreateNextHandler } from '@as-integrations/next'
 import resolvers from '@/api/resolvers'
 import models from '@/api/models'
@@ -8,7 +9,6 @@ import { getServerSession } from 'next-auth/next'
 import { getAuthOptions } from './auth/[...nextauth]'
 import search from '@/api/search'
 import { multiAuthMiddleware } from '@/lib/auth'
-import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled'
 
 const apolloServer = new ApolloServer({
   typeDefs,
@@ -42,7 +42,10 @@ const apolloServer = new ApolloServer({
         }
       }
     }
-  }, ApolloServerPluginLandingPageDisabled()]
+  },
+  process.env.NODE_ENV === 'development' && ApolloServerPluginLandingPageLocalDefault(
+    { embed: { endpointIsEditable: false, persistExplorerState: true, displayOptions: { theme: 'dark' } }, footer: false })
+  ].filter(Boolean)
 })
 
 export default startServerAndCreateNextHandler(apolloServer, {


### PR DESCRIPTION
## Description

based on #2605 

This is just a PoC how we could put our authorization logic into the GraphQL layer via [schema directives](https://the-guild.dev/graphql/tools/docs/schema-directives#enforcing-access-permissions).

I think I've mentioned this idea before, so here is this idea with code.

To repeat the main argument for this:

Our auth code is currently spread around and easy to miss. This makes it hard to (quickly) verify if authorization was correctly implemented for something and too easy to treat authorization like an afterthought during implementation.

Putting all (or at least most) of our auth code into one place to make it clear which fields can be accessed by who.

This PoC can be tested with this query:

<details>
<summary>GraphQL query</summary>

```gql
fragment UserFields on User {
  id
  name
  privates {
    sats
  }
}

query users($id: ID) {
  me {
    ...UserFields
  }
  user(id: $id) {
    ...UserFields
  }
}
```

</details>

`id` should be the id of any existing user, like 624 in the db seed.

When logged in and trying to access `user.privates` of another user, the API will now reply this:

<details>
<summary>API response</summary>

```json
{
  "errors": [
    {
      "message": "you must be the owner to access this field",
      "locations": [
        {
          "line": 4,
          "column": 3
        }
      ],
      "path": [
        "user",
        "privates"
      ],
      "extensions": {
        "code": "E_FORBIDDEN",
        "stacktrace": [
          "GraphQLError: you must be the owner to access this field",
          "    at constructor (webpack://stackernews/lib/error.js?0d59:10:5)",
          "    at checkFieldPermissions (webpack://stackernews/api/directives/auth.js?bdee:47:17)",
          "    at resolve (webpack://stackernews/api/directives/auth.js?bdee:27:13)",
          "    at field.resolve (/app/node_modules/@apollo/server/src/utils/schemaInstrumentation.ts:82:22)",
          "    at executeField (/app/node_modules/graphql/execution/execute.js:492:20)",
          "    at executeFields (/app/node_modules/graphql/execution/execute.js:414:22)",
          "    at completeObjectValue (/app/node_modules/graphql/execution/execute.js:925:10)",
          "    at completeValue (/app/node_modules/graphql/execution/execute.js:646:12)",
          "    at /app/node_modules/graphql/execution/execute.js:497:9",
          "    at async Promise.all (index 1)",
          "    at execute (/app/node_modules/@apollo/server/src/requestPipeline.ts:543:31)",
          "    at processGraphQLRequest (/app/node_modules/@apollo/server/src/requestPipeline.ts:429:26)",
          "    at internalExecuteOperation (/app/node_modules/@apollo/server/src/ApolloServer.ts:1331:12)",
          "    at runHttpQuery (/app/node_modules/@apollo/server/src/runHttpQuery.ts:232:27)",
          "    at runPotentiallyBatchedHttpQuery (/app/node_modules/@apollo/server/src/httpBatching.ts:85:12)"
        ]
      }
    }
  ],
  "data": {
    "me": {
      "id": "21858",
      "name": "test01",
      "privates": {
        "sats": 0
      }
    },
    "user": {
      "id": "624",
      "name": "FrancesSalazarPBH",
      "privates": null
    }
  }
}
```

</details>

However, I am not sure how schema directives can support conditional validation like we need for fields that are conditionally private. Conditional validation might need to continue exist as custom code in the resolvers.

**TODO**

- :construction: replace other duplicate auth code in resolvers 
- :question: remove `UserPrivates` and add each field directly to `User` with `@auth` directive?

## Additional context

This has no priority. I wrote this code a while ago. I am pushing it now and creating a PR to not accidentally lose my changes and to let you know there's already code to look at so it's not only theory.

## Checklist

**Are your changes backward compatible? Please answer below:**

tbd

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

tbd

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

tbd

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds schema directives (including @auth) and wires a shared executable schema for API and SSR; enforces OWNER access on User.privates and enables dev landing page.
> 
> - **GraphQL/Schema**:
>   - **Directives**: Add directive framework with `@upper` and `@auth` (`api/directives/*`), plus helper `makeExecutableSchemaWithDirectives` to compose schema.
>   - **Authorization**: Apply `@auth(allow: [OWNER])` to `User.privates` (`api/typeDefs/user.js`); remove resolver-side ownership check (`api/resolvers/user.js`).
> - **Server Integration**:
>   - Build and export shared `schema` in `pages/api/graphql.js` using directives; swap ApolloServer to use `schema`.
>   - Enable local landing page in development; keep performance logging plugin.
> - **SSR**:
>   - Use shared `schema` in `api/ssrApollo.js` via `SchemaLink` instead of creating a new executable schema.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a58aa3ae7b4a0bc8323a93dac96bc2934229014. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->