### PR TITLE
fix: disable single dollar markdown syntax

### DIFF
--- a/lib/lexical/utils/mdast.js
+++ b/lib/lexical/utils/mdast.js
@@ -31,7 +31,7 @@ export function markdownToLexical (editor, markdown) {
       visitors: importVisitors,
       syntaxExtensions: [
         gfm(),
-        math()
+        math({ singleDollarTextMath: false })
       ],
       mdastExtensions: [
         gfmFromMarkdown(),
@@ -63,7 +63,7 @@ export function lexicalToMarkdown (editor) {
       visitors: exportVisitors,
       toMarkdownExtensions: [
         gfmToMarkdown(),
-        mathToMarkdown(),
+        mathToMarkdown({ singleDollarTextMath: false }),
         customToMarkdownExtensions
       ],
       toMarkdownOptions: {


### PR DESCRIPTION
## Description

Context: https://stacker.news/items/1357577

Disables single dollar math syntax on the related micromark and mdast extensions.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**


**Did you use AI for this? If so, how much did it assist you?**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables single-dollar math parsing by configuring math extensions with `singleDollarTextMath: false` for both markdown import and export.
> 
> - **Markdown processing**
>   - In `lib/lexical/utils/mdast.js`:
>     - Configure micromark `math({ singleDollarTextMath: false })` in `markdownToLexical` syntax extensions.
>     - Configure mdast `mathToMarkdown({ singleDollarTextMath: false })` in `lexicalToMarkdown` toMarkdown extensions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0aa718fd479dc2b50ce9b29886975fb028e7fa1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->