### PR TITLE
Propagate formatting to TextNode children

### DIFF
--- a/lib/lexical/exts/autolink.js
+++ b/lib/lexical/exts/autolink.js
@@ -20,6 +20,8 @@ function getEmbed (src) {
   return embed ? { ...embed, src: href } : { provider: null }
 }
 
+// note: this doesn't support formatting, e.g. **https://stacker.news**
+// because we're using `MediaNode` as a step for media checks
 export const AutoLinkExtension = defineExtension({
   name: 'AutoLinkExtension',
   register: (editor) => {

--- a/lib/lexical/mdast/import.js
+++ b/lib/lexical/mdast/import.js
@@ -153,6 +153,14 @@ export function importMdastTreeToLexical ({
           lexicalParent.append(lexicalNode)
           // only element nodes can have children
           if (isParent(mdastNode) && $isElementNode(lexicalNode)) {
+            // propagate parent formatting to current node so children can inherit it
+            // this handles cases like **[link](url)**, the formatting is propagated to the TextNode inside the link
+            if (!formattingMap.has(mdastNode)) {
+              const parentFormat = formattingMap.get(mdastParent) ?? 0
+              if (parentFormat) {
+                formattingMap.set(mdastNode, parentFormat)
+              }
+            }
             visitChildren(mdastNode, lexicalNode)
           }
         },


### PR DESCRIPTION
## Description

Context: https://stacker.news/items/1369981
By writing `**[test](test.com)**` , we're applying formatting to the `LinkNode` but not the `TextNode` underneath, because to do that we would write `[**test**](test.com`.

This PR makes it a bit easier to apply formatting by propagating it down to the children TextNode.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No

**Did you use AI for this? If so, how much did it assist you?**
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures markdown formatting applied to a parent node is inherited by its children during mdast→Lexical import.
> 
> - In `mdast/import`, `addAndStepInto` now propagates parent `formattingMap` to the current mdast node so descendants inherit styles, fixing cases like `**[link](url)**` where TextNodes inside links previously lost formatting
> - `exts/autolink` updated with a note-only comment (no functional change)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb0996c8d9e157b98f00315782d04289a8e93b14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->