### PR TITLE
Fix process substitution is not POSIX-compliant

### DIFF
--- a/sndev
+++ b/sndev
@@ -56,18 +56,11 @@ sndev__start() {
 }
 
 sndev__dmenu_profile() {
-  # dmenu allows to select multiple profiles with CTRL+Enter
-  # in which case it will immediately write the selected profile to stdout
-  # so we loop over each line of the output and add each profile to an array
-  # to make sure we don't add duplicates
+  # dmenu allows to select multiple profiles with CTRL+Enter in which case it will
+  # immediately write the selected profile to stdout even if it was already selected
+  # so we use sort+uniq to remove duplicates
   profiles="minimal payments wallets email search images capture"
-  selected=()
-  while read -r sel; do
-    if [[ ! " ${selected[*]} " =~ " ${sel} " ]]; then
-      selected+=("$sel")
-    fi
-  done < <(echo "$profiles" | tr ' ' '\n' | dmenu)
-  printf '%s,' "${selected[@]}" | sed 's/,$//'
+  echo "$profiles" | tr ' ' '\n' | dmenu | sort | uniq | tr '\n' ',' | sed 's/,$//'
 }
 
 sndev__help_start() {


### PR DESCRIPTION
This should fix https://github.com/stackernews/stacker.news/pull/2603#issuecomment-3419750758:

> Heads up, this doesn't work in `#!/bin/sh` because there's no process substitution, so sndev fails.
> 
> `./sndev: line 69: syntax error near unexpected token '<'`

Can you verify @Soxasora?

It already worked with `sh` before for me but looks like `sh` is linked to `bash` anyway on my system:

```
$ sh --version
GNU bash, version 5.2.37(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

_For whom it may concern, I noticed arrays also aren't part of POSIX so this would have been another issue._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace bash-specific array/process substitution in `sndev__dmenu_profile` with a POSIX `dmenu | sort | uniq` pipeline to dedupe selected profiles.
> 
> - **Shell script (`sndev`)**:
>   - **`sndev__dmenu_profile`**: Replace array + process substitution logic with `echo "$profiles" | tr ' ' '\n' | dmenu | sort | uniq | tr '\n' ',' | sed 's/,$//'` to dedupe selections and maintain POSIX `/bin/sh` compatibility.
>   - Update inline comments to reflect new deduplication approach using `sort`/`uniq`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14c8a268f2bc94982585bc87f0668a81591f541e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->