### PR TITLE
Don't trim whitespaces by default on markdown insertion

### DIFF
--- a/lib/lexical/utils/index.js
+++ b/lib/lexical/utils/index.js
@@ -74,7 +74,7 @@ export function $appendMarkdown (markdown, spacing = 0) {
 }
 
 /** parses plain text content to Lexical Paragraphs */
-export function $getNodesFromMarkdown (markdown, trimWhitespace = true) {
+export function $getNodesFromMarkdown (markdown, trimWhitespace = false) {
   const nodes = []
   const value = cleanMarkdown(markdown, trimWhitespace)
 
@@ -94,7 +94,7 @@ export function $getNodesFromMarkdown (markdown, trimWhitespace = true) {
  * initializes editor state with markdown
  * @param {string} [initialValue=''] - initial content
  */
-export function $setMarkdown (initialValue = '', trimWhitespace = true) {
+export function $setMarkdown (initialValue = '', trimWhitespace = false) {
   const root = $getRoot()
   root.clear()
   const nodes = $getNodesFromMarkdown(initialValue, trimWhitespace)


### PR DESCRIPTION
## Description

Trimming whitespaces by default led to an unnatural experience when inserting a block on a collapsed selection. For example a list would start with "1." instead of "1. ", etc.
This PR flips the defaults for markdown insertion.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, didn't find any problems on normal usage

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small default-parameter change limited to markdown parsing/initialization; main risk is subtle behavior differences for callers that relied on implicit trimming.
> 
> **Overview**
> Stops trimming leading/trailing whitespace by default when converting markdown to Lexical nodes. This flips the default `trimWhitespace` parameter in `$getNodesFromMarkdown` and `$setMarkdown`, preserving spaces in inserted/initialized content unless callers explicitly opt into trimming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c21e4782d50ca623f078dbf4d660f509deeeb8e9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->