### PR TITLE
Fix no toast on avatar upload error

### DIFF
--- a/components/avatar.js
+++ b/components/avatar.js
@@ -7,6 +7,7 @@ import Moon from '@/svgs/moon-fill.svg'
 import { useShowModal } from './modal'
 import { FileUpload } from './file-upload'
 import { gql, useMutation } from '@apollo/client'
+import { useToast } from './toast'
 
 export default function Avatar ({ onSuccess }) {
   const [cropPhoto] = useMutation(gql`
@@ -16,6 +17,7 @@ export default function Avatar ({ onSuccess }) {
   `)
   const [uploading, setUploading] = useState()
   const showModal = useShowModal()
+  const toaster = useToast()
 
   const Body = ({ onClose, file, onSave }) => {
     const [scale, setScale] = useState(1)
@@ -91,6 +93,7 @@ export default function Avatar ({ onSuccess }) {
               onSuccess?.(croppedPhotoId)
               setUploading(false)
             } catch (e) {
+              toaster.danger(e.message)
               console.error(e)
               setUploading(false)
               reject(e)


### PR DESCRIPTION
## Description

fix part of https://stacker.news/items/1260135?commentId=1260221

On avatar upload errors, we were not notifying the user about it but only logging it to the console.

However, I don't know why a 2.1MB JPEG failed, the limit is 5MB. I verified with a 4.5MB GIF.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested with 7MB file and 4.5MB file

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Display a danger toast when avatar upload/crop fails in `components/avatar.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8a4640b7c522dfd923ce9b9865275f12b0e77cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->