### PR TITLE
fix: encode relays into nostr zap notification links

### DIFF
--- a/lib/nostr.js
+++ b/lib/nostr.js
@@ -188,7 +188,10 @@ export function nostrZapDetails (zap) {
     }
   }
   const event = tags.filter(t => t?.length >= 2 && t[0] === 'e')?.[0]?.[1]
-  const note = event ? hexToBech32(event, 'note') : null
+  const relays = tags.find(t => t?.length >= 2 && t[0] === 'relays')?.slice(1) || []
+  const note = event
+    ? nip19.neventEncode({ id: event, relays: relays.slice(0, 3) })
+    : null
 
   return { npub, content, note }
 }


### PR DESCRIPTION
## Summary

- Fixes #502 — zap notification links now use `nevent1` (NIP-19) instead of `note1`, encoding relay hints so nostr clients can find events on the correct relays
- Extracts relay URLs from the zap request's `relays` tag and includes up to 3 in the `nevent` encoding
- No changes needed in the notification component — `njump.me` already supports `nevent1` URLs

## Changes

In `lib/nostr.js` → `nostrZapDetails()`:
- Extract `relays` from the zap note's tags (same format used in `worker/nostr.js` for NIP-57 receipt publishing)
- Replace `hexToBech32(event, 'note')` with `nip19.neventEncode({ id: event, relays })` per NIP-19 spec
- Limit to 3 relays to keep the encoded string concise

## Test plan

- [x] All CI checks pass (lint, shellcheck, unit tests, security)
- [x] Uses existing `nip19` import already present in `lib/nostr.js`
- [x] Extracts relays from standard NIP-57 `relays` tag format
- [x] Limits to 3 relays for concise encoding
- [x] Falls back gracefully when no `e` tag present (unchanged "nostr" text)