### PR TITLE
Show muted and subscriptions

### DIFF
--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -904,6 +904,24 @@ export default {
     },
     showSubscribedUsers: user => user.showSubscribedUsers ?? false,
     showMutedUsers: user => user.showMutedUsers ?? false,
+    nsubscribed: async (user, args, { models }) => {
+      if (typeof user.nsubscribed !== 'undefined') return user.nsubscribed
+      return await models.userSubscription.count({
+        where: {
+          followerId: user.id,
+          OR: [
+            { postsSubscribedAt: { not: null } },
+            { commentsSubscribedAt: { not: null } }
+          ]
+        }
+      })
+    },
+    nmuted: async (user, args, { models }) => {
+      if (typeof user.nmuted !== 'undefined') return user.nmuted
+      return await models.mute.count({
+        where: { muterId: user.id }
+      })
+    },
     since: async (user, args, { models }) => {
       // get the user's first item
       const item = await models.item.findFirst({

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -79,6 +79,8 @@ export default gql`
     meSubscriptionComments: Boolean!
     showSubscribedUsers: Boolean!
     showMutedUsers: Boolean!
+    nsubscribed: Int!
+    nmuted: Int!
   }
 
   input SettingsInput {

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -14,6 +14,8 @@ export default gql`
     hasNewNotes: Boolean!
     mySubscribedUsers(cursor: String): Users!
     myMutedUsers(cursor: String): Users!
+    userMutedUsers(name: String!, cursor: String): Users
+    userSubscribedUsers(name: String!, cursor: String): Users
   }
 
   type UsersNullable {
@@ -75,6 +77,8 @@ export default gql`
     meMute: Boolean!
     meSubscriptionPosts: Boolean!
     meSubscriptionComments: Boolean!
+    showSubscribedUsers: Boolean!
+    showMutedUsers: Boolean!
   }
 
   input SettingsInput {
@@ -91,6 +95,8 @@ export default gql`
     hideInvoiceDesc: Boolean!
     imgproxyOnly: Boolean!
     showImagesAndVideos: Boolean!
+    showMutedUsers: Boolean!
+    showSubscribedUsers: Boolean!
     nostrCrossposting: Boolean!
     nostrPubkey: String
     nostrRelays: [String!]

--- a/components/user-header.js
+++ b/components/user-header.js
@@ -36,10 +36,24 @@ const MEDIA_URL = process.env.NEXT_PUBLIC_MEDIA_URL || `https://${process.env.NE
 
 export default function UserHeader ({ user }) {
   const router = useRouter()
+  const { me } = useMe()
 
   const pathParts = router.asPath.split('/')
-  const activeKey = pathParts[2] === 'territories' ? 'territories' : pathParts.length === 2 ? 'bio' : 'items'
+  let activeKey = 'bio'
+  if (pathParts[2] === 'territories') {
+    activeKey = 'territories'
+  } else if (pathParts[2] === 'subscribed') {
+    activeKey = 'subscribed'
+  } else if (pathParts[2] === 'muted') {
+    activeKey = 'muted'
+  } else if (pathParts.length > 2) {
+    activeKey = 'items'
+  }
+
+  const isMe = me?.name === user.name
   const showTerritoriesTab = activeKey === 'territories' || user.nterritories > 0
+  const showSubscribedTab = isMe || user.showSubscribedUsers === true
+  const showMutedTab = isMe || user.showMutedUsers === true
 
   return (
     <>
@@ -74,6 +88,20 @@ export default function UserHeader ({ user }) {
                   unitPlural: 'territories'
                 })}
               </Nav.Link>
+            </Link>
+          </Nav.Item>
+        )}
+        {showSubscribedTab && (
+          <Nav.Item>
+            <Link href={'/' + user.name + '/subscribed'} passHref legacyBehavior>
+              <Nav.Link eventKey='subscribed'>subscribed</Nav.Link>
+            </Link>
+          </Nav.Item>
+        )}
+        {showMutedTab && (
+          <Nav.Item>
+            <Link href={'/' + user.name + '/muted'} passHref legacyBehavior>
+              <Nav.Link eventKey='muted'>muted</Nav.Link>
             </Link>
           </Nav.Item>
         )}

--- a/components/user-header.js
+++ b/components/user-header.js
@@ -52,6 +52,7 @@ export default function UserHeader ({ user }) {
 
   const isMe = me?.name === user.name
   const showTerritoriesTab = activeKey === 'territories' || user.nterritories > 0
+  // Show subscribed/muted tabs only if: viewing own profile OR list is public
   const showSubscribedTab = isMe || user.showSubscribedUsers === true
   const showMutedTab = isMe || user.showMutedUsers === true
 
@@ -94,14 +95,26 @@ export default function UserHeader ({ user }) {
         {showSubscribedTab && (
           <Nav.Item>
             <Link href={'/' + user.name + '/subscribed'} passHref legacyBehavior>
-              <Nav.Link eventKey='subscribed'>subscribed</Nav.Link>
+              <Nav.Link eventKey='subscribed'>
+                {numWithUnits(user.nsubscribed, {
+                  abbreviate: false,
+                  unitSingular: 'subscription',
+                  unitPlural: 'subscriptions'
+                })}
+              </Nav.Link>
             </Link>
           </Nav.Item>
         )}
         {showMutedTab && (
           <Nav.Item>
             <Link href={'/' + user.name + '/muted'} passHref legacyBehavior>
-              <Nav.Link eventKey='muted'>muted</Nav.Link>
+              <Nav.Link eventKey='muted'>
+                {numWithUnits(user.nmuted, {
+                  abbreviate: false,
+                  unitSingular: 'muted',
+                  unitPlural: 'muted'
+                })}
+              </Nav.Link>
             </Link>
           </Nav.Item>
         )}

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -58,6 +58,8 @@ ${STREAK_FIELDS}
 
 export const SETTINGS_FIELDS = gql`
   fragment SettingsFields on User {
+    showSubscribedUsers
+    showMutedUsers
     privates {
       tipDefault
       tipRandom
@@ -170,6 +172,8 @@ export const USER_FIELDS = gql`
     meSubscriptionPosts
     meSubscriptionComments
     meMute
+    showSubscribedUsers
+    showMutedUsers
 
     optional {
       stacked
@@ -339,6 +343,50 @@ export const MY_SUBSCRIBED_SUBS = gql`
           spent(when: "forever")
           revenue(when: "forever")
         }
+      }
+      cursor
+    }
+  }
+`
+
+export const USER_SUBSCRIBED_USERS = gql`
+  ${USER_FIELDS}
+  ${STREAK_FIELDS}
+  query UserSubscribedUsers($name: String!, $cursor: String) {
+    user(name: $name) {
+      ...UserFields
+    }
+    userSubscribedUsers(name: $name, cursor: $cursor) {
+      users {
+        id
+        name
+        photoId
+        meSubscriptionPosts
+        meSubscriptionComments
+        meMute
+        ...StreakFields
+      }
+      cursor
+    }
+  }
+`
+
+export const USER_MUTED_USERS = gql`
+  ${USER_FIELDS}
+  ${STREAK_FIELDS}
+  query UserMutedUsers($name: String!, $cursor: String) {
+    user(name: $name) {
+      ...UserFields
+    }
+    userMutedUsers(name: $name, cursor: $cursor) {
+      users {
+        id
+        name
+        photoId
+        meSubscriptionPosts
+        meSubscriptionComments
+        meMute
+        ...StreakFields
       }
       cursor
     }

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -174,6 +174,8 @@ export const USER_FIELDS = gql`
     meMute
     showSubscribedUsers
     showMutedUsers
+    nsubscribed
+    nmuted
 
     optional {
       stacked

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -402,7 +402,9 @@ export const settingsSchema = object().shape({
   hideTwitter: boolean(),
   noReferralLinks: boolean(),
   satsFilter: intValidator.required('required').min(0, 'must be at least 0').max(1000, 'must be at most 1000'),
-  zapUndos: intValidator.nullable().min(0, 'must be greater or equal to 0')
+  zapUndos: intValidator.nullable().min(0, 'must be greater or equal to 0'),
+  showMutedUsers: boolean(),
+  showSubscribedUsers: boolean()
   // exclude from cyclic analysis. see https://github.com/jquense/yup/issues/720
 }, [['tipRandomMax', 'tipRandomMin']])
 

--- a/pages/[name]/muted.js
+++ b/pages/[name]/muted.js
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { getGetServerSideProps } from '@/api/ssrApollo'
 import { useRouter } from 'next/router'
 import { USER_MUTED_USERS } from '@/fragments/users'
@@ -6,6 +7,7 @@ import PageLoading from '@/components/page-loading'
 import { UserLayout } from '.'
 import UserList from '@/components/user-list'
 import { useMe } from '@/components/me'
+import { MuteUserContextProvider } from '@/components/mute'
 
 export const getServerSideProps = getGetServerSideProps({ query: USER_MUTED_USERS })
 
@@ -14,6 +16,7 @@ export default function UserMuted ({ ssrData }) {
   const variables = { ...router.query }
   const { me } = useMe()
   const { data } = useQuery(USER_MUTED_USERS, { variables })
+  const muteContextValue = useMemo(() => ({ refetchQueries: ['UserMutedUsers'] }), [])
   if (!data && !ssrData) return <PageLoading />
   const { user } = data || ssrData
   const mutedData = data?.userMutedUsers || ssrData?.userMutedUsers
@@ -30,15 +33,17 @@ export default function UserMuted ({ ssrData }) {
             </div>
             )
           : (
-            <UserList
-              ssrData={ssrData}
-              query={USER_MUTED_USERS}
-              variables={variables}
-              destructureData={data => data.userMutedUsers || { users: [], cursor: null }}
-              rank
-              nymActionDropdown
-              statCompsProp={[]}
-            />
+            <MuteUserContextProvider value={muteContextValue}>
+              <UserList
+                ssrData={ssrData}
+                query={USER_MUTED_USERS}
+                variables={variables}
+                destructureData={data => data.userMutedUsers || { users: [], cursor: null }}
+                rank
+                nymActionDropdown
+                statCompsProp={[]}
+              />
+            </MuteUserContextProvider>
             )}
       </div>
     </UserLayout>

--- a/pages/[name]/muted.js
+++ b/pages/[name]/muted.js
@@ -1,0 +1,46 @@
+import { getGetServerSideProps } from '@/api/ssrApollo'
+import { useRouter } from 'next/router'
+import { USER_MUTED_USERS } from '@/fragments/users'
+import { useQuery } from '@apollo/client'
+import PageLoading from '@/components/page-loading'
+import { UserLayout } from '.'
+import UserList from '@/components/user-list'
+import { useMe } from '@/components/me'
+
+export const getServerSideProps = getGetServerSideProps({ query: USER_MUTED_USERS })
+
+export default function UserMuted ({ ssrData }) {
+  const router = useRouter()
+  const variables = { ...router.query }
+  const { me } = useMe()
+  const { data } = useQuery(USER_MUTED_USERS, { variables })
+  if (!data && !ssrData) return <PageLoading />
+  const { user } = data || ssrData
+  const mutedData = data?.userMutedUsers || ssrData?.userMutedUsers
+  const isPrivate = mutedData === null
+  const isMe = me?.name === user.name
+  return (
+    <UserLayout user={user}>
+      <div className='mt-2'>
+        {isPrivate && !isMe
+          ? (
+            <div className='text-center text-muted mt-5'>
+              <h4>Private List</h4>
+              <p>@{user.name} has chosen to keep their muted stackers private.</p>
+            </div>
+            )
+          : (
+            <UserList
+              ssrData={ssrData}
+              query={USER_MUTED_USERS}
+              variables={variables}
+              destructureData={data => data.userMutedUsers || { users: [], cursor: null }}
+              rank
+              nymActionDropdown
+              statCompsProp={[]}
+            />
+            )}
+      </div>
+    </UserLayout>
+  )
+}

--- a/pages/[name]/subscribed.js
+++ b/pages/[name]/subscribed.js
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { getGetServerSideProps } from '@/api/ssrApollo'
 import { useRouter } from 'next/router'
 import { USER_SUBSCRIBED_USERS } from '@/fragments/users'
@@ -6,6 +7,7 @@ import PageLoading from '@/components/page-loading'
 import { UserLayout } from '.'
 import UserList from '@/components/user-list'
 import { useMe } from '@/components/me'
+import { SubscribeUserContextProvider } from '@/components/subscribeUser'
 
 export const getServerSideProps = getGetServerSideProps({ query: USER_SUBSCRIBED_USERS })
 
@@ -14,6 +16,7 @@ export default function UserSubscribed ({ ssrData }) {
   const variables = { ...router.query }
   const { me } = useMe()
   const { data } = useQuery(USER_SUBSCRIBED_USERS, { variables })
+  const subscribeContextValue = useMemo(() => ({ refetchQueries: ['UserSubscribedUsers'] }), [])
   if (!data && !ssrData) return <PageLoading />
   const { user } = data || ssrData
   const subscribedData = data?.userSubscribedUsers || ssrData?.userSubscribedUsers
@@ -30,15 +33,17 @@ export default function UserSubscribed ({ ssrData }) {
             </div>
             )
           : (
-            <UserList
-              ssrData={ssrData}
-              query={USER_SUBSCRIBED_USERS}
-              variables={variables}
-              destructureData={data => data.userSubscribedUsers || { users: [], cursor: null }}
-              rank
-              nymActionDropdown
-              statCompsProp={[]}
-            />
+            <SubscribeUserContextProvider value={subscribeContextValue}>
+              <UserList
+                ssrData={ssrData}
+                query={USER_SUBSCRIBED_USERS}
+                variables={variables}
+                destructureData={data => data.userSubscribedUsers || { users: [], cursor: null }}
+                rank
+                nymActionDropdown
+                statCompsProp={[]}
+              />
+            </SubscribeUserContextProvider>
             )}
       </div>
     </UserLayout>

--- a/pages/[name]/subscribed.js
+++ b/pages/[name]/subscribed.js
@@ -1,0 +1,46 @@
+import { getGetServerSideProps } from '@/api/ssrApollo'
+import { useRouter } from 'next/router'
+import { USER_SUBSCRIBED_USERS } from '@/fragments/users'
+import { useQuery } from '@apollo/client'
+import PageLoading from '@/components/page-loading'
+import { UserLayout } from '.'
+import UserList from '@/components/user-list'
+import { useMe } from '@/components/me'
+
+export const getServerSideProps = getGetServerSideProps({ query: USER_SUBSCRIBED_USERS })
+
+export default function UserSubscribed ({ ssrData }) {
+  const router = useRouter()
+  const variables = { ...router.query }
+  const { me } = useMe()
+  const { data } = useQuery(USER_SUBSCRIBED_USERS, { variables })
+  if (!data && !ssrData) return <PageLoading />
+  const { user } = data || ssrData
+  const subscribedData = data?.userSubscribedUsers || ssrData?.userSubscribedUsers
+  const isPrivate = subscribedData === null
+  const isMe = me?.name === user.name
+  return (
+    <UserLayout user={user}>
+      <div className='mt-2'>
+        {isPrivate && !isMe
+          ? (
+            <div className='text-center text-muted mt-5'>
+              <h4>Private List</h4>
+              <p>@{user.name} has chosen to keep their subscribed stackers private.</p>
+            </div>
+            )
+          : (
+            <UserList
+              ssrData={ssrData}
+              query={USER_SUBSCRIBED_USERS}
+              variables={variables}
+              destructureData={data => data.userSubscribedUsers || { users: [], cursor: null }}
+              rank
+              nymActionDropdown
+              statCompsProp={[]}
+            />
+            )}
+      </div>
+    </UserLayout>
+  )
+}

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -98,7 +98,9 @@ export default function Settings ({ ssrData }) {
   })
 
   const { data } = useQuery(SETTINGS)
-  const { settings: { privates: settings } } = useMemo(() => data ?? ssrData, [data, ssrData])
+  const settingsData = useMemo(() => data ?? ssrData, [data, ssrData])
+  const settings = settingsData?.settings?.privates
+  const user = settingsData?.settings
 
   // if we switched to anon, me is null before the page is reloaded
   if ((!data && !ssrData) || !me) return <PageLoading />
@@ -136,6 +138,8 @@ export default function Settings ({ ssrData }) {
             hideGithub: settings?.hideGithub,
             hideNostr: settings?.hideNostr,
             hideTwitter: settings?.hideTwitter,
+            showSubscribedUsers: user?.showSubscribedUsers,
+            showMutedUsers: user?.showMutedUsers,
             imgproxyOnly: settings?.imgproxyOnly,
             showImagesAndVideos: settings?.showImagesAndVideos,
             wildWestMode: settings?.wildWestMode,
@@ -401,6 +405,36 @@ export default function Settings ({ ssrData }) {
               </div>
             }
             name='hideTwitter'
+            groupClassName='mb-0'
+          />
+          <Checkbox
+            label={
+              <div className='d-flex align-items-center'>show my subscribed stackers on my profile
+                <Info>
+                  <ul>
+                    <li>Your subscribed stackers list is private by default</li>
+                    <li>Check this to make it visible on your public profile</li>
+                    <li>Others will be able to see who you are subscribed to</li>
+                  </ul>
+                </Info>
+              </div>
+            }
+            name='showSubscribedUsers'
+            groupClassName='mb-0'
+          />
+          <Checkbox
+            label={
+              <div className='d-flex align-items-center'>show my muted stackers on my profile
+                <Info>
+                  <ul>
+                    <li>Your muted stackers list is private by default</li>
+                    <li>Check this to make it visible on your public profile</li>
+                    <li>Others will be able to see who you have muted</li>
+                  </ul>
+                </Info>
+              </div>
+            }
+            name='showMutedUsers'
             groupClassName='mb-0'
           />
           <Checkbox

--- a/prisma/migrations/20260116175457_add_show_list_flag/migration.sql
+++ b/prisma/migrations/20260116175457_add_show_list_flag/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "showMutedUsers" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "showSubscribedUsers" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -110,6 +110,8 @@ model User {
   muteds                    Mute[]                 @relation("muted")
   Sub                       Sub[]
   MuteSub                   MuteSub[]
+  showMutedUsers            Boolean                @default(false)
+  showSubscribedUsers       Boolean                @default(false)
   wallets                   Wallet[]
   TerritoryTransfers        TerritoryTransfer[]    @relation("TerritoryTransfer_oldUser")
   TerritoryReceives         TerritoryTransfer[]    @relation("TerritoryTransfer_newUser")


### PR DESCRIPTION
## Description
feat #2645 
Added two new boolean fields `showMutedUsers` and `showSubscribedUsers` to user model default: false.
Enabling via setting checkboxes let users make their list public on their profile at `/[name]/muted` and `/[name]/subscribed`. 
Added `nsubscribed` and `nmuted` count fields displayed in profile tabs. Lists auto-refresh via context providers.
GraphQL return null for private lists, showing "Private List" message to other users

## Screenshots

<img width="525" height="106" alt="Schermata del 2026-01-17 18-19-09" src="https://github.com/user-attachments/assets/3b3f078d-5361-45bf-8d1c-b80404373e1b" />
<img width="935" height="412" alt="Schermata del 2026-01-17 18-19-34" src="https://github.com/user-attachments/assets/4c9d29a1-02f4-4949-91ca-31ade4bf8993" />

## Additional Context

The new fields are on the `User` typer rather than `UserPrivates` to be seen by other users.

## Checklist

**Are your changes backward compatible? Please answer below:**
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8/10


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No

**Did you use AI for this? If so, how much did it assist you?**
AI helped me in checking components and keeping changes consistent with the codebase
