### PR TITLE
add sox to contributors

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -16,3 +16,4 @@ SimpleStacker
 klk
 brymut
 abhishandy
+sox


### PR DESCRIPTION
I forgot to add myself to the contributors list. Should've done this 1 year and 2 months ago lol

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the contributors list.
> 
> - Adds `sox` to `contributors.txt`
> - Fixes `abhishandy` entry formatting (removes stray dash, ensures proper newline)
>   - sox: whatever this means
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aeeaa174ceebf2f91ed923c362a5b0b33040af84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->