### PR TITLE
add lnurl_auth and lnurl_withdraw to sndev

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ COMMANDS
   lightning:
     fund                   pay a bolt11 for funding
     withdraw               create a bolt11 for withdrawal
+    lnurl_auth             mock lnurl-auth
+    lnurl_withdraw         mock lnurl-withdraw
 
   db:
     psql                   open psql on db

--- a/scripts/lnurl-auth.js
+++ b/scripts/lnurl-auth.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+const { secp256k1 } = require('@noble/curves/secp256k1')
+const { createHash } = require('crypto')
+const k1 = process.argv[2]
+const identityPubkey = process.argv[3]
+const domain = process.argv[4]
+const callbackBase = process.argv[5]
+if (!k1 || !identityPubkey || !domain || !callbackBase) {
+  console.error('Usage: lnurl-auth.js <k1> <identity_pubkey> <domain> <callback_base>')
+  process.exit(1)
+}
+try {
+  const linkingKey = createHash('sha256')
+    .update(identityPubkey + domain)
+    .digest()
+  const k1Bytes = Buffer.from(k1, 'hex')
+  const signature = secp256k1.sign(k1Bytes, linkingKey)
+  const publicKey = secp256k1.getPublicKey(linkingKey)
+  const params = new URLSearchParams({
+    k1,
+    sig: Buffer.from(signature.toCompactRawBytes()).toString('hex'),
+    key: Buffer.from(publicKey).toString('hex')
+  })
+  console.log(`${callbackBase}?${params}`)
+} catch (err) {
+  console.error('Failed to sign LNURL-auth:', err.message)
+  process.exit(1)
+}

--- a/scripts/lnurl-decode.js
+++ b/scripts/lnurl-decode.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+const { bech32 } = require('bech32')
+
+const lnurl = process.argv[2]
+if (!lnurl) {
+  console.error('Usage: lnurl-decode.js <lnurl>')
+  process.exit(1)
+}
+try {
+  const { words } = bech32.decode(lnurl, 2000)
+  const url = Buffer.from(bech32.fromWords(words)).toString('utf8')
+  console.log(url)
+} catch (err) {
+  console.error('Failed to decode LNURL:', err.message)
+  process.exit(1)
+}

--- a/sndev
+++ b/sndev
@@ -287,6 +287,73 @@ sndev__withdraw() {
   fi
 }
 
