### PR TITLE
fix: render unrecognized HTML tags as plain text

### DIFF
--- a/lib/lexical/mdast/visitors/formatting.js
+++ b/lib/lexical/mdast/visitors/formatting.js
@@ -71,7 +71,18 @@ export const MdastStrongVisitor = {
   }
 }
 
+// html fallback: plain text
+export const MdastHtmlFallbackVisitor = {
+  testNode: 'html',
+  visitNode ({ mdastNode, lexicalParent, actions }) {
+    const textNode = $createTextNode(mdastNode.value)
+    textNode.setFormat(actions.getParentFormatting())
+    lexicalParent.append(textNode)
+  }
+}
+
 // all formatting visitors combined
+// order matters: specific html tag visitors must come before the fallback
 export const formattingVisitors = [
   MdastEmphasisVisitor,
   MdastStrongVisitor,
@@ -79,5 +90,6 @@ export const formattingVisitors = [
   MdastStrikeThroughVisitor,
   MdastHighlightVisitor,
   ...buildHtmlTagVisitors('sup', IS_SUPERSCRIPT),
-  ...buildHtmlTagVisitors('sub', IS_SUBSCRIPT)
+  ...buildHtmlTagVisitors('sub', IS_SUBSCRIPT),
+  MdastHtmlFallbackVisitor
 ]


### PR DESCRIPTION
## Description

Context https://stacker.news/items/1371376
Adds a fallback visitor for HTML tags that creates a plain `TextNode` instead of going to the *unrecognized markdown construct* route and create a whole paragraph.

## Screenshots

Before:
<img width="167" height="132" alt="image" src="https://github.com/user-attachments/assets/f6224b90-7b77-4f3d-8da5-78a88ff9a184" />

After:
<img width="659" height="111" alt="image" src="https://github.com/user-attachments/assets/89622c92-ff71-480a-a5ce-21abd4df9bf3" />

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
no

**Did you use AI for this? If so, how much did it assist you?**
no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a plain-text fallback for mdast `html` nodes to avoid creating standalone paragraphs for unrecognized tags.
> 
> - Adds `MdastHtmlFallbackVisitor` that appends a `TextNode` with parent formatting for any `html` node
> - Updates `formattingVisitors` order to run specific HTML tag visitors (`sup`, `sub`) before the fallback
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0931ceffea4d97f1c6deaac95a1ff0e484ae1ff7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->