### PR TITLE
fix: share internal/external link logic with Media, Autolink and MDAST

### DIFF
--- a/components/editor/nodes/media.js
+++ b/components/editor/nodes/media.js
@@ -1,5 +1,5 @@
 import MediaOrLink from '@/components/media-or-link'
-import { IMGPROXY_URL_REGEXP, decodeProxyUrl } from '@/lib/url'
+import { IMGPROXY_URL_REGEXP, decodeProxyUrl, getLinkAttributes } from '@/lib/url'
 import { useState, useEffect } from 'react'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { $createLinkNode } from '@lexical/link'
@@ -39,9 +39,11 @@ export default function MediaComponent ({ src, srcSet, bestResSrc, width, height
       const parent = node.getParent()
       if (!parent) return
 
+      const { target, rel } = getLinkAttributes(url)
       const linkNode = $createLinkNode(url, {
         title: url,
-        rel: UNKNOWN_LINK_REL
+        target,
+        rel
       }).append($createTextNode(url))
 
       // If parent is a paragraph, directly replace the media node with the link

--- a/lib/lexical/exts/autolink.js
+++ b/lib/lexical/exts/autolink.js
@@ -2,7 +2,7 @@ import { defineExtension } from '@lexical/extension'
 import { $createItemMentionNode } from '@/lib/lexical/nodes/decorative/mentions/item'
 import { $createEmbedNode } from '@/lib/lexical/nodes/content/embed'
 import { $createMediaNode } from '@/lib/lexical/nodes/content/media'
-import { parseInternalLinks, parseEmbedUrl, ensureProtocol, isExternal } from '@/lib/url'
+import { parseInternalLinks, parseEmbedUrl, ensureProtocol, getLinkAttributes } from '@/lib/url'
 import { AutoLinkNode, $createLinkNode } from '@lexical/link'
 import { $isParagraphNode, $createTextNode } from 'lexical'
 
@@ -62,13 +62,12 @@ export const AutoLinkExtension = defineExtension({
         return
       }
 
-      const isHashLink = url?.startsWith('#')
-      const isInternalLink = isHashLink || !isExternal(url)
       // step 4: fallback to full link node
+      const { target, rel } = getLinkAttributes(url)
       const linkNode = $createLinkNode(url, {
         title: url,
-        target: isInternalLink ? '' : '_blank',
-        rel: isInternalLink ? '' : 'noopener nofollow noreferrer'
+        target,
+        rel
       }).append($createTextNode(url))
       node.replace(linkNode)
     })

--- a/lib/lexical/mdast/visitors/link.js
+++ b/lib/lexical/mdast/visitors/link.js
@@ -1,7 +1,7 @@
 import { $createTextNode } from 'lexical'
 import { $createLinkNode, $isLinkNode, $createAutoLinkNode, $isAutoLinkNode } from '@lexical/link'
 import { $isEmbedNode } from '@/lib/lexical/nodes/content/embed'
-import { isExternal } from '@/lib/url'
+import { getLinkAttributes } from '@/lib/url'
 
 // check if link is a "bare link" (text matches url)
 function isBareLink (mdastNode) {
@@ -26,12 +26,11 @@ export const MdastAutolinkVisitor = {
 export const MdastLinkVisitor = {
   testNode: 'link',
   visitNode ({ mdastNode, actions }) {
-    const isHashLink = mdastNode.url?.startsWith('#')
-    const isInternalLink = isHashLink || !isExternal(mdastNode.url)
-
-    // empty for hash links, use stored value or default to security attributes
-    const target = isInternalLink ? '' : (mdastNode.target ?? '_blank')
-    const rel = isInternalLink ? '' : (mdastNode.rel ?? 'noopener nofollow noreferrer')
+    // use stored values from mdast or defaults for external links
+    const { target, rel } = getLinkAttributes(mdastNode.url, {
+      target: mdastNode.target,
+      rel: mdastNode.rel
+    })
 
     const link = $createLinkNode(mdastNode.url, {
       title: mdastNode.title,

--- a/lib/url.js
+++ b/lib/url.js
@@ -27,6 +27,22 @@ export function isExternal (url) {
   return !url.startsWith(process.env.NEXT_PUBLIC_URL + '/') && !url.startsWith('/')
 }
 
+export function isHashLink (url) {
+  return url?.startsWith('#')
+}
+
+export function isInternalLink (url) {
+  return isHashLink(url) || !isExternal(url)
+}
+
+export function getLinkAttributes (url, { target, rel } = {}) {
+  const internal = isInternalLink(url)
+  return {
+    target: internal ? '' : (target ?? '_blank'),
+    rel: internal ? '' : (rel ?? 'noopener nofollow noreferrer')
+  }
+}
+
 export function removeTracking (value) {
   if (!value) return value
   const exprs = [


### PR DESCRIPTION
## Description

There was a `LinkNode` behavioral divergence between the MDAST pipeline and Lexical extensions.
MDAST would create a link with `target: _blank` or an autolink in the case of missing markdown syntax.

Before creating a link, `AutolinkExtension` checks the type of the URL by trying to run it as a `MediaNode`, this triggers `MediaOrLink` media checks: if it's not media, the `MediaNode` gets replaced with a full `LinkNode`.

This PR fixes the behavioral inconsistency by sharing an helper function between link handlers.

## Additional Context

We should bring back `MediaCheckExtension` to do better separation of concerns. I removed it because it was heavily over-engineered, I'm up for a rewrite!

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**


**Did you use AI for this? If so, how much did it assist you?**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes internal/external link handling via `getLinkAttributes` and applies it to Media replacement, Autolink, and MDAST link visitors for consistent `target`/`rel`.
> 
> - **Core URL utils**:
>   - Add `isHashLink`, `isInternalLink`, and `getLinkAttributes` in `lib/url.js` to derive `target`/`rel` for links.
> - **Editor/Lexical**:
>   - **AutolinkExtension (`lib/lexical/exts/autolink.js`)**: Use `getLinkAttributes` when creating `LinkNode` instead of inline internal/external checks.
>   - **Media node (`components/editor/nodes/media.js`)**: When converting media to a link, populate `target`/`rel` via `getLinkAttributes`.
>   - **MDAST visitors (`lib/lexical/mdast/visitors/link.js`)**: Use `getLinkAttributes`, honoring existing `mdastNode.target`/`rel` if provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff126dfb09b71700a8029f5334c5ecc772eb5541. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->