### PR TITLE
Reduce GraphQL fragments redundancies

### DIFF
--- a/fragments/comments.js
+++ b/fragments/comments.js
@@ -1,68 +1,5 @@
 import { gql } from '@apollo/client'
-
-// we can't import from users because of circular dependency
-const STREAK_FIELDS = gql`
-  fragment StreakFields on User {
-    optional {
-      streak
-      hasSendWallet
-      hasRecvWallet
-    }
-  }
-`
-
-export const COMMENT_FIELDS = gql`
-  ${STREAK_FIELDS}
-  fragment CommentFields on Item {
-    id
-    position
-    parentId
-    createdAt
-    deletedAt
-    text
-    user {
-      id
-      name
-      meMute
-      ...StreakFields
-    }
-    payIn {
-      id
-      payInState
-      payInType
-      payInStateChangedAt
-      payerPrivates {
-        payInFailureReason
-        retryCount
-      }
-    }
-    sats
-    credits
-    meAnonSats @client
-    upvotes
-    freedFreebie
-    boost
-    meSats
-    meCredits
-    meDontLikeSats
-    meBookmark
-    meSubscription
-    outlawed
-    freebie
-    path
-    commentSats
-    commentCredits
-    mine
-    otsHash
-    ncomments
-    nDirectComments
-    live @client
-    imgproxyUrls
-    rel
-    apiKey
-    cost
-  }
-`
+import { STREAK_FIELDS } from './common'
 
 export const COMMENT_FIELDS_NO_CHILD_COMMENTS = gql`
   ${STREAK_FIELDS}
@@ -102,6 +39,25 @@ export const COMMENT_FIELDS_NO_CHILD_COMMENTS = gql`
     rel
     apiKey
     cost
+  }
+`
+
+export const COMMENT_FIELDS = gql`
+  ${COMMENT_FIELDS_NO_CHILD_COMMENTS}
+  fragment CommentFields on Item {
+    ...CommentFieldsNoChildComments
+    payIn {
+      id
+      payInState
+      payInType
+      payInStateChangedAt
+      payerPrivates {
+        payInFailureReason
+        retryCount
+      }
+    }
+    ncomments
+    nDirectComments
   }
 `
 

--- a/fragments/common.js
+++ b/fragments/common.js
@@ -1,0 +1,11 @@
+import { gql } from '@apollo/client'
+
+export const STREAK_FIELDS = gql`
+  fragment StreakFields on User {
+    optional {
+      streak
+      hasSendWallet
+      hasRecvWallet
+    }
+  }
+`

--- a/fragments/invites.js
+++ b/fragments/invites.js
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { STREAK_FIELDS } from './users'
+import { STREAK_FIELDS } from './common'
 
 export const INVITE_FIELDS = gql`
   ${STREAK_FIELDS}

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -1,16 +1,6 @@
 import { gql } from '@apollo/client'
 import { COMMENTS } from './comments'
-
-// we can't import from users because of circular dependency
-const STREAK_FIELDS = gql`
-  fragment StreakFields on User {
-    optional {
-      streak
-      hasSendWallet
-      hasRecvWallet
-    }
-  }
-`
+import { STREAK_FIELDS } from './common'
 
 export const ITEM_FIELDS = gql`
   ${STREAK_FIELDS}
@@ -128,6 +118,7 @@ export const ITEM_FULL_FIELDS = gql`
     }
   }`
 
+/** displays timestamp verification infos */
 export const ITEM_OTS_FIELDS = gql`
   fragment ItemOtsFields on Item {
     id

--- a/fragments/subs.js
+++ b/fragments/subs.js
@@ -1,17 +1,7 @@
 import { gql } from '@apollo/client'
 import { ITEM_FIELDS, ITEM_FULL_FIELDS } from './items'
 import { COMMENTS_ITEM_EXT_FIELDS } from './comments'
-
-// we can't import from users because of circular dependency
-const STREAK_FIELDS = gql`
-  fragment StreakFields on User {
-    optional {
-      streak
-      hasSendWallet
-      hasRecvWallet
-    }
-  }
-`
+import { STREAK_FIELDS } from './common'
 
 export const SUB_FIELDS = gql`
   fragment SubFields on Sub {

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -2,16 +2,7 @@ import { gql } from '@apollo/client'
 import { COMMENTS, COMMENTS_ITEM_EXT_FIELDS } from './comments'
 import { ITEM_FIELDS, ITEM_FULL_FIELDS } from './items'
 import { SUB_FULL_FIELDS } from './subs'
-
-export const STREAK_FIELDS = gql`
-  fragment StreakFields on User {
-    optional {
-      streak
-      hasSendWallet
-      hasRecvWallet
-    }
-  }
-`
+import { STREAK_FIELDS } from './common'
 
 export const ME = gql`
 ${STREAK_FIELDS}

--- a/worker/ots.js
+++ b/worker/ots.js
@@ -3,8 +3,9 @@ import stringifyCanon from 'canonical-json'
 import { createHash } from 'crypto'
 import Ots from 'opentimestamps'
 
-const ITEM_OTS_FIELDS = gql`
-  fragment ItemOTSFields on Item {
+/** fetches the necessary fields to compute the ots hash */
+const ITEM_OTS_HASH_FIELDS = gql`
+  fragment ItemOtsHashFields on Item {
     parentId
     parentOtsHash
     title
@@ -15,10 +16,10 @@ const ITEM_OTS_FIELDS = gql`
 export async function timestampItem ({ data: { id }, apollo, models }) {
   const { data: { item: { parentId, parentOtsHash, title, text, url } } } = await apollo.query({
     query: gql`
-        ${ITEM_OTS_FIELDS}
+        ${ITEM_OTS_HASH_FIELDS}
         query Item {
           item(id: ${id}) {
-            ...ItemOTSFields
+            ...ItemOtsHashFields
           }
         }`
   })


### PR DESCRIPTION
## Description

With #2656 we realized that the `COMMENT_FIELDS` and `COMMENT_FIELDS_NO_CHILD_COMMENTS` fragments were identical.
This PR solves some (the most visible) redundancies and inconsistencies across our fragments.

## Screenshots
n/a

## Additional Context
I changed the name of one of the similarly-named ITEM_OTS_FIELDS fragments, as they serve slightly different purposes. It wasn't necessary but the opportunity was right there.

Also noticed that our `gql` imports are not consistent everywhere, sometimes it's from `graphql-tag` and other times from `apollo/client`. Didn't touch them, but it seems that `apollo/client`'s is the one that we'd want to use (?)

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, QA on every behavior related to the modified fragments.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No, started by searching redundancies and just touched the most apparent ones (comments, streak fields and OTS)