### PR TITLE
fix: don't convert Fediverse handles to mailto links

### DIFF
--- a/lib/lexical/mdast/transforms/index.js
+++ b/lib/lexical/mdast/transforms/index.js
@@ -1,5 +1,5 @@
 export { mentionTransform } from './mentions.js'
 export { nostrTransform } from './nostr.js'
-export { misleadingLinkTransform, malformedLinkEncodingTransform } from './links.js'
+export { misleadingLinkTransform, malformedLinkEncodingTransform, emailAutolinkTransform } from './links.js'
 export { footnoteTransform } from './footnotes.js'
 export { tocTransform } from './toc.js'

--- a/lib/lexical/mdast/transforms/links.js
+++ b/lib/lexical/mdast/transforms/links.js
@@ -27,6 +27,47 @@ export function misleadingLinkTransform (tree) {
   })
 }
 
+/**
+ * GFM autolinks aggressively detect email addresses. This causes
+ * Fediverse-style handles like @user@instance.org to be parsed as
+ * mailto:user@instance.org with the leading @ left as plain text.
+ *
+ * This transform detects when a mailto autolink is immediately preceded
+ * by @ or ! (Fediverse mention/group prefixes) and unwraps the link
+ * back into plain text, merging it with the surrounding text nodes.
+ *
+ * Fixes https://github.com/stackernews/stacker.news/issues/93
+ */
+export function emailAutolinkTransform (tree) {
+  visit(tree, 'link', (node, index, parent) => {
+    if (!node.url?.startsWith('mailto:')) return
+    if (!parent || index === undefined) return
+
+    const prev = index > 0 ? parent.children[index - 1] : null
+    if (!prev || prev.type !== 'text') return
+
+    // if the preceding text ends with @ or !, this is a Fediverse-style
+    // handle, not a real email address
+    if (!prev.value.endsWith('@') && !prev.value.endsWith('!')) return
+
+    // unwrap: replace the link node with its text content
+    const linkText = toString(node)
+    parent.children[index] = { type: 'text', value: linkText }
+
+    // merge adjacent text nodes (prev + unwrapped link + next if also text)
+    const merged = prev.value + linkText
+    const next = parent.children[index + 1]
+    if (next?.type === 'text') {
+      parent.children.splice(index - 1, 3, { type: 'text', value: merged + next.value })
+    } else {
+      parent.children.splice(index - 1, 2, { type: 'text', value: merged })
+    }
+
+    // revisit from the merged node position
+    return index - 1
+  })
+}
+
 /** LinkeDOM patch: decodeURI(url) fails on malformed URLs,
  * so we replace the link node with a text node */
 export function malformedLinkEncodingTransform (tree) {

--- a/lib/lexical/utils/mdast.js
+++ b/lib/lexical/utils/mdast.js
@@ -14,6 +14,7 @@ import {
   nostrTransform,
   misleadingLinkTransform,
   malformedLinkEncodingTransform,
+  emailAutolinkTransform,
   footnoteTransform,
   tocTransform
 } from '@/lib/lexical/mdast/transforms'
@@ -39,6 +40,7 @@ export function $markdownToLexical (markdown, splitInParagraphs = false) {
       mathFromMarkdown()
     ],
     mdastTransforms: [
+      emailAutolinkTransform,
       mentionTransform,
       nostrTransform,
       misleadingLinkTransform,


### PR DESCRIPTION
## Summary

- Fixes #93 — Fediverse-style handles like `@Cointastical@BitcoinHackers.org` and `!group@server.org` are no longer incorrectly converted to `mailto:` links
- Adds a new `emailAutolinkTransform` to the markdown processing pipeline that detects and unwraps these false-positive email autolinks
- Regular email addresses (e.g. `user@example.com`) are unaffected

## How it works

GFM autolink detection aggressively matches `text@domain.tld` as an email address. When the original text is `@user@domain.tld`, GFM splits it into:
1. Text node: `"...@"` (the leading `@` gets consumed into preceding text)
2. Link node: `mailto:user@domain.tld`

The new transform checks if a `mailto:` link is immediately preceded by a text node ending with `@` or `!` (Fediverse mention/group prefixes). If so, it unwraps the link back to plain text and merges adjacent text nodes.

## Changes

- `lib/lexical/mdast/transforms/links.js` — new `emailAutolinkTransform` function
- `lib/lexical/mdast/transforms/index.js` — export the new transform
- `lib/lexical/utils/mdast.js` — add transform to the pipeline (runs before other link transforms)

## Test plan

- [x] All CI checks pass (lint, shellcheck, unit tests, security)
- [x] Transform only triggers when preceding text ends with `@` or `!` — no false positives on regular emails
- [x] Adjacent text nodes are properly merged after unwrapping
- [x] Transform runs before mention/nostr transforms to avoid interference
- [x] Existing email autolink behavior unchanged for standard addresses