### PR TITLE
Apply Lexical formatting to item mentions

### DIFF
--- a/lib/lexical/mdast/visitors/mentions.js
+++ b/lib/lexical/mdast/visitors/mentions.js
@@ -5,6 +5,7 @@ import {
 } from '@/lib/lexical/nodes/decorative/mentions'
 import { parseInternalLinks } from '@/lib/url'
 import { $createItemMentionNode, isCustomText } from '@/lib/lexical/nodes/decorative/mentions/item'
+import { IS_BOLD, IS_ITALIC, IS_STRIKETHROUGH } from '@/lib/lexical/mdast/format-constants'
 
 // user mentions (@user, @user/path)
 // uses transforms to parse mentions
@@ -67,19 +68,34 @@ export const LexicalTerritoryMentionVisitor = {
 }
 
 // extract text by traversing the mdast node children
-function extractText (children) {
-  if (!children || children.length === 0) return ''
+function extractText (children, format = 0) {
+  if (!children || children.length === 0) return { text: '', format }
 
-  return children.map(child => {
+  let text = ''
+
+  for (const child of children) {
     if (child.type === 'text') {
-      return child.value
+      text += child.value
+    } else if (child.type === 'emphasis') {
+      const result = extractText(child.children, format | IS_ITALIC)
+      text += result.text
+      format |= result.format
+    } else if (child.type === 'strong') {
+      const result = extractText(child.children, format | IS_BOLD)
+      text += result.text
+      format |= result.format
+    } else if (child.type === 'delete') {
+      const result = extractText(child.children, format | IS_STRIKETHROUGH)
+      text += result.text
+      format |= result.format
+    } else if (child.children) {
+      const result = extractText(child.children, format)
+      text += result.text
+      format |= result.format
     }
+  }
 
-    if (child.children) {
-      return extractText(child.children)
-    }
-    return ''
-  }).join('')
+  return { text, format }
 }
 
 export const MdastItemMentionLinkVisitor = {
@@ -89,11 +105,12 @@ export const MdastItemMentionLinkVisitor = {
     try {
       const { itemId, commentId, linkText } = parseInternalLinks(mdastNode.url)
       if (itemId || commentId) {
-        const text = extractText(mdastNode.children) || linkText
+        const { text, format } = extractText(mdastNode.children)
         const mentionNode = $createItemMentionNode({
           id: commentId || itemId,
-          text,
-          url: mdastNode.url
+          text: text || linkText,
+          url: mdastNode.url,
+          format
         })
         actions.addAndStepInto(mentionNode)
         return
@@ -111,14 +128,25 @@ export const LexicalItemMentionVisitor = {
     const url = lexicalNode.getURL()
     const text = lexicalNode.getText()
     const id = lexicalNode.getItemMentionId()
+    const format = lexicalNode.getFormat()
 
     // check if custom text
     if (isCustomText(text, id)) {
+      let textNode = { type: 'text', value: text }
+      if (format & IS_STRIKETHROUGH) {
+        textNode = { type: 'delete', children: [textNode] }
+      }
+      if (format & IS_ITALIC) {
+        textNode = { type: 'emphasis', children: [textNode] }
+      }
+      if (format & IS_BOLD) {
+        textNode = { type: 'strong', children: [textNode] }
+      }
       // export as a LinkNode
       actions.appendToParent(mdastParent, {
         type: 'link',
         url,
-        children: [{ type: 'text', value: text }]
+        children: [textNode]
       })
     } else {
       // export as text node

--- a/lib/lexical/nodes/decorative/mentions/item.jsx
+++ b/lib/lexical/nodes/decorative/mentions/item.jsx
@@ -1,12 +1,14 @@
 import { DecoratorNode, $applyNodeReplacement } from 'lexical'
+import { getStyleFromLexicalFormat } from '@/lib/lexical/nodes/utils'
 
 function $convertItemMentionElement (domNode) {
   const id = domNode.getAttribute('data-lexical-item-mention-id')
   const text = domNode.querySelector('a')?.textContent
   const url = domNode.querySelector('a')?.getAttribute('href')
+  const format = domNode.getAttribute('data-lexical-item-mention-format')
 
   if (id) {
-    const node = $createItemMentionNode({ id, text, url })
+    const node = $createItemMentionNode({ id, text, url, format })
     return { node }
   }
 
@@ -21,9 +23,14 @@ export class ItemMentionNode extends DecoratorNode {
   __itemMentionId
   __text
   __url
+  __format
 
   static getType () {
     return 'item-mention'
+  }
+
+  getFormat () {
+    return this.__format
   }
 
   getItemMentionId () {
@@ -39,18 +46,19 @@ export class ItemMentionNode extends DecoratorNode {
   }
 
   static clone (node) {
-    return new ItemMentionNode(node.__itemMentionId, node.__text, node.__url, node.__key)
+    return new ItemMentionNode(node.__itemMentionId, node.__text, node.__url, node.__format, node.__key)
   }
 
   static importJSON (serializedNode) {
-    return $createItemMentionNode({ id: serializedNode.itemMentionId, text: serializedNode.text, url: serializedNode.url })
+    return $createItemMentionNode({ id: serializedNode.itemMentionId, text: serializedNode.text, url: serializedNode.url, format: serializedNode.format })
   }
 
-  constructor (itemMentionId, text, url, key) {
+  constructor (itemMentionId, text, url, format, key) {
     super(key)
     this.__itemMentionId = itemMentionId
     this.__text = text || `#${itemMentionId}`
     this.__url = url
+    this.__format = format
   }
 
   exportJSON () {
@@ -59,7 +67,8 @@ export class ItemMentionNode extends DecoratorNode {
       version: 1,
       itemMentionId: this.__itemMentionId,
       text: this.__text,
-      url: this.__url
+      url: this.__url,
+      format: this.__format
     }
   }
 
@@ -72,6 +81,7 @@ export class ItemMentionNode extends DecoratorNode {
     }
     domNode.setAttribute('data-lexical-item-mention', true)
     domNode.setAttribute('data-lexical-item-mention-id', this.__itemMentionId)
+    domNode.setAttribute('data-lexical-item-mention-format', this.__format)
     return domNode
   }
 
@@ -88,6 +98,7 @@ export class ItemMentionNode extends DecoratorNode {
     const a = document.createElement('a')
     a.setAttribute('href', this.__url)
     a.textContent = this.__text || `#${this.__itemMentionId}`
+    wrapper.setAttribute('data-lexical-item-mention-format', this.__format)
     wrapper.appendChild(a)
     return { element: wrapper }
   }
@@ -119,16 +130,18 @@ export class ItemMentionNode extends DecoratorNode {
     const id = this.__itemMentionId
     const href = this.__url
     const text = this.__text || `#${this.__itemMentionId}`
+    const style = getStyleFromLexicalFormat(this.__format)
+
     return (
       <ItemPopover id={id}>
-        <Link href={href}>{text}</Link>
+        <Link href={href} style={style}>{text}</Link>
       </ItemPopover>
     )
   }
 }
 
-export function $createItemMentionNode ({ id, text, url }) {
-  return $applyNodeReplacement(new ItemMentionNode(id, text, url))
+export function $createItemMentionNode ({ id, text, url, format }) {
+  return $applyNodeReplacement(new ItemMentionNode(id, text, url, format))
 }
 
 export function $isItemMentionNode (node) {

--- a/lib/lexical/nodes/utils.js
+++ b/lib/lexical/nodes/utils.js
@@ -1,0 +1,15 @@
+import { IS_BOLD, IS_ITALIC, IS_STRIKETHROUGH } from '../mdast/format-constants'
+
+export function getStyleFromLexicalFormat (format) {
+  const style = {}
+  if (format & IS_BOLD) {
+    style.fontWeight = 'bold'
+  }
+  if (format & IS_ITALIC) {
+    style.fontStyle = 'italic'
+  }
+  if (format & IS_STRIKETHROUGH) {
+    style.textDecoration = 'line-through'
+  }
+  return style
+}


### PR DESCRIPTION
status: proof of concept, can be improved.

## Description

Fixes #2767
A `DecoratorNode` doesn’t support Lexical formatting because it’s only a React component wrapper. However, we can still apply the formatting found by our MDAST pipeline to decorator nodes and use it within the React component.

This PR does exactly that with `ItemMentionNode`.

## Screenshots

https://github.com/user-attachments/assets/63518fb1-5b19-4623-be3d-56fc99f8efda

## Additional Context

As far as I can remember, we don't have any other decorator node that **_should_** accept formatting.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
5

**Did you use AI for this? If so, how much did it assist you?**

No