### PR TITLE
add custom user agent header for lnaddr reqs

### DIFF
--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -11,9 +11,20 @@ export class FetchTimeoutError extends TimeoutError {
 }
 
 export async function fetchWithTimeout (resource, { signal, timeout = 1000, ...options } = {}) {
+  const isServer = typeof window === 'undefined'
+  const isProd = process.env.NODE_ENV === 'production'
+  const commitHash = isProd ? process.env.NEXT_PUBLIC_COMMIT_HASH : 'dev'
+
+  const headers = new Headers(options.headers || undefined)
+
+  if (isServer && !headers.has('user-agent')) {
+    headers.set('user-agent', `StackerNews/${commitHash} (+https://stacker.news; ops@stacker.news)`)
+  }
+
   try {
     return await fetch(resource, {
       ...options,
+      headers,
       signal: signal ?? timeoutSignal(timeout)
     })
   } catch (err) {


### PR DESCRIPTION
Alby's rate limiting rejects our lightning address requests on the basis of the `User-Agent` which is set to `node` in `Node` by default.

This seems to prevent this in vitro, but who knows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a default `user-agent` header in `fetchWithTimeout` for server-side requests to avoid provider rate limits.
> 
> - Builds `Headers` from provided options and, when running on the server, sets `user-agent` to `StackerNews/<commitHash> (+https://stacker.news; ops@stacker.news)` if not already present (commit hash from `NEXT_PUBLIC_COMMIT_HASH` in production, otherwise `dev`)
> - Passes the constructed `headers` into `fetch` alongside existing timeout/abort handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 682596c6cdaf1adc29e5f87e9b873fb96ec09d42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->