### PR TITLE
fix_cropbox_pfp

### DIFF
--- a/worker/imgproxy.js
+++ b/worker/imgproxy.js
@@ -203,12 +203,12 @@ const sign = (target) => {
 }
 
 export async function processCrop ({ photoId, cropData }) {
-  const { x, y, width, height, originalWidth, originalHeight, scale } = cropData
+  const { x, y, width, height, originalWidth, originalHeight } = cropData
   const cropWidth = Math.round(originalWidth * width)
   const cropHeight = Math.round(originalHeight * height)
 
-  const centerX = x + width / scale
-  const centerY = y + height / scale
+  const centerX = x + width / 2
+  const centerY = y + height / 2
 
   const size = 200 // 200px avatar size
 


### PR DESCRIPTION
## Description

fix #2639 

The issue was in the center point calculation for `imgproxy`. The original formula `x + width / scale` was incorrect because `getCroppingRect() `returns normalized coordinates (0-1) relative to the original image. Changed it to `x + width / 2` which correctly calculates the center of the crop box

## Screenshots

https://github.com/user-attachments/assets/5e772e50-f913-4604-9f46-963277be9328


## Additional Context

The `scale` variable from the avatar editor should not be used in the center calculation since the coordinates returned by `react-avatar-editor` are already normalized relative to the image dimensions regardless of zoom.

## Checklist

**Are your changes backward compatible? Please answer below:**
Yes


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8/10 Tested the cropbox with various image sizes and verified the cropped output matches the selected area in the editor

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
No


**Did you introduce any new environment variables? If so, call them out explicitly here:**
NaN


**Did you use AI for this? If so, how much did it assist you?**
Used AI to analyze the `react-avatar-editor` documentation to understand what `getCroppingRect()` returned.