### PR TITLE
Prop key to update value every time button is clicked

### DIFF
--- a/components/item-act.js
+++ b/components/item-act.js
@@ -27,7 +27,7 @@ const Tips = ({ setOValue }) => {
     <Button
       size='sm'
       key={num}
-      onClick={() => { setOValue({ value: num, ts: Date.now() }) }}
+      onClick={() => { setOValue(num) }}
     >
       <UpBolt
         className='me-1'
@@ -125,16 +125,16 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
       onSubmit={onSubmit}
     >
       <Input
-        key={oValue?.ts || 0}
         label='amount'
         name='amount'
         type='number'
         innerRef={inputRef}
-        overrideValue={oValue?.value}
+        overrideValue={oValue}
         step={step}
         required
         autoFocus
         append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
+        onChange={() => setOValue(undefined)}
       />
 
       <div className='d-flex flex-wrap gap-2'>

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -27,7 +27,7 @@ const Tips = ({ setOValue }) => {
     <Button
       size='sm'
       key={num}
-      onClick={() => { setOValue(num) }}
+      onClick={() => { setOValue({ value: num, ts: Date.now() }) }}
     >
       <UpBolt
         className='me-1'
@@ -125,11 +125,12 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
       onSubmit={onSubmit}
     >
       <Input
+        key={oValue?.ts || 0}
         label='amount'
         name='amount'
         type='number'
         innerRef={inputRef}
-        overrideValue={oValue}
+        overrideValue={oValue?.value}
         step={step}
         required
         autoFocus


### PR DESCRIPTION
## Description
closes #2703 

Fixed forcing input remounting via a prop key that is updated every time the suggestion is clicked, so the value is always updated even when selecting the same option.

## Screenshots


https://github.com/user-attachments/assets/53e0b3db-be56-4ce0-8045-ec2e9298c6dc



## Additional Context


## Checklist

**Are your changes backward compatible? Please answer below:**
Yes

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8/10


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes


**Did you introduce any new environment variables? If so, call them out explicitly here:**
NaN


**Did you use AI for this? If so, how much did it assist you?**
AI was not used for fixing this bug
