### PR TITLE
Adjusting rows and cols in /statistics page for better visibility of graphs

### DIFF
--- a/components/charts-skeletons.js
+++ b/components/charts-skeletons.js
@@ -1,17 +1,17 @@
 export function GrowthPieChartSkeleton ({ height = '250px', minWidth = '200px' }) {
-  return <ChartSkeleton {...{ height, minWidth }} />
+  return <ChartSkeleton {...{ height, width: '100%' }} />
 }
 
 export function WhenComposedChartSkeleton ({ height = '300px', minWidth = '300px' }) {
-  return <ChartSkeleton {...{ height, minWidth }} />
+  return <ChartSkeleton {...{ height, width: '100%' }} />
 }
 
 export function WhenAreaChartSkeleton ({ height = '300px', minWidth = '300px' }) {
-  return <ChartSkeleton {...{ height, minWidth }} />
+  return <ChartSkeleton {...{ height, width: '100%' }} />
 }
 
 export function WhenLineChartSkeleton ({ height = '300px', minWidth = '300px' }) {
-  return <ChartSkeleton {...{ height, minWidth }} />
+  return <ChartSkeleton {...{ height, width: '100%' }} />
 }
 
 function ChartSkeleton (props) {

--- a/pages/satistics/graphs/[when].js
+++ b/pages/satistics/graphs/[when].js
@@ -70,6 +70,8 @@ export default function Growth ({ ssrData }) {
           <div className='text-center text-muted fw-bold'>sats stacked</div>
           <WhenAreaChart data={stackingGrowth} />
         </Col>
+      </Row>
+      <Row>
         <Col className='mt-3'>
           <div className='text-center text-muted fw-bold'>sats spent</div>
           <WhenAreaChart data={spendingGrowth} />
@@ -80,7 +82,6 @@ export default function Growth ({ ssrData }) {
           <div className='text-center text-muted fw-bold'>spend counts</div>
           <WhenLineChart data={itemGrowth} />
         </Col>
-        <Col className='mt-3' />
       </Row>
     </Layout>
   )


### PR DESCRIPTION
## Description

fix #2725 

Changed the layout of the statistics graphs page to display one chart per row instead of two.

## Screenshots

https://github.com/user-attachments/assets/8e359952-879f-403d-8cd5-af4aec05229e


https://github.com/user-attachments/assets/705b3bd5-1b3f-4c23-9778-c6af6ac0cbd2


## Additional Context

The main modification is in the page layout structure, where each chart is now wrapped in its own Row component instead of having two Col components side by side.

Still not sure about how the graphs are shown on mobile 

## Checklist

**Are your changes backward compatible? Please answer below:**
Yes


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8/10

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes


**Did you introduce any new environment variables? If so, call them out explicitly here:**
No


**Did you use AI for this? If so, how much did it assist you?**
Didn't use AI at all
