### PR TITLE
Mobile multi select sheet

### DIFF
--- a/components/multi-select.js
+++ b/components/multi-select.js
@@ -1,12 +1,29 @@
-import { useEffect } from 'react'
+import React, { useEffect, useState, useRef } from 'react'
+import { createPortal } from 'react-dom'
 import BootstrapForm from 'react-bootstrap/Form'
 import { useFormikContext, useField } from 'formik'
 import ReactSelect, { components as ReactSelectComponents } from 'react-select'
 import ArrowDownSFill from '@/svgs/arrow-down-s-fill.svg'
 import CloseIcon from '@/svgs/close-line.svg'
+import CheckIcon from '@/svgs/check-line.svg'
 import Info from './info'
 import styles from './multi-select.module.css'
 import classNames from 'classnames'
+
+function useIsMobile () {
+  const [isMobile, setIsMobile] = useState(false)
+
+  useEffect(() => {
+    const mql = window.matchMedia('(max-width: 767px)')
+    setIsMobile(mql.matches)
+
+    const handler = (e) => setIsMobile(e.matches)
+    mql.addEventListener('change', handler)
+    return () => mql.removeEventListener('change', handler)
+  }, [])
+
+  return isMobile
+}
 
 function FormGroup ({ className, label, children }) {
   return (
@@ -48,10 +65,25 @@ const MultiValueRemove = (props) => {
   )
 }
 
+// Custom indicators container to put clear button on the outer right
+const IndicatorsContainer = (props) => {
+  const { children, ...rest } = props
+  // children is an array: [ClearIndicator, IndicatorSeparator, DropdownIndicator]
+  // Reverse to put dropdown first, then clear on the outside
+  const reversed = children ? [...children].reverse() : children
+  return (
+    <ReactSelectComponents.IndicatorsContainer {...rest}>
+      {reversed}
+    </ReactSelectComponents.IndicatorsContainer>
+  )
+}
+
 export function MultiSelect ({ label, items, size = 'lg', info, groupClassName, onChange, noForm, overrideValue, hint, placeholder, onValueClick, ...props }) {
   const [field, meta, helpers] = noForm ? [{}, {}, {}] : useField(props)
   const formik = noForm ? null : useFormikContext()
   const invalid = meta.touched && meta.error
+  const isMobile = useIsMobile()
+  const [sheetOpen, setSheetOpen] = useState(false)
 
   useEffect(() => {
     if (overrideValue) {
@@ -80,6 +112,30 @@ export function MultiSelect ({ label, items, size = 'lg', info, groupClassName, 
   const currentValue = field.value || props.value || []
   const selectValue = flatOptions.filter(option => currentValue.includes(option.value))
 
+  const handleChange = (values) => {
+    helpers?.setValue?.(values)
+    if (onChange) {
+      onChange(formik, values)
+    }
+  }
+
+  const toggleOption = (optionValue) => {
+    const newValues = currentValue.includes(optionValue)
+      ? currentValue.filter(v => v !== optionValue)
+      : [...currentValue, optionValue]
+    handleChange(newValues)
+  }
+
+  const removeValue = (valueToRemove, e) => {
+    e?.stopPropagation?.()
+    handleChange(currentValue.filter(v => v !== valueToRemove))
+  }
+
+  const clearAll = (e) => {
+    e?.stopPropagation?.()
+    handleChange([])
+  }
+
   const MultiValueLabel = (props) => {
     const { data } = props
 
@@ -101,6 +157,83 @@ export function MultiSelect ({ label, items, size = 'lg', info, groupClassName, 
     )
   }
 
+  // Mobile bottom sheet version
+  if (isMobile) {
+    return (
+      <FormGroup label={label} className={groupClassName}>
+        <span className='d-flex align-items-center'>
+          {/* Custom control that mimics react-select appearance */}
+          <div
+            className={classNames(styles.multiSelect, styles[size], invalid && styles.isInvalid, styles.mobileControl)}
+            onClick={() => setSheetOpen(true)}
+          >
+            <div className={styles.mobileValueContainer}>
+              {selectValue.length === 0 && (
+                <span className={styles.mobilePlaceholder}>{placeholder}</span>
+              )}
+              {selectValue.map(opt => (
+                <div key={opt.value} className={styles.mobileMultiValue}>
+                  <span
+                    className={onValueClick ? styles.multiValueLabelClickable : styles.multiValueLabelDefault}
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      if (onValueClick) {
+                        onValueClick(opt.value)
+                      } else {
+                        setSheetOpen(true)
+                      }
+                    }}
+                  >
+                    {opt.label}
+                  </span>
+                  <div
+                    className={styles.mobileMultiValueRemove}
+                    onClick={(e) => removeValue(opt.value, e)}
+                  >
+                    <CloseIcon width={10} height={10} />
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className={styles.mobileIndicators}>
+              <div className={styles.dropdownIndicator}>
+                <ArrowDownSFill width={20} height={20} className='fill-grey' />
+              </div>
+              {currentValue.length > 0 && (
+                <div className={styles.mobileClearIndicator} onClick={clearAll}>
+                  <CloseIcon width={16} height={16} className='fill-grey' />
+                </div>
+              )}
+            </div>
+          </div>
+          {info && <Info>{info}</Info>}
+        </span>
+
+        {/* Bottom Sheet */}
+        <BottomSheet
+          isOpen={sheetOpen}
+          onClose={() => setSheetOpen(false)}
+          options={options}
+          currentValue={currentValue}
+          onToggle={(value) => {
+            toggleOption(value)
+            setSheetOpen(false)
+          }}
+          placeholder={placeholder}
+        />
+
+        <BootstrapForm.Control.Feedback type='invalid' className={meta.touched && meta.error ? 'd-block' : ''}>
+          {meta.touched && meta.error}
+        </BootstrapForm.Control.Feedback>
+        {hint &&
+          <BootstrapForm.Text>
+            {hint}
+          </BootstrapForm.Text>}
+      </FormGroup>
+    )
+  }
+
+  // Desktop react-select version
   return (
     <FormGroup label={label} className={groupClassName}>
       <span className='d-flex align-items-center'>
@@ -117,15 +250,11 @@ export function MultiSelect ({ label, items, size = 'lg', info, groupClassName, 
           isMulti
           size={size}
           options={options}
-          components={{ DropdownIndicator, ClearIndicator, MultiValueRemove, MultiValueLabel }}
+          components={{ DropdownIndicator, ClearIndicator, MultiValueRemove, MultiValueLabel, IndicatorsContainer }}
           onChange={(selectedOptions) => {
             // Extract just the string values for formik
             const values = selectedOptions ? selectedOptions.map(item => item.value) : []
-            helpers?.setValue?.(values)
-
-            if (onChange) {
-              onChange(formik, values)
-            }
+            handleChange(values)
           }}
           unstyled={false}
         />
@@ -139,5 +268,223 @@ export function MultiSelect ({ label, items, size = 'lg', info, groupClassName, 
           {hint}
         </BootstrapForm.Text>}
     </FormGroup>
+  )
+}
+
+function SheetOption ({ option, isSelected, onToggle }) {
+  return (
+    <div
+      className={classNames(styles.sheetOption, isSelected && styles.sheetOptionSelected)}
+      onClick={onToggle}
+    >
+      <span className={styles.sheetOptionLabel}>{option.label}</span>
+      {isSelected && <CheckIcon width={20} height={20} className='fill-grey' />}
+    </div>
+  )
+}
+
+function BottomSheet ({ isOpen, onClose, options, currentValue, onToggle, placeholder }) {
+  const [mounted, setMounted] = useState(false)
+  const [search, setSearch] = useState('')
+  const [dragY, setDragY] = useState(0)
+  const [isDragging, setIsDragging] = useState(false)
+  const [viewportInfo, setViewportInfo] = useState(null)
+  const dragStartY = useRef(0)
+  const sheetRef = useRef(null)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  // Handle keyboard visibility using visualViewport
+  useEffect(() => {
+    if (!isOpen || typeof window === 'undefined') return
+
+    const updateViewport = () => {
+      if (window.visualViewport) {
+        // Calculate how far from the bottom of the window the visual viewport ends
+        const bottomOffset = window.innerHeight - (window.visualViewport.offsetTop + window.visualViewport.height)
+        setViewportInfo({
+          height: window.visualViewport.height,
+          bottomOffset
+        })
+      } else {
+        setViewportInfo({ height: window.innerHeight, bottomOffset: 0 })
+      }
+    }
+
+    updateViewport()
+
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener('resize', updateViewport)
+      window.visualViewport.addEventListener('scroll', updateViewport)
+      return () => {
+        window.visualViewport.removeEventListener('resize', updateViewport)
+        window.visualViewport.removeEventListener('scroll', updateViewport)
+      }
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (isOpen) {
+      // Lock body scroll (works better across Android/iOS)
+      const scrollY = window.scrollY
+      document.body.style.position = 'fixed'
+      document.body.style.top = `-${scrollY}px`
+      document.body.style.left = '0'
+      document.body.style.right = '0'
+      document.body.style.overflow = 'hidden'
+      setSearch('')
+      setDragY(0)
+      setViewportInfo(null)
+    } else {
+      // Restore scroll position
+      const scrollY = document.body.style.top
+      document.body.style.position = ''
+      document.body.style.top = ''
+      document.body.style.left = ''
+      document.body.style.right = ''
+      document.body.style.overflow = ''
+      if (scrollY) {
+        window.scrollTo(0, parseInt(scrollY || '0', 10) * -1)
+      }
+    }
+    return () => {
+      document.body.style.position = ''
+      document.body.style.top = ''
+      document.body.style.left = ''
+      document.body.style.right = ''
+      document.body.style.overflow = ''
+    }
+  }, [isOpen])
+
+  const handleTouchStart = (e) => {
+    dragStartY.current = e.touches[0].clientY
+    setIsDragging(true)
+  }
+
+  const handleTouchMove = (e) => {
+    if (!isDragging) return
+    const currentY = e.touches[0].clientY
+    const diff = currentY - dragStartY.current
+    // Only allow dragging down
+    if (diff > 0) {
+      setDragY(diff)
+    }
+  }
+
+  const handleTouchEnd = () => {
+    setIsDragging(false)
+    // If dragged more than 100px, close the sheet
+    if (dragY > 100) {
+      onClose()
+    }
+    setDragY(0)
+  }
+
+  // Filter options based on search
+  const filterOptions = (opts) => {
+    if (!search) return opts
+    const searchLower = search.toLowerCase()
+    return opts.map(opt => {
+      if (opt.options) {
+        // Grouped options
+        const filteredSubs = opt.options.filter(sub =>
+          sub.label.toLowerCase().includes(searchLower)
+        )
+        if (filteredSubs.length === 0) return null
+        return { ...opt, options: filteredSubs }
+      }
+      // Regular option
+      return opt.label.toLowerCase().includes(searchLower) ? opt : null
+    }).filter(Boolean)
+  }
+
+  const filteredOptions = filterOptions(options)
+
+  if (!mounted) return null
+
+  return createPortal(
+    <div className={classNames(styles.sheetOverlay, isOpen && styles.sheetOpen)}>
+      <div className={styles.sheetBackdrop} onClick={onClose} />
+      <div
+        ref={sheetRef}
+        className={styles.sheetContainer}
+        style={{
+          transform: isOpen ? `translateY(${dragY}px)` : 'translateY(100%)',
+          transition: isDragging ? 'none' : 'transform 0.3s ease',
+          bottom: viewportInfo?.bottomOffset ? `${viewportInfo.bottomOffset}px` : '0',
+          maxHeight: viewportInfo ? `${Math.min(viewportInfo.height * 0.85, viewportInfo.height - 20)}px` : '70vh'
+        }}
+      >
+        <div
+          className={styles.sheetHeader}
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleTouchEnd}
+        >
+          <div className={styles.sheetHandle} />
+        </div>
+        <div className={styles.sheetSearch}>
+          <input
+            type='text'
+            className={styles.sheetSearchInput}
+            placeholder={placeholder || 'Search...'}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onBlur={(e) => {
+              // Close if blur is not to something inside the sheet
+              if (!e.relatedTarget || !sheetRef.current?.contains(e.relatedTarget)) {
+                // Delay to allow click events to fire first (longer for Android)
+                setTimeout(() => onClose(), 150)
+              }
+            }}
+            autoFocus
+          />
+          {search && (
+            <button
+              className={styles.sheetSearchClear}
+              onClick={() => setSearch('')}
+              type='button'
+            >
+              <CloseIcon width={16} height={16} className='fill-grey' />
+            </button>
+          )}
+        </div>
+        <div className={styles.sheetContent}>
+          {filteredOptions.map((opt) => {
+            // Handle grouped options
+            if (opt.options) {
+              return (
+                <div key={opt.label} className={styles.sheetGroup}>
+                  <div className={styles.sheetGroupLabel}>{opt.label}</div>
+                  {opt.options.map(subOpt => (
+                    <SheetOption
+                      key={subOpt.value}
+                      option={subOpt}
+                      isSelected={currentValue.includes(subOpt.value)}
+                      onToggle={() => onToggle(subOpt.value)}
+                    />
+                  ))}
+                </div>
+              )
+            }
+            // Regular option
+            return (
+              <SheetOption
+                key={opt.value}
+                option={opt}
+                isSelected={currentValue.includes(opt.value)}
+                onToggle={() => onToggle(opt.value)}
+              />
+            )
+          })}
+          {filteredOptions.length === 0 && (
+            <div className={styles.sheetNoResults}>No results found</div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
   )
 }

--- a/components/multi-select.module.css
+++ b/components/multi-select.module.css
@@ -82,25 +82,41 @@
 /* Multi value (tags) */
 .multiSelect :global(.ms__multi-value) {
   background-color: var(--theme-clickToContextColor);
-  margin: 0;
-  padding-top: 0;
-  padding-bottom: 0;
+  margin: 2px;
+  padding: 0;
+  align-items: center;
+  border-radius: 2px;
 }
 
 .multiSelect :global(.ms__multi-value__label) {
   color: var(--bs-body-color);
   font-weight: bold;
-  padding: 2px 6px;
+  padding: 6px 10px;
 }
 
 .multiSelect :global(.ms__multi-value__remove) {
-  color: var(--theme-grey);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  margin: 4px;
+  margin-left: 6px;
+  border-left: 1px solid var(--theme-borderColor);
+  opacity: 0.5;
+  cursor: pointer;
+}
+
+.multiSelect :global(.ms__multi-value__remove svg) {
+  width: 10px;
+  height: 10px;
 }
 
 @media (hover: hover) {
   .multiSelect :global(.ms__multi-value__remove:hover) {
-    background-color: var(--theme-clickToContextColor);
+    background-color: transparent;
     color: var(--bs-body-color);
+    opacity: 1;
   }
 }
 
@@ -173,7 +189,9 @@
 }
 
 .clearIndicator {
-  padding: 0 4px;
+  padding: 0 8px;
+  margin-left: 4px;
+  border-left: 1px solid var(--theme-borderColor);
   display: flex;
   align-items: center;
   cursor: pointer;
@@ -182,9 +200,18 @@
 .multiValueRemove {
   display: flex;
   align-items: center;
-  padding: 0 4px;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  margin: 4px;
+  margin-left: 6px;
+  border-left: 1px solid var(--theme-borderColor);
   cursor: pointer;
-  border-radius: 0 2px 2px 0;
+  opacity: 0.5;
+}
+
+.multiValueRemove:hover {
+  opacity: 1;
 }
 
 .multiValueLabelClickable {
@@ -195,7 +222,7 @@
   cursor: default;
 }
 
-/* Mobile touch targets */
+/* Mobile touch targets (for react-select fallback) */
 @media (max-width: 767px) {
   .multiSelect :global(.ms__option) {
     min-height: 44px;
@@ -212,8 +239,10 @@
     padding: 6px 8px;
   }
 
-  .multiValueRemove {
-    padding: 6px 8px;
+  .multiSelect :global(.ms__multi-value__remove) {
+    padding: 4px;
+    width: 20px;
+    height: 20px;
   }
 
   .clearIndicator {
@@ -229,5 +258,247 @@
     min-height: 44px;
     justify-content: center;
   }
+}
+
+/* Mobile control (mimics react-select appearance) */
+.mobileControl {
+  background-color: var(--theme-inputBg);
+  border: 1px solid var(--theme-borderColor);
+  border-radius: .4rem;
+  min-width: 200px;
+  min-height: calc(1.75em + 1rem + 2px);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  width: 100%;
+}
+
+.mobileControl.isInvalid {
+  border-color: #c03221;
+}
+
+.mobileValueContainer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px 1rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.mobilePlaceholder {
+  color: #6c757d;
+  font-size: 1.25rem;
+}
+
+.mobileMultiValue {
+  background-color: var(--theme-clickToContextColor);
+  display: flex;
+  align-items: center;
+  border-radius: 2px;
+  margin-right: 4px;
+  pointer-events: none; /* Let clicks fall through to parent */
+}
+
+.mobileMultiValue > span {
+  color: var(--bs-body-color);
+  font-weight: bold;
+  padding: 6px 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  pointer-events: auto; /* Re-enable clicks on label */
+}
+
+.mobileMultiValueRemove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  margin: 4px;
+  margin-left: 6px;
+  border-left: 1px solid var(--theme-borderColor);
+  cursor: pointer;
+  opacity: 0.5;
+  flex-shrink: 0;
+  pointer-events: auto;
+}
+
+.mobileIndicators {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.mobileClearIndicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 12px;
+  margin-left: 4px;
+  border-left: 1px solid var(--theme-borderColor);
+  min-width: 44px;
+  min-height: 44px;
+  cursor: pointer;
+}
+
+/* Sheet styles */
+.sheetOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.sheetOverlay.sheetOpen {
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.sheetBackdrop {
+  position: absolute;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  touch-action: none; /* Prevent scroll on backdrop tap */
+  -webkit-tap-highlight-color: transparent;
+}
+
+.sheetOpen .sheetBackdrop {
+  opacity: 1;
+}
+
+.sheetContainer {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  max-height: 70vh;
+  background-color: var(--theme-inputBg);
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+  transform: translateY(100%);
+  transition: transform 0.3s ease;
+  display: flex;
+  flex-direction: column;
+}
+
+.sheetOpen .sheetContainer {
+  transform: translateY(0);
+}
+
+.sheetHeader {
+  display: flex;
+  justify-content: center;
+  padding: 12px;
+  flex-shrink: 0;
+  touch-action: none; /* Enable swipe-to-close */
+  cursor: grab;
+}
+
+.sheetHandle {
+  width: 36px;
+  height: 4px;
+  background-color: var(--theme-grey);
+  border-radius: 2px;
+  opacity: 0.5;
+}
+
+.sheetSearch {
+  padding: 0 12px 12px;
+  position: relative;
+  flex-shrink: 0;
+}
+
+.sheetSearchInput {
+  width: 100%;
+  padding: 12px 40px 12px 16px;
+  font-size: 1rem;
+  border: 1px solid var(--theme-borderColor);
+  border-radius: 8px;
+  background-color: var(--theme-inputBg);
+  color: var(--bs-body-color);
+  outline: none;
+}
+
+.sheetSearchInput:focus {
+  border-color: var(--bs-primary);
+  box-shadow: 0 0 0 0.2rem rgb(250 218 94 / 25%);
+}
+
+.sheetSearchInput::placeholder {
+  color: #6c757d;
+}
+
+.sheetSearchClear {
+  position: absolute;
+  right: 20px;
+  top: 0;
+  height: calc(100% - 12px); /* account for container's bottom padding */
+  background: none;
+  border: none;
+  padding: 0 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sheetContent {
+  overflow-y: auto;
+  padding-bottom: env(safe-area-inset-bottom, 20px);
+  flex: 1;
+}
+
+.sheetNoResults {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--theme-grey);
+  font-size: 1rem;
+}
+
+.sheetGroup {
+  margin-bottom: 8px;
+}
+
+.sheetGroupLabel {
+  padding: 12px 16px 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--theme-grey);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.sheetOption {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  min-height: 52px;
+  cursor: pointer;
+  color: var(--bs-body-color);
+  font-size: 1.1rem;
+  border-bottom: 1px solid var(--theme-borderColor);
+}
+
+.sheetOption:active {
+  background-color: var(--theme-clickToContextColor);
+}
+
+.sheetOptionSelected {
+  background-color: var(--theme-clickToContextColor);
+}
+
+.sheetOptionLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  margin-right: 12px;
 }
 


### PR DESCRIPTION
This is an attempt at creating a better multi-select UI for mobile. It's a full width scrollable modal "sheet" that comes up from the bottom when the select is clicked. You can drag it down, click off, hit 'done' on the keyboard, or make a selection to close it.

<img width="295" height="639" alt="Simulator Screenshot - iPhone 15 Pro - 2026-01-10 at 23 34 27" src="https://github.com/user-attachments/assets/e0ab0710-f994-4da9-8802-a1482c0ba372" />
<img width="295" height="639" alt="Simulator Screenshot - iPhone 15 Pro - 2026-01-10 at 23 34 46" src="https://github.com/user-attachments/assets/af99ebb5-ad3b-4df0-a5e0-130eff609f6d" />

It works prrrretty great. It's entirely vibed though and I haven't reviewed it much.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a mobile-first multi-select experience and refines desktop behavior.
> 
> - Adds `useIsMobile` and a mobile bottom-sheet for `MultiSelect` with searchable options, selection toggling, drag-to-close, backdrop click, keyboard-aware layout, and body scroll locking
> - Centralizes value updates via `handleChange`, plus helpers (`toggleOption`, `removeValue`, `clearAll`); preserves `onChange(formik, values)` behavior
> - Desktop: sets `maxMenuHeight`/`menuPlacement`, reverses indicators via custom `IndicatorsContainer`, and keeps custom label/remove components
> - CSS overhaul in `multi-select.module.css`: mobile control/overlay/sheet styles, touch target sizing, indicator/tag layout updates, hover-safe media queries, and menu/option truncation improvements
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b9f2d54b233ff74f64ae89163b263bff7341ed9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->