+sndev__lnurl_auth() {
+  shift
+  lnurl="$1"
+  if [ -z "$lnurl" ]; then
+    echo "LNURL required"
+    sndev__help_lnurl_auth
+    exit 1
+  fi
+  docker__exec app node -e "const{bech32}=require('bech32');const{words}=bech32.decode('$lnurl',2000);console.log(Buffer.from(bech32.fromWords(words)).toString('utf8'));" > /tmp/sndev_lnurl
+  decoded=$(cat /tmp/sndev_lnurl)
+  echo "Decoded: $decoded"
+  k1=$(echo "$decoded" | grep -oP 'k1=\K[^&]*')
+  identity_pubkey=$(sndev__cli lnd getinfo | jq -r '.identity_pubkey')
+  domain=$(echo "$decoded" | grep -oP '://\K[^/]*')
+  docker__exec app node -e "const{secp256k1}=require('@noble/curves/secp256k1');const{createHash}=require('crypto');const k1='$k1';const key=createHash('sha256').update('$identity_pubkey'+'$domain').digest();const sig=secp256k1.sign(Buffer.from(k1,'hex'),key);const pub=secp256k1.getPublicKey(key);const cb='$decoded'.split('?')[0];const p=new URLSearchParams({k1,sig:Buffer.from(sig.toCompactRawBytes()).toString('hex'),key:Buffer.from(pub).toString('hex')});console.log(\`\${cb}?\${p}\`);" | xargs curl -s | jq
+  rm -f /tmp/sndev_lnurl
+}
+
+sndev__help_lnurl_auth() {
+  help="
+mock lnurl-auth for local testing
+
+USAGE
+  $ sndev lnurl_auth LNURL
+
+DESCRIPTION
+  Decodes the LNURL, derives a linking key from stacker_lnd identity,
+  signs the k1 challenge, and sends the response to the callback URL.
+"
+  echo "$help"
+}
+
+sndev__lnurl_withdraw() {
+  shift
+  lnurl="$1"
+  if [ -z "$lnurl" ]; then
+    echo "LNURL required"
+    sndev__help_lnurl_withdraw
+    exit 1
+  fi
+  docker__exec app node -e "const{bech32}=require('bech32');const{words}=bech32.decode('$lnurl',2000);console.log(Buffer.from(bech32.fromWords(words)).toString('utf8'));" > /tmp/sndev_lnurl
+  decoded=$(cat /tmp/sndev_lnurl)
+  echo "Decoded: $decoded"
+  params=$(curl -s "$decoded")
+  echo "$params" | jq
+  callback=$(echo "$params" | jq -r '.callback')
+  max=$(echo "$params" | jq -r '.maxWithdrawable')
+  k1=$(echo "$params" | jq -r '.k1')
+  bolt11=$(sndev__cli lnd addinvoice --amt $((max/1000)) | jq -r '.payment_request')
+  echo "Invoice: $bolt11"
+  curl -s "${callback}?k1=${k1}&pr=${bolt11}" | jq
+  rm -f /tmp/sndev_lnurl
+}
+
+sndev__help_lnurl_withdraw() {
+  help="
+mock lnurl-withdraw for local testing
+
+USAGE
+  $ sndev lnurl_withdraw LNURL
+
+DESCRIPTION
+  Decodes the LNURL, fetches withdrawal parameters, creates an invoice
+  for the maximum amount, and sends it to the callback URL.
+"
+  echo "$help"
+}
 sndev__help_withdraw() {
   help="
 create a bolt11 for withdrawal
@@ -689,6 +756,8 @@ COMMANDS
   lightning:
     fund                   pay a bolt11 for funding
     withdraw               create a bolt11 for withdrawal
+    lnurl_auth             mock lnurl-auth
+    lnurl_withdraw         mock lnurl-withdraw
 
   db:
     psql                   open psql on db

--- a/sndev
+++ b/sndev
@@ -295,14 +295,15 @@ sndev__lnurl_auth() {
     sndev__help_lnurl_auth
     exit 1
   fi
-  docker__exec app node -e "const{bech32}=require('bech32');const{words}=bech32.decode('$lnurl',2000);console.log(Buffer.from(bech32.fromWords(words)).toString('utf8'));" > /tmp/sndev_lnurl
-  decoded=$(cat /tmp/sndev_lnurl)
+  decoded=$(docker__exec app node /app/scripts/lnurl-decode.js "$lnurl")
   echo "Decoded: $decoded"
-  k1=$(echo "$decoded" | grep -oP 'k1=\K[^&]*')
+  k1=$(echo "$decoded" | sed -n 's/.*k1=\([^&]*\).*/\1/p')
   identity_pubkey=$(sndev__cli lnd getinfo | jq -r '.identity_pubkey')
-  domain=$(echo "$decoded" | grep -oP '://\K[^/]*')
-  docker__exec app node -e "const{secp256k1}=require('@noble/curves/secp256k1');const{createHash}=require('crypto');const k1='$k1';const key=createHash('sha256').update('$identity_pubkey'+'$domain').digest();const sig=secp256k1.sign(Buffer.from(k1,'hex'),key);const pub=secp256k1.getPublicKey(key);const cb='$decoded'.split('?')[0];const p=new URLSearchParams({k1,sig:Buffer.from(sig.toCompactRawBytes()).toString('hex'),key:Buffer.from(pub).toString('hex')});console.log(\`\${cb}?\${p}\`);" | xargs curl -s | jq
-  rm -f /tmp/sndev_lnurl
+  domain=$(echo "$decoded" | sed 's|.*://\([^/]*\).*|\1|')
+  callback_base=$(echo "$decoded" | cut -d'?' -f1)
+  callback_url=$(docker__exec app node /app/scripts/lnurl-auth.js "$k1" "$identity_pubkey" "$domain" "$callback_base")
+  echo "Callback: $callback_url"
+  curl -s "$callback_url" | jq
 }
 
 sndev__help_lnurl_auth() {
@@ -327,8 +328,7 @@ sndev__lnurl_withdraw() {
     sndev__help_lnurl_withdraw
     exit 1
   fi
-  docker__exec app node -e "const{bech32}=require('bech32');const{words}=bech32.decode('$lnurl',2000);console.log(Buffer.from(bech32.fromWords(words)).toString('utf8'));" > /tmp/sndev_lnurl
-  decoded=$(cat /tmp/sndev_lnurl)
+  decoded=$(docker__exec app node /app/scripts/lnurl-decode.js "$lnurl")
   echo "Decoded: $decoded"
   params=$(curl -s "$decoded")
   echo "$params" | jq
@@ -338,7 +338,6 @@ sndev__lnurl_withdraw() {
   bolt11=$(sndev__cli lnd addinvoice --amt $((max/1000)) | jq -r '.payment_request')
   echo "Invoice: $bolt11"
   curl -s "${callback}?k1=${k1}&pr=${bolt11}" | jq
-  rm -f /tmp/sndev_lnurl
 }
 
 sndev__help_lnurl_withdraw() {


### PR DESCRIPTION
## Description

This fix closes #919 #920

Added lnurl_auth and lnurl_withdraw commands to the sndev CLI tool for local testing. Both commands decode LNURL bech32 strings, interact with the Lightning Network node, and send authenticated responses to callback URLs. I used inline Node.js execution within the app container with existing dependencies.


## Screenshots
<img width="1014" height="755" alt="Schermata del 2025-11-29 18-32-06" src="https://github.com/user-attachments/assets/f2dbbf65-21e4-4eba-9640-6454b3c8b1dd" />
<img width="1201" height="1088" alt="Schermata del 2025-11-29 18-34-08" src="https://github.com/user-attachments/assets/e8439b1d-33aa-434c-9069-2de229b242b1" />
<img width="1201" height="1088" alt="Schermata del 2025-11-29 18-34-27" src="https://github.com/user-attachments/assets/33c5726c-3f83-4acf-9ecb-27dc272b691a" />

## Additional Context

The lnurl_auth command was tested end-to-end with createAuth mutation and successfully authenticated. The lnurl_withdraw command was tested for LNURL decoding and invoice generation logic but requires an external LNURL-withdraw service (like LNbits) for complete end-to-end testing.

## Checklist

**Are your changes backward compatible? Please answer below:**
Yes


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7/10


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
NaN


**Did you introduce any new environment variables? If so, call them out explicitly here:**
NaN


**Did you use AI for this? If so, how much did it assist you?**
AI assisted me in the exploration of LNURL protocol details and cryptographic operations.
