### PR TITLE
fix: bigger font on small screens

### DIFF
--- a/components/editor/editor.js
+++ b/components/editor/editor.js
@@ -87,13 +87,14 @@ function EditorContent ({ name, placeholder, lengthOptions, topLevel, required =
   const { ref: containerRef, onRef: onContainerRef } = useCallbackRef()
 
   return (
-    <div className={classNames(styles.editorContainer, topLevel && 'sn-text--top-level')}>
+    <div className={classNames(styles.editorContainer)} data-top-level={topLevel ? 'true' : 'false'}>
       <EditorRefPlugin editorRef={editorRef} />
       <ToolbarPlugin topLevel={topLevel} name={name} />
       {/* we only need a plain text editor for markdown */}
       <div className={styles.editor} ref={onContainerRef}>
         <ContentEditable
-          className={classNames(styles.editorInput, 'sn-text')}
+          data-sn-editor='true'
+          className={classNames(styles.editorContent, styles.editorContentInput, 'sn-text')}
           /* lh is a css unit that is equal to the line height of the element
               probably the worst thing is that we have to add 1 to the minRows to get the correct height
           */

--- a/components/editor/plugins/preview.js
+++ b/components/editor/plugins/preview.js
@@ -63,7 +63,7 @@ export default function PreviewPlugin ({ editorRef, topLevel, name }) {
       className={styles.editor}
       onKeyDown={handlePreviewKeyDown}
     >
-      <Text className={styles.editorInput} topLevel={topLevel} preview name={name} />
+      <Text className={styles.editorContent} topLevel={topLevel} preview name={name} />
     </div>
   )
 }

--- a/components/editor/reader.js
+++ b/components/editor/reader.js
@@ -62,7 +62,7 @@ export default function Reader ({ topLevel, state, text, preview, name, readerRe
   return (
     <LexicalExtensionComposer extension={reader} contentEditable={null}>
       <EditorRefPlugin editorRef={readerRef} />
-      <ContentEditable />
+      <ContentEditable data-sn-reader='true' />
       {preview && <PreviewSyncPlugin name={name} />}
       <CodeThemePlugin />
       <NextLinkPlugin />

--- a/lib/lexical/theme/editor.module.css
+++ b/lib/lexical/theme/editor.module.css
@@ -19,13 +19,13 @@
 }
 
 /* non-top-level editor for things such as comments */
-.editorContainer:not(:global(.sn-text--top-level)) .editor {
+.editorContainer:not([data-top-level='true']) .editor {
   --editor-border-color: color-mix(in srgb, var(--theme-borderColor) 50%, transparent);
   --editor-bg: var(--theme-forceCommentBg);
 }
 
 /* editor focus state */
-.editor:has(.editorInput:focus-within) {
+.editor:has(.editorContent:focus-within) {
   --editor-border-color: var(--bs-primary);
   outline: 0;
   box-shadow: 0 0 4px var(--bs-primary);
@@ -47,13 +47,9 @@
 
 /* editor input */
 
-.editorInput {
-  caret-color: var(--theme-color);
+.editorContent {
   margin-top: -1px;
-  font-size: 94%;
-  line-height: 140%;
   position: relative;
-  tab-size: 1;
   outline: 0;
   padding: 8px;
   min-height: 120px;
@@ -62,8 +58,15 @@
   background-color: transparent;
 }
 
+.editorContentInput {
+  caret-color: var(--theme-color);
+  font-size: 94%;
+  line-height: 140%;
+  tab-size: 1;
+}
+
 @media screen and (min-width: 767px) {
-  .editorInput {
+  .editorContentInput {
     line-height: 130%;
   }
 }
@@ -80,22 +83,6 @@
   white-space: nowrap;
   display: inline-block;
   pointer-events: none;
-}
-
-/* markdown mode code block styling */
-
-.editorInput code[data-language="markdown"] {
-  background-color: var(--theme-body) !important;
-  color: var(--theme-color);
-  font-family: inherit;
-  font-size: 100% !important;
-  display: block;
-  padding: 0 !important;
-  line-height: 1.53;
-  margin: 0 0 8px;
-  tab-size: 2;
-  overflow-x: auto;
-  position: relative;
 }
 
 /* toolbar */
@@ -360,7 +347,7 @@
 /* editor mode tabs */
 .modeTabs {
   --tab-border-color: var(--theme-borderColor);
-  --tab-bg: var(--theme-commentBg);
+  --tab-bg: var(--theme-inputBg);
   --tab-shadow: none;
   --tab-clip: none;
 
@@ -378,13 +365,13 @@
 }
 
 /* non-top-level editor tabs (comments, etc.) */
-.editorContainer:not(:global(.sn-text--top-level)) .modeTabs {
+.editorContainer:not([data-top-level='true']) .modeTabs {
   --tab-border-color: color-mix(in srgb, var(--theme-borderColor) 50%, transparent);
   --tab-bg: var(--theme-forceCommentBg);
 }
 
 /* focus state for tabs */
-.toolbar:has(~ .editor .editorInput:focus-within) .modeTabs {
+.toolbar:has(~ .editor .editorContent:focus-within) .modeTabs {
   --tab-border-color: var(--bs-primary);
   --tab-shadow: 0 0 4px var(--bs-primary);
   --tab-clip: inset(-0.2rem -0.2rem -0.1rem -0.2rem);
@@ -634,7 +621,7 @@
 }
 
 /* focus state for mode switcher */
-.toolbar:has(~ .editor .editorInput:focus-within) .modeSwitcherContainer {
+.toolbar:has(~ .editor .editorContent:focus-within) .modeSwitcherContainer {
   --switcher-border-color: var(--bs-primary);
   --switcher-shadow: 0 0 0 0.2rem rgb(240 218 94 / 25%);
   --switcher-clip: inset(-0.2rem -0.2rem -0.005rem -0.2rem);

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -450,7 +450,7 @@ a:hover {
 }
 
 select,
-div[contenteditable]:not(.sn-text):not(.sn-text *),
+div[contenteditable]:not([data-lexical-editor]):not([data-lexical-editor] *),
 .form-control {
   background-color: var(--theme-inputBg);
   color: var(--bs-body-color);
@@ -492,7 +492,7 @@ select:focus {
 }
 
 
-div[contenteditable]:not(.sn-text):not(.sn-text *):focus,
+div[contenteditable]:not([data-lexical-editor]):not([data-lexical-editor] *):focus,
 .form-control:focus {
   background-color: var(--theme-inputBg);
   color: var(--bs-body-color);
@@ -500,7 +500,7 @@ div[contenteditable]:not(.sn-text):not(.sn-text *):focus,
   box-shadow: 0 0 0 0.2rem rgb(250 218 94 / 25%);
 }
 
-div[contenteditable]:not(.sn-text):not(.sn-text *):disabled,
+div[contenteditable]:not([data-lexical-editor]):not([data-lexical-editor] *):disabled,
 .form-control:disabled,
 .form-control[readonly] {
   background-color: var(--theme-inputDisabledBg);
@@ -628,14 +628,15 @@ footer {
   cursor: pointer;
 }
 
+/* prevent zooming on mobile */
 @media screen and (max-width: 767px) {
 
   input,
   textarea,
   .form-control,
   .form-control:focus,
-  div[contenteditable]:not(.sn-text):not(.sn-text *),
-  div[contenteditable]:not(.sn-text):not(.sn-text *):focus,
+  div[contenteditable]:not([data-sn-reader]):not([data-sn-reader] *),
+  div[contenteditable]:not([data-sn-reader]):not([data-sn-reader] *):focus,
   .input-group-text {
     font-size: 1rem !important;
   }
@@ -648,7 +649,7 @@ footer {
 }
 
 textarea.form-control,
-div[contenteditable]:not(.sn-text):not(.sn-text *) {
+div[contenteditable]:not([data-sn-reader]):not([data-sn-reader] *) {
   line-height: 1rem;
 }
 
@@ -749,7 +750,7 @@ header .navbar:not(:first-child) {
   text-shadow: 0 0 10px var(--bs-primary);
 }
 
-div[contenteditable]:not(.sn-text):not(.sn-text *):focus,
+div[contenteditable]:not([data-lexical-editor]):not([data-lexical-editor] *):focus,
 .form-control:focus {
   border-color: var(--bs-primary);
 }


### PR DESCRIPTION
## Description

Fixes #2692 
Allows globals' mobile focus fix and line-height on `contenteditable`s that are not `data-sn-reader`. Only the Editor will feature a bigger font.

## Screenshots

tbd

## Additional Context

I'm failing to remember if preview too had a bigger font on mobile, so there's this font size mismatch between `write` and `preview` tabs.

---

The switch from the original rich text PR and the plain text (prod) caused some dirt to be left in various stylesheets.

## Style changes

- split editorInput class in:
  - editorContent: shape and boundaries of text content (for editor and preview)
  - editorContentInput: text styling (for editor)
- add data-sn-editor and data-sn-reader for easier CSS selection
- add data-top-level to Editor instead of injecting sn-text--top-level (we're in plaintext not richtext)
- prevent globals on data-lexical-editor
- allow globals' mobile focus fix and line-height on contenteditables that are not data-sn-reader

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Split editor input styling (`.editorContent`/`.editorContentInput`), add `data-top-level`, `data-sn-editor`, `data-sn-reader`, and update CSS/globals to properly scope Lexical vs reader with improved mobile font/focus behavior.
> 
> - **Editor/Preview/Reader**:
>   - Replace injected `sn-text--top-level` usage with `data-top-level` on `Editor` container; update non-top-level selectors to `[data-top-level='true']` checks.
>   - Add `data-sn-editor` on editor `ContentEditable` and `data-sn-reader` on reader `ContentEditable`.
>   - Preview/Reader use new `styles.editorContent` class.
> - **Styling (CSS modules)**:
>   - Rename/split `.editorInput` into `.editorContent` (layout/container) and `.editorContentInput` (text styling); update focus selectors to `.editorContent:focus-within`.
>   - Adjust mode tabs background var to `--tab-bg: var(--theme-inputBg)` and focus rules to target `.editorContent`.
> - **Globals (`styles/globals.scss`)**:
>   - Retarget generic `contenteditable` selectors to exclude `[data-lexical-editor]` instead of `.sn-text`.
>   - Apply mobile font-size/line-height and focus styles only to `contenteditable` not marked with `data-sn-reader`; keep Lexical editor unaffected.
>   - Keep consistent focus/disabled/border styles using the new selectors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 642656b637a6cb5414f1b602d8960d5441fa83ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->