### PR TITLE
add dropdown menu to download stacker analytics

### DIFF
--- a/pages/stackers/[sub]/[when].js
+++ b/pages/stackers/[sub]/[when].js
@@ -93,15 +93,39 @@ export default function Growth ({ ssrData }) {
   const { data } = useQuery(GROWTH_QUERY, { variables: { when, from, to, sub, subSelect: sub !== 'all' } })
   if (!data && !ssrData) return <PageLoading />
 
-  const genHrefDownloadBlob = (data) => {
+  const downloadLinkStyle = { textDecoration: "inherit", color: "inherit" };
+
+  const genHrefDownloadBlobJSON = (data) => {
     const blob = new Blob([
       JSON.stringify(data, null, 2),
     ], {
-      type: 'text/plain'
+      type: 'text/plain;charset=utf-8;'
     });
     return URL.createObjectURL(blob);
   };
-  const downloadLinkStyle = { textDecoration: "inherit", color: "inherit" };
+
+  const genHrefDownloadBlobCSV = (data) => {
+    if (data.length > 0) {
+      data = flattenTimeDataForCsv(data);
+      const headers = Object.keys(data[0]);
+      const rows = data.map((item) => headers.map((header) => item[header]));
+      const csvStr = [headers.join(","), ...rows.map((row) => row.join(","))].join("\n");
+      const blob = new Blob([csvStr,], {type: 'text/csv;charset=utf-8;'});
+      return URL.createObjectURL(blob);
+    }
+    return ""
+  };
+
+  const flattenTimeDataForCsv = (timeData) => {
+    let rows = [];
+    for (const timeI in timeData) {
+      let flattened = {};
+      flattened.time = timeData[timeI].time;
+      timeData[timeI].data.forEach(kv => {flattened[kv.name] = kv.value;});
+      rows.push(flattened);
+    }
+    return rows;
+  };
 
   const {
     registrationGrowth,
@@ -120,46 +144,92 @@ export default function Growth ({ ssrData }) {
         <Row>
           <Col><SubAnalyticsHeader /></Col>
           <Col>
+            <DropdownButton id="dropdown-item-button" title="Download CSV Data" style={{ float: "right" }}>            
+              <Dropdown.Item as="button">
+                <Button variant="outlined">
+                  <a download="stacker_growth.csv" target="_blank" rel="noreferrer"
+                    href={ genHrefDownloadBlobCSV(stackerGrowth) }
+                    style={ downloadLinkStyle }>stacker</a>
+                </Button>
+              </Dropdown.Item>
+              <Dropdown.Item as="button">
+                <Button variant="outlined">
+                  <a download="stacking_growth.csv" target="_blank" rel="noreferrer"
+                    href={ genHrefDownloadBlobCSV(stackingGrowth) }
+                    style={ downloadLinkStyle }>stacking</a>
+                </Button>
+              </Dropdown.Item>
+              <Dropdown.Item as="button">
+                <Button variant="outlined">
+                  <a download="spender_growth.csv" target="_blank" rel="noreferrer"
+                    href={ genHrefDownloadBlobCSV(spenderGrowth) }
+                    style={ downloadLinkStyle }>spenders</a>
+                </Button>
+              </Dropdown.Item>
+              <Dropdown.Item as="button">
+                <Button variant="outlined">
+                  <a download="spending_growth.csv" target="_blank" rel="noreferrer"
+                    href={ genHrefDownloadBlobCSV(spendingGrowth) }
+                    style={ downloadLinkStyle }>spending</a>
+                </Button>
+              </Dropdown.Item>
+              <Dropdown.Item as="button">
+                <Button variant="outlined">
+                  <a download="registration_growth.csv" target="_blank" rel="noreferrer"
+                    href={ genHrefDownloadBlobCSV(registrationGrowth) }
+                    style={ downloadLinkStyle }>registration</a>
+                </Button>
+              </Dropdown.Item>
+              <Dropdown.Item as="button">
+                <Button variant="outlined">
+                  <a download="item_growth.csv" target="_blank" rel="noreferrer"
+                    href={ genHrefDownloadBlobCSV(itemGrowth) }
+                    style={ downloadLinkStyle }>items</a>
+                </Button>
+              </Dropdown.Item>
+            </DropdownButton>
+          </Col>
+          <Col>
             <DropdownButton id="dropdown-item-button" title="Download JSON Data" style={{ float: "right" }}>            
               <Dropdown.Item as="button">
                 <Button variant="outlined">
                   <a download="stacker_growth.txt" target="_blank" rel="noreferrer"
-                    href={ genHrefDownloadBlob(stackerGrowth) }
+                    href={ genHrefDownloadBlobJSON(stackerGrowth) }
                     style={ downloadLinkStyle }>stacker</a>
                 </Button>
               </Dropdown.Item>
               <Dropdown.Item as="button">
                 <Button variant="outlined">
                   <a download="stacking_growth.txt" target="_blank" rel="noreferrer"
-                    href={ genHrefDownloadBlob(stackingGrowth) }
+                    href={ genHrefDownloadBlobJSON(stackingGrowth) }
                     style={ downloadLinkStyle }>stacking</a>
                 </Button>
               </Dropdown.Item>
               <Dropdown.Item as="button">
                 <Button variant="outlined">
                   <a download="spender_growth.txt" target="_blank" rel="noreferrer"
-                    href={ genHrefDownloadBlob(spenderGrowth) }
+                    href={ genHrefDownloadBlobJSON(spenderGrowth) }
                     style={ downloadLinkStyle }>spenders</a>
                 </Button>
               </Dropdown.Item>
               <Dropdown.Item as="button">
                 <Button variant="outlined">
                   <a download="spending_growth.txt" target="_blank" rel="noreferrer"
-                    href={ genHrefDownloadBlob(spendingGrowth) }
+                    href={ genHrefDownloadBlobJSON(spendingGrowth) }
                     style={ downloadLinkStyle }>spending</a>
                 </Button>
               </Dropdown.Item>
               <Dropdown.Item as="button">
                 <Button variant="outlined">
                   <a download="registration_growth.txt" target="_blank" rel="noreferrer"
-                    href={ genHrefDownloadBlob(registrationGrowth) }
+                    href={ genHrefDownloadBlobJSON(registrationGrowth) }
                     style={ downloadLinkStyle }>registration</a>
                 </Button>
               </Dropdown.Item>
               <Dropdown.Item as="button">
                 <Button variant="outlined">
                   <a download="item_growth.txt" target="_blank" rel="noreferrer"
-                    href={ genHrefDownloadBlob(itemGrowth) }
+                    href={ genHrefDownloadBlobJSON(itemGrowth) }
                     style={ downloadLinkStyle }>items</a>
                 </Button>
               </Dropdown.Item>
@@ -204,18 +274,36 @@ export default function Growth ({ ssrData }) {
         <Row>
           <Col><SubAnalyticsHeader /></Col>
           <Col>
+            <DropdownButton id="dropdown-item-button" title="Download CSV Data" style={{ float: "right" }}>
+              <Dropdown.ItemText>
+                <Button variant="outlined">
+                  <a download="item_growth_subs.csv" target="_blank" rel="noreferrer"
+                    href={ genHrefDownloadBlobCSV(itemGrowthSubs) }
+                    style={ downloadLinkStyle }>item</a>
+                </Button>
+              </Dropdown.ItemText>
+              <Dropdown.Item as="button">
+                <Button variant="outlined">
+                  <a download="revenue_growth_subs.csv" target="_blank" rel="noreferrer"
+                    href={ genHrefDownloadBlobCSV(revenueGrowthSubs) }
+                    style={ downloadLinkStyle }>sats</a>
+                </Button>
+              </Dropdown.Item>
+            </DropdownButton>
+          </Col>
+          <Col>
             <DropdownButton id="dropdown-item-button" title="Download JSON Data" style={{ float: "right" }}>
               <Dropdown.ItemText>
                 <Button variant="outlined">
                   <a download="item_growth_subs.txt" target="_blank" rel="noreferrer"
-                    href={ genHrefDownloadBlob(itemGrowthSubs) }
+                    href={ genHrefDownloadBlobJSON(itemGrowthSubs) }
                     style={ downloadLinkStyle }>item</a>
                 </Button>
               </Dropdown.ItemText>
               <Dropdown.Item as="button">
                 <Button variant="outlined">
                   <a download="revenue_growth_subs.txt" target="_blank" rel="noreferrer"
-                    href={ genHrefDownloadBlob(revenueGrowthSubs) }
+                    href={ genHrefDownloadBlobJSON(revenueGrowthSubs) }
                     style={ downloadLinkStyle }>sats</a>
                 </Button>
               </Dropdown.Item>


### PR DESCRIPTION
## Description

https://github.com/stackernews/stacker.news/issues/2612

To avoid data formatting json download was chosen. This allows the user access to the data as its used to populate the charts for them to restructure as they see fit. 

## Screenshots
<img width="826" height="768" alt="Screenshot 2025-10-28 at 2 00 49 PM" src="https://github.com/user-attachments/assets/144b739f-ae7a-41e9-a6f4-89a3c68f03ad" />
<img width="821" height="784" alt="Screenshot 2025-10-28 at 2 03 38 PM" src="https://github.com/user-attachments/assets/c7b5dccd-431c-4219-9db5-bc1cd3ace0f6" />
<img width="658" height="707" alt="Screenshot 2025-10-28 at 2 01 23 PM" src="https://github.com/user-attachments/assets/fa4f75eb-4d34-496f-ab05-16eda15de526" />
<img width="655" height="783" alt="Screenshot 2025-10-28 at 2 01 08 PM" src="https://github.com/user-attachments/assets/f474767e-6d8c-4691-b3ac-97bf0a842767" />
<img width="575" height="660" alt="Screenshot 2025-10-28 at 2 03 26 PM" src="https://github.com/user-attachments/assets/33333d27-af34-4ffc-947a-81a6e467f874" />


## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_
No. I wasn't sure where to add sample data files that are generated when clicking download so I thought I'd add them here.

endpoint (six downloads for all charts exposed):
[registration_growth.txt](https://github.com/user-attachments/files/23195191/registration_growth.txt)
[spending_growth.txt](https://github.com/user-attachments/files/23195192/spending_growth.txt)
[spender_growth.txt](https://github.com/user-attachments/files/23195193/spender_growth.txt)
[item_growth.txt](https://github.com/user-attachments/files/23195194/item_growth.txt)
[stacking_growth.txt](https://github.com/user-attachments/files/23195195/stacking_growth.txt)
[stacker_growth.txt](https://github.com/user-attachments/files/23195196/stacker_growth.txt)

endpoint (two downloads for two charts exposed): /stackers/bitcoin/month
[revenue_growth_subs.txt](https://github.com/user-attachments/files/23195183/revenue_growth_subs.txt)
[item_growth_subs.txt](https://github.com/user-attachments/files/23195184/item_growth_subs.txt)

## Checklist

**Are your changes backward compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes


**Did you introduce any new environment variables? If so, call them out explicitly here:**
No


**Did you use AI for this? If so, how much did it assist you?**
No
