### PR TITLE
fix: close Mentions menu on blur events

### DIFF
--- a/components/editor/plugins/mentions.js
+++ b/components/editor/plugins/mentions.js
@@ -7,6 +7,7 @@ import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext
 import { USER_SUGGESTIONS } from '@/fragments/users'
 import { SUB_SUGGESTIONS } from '@/fragments/subs'
 import styles from '@/lib/lexical/theme/editor.module.css'
+import { BLUR_COMMAND, COMMAND_PRIORITY_HIGH } from 'lexical'
 
 /** regex to match \@user or \~sub mentions */
 const MENTION_PATTERN = /(^|\s|\()([@~]\w{0,75})$/
@@ -74,6 +75,14 @@ export default function MentionsPlugin () {
   const [query, setQuery] = useState(null)
   const suggestions = useSuggestions({ query })
 
+  // close menu on blur
+  useEffect(() => {
+    return editor.registerCommand(BLUR_COMMAND, () => {
+      setQuery(null)
+      return false // let other handlers handle the blur
+    }, COMMAND_PRIORITY_HIGH)
+  }, [editor])
+
   const options = useMemo(() => {
     if (!suggestions?.length) return []
     return suggestions.map(s => new MentionOption(s.name))
@@ -104,7 +113,7 @@ export default function MentionsPlugin () {
         anchorElementRef.current && suggestions?.length
           ? createPortal(
             <Dropdown show style={{ zIndex: 1000 }}>
-              <Dropdown.Menu className={styles.suggestionsMenu}>
+              <Dropdown.Menu className={styles.suggestionsMenu} onMouseDown={e => e.preventDefault()}>
                 {options.map((o, i) =>
                   <Dropdown.Item
                     key={o.key}


### PR DESCRIPTION
## Description

Context: https://stacker.news/items/1363849
Fixes Mentions menu staying open when editor is unfocused by resetting the mentions `query` on `blur` events.

## Screenshots

tbd

## Additional Context

n/a

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8, on blur mentions menu closes

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Closes the mentions typeahead on editor blur and prevents dropdown mousedown from blurring the editor.
> 
> - **Editor Mentions Plugin** (`components/editor/plugins/mentions.js`):
>   - **Behavior**: Register `BLUR_COMMAND` with `COMMAND_PRIORITY_HIGH` to reset `query` and close the suggestions menu on editor blur.
>   - **UI Interaction**: Add `onMouseDown={e => e.preventDefault()}` to `Dropdown.Menu` to avoid unintended blur while interacting with the suggestions menu.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28056faae524b0a4bd21663cd87952979c419ebd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->