### PR TITLE
Fix duplicate detection for redirected URLs

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -649,6 +649,10 @@ export default {
       const res = {}
       try {
         const response = await snFetch(url, { protocol: 'http', redirect: 'follow' })
+        // capture the final URL after following redirects
+        if (response.url && response.url !== url) {
+          res.redirected = response.url
+        }
         const html = await response.text()
         const doc = domino.createWindow(html).document
         const titleRuleSet = {

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -16,6 +16,7 @@ export default gql`
   type TitleUnshorted {
     title: String
     unshorted: String
+    redirected: String
   }
 
   extend type Mutation {

--- a/components/link-form.js
+++ b/components/link-form.js
@@ -38,6 +38,7 @@ export function LinkForm ({ item, subs, EditInfo, children }) {
       pageTitleAndUnshorted(url: $url) {
         title
         unshorted
+        redirected
       }
     }`)
   const [getDupes, { data: dupesData, loading: dupesLoading }] = useLazyQuery(gql`
@@ -93,6 +94,14 @@ export function LinkForm ({ item, subs, EditInfo, children }) {
       })
     }
   }, [data?.pageTitleAndUnshorted?.unshorted, getDupesDebounce])
+
+  useEffect(() => {
+    if (data?.pageTitleAndUnshorted?.redirected) {
+      getDupesDebounce({
+        variables: { url: data?.pageTitleAndUnshorted?.redirected }
+      })
+    }
+  }, [data?.pageTitleAndUnshorted?.redirected, getDupesDebounce])
 
   const [postDisabled, setPostDisabled] = useState(false)
   const [titleOverride, setTitleOverride] = useState()


### PR DESCRIPTION
## Summary

Closes #254

When users post URLs that redirect to a canonical form (e.g. `open.substack.com/pub/author/p/article` → `author.substack.com/p/article`, or `medium.com/@user/article` → `user.medium.com/article`), the duplicate checker now catches these as duplicates of the canonical URL.

## How it works

The `pageTitleAndUnshorted` resolver already follows redirects via `snFetch(..., { redirect: 'follow' })`. This PR captures `response.url` (the final URL after redirects) and returns it to the client as a new `redirected` field. The client then runs a duplicate check against this redirected URL, just like it already does for unshorted URLs.

## Changes

- `api/typeDefs/item.js`: Add `redirected` field to `TitleUnshorted` GraphQL type
- `api/resolvers/item.js`: Capture `response.url` after redirect, return when it differs from input
- `components/link-form.js`: Query `redirected` field and trigger dup check with it

## Test plan

- [x] All CI checks pass (lint, unit tests, shellcheck, security)
- [x] Only sets `redirected` when `response.url` differs from input URL — no redundant dup checks
- [x] Follows same pattern as existing `unshorted` dup check
- [x] No changes to the `dupes` query itself — same regex matching logic applies