### PR TITLE
fix: sync Lexical selection with DOM selection on Android

### DIFF
--- a/components/editor/plugins/patch/softkey-unborker.js
+++ b/components/editor/plugins/patch/softkey-unborker.js
@@ -110,6 +110,7 @@ function applySoftkeyWorkaround (el, editor) {
       editor.update(() => {
         const selection = $getSelection()
         if (!$isRangeSelection(selection)) return
+        // lexical will check if the selection is within the editor before applying it
         selection.applyDOMRange(range)
       })
       // stop the event from propagating further


### PR DESCRIPTION
## Description

Context: https://stacker.news/items/1402280/?commentId=1402451
The selection suppression patch is essential to some Android IMEs, but Lexical depends on its own selection for a lot of things.
This PR fixes cut, copy, paste, and everything that uses Lexical selection by syncing Lexical selection with DOM selection the moment we're suppressing the `selectionchange` event on Android.

## Screenshots

tbd

## Additional Context

This fix is only for Android; iOS and Desktop are unaffected.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6, in QA

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
At first to try to make some sense on LexicalClipboard but then the fix was entirely something else, so no, ultimately no AI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix Android selection handling in `softkey-unborker`**
> 
> - During `selectionchange` suppression, mirror DOM range to Lexical by calling `editor.update()` and `selection.applyDOMRange(range)` to keep internal selection in sync
> - Update `applySoftkeyWorkaround` to accept `editor`; pass `editor` from `SoftkeyUnborkerPlugin`
> - Add imports for `$getSelection` and `$isRangeSelection`; logic remains Android-only via `IS_ANDROID`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6604ed33150df6de245156c6bcba5295ce0ac108. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->