### PR TITLE
Check and handling of reciver wallet errors

### DIFF
--- a/api/payIn/transitions.js
+++ b/api/payIn/transitions.js
@@ -13,6 +13,13 @@ import { PayInFailureReasonError } from './errors'
 export const PAY_IN_TERMINAL_STATES = ['PAID', 'FAILED']
 export const PAY_IN_PENDING_STATES = Object.values(PayInState).filter(state => !PAY_IN_TERMINAL_STATES.includes(state))
 
+export const RECEIVER_INVOICE_ERRORS = [
+  'INVOICE_CREATION_FAILED',
+  'INVOICE_WRAPPING_FAILED_HIGH_PREDICTED_FEE',
+  'INVOICE_WRAPPING_FAILED_HIGH_PREDICTED_EXPIRY',
+  'INVOICE_WRAPPING_FAILED_UNKNOWN'
+]
+
 const FINALIZE_OPTIONS = { retryLimit: 2 ** 31 - 1, retryBackoff: false, retryDelay: 5, priority: 1000 }
 
 async function transitionPayIn (jobName, data,
@@ -563,7 +570,7 @@ export async function payInCancel ({ data, models, lnd, boss, ...args }) {
 
 export async function payInFailed ({ data, models, lnd, boss, ...args }) {
   const { payInId, payInFailureReason } = data
-  return await transitionPayIn('payInFailed', data, {
+  const transitionedPayIn = await transitionPayIn('payInFailed', data, {
     payInId,
     // any of these states can transition to FAILED
     fromStates: ['PENDING', 'PENDING_HELD', 'HELD', 'FAILED_FORWARD', 'CANCELLED', 'PENDING_INVOICE_CREATION', 'PENDING_INVOICE_WRAP'],
@@ -589,6 +596,26 @@ export async function payInFailed ({ data, models, lnd, boss, ...args }) {
       }
     }
   }, { models, lnd, boss, ...args })
+
+  if (transitionedPayIn?.payOutBolt11 && RECEIVER_INVOICE_ERRORS.includes(transitionedPayIn.payInFailureReason)) {
+    const { userId: receiverId } = transitionedPayIn.payOutBolt11
+    const receiver = await models.user.findUnique({ where: { id: receiverId }, select: { name: true } })
+    const senderProtocol = await models.walletProtocol.findFirst({
+      where: {
+        userId: transitionedPayIn.userId,
+        walletType: 'send',
+        enabled: true
+      },
+      orderBy: { priority: 'desc' }
+    })
+    if (senderProtocol) {
+      const logger = walletLogger({ protocolId: senderProtocol.id, userId: transitionedPayIn.userId, payInId, models })
+      const reasonText = transitionedPayIn.payInFailureReason.replace(/_/g, ' ').toLowerCase()
+      const receiverName = receiver?.name || `id:${receiverId}`
+      logger.error(`payment failed: receiver @${receiverName}'s wallet ${reasonText}`)
+    }
+  }
+  return transitionedPayIn
 }
 
 function deducePayInFailureReason ({ payInFailureReason, payIn, lndPayInBolt11 }) {


### PR DESCRIPTION
## Description

Feat #2468 
When zapping fails due to receiver wallet errors (`INVOICE_CREATION_FAILED` or `INVOICE_WRAPPING_FAILED_*`), the sender now sees a clear error message in their wallet logs.

## Screenshots

N/A

## Additional Context
The implementation follows the existing pattern in payInFailed() by checking for receiver wallet errors after successful state transition.

## Checklist

**Are your changes backward compatible? Please answer below:**
Yes


**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
6/10


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
N/A


**Did you introduce any new environment variables? If so, call them out explicitly here:**
No


**Did you use AI for this? If so, how much did it assist you?**
AI helped me understand how the components that handle payment errors work

