### PR TITLE
Fix grid for custom zaps

### DIFF
--- a/components/item-act.js
+++ b/components/item-act.js
@@ -26,7 +26,6 @@ const Tips = ({ setOValue }) => {
   return tips.map((num, i) =>
     <Button
       size='sm'
-      className={`${i > 0 ? 'ms-2' : ''} mb-2`}
       key={num}
       onClick={() => { setOValue(num) }}
     >
@@ -178,7 +177,7 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
           append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
         />
 
-        <div>
+        <div className='d-flex flex-wrap gap-2'>
           <Tips setOValue={setOValue} />
         </div>
         <div className='d-flex mt-3'>


### PR DESCRIPTION
before:

<img width="300" height="534" alt="localhost_3000_(iPhone SE) (1)" src="https://github.com/user-attachments/assets/a15e3430-fe48-48e5-b6f2-2d25564d46dd" />

after:

<img width="300" height="534" alt="localhost_3000_(iPhone SE)" src="https://github.com/user-attachments/assets/824fa182-c30c-43b5-aeba-be2ec26ab44a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors tip buttons layout by removing per-button margins and using a flex-wrap container with gaps for consistent spacing and wrapping.
> 
> - **UI**
>   - **Tips layout (`components/item-act.js`)**:
>     - Remove per-button margin classes from `Button`.
>     - Wrap tips in a container with `d-flex flex-wrap gap-2` for consistent spacing and wrapping.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 178ade19f4d039837a0d3bf7e3de4fd907f00f08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->