### PR TITLE
Fix mentions leaking into link nodes

### DIFF
--- a/lib/lexical/mdast/transforms/mentions.js
+++ b/lib/lexical/mdast/transforms/mentions.js
@@ -6,7 +6,7 @@ const subGroup = '[A-Za-z][\\w_]+'
 
 const USER_MENTION_PATTERN = new RegExp('\\B@(' + userGroup + '(?:\\/' + userGroup + ')?)', 'gi')
 const TERRITORY_MENTION_PATTERN = new RegExp('~(' + subGroup + '(?:\\/' + subGroup + ')?)', 'gi')
-const IGNORE_TYPES = ['code', 'inlineCode']
+const IGNORE_TYPES = ['code', 'inlineCode', 'link']
 
 export function mentionTransform (tree) {
   findAndReplace(


### PR DESCRIPTION
## Description

Context: https://stacker.news/items/1374726
When a mention is recognized by its post-processing transformer, it injects the custom mention type in the tree. This will then be picked up by the link MDAST visitors that cannot actually recognize the mention and ignores it.

I don't think we should allow true *decorated* mentions inside links anyway as it would be confusing to the user, so this PR ignores mentions present inside `link` nodes. 

## Screenshots

tbd

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents mention parsing inside links to avoid mentions being injected into `link` nodes.
> 
> - Adds `link` to `IGNORE_TYPES` in `lib/lexical/mdast/transforms/mentions.js` so `findAndReplace` skips mention patterns within links
> - Mention detection for `@user` and `~territory` remains unchanged; behavior in `code`/`inlineCode` still ignored
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 742bf18061230495620342dc520ad47d70476976. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->