### PR TITLE
fix_timer_bug

### DIFF
--- a/components/payIn/hooks/use-qr-pay-in.js
+++ b/components/payIn/hooks/use-qr-pay-in.js
@@ -29,7 +29,7 @@ export default function useQrPayIn () {
       let updatedPayIn
       const cancelAndReject = async (onClose) => {
         if (!updatedPayIn && cancelOnClose) {
-          const updatedPayIn = await payInHelper.cancel(payIn, { userCancel: true })
+          updatedPayIn = await payInHelper.cancel(payIn, { userCancel: true })
           reject(new InvoiceCanceledError(updatedPayIn?.payerPrivates.payInBolt11))
         }
         resolve(updatedPayIn)

--- a/components/payIn/hooks/use-watch-pay-in.js
+++ b/components/payIn/hooks/use-watch-pay-in.js
@@ -1,10 +1,25 @@
 import { useQuery } from '@apollo/client'
 import { GET_PAY_IN_RESULT } from '@/fragments/payIn'
 import usePayInHelper, { WaitCheckControllerAbortedError } from './use-pay-in-helper'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
+import { FAST_POLL_INTERVAL_MS, SSR } from '@/lib/constants'
 
 export default function useWatchPayIn ({ id, query = GET_PAY_IN_RESULT, onPaymentError, onPaymentSuccess, waitFor }) {
   const payInHelper = usePayInHelper()
+  const queryOptions = useMemo(() => {
+    if (SSR) {
+      return { variables: { id }, fetchPolicy: 'cache-first' }
+    }
+    return {
+      variables: { id },
+      pollInterval: FAST_POLL_INTERVAL_MS,
+      fetchPolicy: 'network-only',
+      nextFetchPolicy: 'cache-and-network',
+      notifyOnNetworkStatusChange: true
+    }
+  }, [id])
+  const queryResult = useQuery(query, queryOptions)
+  const { refetch } = queryResult
 
   // we use the controller in a useEffect like this so we can reuse the same logic
   // ... this controller is used in loops elsewhere where hooks are not allowed
@@ -14,6 +29,7 @@ export default function useWatchPayIn ({ id, query = GET_PAY_IN_RESULT, onPaymen
     const check = async () => {
       try {
         const payIn = await controller.wait(waitFor, { query })
+        await refetch().catch(() => {})
         onPaymentSuccess?.(payIn)
       } catch (error) {
         // check for error type so that we don't callback when the controller is stopped
@@ -26,8 +42,8 @@ export default function useWatchPayIn ({ id, query = GET_PAY_IN_RESULT, onPaymen
     check()
 
     return () => controller.stop()
-  }, [id, waitFor, payInHelper, onPaymentError, onPaymentSuccess])
+  }, [id, waitFor, payInHelper, onPaymentError, onPaymentSuccess, query, refetch])
 
   // this will return the payIn in the cache as the useEffect updates the cache
-  return useQuery(query, { variables: { id } })
+  return queryResult
 }

--- a/components/payIn/status.js
+++ b/components/payIn/status.js
@@ -12,12 +12,14 @@ function StatusText ({ color, children }) {
 }
 
 export function PayInStatus ({ payIn }) {
+  const expiresAt = payIn.payerPrivates?.payInBolt11?.expiresAt
+  const expiresAtUTC = expiresAt && !expiresAt.endsWith('Z') ? expiresAt + 'Z' : expiresAt
   return (
     <div className='d-flex align-items-center'>
       {(payIn.payInState === 'PAID' && <><Check width={statusIconSize} height={statusIconSize} className='fill-success' /><StatusText color='success'>{payIn.mcost > 0 ? 'paid' : 'free'}</StatusText></>) ||
         ((payIn.payInState === 'FAILED' || payIn.payInState === 'CANCELLED' || payIn.payInState === 'FORWARD_FAILED') && <><ThumbDown width={statusIconSize} height={statusIconSize} className='fill-danger' /><StatusText color='danger'>failed</StatusText></>) ||
         ((payIn.payInState === 'FORWARDING' || payIn.payInState === 'FORWARDED' || !payIn.payerPrivates.payInBolt11) && <><Moon width={statusIconSize} height={statusIconSize} className='spin fill-grey' /><StatusText color='muted'>settling</StatusText></>) ||
-        (<CompactLongCountdown className='text-muted' date={payIn.payerPrivates.payInBolt11.expiresAt} />)}
+        (<CompactLongCountdown className='text-muted' date={expiresAtUTC} />)}
     </div>
   )
 }


### PR DESCRIPTION
## Description

Fixed #2646 

QR code payment status timer was stuck at 00:00, the cause was a timezone interpretation bug. GraphQL Date scalar returns ISO 8601 strings without the 'Z' UTC suffix (e.g., "2025-11-21T12:31:08"), causing browsers to interpret them as local time instead of UTC. This made invoices appear expired immediately in non-UTC timezones. This fix adds 'Z' to `expiresAt` timestamps when missing. 

## Screenshots

https://github.com/user-attachments/assets/1e835967-5e3e-492e-a466-94976138ba6b

## Additional Context

Also fixed a shadow variable bug in `cancelAndReject` that prevented proper state updates. added polling with `FAST_POLL_INTERVAL_MS` to keep payment status updated.

## Checklist

**Are your changes backward compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8/10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
nan

**Did you introduce any new environment variables? If so, call them out explicitly here:**
nan

**Did you use AI for this? If so, how much did it assist you?**
I used AI to create a strategy to catch and understand the bug to apply the correct changes