### PR TITLE
Fix align-self-center of gun, horse, biohazard

### DIFF
--- a/components/notifications.js
+++ b/components/notifications.js
@@ -218,7 +218,7 @@ function Horse ({ n }) {
 
   return (
     <div className='d-flex'>
-      <div style={{ fontSize: '2rem' }}><Icon className='align-self-center fill-grey' height={40} width={40} /></div>
+      <div style={{ fontSize: '2rem', alignSelf: 'center' }}><Icon className='fill-grey' height={40} width={40} /></div>
       <div className='ms-1 p-1'>
         <span className='fw-bold'>you {found ? 'found a' : 'lost your'} horse</span>
         <div><small style={{ lineHeight: '140%', display: 'inline-block' }}>{blurb(n)}</small></div>
@@ -233,7 +233,7 @@ function Gun ({ n }) {
 
   return (
     <div className='d-flex'>
-      <div style={{ fontSize: '2rem' }}><Icon className='align-self-center fill-grey' height={40} width={40} /></div>
+      <div style={{ fontSize: '2rem', alignSelf: 'center' }}><Icon className='fill-grey' height={40} width={40} /></div>
       <div className='ms-1 p-1'>
         <span className='fw-bold'>you {found ? 'found a' : 'lost your'} gun</span>
         <div><small style={{ lineHeight: '140%', display: 'inline-block' }}>{blurb(n)}</small></div>
@@ -246,7 +246,7 @@ function Infection ({ n }) {
   // TODO: use random blurbs?
   return (
     <div className='d-flex'>
-      <BioHazardIcon className='align-self-center fill-grey mx-1' width={40} height={40} />
+      <div style={{ fontSize: '2rem', alignSelf: 'center' }}><BioHazardIcon className='fill-grey mx-1' width={40} height={40} /></div>
       <div className='ms-2'>
         <NoteHeader big>
           you have been bitten by a zombie


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjusts icon containers to center icons vertically in `Horse`, `Gun`, and `Infection` notifications.
> 
> - **Frontend – notifications**:
>   - Align icons vertically by moving centering to container (`alignSelf: 'center'`) and removing `align-self-center` from SVGs in `Horse`, `Gun`, and `Infection` components.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d96dbd1d9917ce4cb17ad86faea1cbe7760f8050. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->