### PR TITLE
Update section about wallets in FAQ

### DIFF
--- a/docs/user/faq.md
+++ b/docs/user/faq.md
@@ -84,19 +84,7 @@ Stacker News is non-custodial. To send and receive sats, you need to attach a wa
 
 Click [here](/wallets) or click on your name and select 'wallets'. You should then see this:
 
-![](https://m.stacker.news/100486)
-
-We currently support the following wallets:
-
-- [WebLN](https://www.webln.guide/ressources/webln-providers)
-- [Blink](https://www.blink.sv/) | [guide](https://stacker.news/items/705629/r/supratic)
-- [Core Lightning](https://docs.corelightning.org/) via [CLNRest](https://docs.corelightning.org/docs/rest) | [guide](https://stacker.news/items/545926/r/supratic)
-- [Lightning Node Connect](https://docs.lightning.engineering/lightning-network-tools/lightning-terminal/lightning-node-connect) (LNC)
-- [Lightning Network Daemon](https://github.com/lightningnetwork/lnd) (LND) via [gRPC](https://lightning.engineering/api-docs/api/lnd/) | [guide](https://stacker.news/items/704693/r/supratic)
-- [LNbits](https://lnbits.com/) | [guide](https://stacker.news/items/697132/r/supratic)
-- [Nostr Wallet Connect](https://nwc.dev/) (NWC) | [guide](https://stacker.news/items/698497/r/supratic)
-- [lightning address](https://strike.me/learn/what-is-a-lightning-address/) | [guide](https://stacker.news/items/694593/r/supratic)
-- [phoenixd](https://phoenix.acinq.co/server) | [guide](https://stacker.news/items/695912/r/supratic)
+![](https://m.stacker.news/112907)
 
 ### I can't find my wallet. Can I not attach one?
 


### PR DESCRIPTION
Turns out I already updated the checked-in FAQ for the new wallets, I just never updated the FAQ in prod. Did that now.

Meanwhile, [the image](https://m.stacker.news/100486) expired so I had to upload it again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit d4fab9db1e086fa99db337d2e0850dbc861a79ae. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->