### PR TITLE
fix: don't pass aspect-ratio as a CSS variable to media

### DIFF
--- a/components/media-or-link.js
+++ b/components/media-or-link.js
@@ -151,8 +151,7 @@ export const useMediaHelper = ({ src, srcSet, srcSetIntital, bestResSrc, width, 
     if (width && height && width > 0 && height > 0) {
       style = {
         '--height': `${height}px`,
-        '--width': `${width}px`,
-        '--aspect-ratio': `${width} / ${height}`
+        '--width': `${width}px`
       }
     }
   }

--- a/components/text.module.css
+++ b/components/text.module.css
@@ -169,7 +169,7 @@
     height: auto;
     overflow: hidden;
     max-height: 25vh;
-    aspect-ratio: var(--aspect-ratio);
+    aspect-ratio: var(--width) / var(--height);
     margin: 0;
 }
 
@@ -226,7 +226,7 @@
     max-height: inherit;
     height: 100%;
     max-width: 100%;
-    aspect-ratio: var(--aspect-ratio);
+    aspect-ratio: var(--width) / var(--height);
 }
 
 .mediaContainer img {

--- a/lib/lexical/nodes/content/media.jsx
+++ b/lib/lexical/nodes/content/media.jsx
@@ -164,7 +164,6 @@ export class MediaNode extends DecoratorNode {
 
     element.style.setProperty('--width', width ? `${width}px` : 'inherit')
     element.style.setProperty('--height', height ? `${height}px` : 'inherit')
-    element.style.setProperty('--aspect-ratio', width && height ? `${width} / ${height}` : 'auto')
     element.style.setProperty('--max-width', `${this.__maxWidth}px`)
 
     const media = document.createElement(kind === 'video' ? 'video' : 'img')
@@ -176,7 +175,7 @@ export class MediaNode extends DecoratorNode {
       media.setAttribute('srcset', srcSet)
       media.setAttribute('sizes', '66vw')
     }
-    if (bestResSrc) {
+    if (bestResSrc && kind === 'video') {
       media.setAttribute('poster', bestResSrc !== this.__src ? bestResSrc : undefined)
       media.setAttribute('preload', bestResSrc !== this.__src ? 'metadata' : undefined)
     }
@@ -204,7 +203,6 @@ export class MediaNode extends DecoratorNode {
     if (height) {
       span.style.setProperty('--height', `${height}px`)
     }
-    span.style.setProperty('--aspect-ratio', width && height ? `${width} / ${height}` : 'auto')
 
     span.style.setProperty('--max-width', `${this.__maxWidth}px`)
     return span

--- a/styles/text.scss
+++ b/styles/text.scss
@@ -175,7 +175,7 @@ span.sn-media-container {
   height: auto;
   overflow: hidden;
   max-height: 25vh;
-  aspect-ratio: var(--aspect-ratio);
+  aspect-ratio: var(--width) / var(--height);
   margin: 0;
 }
 
@@ -204,7 +204,7 @@ span.sn-media-container .outlawed {
   max-height: inherit;
   height: 100%;
   max-width: 100%;
-  aspect-ratio: var(--aspect-ratio);
+  aspect-ratio: var(--width) / var(--height);
   cursor: default;
 }
 


### PR DESCRIPTION
## Description

Fixes #2694 
Safari treats the `--aspect-ratio` variable we pass as a string and never does the calculation `width / height`, breaking images and video rendering. This PR moves the calculation to stylesheets via `width` and `height` variables.

Also prevents `poster` and `preload` from appearing on image nodes.

## Screenshots

Had to fabricate `width` and `height` because without them `aspect-ratio` is `auto` and the bug doesn't happen.

https://github.com/user-attachments/assets/80c919c2-cd4e-41d7-aecb-2c1be0d48d1f



## Additional Context

The weird thing is that Safari actually supports doing something like this: `--aspect-ratio: 1920 / 1080`, we can test this by toggling the property, it's recognized correctly afterwards. Could be first paint, but also carousel stops working and Safari (not us) re-renders all the images on each click, so no calculations as CSS variables 🫡.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Derives media aspect ratios via CSS `--width/--height` vars and limits `poster/preload` to videos, removing the `--aspect-ratio` variable usage.
> 
> - **Media rendering**:
>   - Compute `aspect-ratio` in stylesheets as `var(--width) / var(--height)` and stop using `--aspect-ratio` across `components/text.module.css` and `styles/text.scss` (both container and `img/video`).
>   - Remove inline setting of `--aspect-ratio`; set only `--width`/`--height` in `components/media-or-link.js` and `lib/lexical/nodes/content/media.jsx` (both export and create DOM paths).
>   - Apply `poster`/`preload` only for `video` nodes when `bestResSrc` exists; no longer added for images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8e50e8629439c158f5c5aee856a2edaa2dbed46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->