### PR TITLE
Don't treat links with images as linktext as misleading

### DIFF
--- a/lib/lexical/mdast/transforms/links.js
+++ b/lib/lexical/mdast/transforms/links.js
@@ -6,12 +6,16 @@ import { isMisleadingLink } from '@/lib/url'
  * a link is misleading if the text is not the same as the URL.
  *
  * this transform replaces the link text with the URL if it is misleading.
+ * if the link wraps only an image, the link is removed but the image is kept.
  */
 export function misleadingLinkTransform (tree) {
-  visit(tree, 'link', (node) => {
-    // if the link has an image, we don't want to replace the text with the URL
-    const hasImage = node.children?.some(child => child.type === 'image')
-    if (hasImage) return
+  visit(tree, 'link', (node, index, parent) => {
+    // if the link has only an image child, unwrap it (remove the link but keep the image)
+    const hasOnlyImage = node.children?.length === 1 && node.children[0].type === 'image'
+    if (hasOnlyImage && parent && index !== undefined) {
+      parent.children[index] = node.children[0]
+      return index
+    }
 
     const text = toString(node)
     if (!text) return


### PR DESCRIPTION
## Description

Context: https://stacker.news/items/1359523

The misleading link check was treating image `linktext`s as misleading.
This PR fixes restores the original `rehype-sn` behavior by unwrapping images from links and removing the link.

## Screenshots

https://github.com/user-attachments/assets/6cd77409-594f-47d5-9871-45364cf0c54c


## Additional Context

The misleading link transform was extracted by `rehype-sn`

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**


**Did you use AI for this? If so, how much did it assist you?**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unwrap image-only `link` nodes (remove link, keep image) and retain misleading link text replacement for other links.
> 
> - **MD AST transform**:
>   - Updates `lib/lexical/mdast/transforms/links.js`:
>     - `misleadingLinkTransform` now unwraps `link` nodes that contain only an `image` (removes the link, preserves the image).
>     - Keeps existing behavior to replace misleading link text with the URL via `isMisleadingLink`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d6ac434a61504c6588ac20c3c139e128a451572. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->