### PR TITLE
fix: open external autolinks on a new tab

### DIFF
--- a/lib/lexical/exts/autolink.js
+++ b/lib/lexical/exts/autolink.js
@@ -62,11 +62,13 @@ export const AutoLinkExtension = defineExtension({
         return
       }
 
+      const isHashLink = url?.startsWith('#')
+      const isInternalLink = isHashLink || !isExternal(url)
       // step 4: fallback to full link node
       const linkNode = $createLinkNode(url, {
         title: url,
-        target: isExternal(url) ? '_blank' : '',
-        rel: isExternal(url) ? 'noopener nofollow noreferrer' : ''
+        target: isInternalLink ? '' : '_blank',
+        rel: isInternalLink ? '' : 'noopener nofollow noreferrer'
       }).append($createTextNode(url))
       node.replace(linkNode)
     })


### PR DESCRIPTION
## Description

Context: https://stacker.news/items/1357609/r/k00b?commentId=1357655

Adds `_blank` target to external autolinks that ultimately become full LinkNodes.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**


**Did you use AI for this? If so, how much did it assist you?**


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> External autolinks now open in a new tab with safe rel attrs; internal and hash links remain same-tab.
> 
> - **Editor – `lib/lexical/exts/autolink.js`**:
>   - Import `isExternal` and detect internal links (including hash `#` links).
>   - For fallback `LinkNode`s, set `target: '_blank'` and `rel: 'noopener nofollow noreferrer'` for external links; leave empty for internal links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b5d7241670678378b95921c1f3bc071d95702d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->