### PR TITLE
fix wrong top boost

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -13,7 +13,8 @@ import {
   COMMENTS_OF_COMMENT_LIMIT,
   FULL_COMMENTS_THRESHOLD,
   WALLET_RETRY_BEFORE_MS,
-  WALLET_MAX_RETRIES
+  WALLET_MAX_RETRIES,
+  BOOST_MIN
 } from '@/lib/constants'
 import { msatsToSats } from '@/lib/format'
 import uu from 'url-unshort'
@@ -713,7 +714,6 @@ export default {
           LIMIT 3`
       }, similar)
     },
-<<<<<<< HEAD
     auctionPosition: async (parent, { id, sub, boost }, { models, me }) => {
       const createdAt = id ? (await getItem(parent, { id }, { models, me })).createdAt : new Date()
       let where
@@ -783,8 +783,8 @@ export default {
       }
 
       return {
-        home: homeAgg._count.id === 0 && boost >= BOOST_MULT,
-        sub: subAgg?._count.id === 0 && boost >= BOOST_MULT,
+        home: homeAgg._count.id === 0 && boost >= BOOST_MIN,
+        sub: subAgg?._count.id === 0 && boost >= BOOST_MIN,
         homeMaxBoost: homeAgg._max.boost || 0,
         subMaxBoost: subAgg?._max.boost || 0
       }

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -11,11 +11,19 @@ export default gql`
     search(q: String, sub: String, cursor: String, what: String, sort: String, when: String, from: String, to: String): Items
     itemRepetition(parentId: ID): Int!
     newComments(itemId: ID, after: Date): Comments!
+    auctionPosition(id: ID, sub: String!, boost: Int): Int!
+    boostPosition(id: ID, sub: String, boost: Int): BoostPosition!
   }
 
   type TitleUnshorted {
     title: String
     unshorted: String
+  }
+  type BoostPosition {
+    home: Boolean!
+    sub: Boolean
+    homeMaxBoost: Int!
+    subMaxBoost: Int
   }
 
   extend type Mutation {


### PR DESCRIPTION
## Description
fix #2663 
The `boostPosition` resolver was missing `pinId` and `bio` filters that are present in `getAd` causing wrong boost estimates.

## Screenshots

<img width="827" height="438" alt="Schermata del 2025-12-04 19-33-46" src="https://github.com/user-attachments/assets/349becf8-c503-4e00-9164-063b124ded8b" />
<img width="524" height="725" alt="Schermata del 2025-12-04 19-34-23" src="https://github.com/user-attachments/assets/f2c1d5c0-9e5a-4df8-9fa1-c6d705c999cd" />
<img width="360" height="540" alt="Schermata del 2025-12-04 19-34-43" src="https://github.com/user-attachments/assets/42c34ca7-2fdf-4f1a-9b79-029d58bddf57" />
<img width="397" height="520" alt="Schermata del 2025-12-04 19-34-59" src="https://github.com/user-attachments/assets/6566f622-95a1-43c6-94e0-05c012b504e4" />
<img width="769" height="621" alt="Schermata del 2025-12-04 19-35-13" src="https://github.com/user-attachments/assets/95f39fa4-ee06-4f6a-8639-ead11cfeedeb" />
<img width="778" height="640" alt="Schermata del 2025-12-04 19-35-25" src="https://github.com/user-attachments/assets/673f17bd-6ed2-4293-9cb9-2141807f7e70" />
<img width="719" height="543" alt="Schermata del 2025-12-04 19-35-37" src="https://github.com/user-attachments/assets/7da5308e-1a03-4073-a323-5fcbb3fe43f0" />
<img width="780" height="674" alt="Schermata del 2025-12-04 19-35-49" src="https://github.com/user-attachments/assets/85c936a6-d782-470e-89a9-7727e7199d27" />
<img width="783" height="631" alt="Schermata del 2025-12-04 19-36-03" src="https://github.com/user-attachments/assets/0601ce19-618d-40fb-81cb-542bde1eb70b" />
<img width="779" height="705" alt="Schermata del 2025-12-04 19-36-14" src="https://github.com/user-attachments/assets/d336760b-53e0-48bc-a156-f6f86f38bd85" />
<img width="748" height="559" alt="Schermata del 2025-12-04 19-36-25" src="https://github.com/user-attachments/assets/9ec883c1-9760-43e8-afb3-0b4b4d571657" />
<img width="767" height="697" alt="Schermata del 2025-12-04 19-36-41" src="https://github.com/user-attachments/assets/cbd285b0-203e-42b5-9a54-95f2c9eb180c" />


## Additional Context

~~When a user wanted to pin a post to the homepage, SN showed the wrong cost because it included posts that would never be visible to that user (NSFW posts, muted users, muted subs)~~
When a user wanted to boost a post to the top, SN showed the wrong cost because `boostPosition` was counting items that would never appear as boosted ads as `Bio post` and `Pinned post`.
 if a `Bio post` had 500k boost and a normal post had 100k boost, `boostPosition` would incorrectly return 500k as the max boost, while `getAd` would correctly show the 100k normal post as the top ad.

## Checklist

**Are your changes backward compatible? Please answer below:**
Yes


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8/10 
I tested all filter combinations via SQL queries simulating the resolver logic: logged out users, logged in with NSFW on/off, user mute, sub mute, and viewing specific subs. Tested all filter combinations via SQL queries: bio posts, pinned posts, deleted posts, outlawed posts, stopped posts, and different subs.


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
NaN


**Did you introduce any new environment variables? If so, call them out explicitly here:**
NaN


**Did you use AI for this? If so, how much did it assist you?**
AI helped me generating the SQL test queries to check all filter combinations
