### PR TITLE
add missing payIn fields to the non-children variant of COMMENT_FIELDS fragment

### DIFF
--- a/fragments/comments.js
+++ b/fragments/comments.js
@@ -79,6 +79,16 @@ export const COMMENT_FIELDS_NO_CHILD_COMMENTS = gql`
       meMute
       ...StreakFields
     }
+    payIn {
+      id
+      payInState
+      payInType
+      payInStateChangedAt
+      payerPrivates {
+        payInFailureReason
+        retryCount
+      }
+    }
     sats
     credits
     meAnonSats @client


### PR DESCRIPTION
## Description
(maybe) Fixes #2654

Adds the missing payIn fields to the non-children variant of the `COMMENT_FIELDS` fragment, avoiding Apollo full refetch failsafe strategy

## Screenshots
n/a

## Additional Context

couldn't reproduce the reported behavior, but it could very well be Apollo refetching after encountering a non-conformant fragment injection.

note:

`COMMENT_FIELDS_NO_CHILD_COMMENTS` should be merged with `COMMENT_FIELDS`

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

5 - Apollo doesn't refetch

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `payIn` (including state, type, timestamps, and payerPrivates) to comment GraphQL fragments to keep them consistent.
> 
> - **GraphQL fragments (`fragments/comments.js`)**:
>   - **`CommentFields` / `CommentFieldsNoChildComments`**: add `payIn { id, payInState, payInType, payInStateChangedAt, payerPrivates { payInFailureReason, retryCount } }` to returned fields.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a0d65aec713564d2911513aaf01d485b786f912. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->