### PR TITLE
Refactor NWC lud16 parsing to set initial value for lightning address

### DIFF
--- a/wallets/client/components/form/hooks.js
+++ b/wallets/client/components/form/hooks.js
@@ -104,7 +104,7 @@ export function useProtocolForm (protocol) {
         const { lud16 } = parseNwcUrl(nwcSendFormState.config.url)
         if (lud16?.split('@')[1] === lud16Domain) value = lud16
       }
-      // remove domain part since we will append it automatically if lud16Domain is set
+      // remove domain part since we will append it automatically on submit if lud16Domain is set
       if (lud16Domain && value) {
         value = value.split('@')[0]
       }
@@ -120,6 +120,7 @@ export function useProtocolForm (protocol) {
   if (lud16Domain) {
     schema = schema.transform(({ address, ...rest }) => {
       return {
+        // append domain part to pass validation on submit
         address: address ? `${address}@${lud16Domain}` : '',
         ...rest
       }

--- a/wallets/client/components/form/index.js
+++ b/wallets/client/components/form/index.js
@@ -182,7 +182,7 @@ function WalletProtocolFormField ({ type, ...props }) {
   const [protocol] = useProtocol()
   const formik = useFormikContext()
 
-  function transform ({ validate, encrypt, editable, help, share, ...props }) {
+  function transform ({ validate, encrypt, editable, help, share, populate, ...props }) {
     const [upperHint, bottomHint] = Array.isArray(props.hint) ? props.hint : [null, props.hint]
 
     const parseHelpText = text => Array.isArray(text) ? text.join('\n\n') : text

--- a/wallets/client/components/form/index.js
+++ b/wallets/client/components/form/index.js
@@ -100,6 +100,8 @@ function WalletProtocolForm () {
 
   // create a copy of values to avoid mutating the original
   const onSubmit = useCallback(async ({ ...values }) => {
+    // the schema transformation already does this to pass validation on submit
+    // so it would be better to use the transformed values instead of manually appending the domain part again here
     const lud16Domain = walletLud16Domain(wallet.name)
     if (values.address && lud16Domain) {
       values.address = `${values.address}@${lud16Domain}`

--- a/wallets/lib/protocols/index.js
+++ b/wallets/lib/protocols/index.js
@@ -36,6 +36,14 @@ import clinkSuite from './clink'
  * @property {string} [hint] - hint text shown below field
  * @property {boolean} [share] - whether field can be used to prepopulate field of complementary send/receive protocol
  * @property {boolean} [editable] - whether the field is editable after it was saved
+ * @property {ProtocolFieldPopulate} [populate] - function to populate the field using values from other protocol forms
+ */
+
+/**
+ * @callback ProtocolFieldPopulate
+ * @param {Object} wallet - the wallet we are configuring
+ * @param {Object} formState - the current form state across all protocols
+ * @returns {string|null} - the value to populate the field with, or null if no value is available
  */
 
 /** @type {Protocol[]} */

--- a/wallets/lib/protocols/lnAddr.js
+++ b/wallets/lib/protocols/lnAddr.js
@@ -33,8 +33,9 @@ function addressPopulate (wallet, formState) {
     return null
   }
 
+  const lud16Domain = walletLud16Domain(wallet.name)
   const nwcLud16Domain = nwcLud16.split('@')[1]
-  if (nwcLud16Domain !== walletLud16Domain(wallet.name)) {
+  if (lud16Domain && nwcLud16Domain !== lud16Domain) {
     return null
   }
 

--- a/wallets/lib/protocols/lnAddr.js
+++ b/wallets/lib/protocols/lnAddr.js
@@ -1,4 +1,5 @@
-import { externalLightningAddressValidator } from '@/wallets/lib/validate'
+import { externalLightningAddressValidator, parseNwcUrl } from '@/wallets/lib/validate'
+import { protocolFormId, walletLud16Domain } from '../util'
 
 // Lightning Address (LUD-16)
 // https://github.com/lnurl/luds/blob/luds/16.md
@@ -13,8 +14,29 @@ export default {
       label: 'address',
       type: 'text',
       required: true,
-      validate: externalLightningAddressValidator
+      validate: externalLightningAddressValidator,
+      populate: addressPopulate
     }
   ],
   relationName: 'walletRecvLightningAddress'
+}
+
+function addressPopulate (wallet, formState) {
+  const nwcFormId = protocolFormId({ name: 'NWC', send: true })
+  const nwcFormState = formState[nwcFormId]
+  if (!nwcFormState?.config?.url) {
+    return null
+  }
+
+  const { lud16: nwcLud16 } = parseNwcUrl(nwcFormState.config.url)
+  if (!nwcLud16) {
+    return null
+  }
+
+  const nwcLud16Domain = nwcLud16.split('@')[1]
+  if (nwcLud16Domain !== walletLud16Domain(wallet.name)) {
+    return null
+  }
+
+  return nwcLud16
 }


### PR DESCRIPTION
## Description

This is a *partial* refactor of #2564.

Only partial, because the automatic switch to the lightning address if it has an initial value is still hard-coded in a `useEffect`:

https://github.com/stackernews/stacker.news/blob/6762fc0c9c1d912b742ca76a90c2dc14cb192602/wallets/client/components/form/hooks.js#L59-L64

Ideally, we would generally switch to the first protocol form that has an initial value.

## Additional Context

#2575 will also use this code to set the identity public key from the mnemonic.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`8`. Tested by pasting a Coinos NWC string and seeing the initial lightning address value set to the `lud16` parameter. Also tested skipping NWC and SSR.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a generic `populate` for protocol fields and moves Lightning Address initial value derivation from NWC into the `LN_ADDR` protocol, with domain handling done via schema transform.
> 
> - **Form logic**:
>   - Introduce `field.populate` support in `useProtocolForm`, using global form state to prefill values; remove NWC-specific parsing from `hooks.js`.
>   - Normalize LUD-16 handling: strip domain from `address` in initial values and append via schema transform on submit.
> - **Protocols**:
>   - Extend `ProtocolField` type with `populate` callback.
>   - `LN_ADDR`: add `populate` that reads `lud16` from `NWC` URL (when present and domain-compatible) to prefill `address`.
> - **UI**:
>   - `WalletProtocolFormField` transforms now accept and ignore `populate` prop to avoid passing it to inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02a900d9529f0851ffa281b8d7e529024f957ec3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->