### PR TITLE
fix: switch session cookie via multi-auth also on SSR

### DIFF
--- a/api/ssrApollo.js
+++ b/api/ssrApollo.js
@@ -15,7 +15,7 @@ import { getServerSession } from 'next-auth/next'
 import { getAuthOptions } from '@/pages/api/auth/[...nextauth]'
 import { NOFOLLOW_LIMIT } from '@/lib/constants'
 import { satsToMsats } from '@/lib/format'
-import { MULTI_AUTH_ANON, MULTI_AUTH_POINTER } from '@/lib/auth'
+import { MULTI_AUTH_ANON, MULTI_AUTH_POINTER, multiAuthMiddleware } from '@/lib/auth'
 
 export default async function getSSRApolloClient ({ req, res, me = null }) {
   // switch session cookie before getting session on SSR


### PR DESCRIPTION
## Description

Fixes #2653 

Hypothesis:
The GraphQL api route runs multiAuthMiddleware to switch the session cookie, and to obtain the correct data for the current user.
But the same wasn't happening for SSR: a page reload would correctly clear the cache but SSR will return the previous user data, re-populating the cache.

This PR fixes this behavior by making sure we are switching the session cookie also on SSR Apollo calls.

## Screenshots


https://github.com/user-attachments/assets/951d8eeb-500c-442c-b102-397cdb2f4ad2



## Additional Context

Seems like we had this bug for a long time but we never realized it

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7 - This works correctly but I didn't do an extensive QA because the cache is clearly not getting re-populated this way.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Runs multiAuthMiddleware in SSR Apollo flow to switch the session cookie before getServerSession, ensuring correct user context during SSR.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6ff60c4402cb9706addc61720e4ce3307a2e0bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->