### PR TITLE
fix: disallow URI schemes in post titles

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -34,6 +34,11 @@ const titleValidator = string().required('required').trim().max(
   MAX_TITLE_LENGTH,
   ({ max, value }) => `-${Math.abs(max - value.length)} characters remaining`
 ).min(MIN_TITLE_LENGTH, `must be at least ${MIN_TITLE_LENGTH} characters`)
+  .test({
+    name: 'no-uri-scheme',
+    message: 'title must not contain a URL with a scheme (e.g. https://)',
+    test: value => !value || !/\w+:\/\//.test(value)
+  })
 
 const textValidator = (max) => string().trim().max(
   max,


### PR DESCRIPTION
## Summary

Closes #117

Adds a yup validation test to `titleValidator` that rejects titles containing URIs with a scheme (e.g. `https://`, `http://`, `ftp://`). Domain names without a scheme (e.g. "Crypto.com") are still allowed.

The regex `/\w+:\/\//` matches any word characters followed by `://`, which covers all standard URI schemes without blocking bare domain names.

## Changes

- `lib/validate.js`: Added `.test()` to `titleValidator` that checks for URI scheme patterns

## Test plan

- [x] Title "Bitcoin hits 100k!" -- passes validation
- [x] Title "Crypto.com stadium hosts big game" -- passes validation (no scheme)
- [x] Title "Check https://example.com" -- fails validation (contains URI scheme)
- [x] Title "Visit http://example.com for details" -- fails validation
- [x] Title "Download from ftp://files.example.com" -- fails validation
- [x] Existing title length validations (min/max) still work as before