### PR TITLE
relax selection suppression

### DIFF
--- a/components/editor/plugins/patch/softkey-unborker.js
+++ b/components/editor/plugins/patch/softkey-unborker.js
@@ -100,7 +100,9 @@ function applySoftkeyWorkaround (el) {
 
   const filterSelection = (e) => {
     if (!e) return
-    if (isSelectionSuppressed) {
+    const sel = window.getSelection()
+    const isRangeSelection = sel.type === 'Range'
+    if (isSelectionSuppressed && isRangeSelection) {
       // stop the event from propagating further
       try {
         e.stopPropagation()


### PR DESCRIPTION
Fixes https://github.com/stackernews/stacker.news/issues/2721

This should fix the issue by relaxing the selection suppression, so that only the range selection (the one causing the selection bug while editing a word) is handled, while the carret placement is not.