### PR TITLE
briefly revert RichTextExtension

### DIFF
--- a/components/editor/editor.js
+++ b/components/editor/editor.js
@@ -3,7 +3,7 @@ import { useField } from 'formik'
 import { useMemo } from 'react'
 import BootstrapForm from 'react-bootstrap/Form'
 import { configExtension, defineExtension } from 'lexical'
-import { RichTextExtension } from '@lexical/rich-text'
+import { PlainTextExtension } from '@lexical/plain-text'
 import { ReactExtension } from '@lexical/react/ReactExtension'
 import { ContentEditable } from '@lexical/react/LexicalContentEditable'
 import { LexicalExtensionComposer } from '@lexical/react/LexicalExtensionComposer'
@@ -49,7 +49,7 @@ export default function Editor ({ name, appendValue, autoFocus, topLevel, ...pro
       name: 'editor',
       namespace: 'sn',
       dependencies: [
-        RichTextExtension,
+        PlainTextExtension,
         ApplePatchExtension,
         HistoryExtension,
         ShortcutsExtension,


### PR DESCRIPTION
While the switch PR gets completed, we're briefly reverting to `PlainTextExtension`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the Lexical editor to plain text mode.
> 
> - Replaces `RichTextExtension` with `PlainTextExtension` in `components/editor/editor.js`
> - Updates editor dependencies accordingly; no other logic or UI changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37b3692dba5666205d154b67da46378049f87ba6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->