### PR TITLE
Fix to preserve scroll while back/forward navigation between search results.

### DIFF
--- a/components/search.js
+++ b/components/search.js
@@ -72,7 +72,6 @@ export default function Search ({ sub }) {
               <SearchInput
                 name='q'
                 required
-                autoFocus
                 groupClassName='me-3 mb-0 flex-grow-1'
                 className='flex-grow-1'
                 setOuterQ={setQ}
@@ -144,6 +143,12 @@ function SearchInput ({ name, setOuterQ, ...props }) {
   useEffect(() => {
     if (meta.value !== undefined) setOuterQ(meta.value.trim())
   }, [meta.value, setOuterQ])
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus({ preventScroll: true })
+    }
+  }, [])
 
   const setCaret = useCallback(({ start, end }) => {
     inputRef.current?.setSelectionRange(start, end)


### PR DESCRIPTION
## Description

I think I've seen a similar issue in a different project. Not using the autoFocus prop and just manually focusing using `preventScroll: true` should do the trick.

fixes #2643 

## Screenshots

https://github.com/user-attachments/assets/9f63aaae-449d-46b2-998f-3b31f7fc68f0



## Checklist

**Are your changes backward compatible? Please answer below:**
Y

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
9

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Y

**Did you introduce any new environment variables? If so, call them out explicitly here:**
N

**Did you use AI for this? If so, how much did it assist you?**
N