### PR TITLE
Add charts for stacking and spending growth

### DIFF
--- a/pages/stackers/[sub]/[when].js
+++ b/pages/stackers/[sub]/[when].js
@@ -94,6 +94,8 @@ export default function Growth ({ ssrData }) {
           <div className='text-center text-muted fw-bold'>sats stacked</div>
           <WhenAreaChart data={stackingGrowth} />
         </Col>
+      </Row>
+      <Row>
         <Col className='mt-3'>
           <div className='text-center text-muted fw-bold'>sats spent</div>
           <WhenAreaChart data={spendingGrowth} />
@@ -104,6 +106,8 @@ export default function Growth ({ ssrData }) {
           <div className='text-center text-muted fw-bold'>unique stackers</div>
           <WhenLineChart data={stackerGrowth} />
         </Col>
+      </Row>
+      <Row>
         <Col className='mt-3'>
           <div className='text-center text-muted fw-bold'>unique spenders</div>
           <WhenLineChart data={spenderGrowth} />
@@ -114,6 +118,8 @@ export default function Growth ({ ssrData }) {
           <div className='text-center text-muted fw-bold'>spend counts</div>
           <WhenLineChart data={itemGrowth} />
         </Col>
+      </Row>
+      <Row>
         <Col className='mt-3'>
           {sub === 'all' && <div className='text-center text-muted fw-bold'>registrations</div>}
           <WhenAreaChart data={registrationGrowth} />


### PR DESCRIPTION
## Description
Discussion: #2725 
Can we have full width stats?

/statistics charts are hard to watch at, especially now with all new metrics

## Screenshots
<img width="857" height="493" alt="Screenshot" src="https://github.com/user-attachments/assets/34d6307d-efbc-4bad-8aac-c3070b22866a" />

## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_
no

## Checklist

**Are your changes backward compatible? Please answer below:**
I think so...

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
yes - nothing change on mobile

**Did you introduce any new environment variables? If so, call them out explicitly here:**
no

**Did you use AI for this? If so, how much did it assist you?**
no