### PR TITLE
Remove ek

### DIFF
--- a/api/payIn/lib/territory.js
+++ b/api/payIn/lib/territory.js
@@ -1,6 +1,6 @@
 import { USER_ID } from '@/lib/constants'
 
-export const GLOBAL_SEEDS = [USER_ID.k00b, USER_ID.ek]
+export const GLOBAL_SEEDS = [USER_ID.k00b]
 
 export function initialTrust ({ name, userId }) {
   const results = GLOBAL_SEEDS.map(id => ({

--- a/components/footer.js
+++ b/components/footer.js
@@ -248,9 +248,6 @@ export default function Footer ({ links = true }) {
             <Link href='/k00b' className='ms-1'>
               @k00b
             </Link>
-            <Link href='/ek' className='ms-1'>
-              @ek
-            </Link>
             <Link href='/sox' className='ms-1'>
               @sox
             </Link>

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -58,7 +58,6 @@ export const ANON_ITEM_SPAM_INTERVAL = '0'
 export const INV_PENDING_LIMIT = 100
 export const USER_ID = {
   k00b: 616,
-  ek: 6030,
   sox: 26458,
   sn: 4502,
   anon: 27,
@@ -68,7 +67,7 @@ export const USER_ID = {
   rewards: 9513
 }
 export const SN_SYSTEM_ONLY_IDS = [USER_ID.sn, USER_ID.rewards, USER_ID.saloon, USER_ID.delete, USER_ID.ad]
-export const SN_ADMIN_IDS = [USER_ID.k00b, USER_ID.ek, USER_ID.sox, USER_ID.sn]
+export const SN_ADMIN_IDS = [USER_ID.k00b, USER_ID.sox, USER_ID.sn]
 export const SN_NO_REWARDS_IDS = [USER_ID.anon, USER_ID.sn, USER_ID.saloon, USER_ID.rewards]
 export const MAX_POLL_NUM_CHOICES = 10
 export const MIN_POLL_NUM_CHOICES = 2

--- a/worker/earn.js
+++ b/worker/earn.js
@@ -7,7 +7,7 @@ const PERCENTILE_CUTOFF = 50
 const ZAP_THRESHOLD = 20
 const EACH_ZAP_PORTION = 4.0
 const EACH_ITEM_PORTION = 4.0
-const HANDICAP_IDS = [616, 6030, 4502, 27]
+const HANDICAP_IDS = [616, 4502, 27]
 const HANDICAP_ZAP_MULT = 0.5
 
 export async function earn ({ name }) {


### PR DESCRIPTION
Afaict, this removes all the code where my account is treated in a special way.

I also found this:

https://github.com/stackernews/stacker.news/blob/9bd36db84e4c4ea4369b91461d5d4c65270e92ab/prisma/migrations/20250515161101_reward_threshold/migration.sql#L6

but I'm not sure if this postgres function is still used.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes `ek` from footer contributors, admin IDs, and reward handicap lists.
> 
> - **Backend**:
>   - **Constants**: Remove `USER_ID.ek` and update `SN_ADMIN_IDS` to exclude `ek` in `lib/constants.js`.
> - **Worker**:
>   - **Rewards**: Remove `ek` (6030) from `HANDICAP_IDS` in `worker/earn.js`.
> - **UI**:
>   - **Footer**: Remove `@ek` link from `components/footer.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a57a58fc28f1db6b6cfa5a1bb2d318b802dbce55. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->