### PR TITLE
remove any custom sup sub styling

### DIFF
--- a/lib/lexical/theme/index.js
+++ b/lib/lexical/theme/index.js
@@ -77,8 +77,6 @@ const theme = {
   text: {
     bold: 'sn-text__bold',
     italic: 'sn-text__italic',
-    superscript: 'sn-text__superscript',
-    subscript: 'sn-text__subscript',
     highlight: 'sn-text__highlight',
     underline: 'sn-text__underline',
     strikethrough: 'sn-text__strikethrough',

--- a/styles/text.scss
+++ b/styles/text.scss
@@ -541,23 +541,6 @@ span + .sn-link {
   text-decoration: underline line-through;
 }
 
-.sn-text sup,
-.sn-text sub {
-  vertical-align: baseline;
-  font-size: inherit;
-  position: static;
-}
-
-.sn-text__superscript {
-  vertical-align: super;
-  font-size: smaller;
-}
-
-.sn-text__subscript {
-  vertical-align: sub;
-  font-size: smaller;
-}
-
 .sn-text__highlight {
   background-color: #fada5e5e;
   padding: 0 0.2rem;


### PR DESCRIPTION
## Description

Seems like Safari is fighting our superscript/subscript classes, especially on hidpi resolutions. Thankfully we don't need those classes!

## Screenshots

Before:
<img width="328" height="106" alt="image" src="https://github.com/user-attachments/assets/2c0a6486-bcd9-4eee-ba95-a58c735592a2" />

After:
<img width="408" height="162" alt="image" src="https://github.com/user-attachments/assets/4537696e-2da9-407b-b1f0-ec7229730760" />

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8, looks good on chromium too

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**


**Did you use AI for this? If so, how much did it assist you?**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `sup`/`sub` custom styles and the `text.superscript`/`text.subscript` theme mappings.
> 
> - **Styles (SCSS)**:
>   - Remove custom `sup`/`sub` resets and the `.sn-text__superscript` / `.sn-text__subscript` rules in `styles/text.scss`.
> - **Lexical Theme**:
>   - Drop `text.superscript` and `text.subscript` mappings from `lib/lexical/theme/index.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b69c7e2707a7761e36158c978c988d22aed10e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->