### PR TITLE
fix: avoid parsing external autolinks without protocol as internal ones

### DIFF
--- a/lib/lexical/exts/autolink.js
+++ b/lib/lexical/exts/autolink.js
@@ -15,9 +15,8 @@ function isStandaloneBareLink (node) {
 
 // helper to get embed info from url
 function getEmbed (src) {
-  const href = ensureProtocol(src)
-  const embed = parseEmbedUrl(href)
-  return embed ? { ...embed, src: href } : { provider: null }
+  const embed = parseEmbedUrl(src)
+  return embed ? { ...embed, src } : { provider: null }
 }
 
 // note: this doesn't support formatting, e.g. **https://stacker.news**
@@ -26,7 +25,8 @@ export const AutoLinkExtension = defineExtension({
   name: 'AutoLinkExtension',
   register: (editor) => {
     return editor.registerNodeTransform(AutoLinkNode, (node) => {
-      const url = node.getURL()
+      // ensure protocol to avoid parsing external links as internal ones
+      const url = ensureProtocol(node.getURL())
 
       // step 1: check for item mention
       try {


### PR DESCRIPTION
## Description

The following markdown `[google.com](google.com)` results in `https://stacker.news/items/google.com` because it lacks a protocol and is then considered a relative URL.
This PR uses `ensureProtocol` to **ensure** we add a **protocol** to URLs we manage in the `AutoLinkExtension`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures external links without a protocol aren’t treated as internal links during autolink processing.
> 
> - In `AutoLinkExtension`, wrap `node.getURL()` with `ensureProtocol` before parsing for internal links, embeds, media, and link attrs
> - Simplifies `getEmbed` to pass through `src` directly (protocol already ensured upstream)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6dc5865d447e56c2462c51682550859b3926c6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->