### PR TITLE
fix: prevent duplicate comments when nearing the pagination threshold

### DIFF
--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -333,7 +333,10 @@ function getClient (uri) {
             comments: {
               keyArgs: ['sort'],
               merge (existing, incoming) {
-                const isNotPaginated = !incoming.cursor && incoming.comments?.length >= COMMENTS_LIMIT
+                // check if we're not on a paginated item: it shouldn't have an incoming or an already existing cursor,
+                // and its incoming comments shouldn't be more than COMMENTS_LIMIT
+                // in this case, like isFirstPage, replace the cache
+                const isNotPaginated = !incoming.cursor && !existing?.cursor && incoming.comments?.length >= COMMENTS_LIMIT
                 if (isFirstPage(incoming.cursor, existing?.comments, COMMENTS_LIMIT) || isNotPaginated) {
                   return incoming
                 }


### PR DESCRIPTION
## Description

Fixes #2634 

Example of what happens with an item with 120 comments:
- the comments resolver returns 120 comments with `cursor: null`, because we didn't reach `FULL_COMMENTS_THRESHOLD` (200 atm)
- on first load: `isFirstPage` returns `true` because there are no existing comments to compare the incoming data -> no duplication: **replaces** the cache
- on refetch: `isFirstPage` returns `false` because now the existing comments are 120 and higher than `COMMENTS_LIMIT` -> duplication: **merges** the incoming comments to the existing _(now 240 comments)_

`isFirstPage` thinks it's loading **new pages** of comments, when in reality pagination **never** occurred.

This fix checks if the incoming comments are more than `COMMENTS_LIMIT` (50 atm), if the existing context has no cursor, and if the incoming comments have no cursor.
When this happens, we can assume that we still didn't reach the `FULL_COMMENTS_THRESHOLD` (200 atm) comments limit for pagination and replace the cache instead of merging.

## Screenshots
An item with 120+ comments, 50 direct comments, not paginated

https://github.com/user-attachments/assets/3c61a644-229c-4f0b-9852-e6696d9680dd

An item with 200+ comments, paginated

https://github.com/user-attachments/assets/f3cd94c9-2ec1-4114-b7e0-8ee43f4b0f05



## Additional Context

This only addresses the `comments` field, I'm not aware of this bug anywhere else

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, tried with items with < 50 comments, 120 comments, 200 comments.
Duplication doesn't happen and pagination works correctly.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
no


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `Item.comments` cache merge logic to replace (not append) when no cursors are present and comments >= `COMMENTS_LIMIT`, preventing duplication near the pagination threshold.
> 
> - **Apollo cache (Item.comments)**:
>   - Update `merge` policy to detect non-paginated results (`!incoming.cursor`, `!existing?.cursor`, and `incoming.comments.length >= COMMENTS_LIMIT`).
>   - When detected or on true first page, return `incoming` to replace cache; otherwise merge to append comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ca57f13514663c4c04620991592a44aded1b3d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->