### PR TITLE
fix: don't render the media loading placeholder during html ssr

### DIFF
--- a/lib/lexical/nodes/content/media.jsx
+++ b/lib/lexical/nodes/content/media.jsx
@@ -172,7 +172,7 @@ export class MediaNode extends DecoratorNode {
     width && span.style.setProperty('--width', width)
     height && span.style.setProperty('--height', height)
 
-    const loading = document.createElement('div')
+    const loading = document.createElement('span')
     loading.className = 'sn-media__loading'
     span.appendChild(loading)
 


### PR DESCRIPTION
## Description

Made a mistake by inserting a div inside of a span, which is not permitted. This caused a *collapsed* media loading placeholder rendered outside of the `sn-media` container (see screenshot).

This PR renders a span instead.

## Screenshots

The bar in `commentBg` is the media loading placeholder mistakenly rendered outside of `sn-media`

<img width="891" height="297" alt="image" src="https://github.com/user-attachments/assets/7be982f4-fd71-48b8-9b21-9c118263ac9e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes invalid HTML in media SSR/export.
> 
> - In `MediaNode.exportDOM`, replace `document.createElement('div')` with `document.createElement('span')` for the `sn-media__loading` placeholder to avoid inserting a `div` inside a `span` and ensure correct SSR rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03411561c52837164d03b8ae480f9cee8523e1c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->