### PR TITLE
Reenable GraphQL playground in dev only

### DIFF
--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -1,4 +1,5 @@
 import { ApolloServer } from '@apollo/server'
+import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default'
 import { startServerAndCreateNextHandler } from '@as-integrations/next'
 import resolvers from '@/api/resolvers'
 import models from '@/api/models'
@@ -8,7 +9,6 @@ import { getServerSession } from 'next-auth/next'
 import { getAuthOptions } from './auth/[...nextauth]'
 import search from '@/api/search'
 import { multiAuthMiddleware } from '@/lib/auth'
-import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/disabled'
 
 const apolloServer = new ApolloServer({
   typeDefs,
@@ -42,7 +42,10 @@ const apolloServer = new ApolloServer({
         }
       }
     }
-  }, ApolloServerPluginLandingPageDisabled()]
+  },
+  process.env.NODE_ENV === 'development' && ApolloServerPluginLandingPageLocalDefault(
+    { embed: { endpointIsEditable: false, persistExplorerState: true, displayOptions: { theme: 'dark' } }, footer: false })
+  ].filter(Boolean)
 })
 
 export default startServerAndCreateNextHandler(apolloServer, {


### PR DESCRIPTION
## Description

This partially reverts commit 2a8085a9956edbaa96906da50050f1472adddeef.

I think it's okay to reenable the playground in dev only.

## Additional context

I really want to replace all `process.env.NODE_ENV === 'development'` etc. with a constant like `__DEV__` or `__PROD__` but I also don't want to create conflicts for everyone everywhere just for aesthetics

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`10`. plugin is only added in dev and falsy values are filtered out since they would make Apollo throw

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable Apollo GraphQL landing page (Explorer) in dev-only by conditionally adding `ApolloServerPluginLandingPageLocalDefault` and removing the disabled plugin.
> 
> - **API/GraphQL (`pages/api/graphql.js`)**:
>   - Add `ApolloServerPluginLandingPageLocalDefault` conditionally for `process.env.NODE_ENV === 'development'` with embedded dark-themed Explorer and persisted state.
>   - Remove `ApolloServerPluginLandingPageDisabled`; filter falsy plugins with `.filter(Boolean)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bf36118bc5da7b1600e10c4202e475d68306a0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->