### PR TITLE
Withdraw0

### DIFF
--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -63,9 +63,9 @@ const resolvers = {
 
 export default resolvers
 
-export async function createWithdrawal (parent, { invoice, maxFee }, { me, models, lnd, headers, protocol, logger }) {
+export async function createWithdrawal (parent, { invoice, maxFee, amount }, { me, models, lnd, headers, protocol, logger }) {
   assertApiKeyNotPermitted({ me })
-  await validateSchema(withdrawlSchema, { invoice, maxFee })
+  await validateSchema(withdrawlSchema, { invoice, maxFee, amount })
   await assertGofacYourself({ models, headers })
 
   // remove 'lightning:' prefix if present
@@ -95,7 +95,10 @@ export async function createWithdrawal (parent, { invoice, maxFee }, { me, model
   }
 
   if (!decoded.mtokens || BigInt(decoded.mtokens) <= 0) {
-    throw new GqlInputError('invoice must specify an amount')
+    if (!amount) {
+      throw new GqlInputError('invoice must specify an amount')
+    }
+    decoded.mtokens = BigInt(amount) * 1000n
   }
 
   if (decoded.mtokens > Number.MAX_SAFE_INTEGER) {

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -13,7 +13,7 @@ const typeDefs = gql`
   }
 
   extend type Mutation {
-    createWithdrawl(invoice: String!, maxFee: Int!): PayIn!
+    createWithdrawl(invoice: String!, maxFee: Int!, amount: Int): PayIn!
     sendToLnAddr(addr: String!, amount: Int!, maxFee: Int!, comment: String, identifier: Boolean, name: String, email: String): PayIn!
     dropBolt11(hash: String!): Boolean
     buyCredits(credits: Int!): PayIn!

--- a/fragments/withdrawal.js
+++ b/fragments/withdrawal.js
@@ -1,8 +1,8 @@
 import { gql } from '@apollo/client'
 
 export const CREATE_WITHDRAWL = gql`
-  mutation createWithdrawl($invoice: String!, $maxFee: Int!) {
-    createWithdrawl(invoice: $invoice, maxFee: $maxFee) {
+  mutation createWithdrawl($invoice: String!, $maxFee: Int!, $amount: Int) {
+    createWithdrawl(invoice: $invoice, maxFee: $maxFee, amount: $amount) {
       id
     }
 }`

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -490,7 +490,8 @@ export const lastAuthRemovalSchema = object({
 
 export const withdrawlSchema = object({
   invoice: string().required('required').trim(),
-  maxFee: intValidator.required('required').min(0, 'must be at least 0')
+  maxFee: intValidator.required('required').min(0, 'must be at least 0'),
+  amount: intValidator.optional().min(1, 'must be at least 1 sat')
 })
 
 export const bioSchema = object({


### PR DESCRIPTION


## Description

closes #1109 
Support for Lightning withdrawals using zero/non-specificated amount invoices. Users can now specify the amount when pasting or scanning a zero amount invoice. The backend and validation logic have been updated to handle the optional amount parameter. Error handling for invalid invoices and QR scans has been modified.

## Screenshots


https://github.com/user-attachments/assets/9340b0eb-fdc8-44c6-8948-c15e0189a61c

![Screenshot_2025-12-19-17-51-38-643_fr.acinq.phoenix.mainnet.jpg](https://github.com/user-attachments/assets/2aabe1ac-3ff4-4a3d-85e6-adaed4abb6c3)


## Additional Context

The main challenge was ensuring the amount field appears correctly after both manual input and QR code scanning. Error handling for invalid invoices was also refined to avoid runtime issues.


## Checklist

**Are your changes backward compatible? Please answer below:**
Yes


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7/10


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes


**Did you introduce any new environment variables? If so, call them out explicitly here:**
NaN


**Did you use AI for this? If so, how much did it assist you?**
AI was used for code review and guidance, but all code and logic were written and verified manually.
