### PR TITLE
Fix Apple autocomplete and whole-word delete

### DIFF
--- a/components/editor/editor.js
+++ b/components/editor/editor.js
@@ -24,6 +24,7 @@ import styles from '@/lib/lexical/theme/editor.module.css'
 import { HistoryExtension } from '@lexical/history'
 import useCallbackRef from '../use-callback-ref'
 import { EditorRefPlugin } from '@lexical/react/LexicalEditorRefPlugin'
+import { ApplePatchExtension } from '@/lib/lexical/exts/apple'
 
 /**
  * main lexical editor component with formik integration
@@ -47,6 +48,7 @@ export default function Editor ({ name, appendValue, autoFocus, topLevel, ...pro
       namespace: 'sn',
       dependencies: [
         PlainTextExtension,
+        ApplePatchExtension,
         HistoryExtension,
         ShortcutsExtension,
         MDCommandsExtension,

--- a/lib/lexical/exts/apple.js
+++ b/lib/lexical/exts/apple.js
@@ -1,0 +1,26 @@
+import { defineExtension, KEY_BACKSPACE_COMMAND, COMMAND_PRIORITY_HIGH } from 'lexical'
+import { CAN_USE_BEFORE_INPUT, IS_IOS, IS_SAFARI, IS_APPLE_WEBKIT } from '@lexical/utils'
+
+/**
+ * Apple-related patches for Lexical
+ *
+ * Apple platforms update their autocorrect buffer on `beforeInput` event.
+ * Lexical's KEY_BACKSPACE_COMMAND calls `preventDefault()` on keydown, which prevents
+ * the native `beforeInput` event from firing.
+ *
+ * This extension overrides KEY_BACKSPACE_COMMAND to not `preventDefault()` on Apple platforms.
+ * Fixes autocorrect, autocompletion and whole word deletion (hold backspace)
+ *
+ * @see https://github.com/facebook/lexical/issues/7994
+ */
+export const ApplePatchExtension = defineExtension({
+  name: 'apple-patch',
+  register: (editor) => {
+    return editor.registerCommand(KEY_BACKSPACE_COMMAND, () => {
+      if ((IS_IOS || IS_SAFARI || IS_APPLE_WEBKIT) && CAN_USE_BEFORE_INPUT) {
+        return true
+      }
+      return false
+    }, COMMAND_PRIORITY_HIGH)
+  }
+})


### PR DESCRIPTION
## Description

[related Lexical issue](https://github.com/facebook/lexical/issues/7994)

Apple platforms update their autocorrect buffer on `beforeInput`, but Lexical's `KEY_BACKSPACE_COMMAND` calls `preventDefault()` on keydown, preventing the native `beforeInput` from firing.

This PR overrides the Lexical `KEY_BACKSPACE_COMMAND` to not `preventDefault()` on Apple platforms.
Fixes autocorrect, autocompletion and whole word deletion (hold backspace)

## Additional Context

note: this will get fixed by the Lexical team, the related GitHub issue is linked inside the extension's comment.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, autocorrect and whole-word delete

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an Apple-specific Lexical extension and integrates it into the editor to adjust backspace handling on Apple platforms.
> 
> - **Editor**:
>   - **New extension**: Adds `ApplePatchExtension` in `lib/lexical/exts/apple.js` to register a high-priority `KEY_BACKSPACE_COMMAND` handler that returns `true` on Apple platforms when `CAN_USE_BEFORE_INPUT`, avoiding Lexical's default `preventDefault()` and preserving native `beforeInput` behavior.
>   - **Integration**: Wires `ApplePatchExtension` into `components/editor/editor.js` by adding it to the editor `dependencies`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9ec9ec574fd93f76ae1d64851878499fc638499. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->