### PR TITLE
Delete unpaid images after 24 hours or 7 days

### DIFF
--- a/docs/user/faq.md
+++ b/docs/user/faq.md
@@ -8,7 +8,7 @@ sub: meta
 
 _To quickly browse through this FAQ page, click the chapters icon in the top-right corner. This will let you scroll through all chapters or search for a particular topic within this page._
 
-last updated: August 13, 2025
+last updated: October 20, 2025
 
 ---
 
@@ -229,7 +229,7 @@ Upload fees are applied when you submit your post or comment.
 
 ### Are media uploads stored forever?
 
-Yes, if it was used in a post or comment. **Uploads that haven't been used within 24 hours in a post or comment are deleted.**
+Yes, if it was used in a post or comment. **Uploads that haven't been used within 7 days in a post or comment are deleted.**
 
 ### I no longer want to pay for my territory. What should I do?
 


### PR DESCRIPTION
## Description

Some stackers mentioned that they had to reupload their images because their draft was older than 24 hours. This is bad UX.

The reason for 24 hours was that it should be long enough for this to not happen while short enough to disincentivize using our AWS storage for impermanent but free hosting (of potentially questionable content). 

Since 24 hours is apparently not long enough, unpaid images of stackers are now kept for 7 days instead of 24 hours.

To avoid the same problem with anons, their unpaid images are now kept for 24 hours instead of 1 hour.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`7`. I ran the job locally and query executed fine.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extend unpaid image retention to 7 days for users and 24 hours for anonymous uploads; update FAQ date and retention policy.
> 
> - **Backend**
>   - `worker/deleteUnusedImages.js`: Change cleanup window to `7 days` for users and `24 hours` for anons in SQL `created_at` filter; update inline comment.
> - **Docs**
>   - `docs/user/faq.md`: Update “last updated” date and change media retention note from `24 hours` to `7 days`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31d977d034695950ede9d05242cb522aa7211da8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->