### PR TITLE
unescape markdown characters that got escaped by lexical/markdown

### DIFF
--- a/lib/lexical/utils/index.js
+++ b/lib/lexical/utils/index.js
@@ -14,7 +14,9 @@ function cleanMarkdown (str, trimWhitespace = true) {
 /** gets the markdown string from the editor */
 export function $getMarkdown () {
   const textContent = $convertToMarkdownString(TRANSFORMERS, undefined, true)
-  return cleanMarkdown(textContent)
+  // unescape markdown characters that are escaped by `@lexical/markdown`
+  const unescapedText = textContent.replace(/\\([*_`~\\])/g, '$1')
+  return cleanMarkdown(unescapedText)
 }
 
 export function $isMarkdownEmpty () {


### PR DESCRIPTION
## Description

Context: https://stacker.news/items/1401474/?commentId=1401881
PR #2727 broke markdown processing because we're now using `@lexical/markdown`'s for normalized import/export.
This PR undoes escaping with a specular replace.

## Screenshots

Before: `\*\*test\*\*`
<img width="364" height="206" alt="image" src="https://github.com/user-attachments/assets/ab610a4e-64a5-478a-a80c-6fc52474e3b1" />

After: `**test**`
<img width="396" height="188" alt="image" src="https://github.com/user-attachments/assets/323fc164-a3e6-4363-999f-f13df65cffde" />

## Additional Context

It was probably cheap to use the whole `@lexical/markdown` import/export pipeline when we just needed normalization. I'll do something dedicated.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores expected markdown export by undoing over-escaping from `@lexical/markdown`.
> 
> - Updates `lib/lexical/utils/index.js` to post-process `$convertToMarkdownString` output: unescape `\`-escaped `* _ ` ~ \` via regex before `cleanMarkdown`
> - No other logic changes; read/append/set behavior unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79d628e524e9f9a51f541ace6dc82b8aab923c52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->