### PR TITLE
enhance: add dynamic import for stack trace decoding in error boundary.

### DIFF
--- a/components/error-boundary.js
+++ b/components/error-boundary.js
@@ -1,4 +1,4 @@
-import { Component, useState } from 'react'
+import { Component } from 'react'
 import { StaticLayout } from './layout'
 import styles from '@/styles/error.module.css'
 import Image from 'react-bootstrap/Image'
@@ -61,10 +61,8 @@ export default ErrorBoundary
 // This button is a functional component so we can use `useToast` hook, which
 // can't be easily done in a class component that already consumes a context
 const CopyErrorButton = ({ errorDetails }) => {
-  const [copying, setCopying] = useState(false)
   const toaster = useToast()
   const onClick = async () => {
-    setCopying(true)
     try {
       const { decodeMinifiedStackTrace } = await import('@/lib/stacktrace')
       const decodedDetails = await decodeMinifiedStackTrace(errorDetails)
@@ -73,13 +71,7 @@ const CopyErrorButton = ({ errorDetails }) => {
     } catch (err) {
       console.error(err)
       toaster?.danger?.('failed to copy')
-    } finally {
-      setCopying(false)
     }
   }
-  return (
-    <Button className='mt-3' onClick={onClick} disabled={copying}>
-      {copying ? 'copying...' : 'copy error information'}
-    </Button>
-  )
+  return <Button className='mt-3' onClick={onClick}>copy error information</Button>
 }


### PR DESCRIPTION
## Description

Addresses  #1832 

Reducing bundle size by importing `decodeMinifiedStackTrace` when copy error button is actually clicked. Rare user path so should have minimal impact. Noticed in a different project so figured I could bring it here and looks like it has significant bundle savings.

## Screenshots

**Before fix:**
<img width="532" height="206" alt="Screenshot 2025-12-04 at 16 49 01" src="https://github.com/user-attachments/assets/df1b23d1-a830-4a4b-b1de-093f9b1ac259" />
**After fix:**
<img width="657" height="200" alt="Screenshot 2025-12-04 at 16 55 55" src="https://github.com/user-attachments/assets/b0d04f7b-d366-4a16-aa1b-bf4263eb91d1" />

From 1.01MB -> 917kB, which is about 10%

For testing the functionality I added a window function to force an error in `ErrorBoundary` constructor method:
```
constructor (props) {
    super(props)

    // Define a state variable to track whether is an error or not
    this.state = {
      hasError: false,
      error: undefined,
      errorInfo: undefined
    }

    // DEV error trigger
    if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
      window.__triggerErrorBoundary = () => {
        this.setState({
          hasError: true,
          error: new Error('Test error triggered via window.__triggerErrorBoundary()')
        })
      }
    }
  }
 ```
 Vid:

https://github.com/user-attachments/assets/6dedfcf6-e8ba-499e-96c1-4f89008372b9




## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
9

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**
N

**Did you use AI for this? If so, how much did it assist you?**
Y, coming up with a way to test that wasn't too hacky.