### PR TITLE
fix: re-render Lexical on lexical state or markdown text changes

### DIFF
--- a/components/editor/reader.js
+++ b/components/editor/reader.js
@@ -59,7 +59,7 @@ export default function Reader ({ topLevel, state, text, preview, name, readerRe
       $initialEditorState: (editor) => initiateLexical(editor, state, text),
       onError: (error) => console.error('reader has encountered an error:', error)
     // avoid unnecessary re-renders by only depending on stable values
-    }), [topLevel, preview])
+    }), [topLevel, state, text, preview])
 
   return (
     <LexicalExtensionComposer extension={reader} contentEditable={null}>


### PR DESCRIPTION
## Description

Fixes #2730, #2738 
Reader's memo was missing `state` and `text` preventing re-renders when any of these values change.
This PR adds the aforementioned memo dependencies to allow the rare re-renders to happen (like edits).

## Screenshots

## Additional Context

This was a leftover from the early Preview Plugin development, when I switched to `PreviewSyncPlugin` instead of re-rendering the Reader I uselessly hardened the possibility of Lexical re-renders. `state` and `text` are both values that should be final not causing any re-render per sé, we should then see re-renders only from edits or `text` changes.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the Lexical `Reader` re-initializes when its inputs change.
> 
> - Adds `state` and `text` to `useMemo` dependency array in `components/editor/reader.js` so the editor updates on lexical state or markdown changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1da7f7267b9a830565644764f43f4349323077a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->