### PR TITLE
Fix misleading link check on texts that have something that might resemble a protocol

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -267,7 +267,8 @@ export function isMisleadingLink (text, href) {
 
     try {
       const textUrl = new URL(text)
-      if (textUrl.origin !== hrefUrl.origin) {
+      // if textUrl.origin has value 'null', it means the text is not trying to be a URL
+      if (textUrl.origin !== 'null' && textUrl.origin !== hrefUrl.origin) {
         misleading = true
       }
     } catch {}


### PR DESCRIPTION
## Description

Context: https://stacker.news/items/1374726
Before checking if the `linkText` is misleading, we try to parse the `linkText` as a URL and check if the origin matches the `href` origin. Texts that have something that might resemble a protocol, e.g. `Foo:`, will fail the check even though it's not a real protocol.

This PR fixes this issue by checking if `origin` actually got parsed, if it returns `'null'` then it's not a real protocol and we can move on to the second misleading check (the regex).

## Screenshots

tbd

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, but will QA with more examples

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No, observed that `origin` can be null if the protocol is not `http(s)` or `ftp` and so on.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents false positives in misleading link detection.
> 
> - Updates `isMisleadingLink` to only compare `textUrl.origin` to `hrefUrl.origin` when `textUrl.origin !== 'null'`
> - Ensures texts that resemble protocols but aren't valid URLs (e.g., `Foo:`) aren't flagged as misleading
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4afa64f97002cbbafa82e5942e433744faaa9f8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->