### PR TITLE
fix: evaluate poll expiry min date at validation time

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -232,7 +232,11 @@ export function pollSchema ({ numExistingChoices = 0, ...args }) {
       message: `at least ${MIN_POLL_NUM_CHOICES} choices required`,
       test: arr => arr.length >= MIN_POLL_NUM_CHOICES - numExistingChoices
     }),
-    pollExpiresAt: date().nullable().min(datePivot(new Date(), { days: 1 }), 'Expiration must be at least 1 day in the future'),
+    pollExpiresAt: date().nullable().test({
+      name: 'future-min',
+      message: 'Expiration must be at least 1 day in the future',
+      test: value => !value || value > datePivot(new Date(), { days: 1 })
+    }),
     randPollOptions: boolean(),
     ...advPostSchemaMembers(args),
     ...subSelectSchemaMembers('POLL', args)


### PR DESCRIPTION
## Summary

Fixes #907

The `pollExpiresAt` validation used a static min date computed once at schema creation time via `datePivot(new Date(), { days: 1 })`. This date was frozen when the schema object was instantiated, meaning:

- On the **client**, the min date was set when the component mounted, not when the form was submitted
- On the **server**, a fresh schema is created per request, but any time drift between client default computation and server validation could cause the check to fail

This replaces the static `.min()` with a dynamic `.test()` that evaluates `datePivot(new Date(), { days: 1 })` at the time of each validation run, ensuring the 1-day minimum is always relative to actual submission time.

## Changes

- `lib/validate.js`: Replace static `date().min(...)` with dynamic `date().test(...)` for `pollExpiresAt`

## Test plan

- [x] All CI checks pass (lint, shellcheck, unit tests, security)
- [x] Validation logic uses dynamic `new Date()` — no stale date bug possible
- [x] `pollExpiresAt` remains `nullable()` — null/cleared expiration still valid
- [x] Only `pollExpiresAt` field affected — no other validators changed