### PR TITLE
fix: strip hardcoded inline styles from table cell HTML export

### DIFF
--- a/lib/lexical/nodes/index.js
+++ b/lib/lexical/nodes/index.js
@@ -1,5 +1,6 @@
 import { QuoteNode, HeadingNode } from '@lexical/rich-text'
 import { TableCellNode, TableNode, TableRowNode } from '@lexical/table'
+import { SNTableCellNode, $createSNTableCellNode } from './misc/table-cell'
 import { ListItemNode, ListNode } from '@lexical/list'
 import { CodeHighlightNode, CodeNode } from '@lexical/code'
 import { AutoLinkNode, LinkNode } from '@lexical/link'
@@ -35,7 +36,12 @@ const DefaultNodes = [
   CodeNode,
   CodeHighlightNode,
   TableNode,
-  TableCellNode,
+  SNTableCellNode,
+  {
+    replace: TableCellNode,
+    with: (node) => $createSNTableCellNode(node.__headerState, node.__colSpan, node.__width),
+    withKlass: SNTableCellNode
+  },
   TableRowNode,
   AutoLinkNode,
   LinkNode,

--- a/lib/lexical/nodes/misc/table-cell.js
+++ b/lib/lexical/nodes/misc/table-cell.js
@@ -1,0 +1,61 @@
+import { TableCellNode } from '@lexical/table'
+import { $applyNodeReplacement, isHTMLElement } from 'lexical'
+
+/**
+ * SNTableCellNode strips hardcoded inline styles from Lexical's exportDOM
+ * so that SSR HTML matches the hydrated Lexical styling (via CSS classes).
+ *
+ * Without this, table cells flash with black borders and gray headers
+ * before Lexical hydrates and applies theme classes.
+ *
+ * Fixes: https://github.com/stackernews/stacker.news/issues/2777
+ */
+export class SNTableCellNode extends TableCellNode {
+  static getType () {
+    return 'sn-tablecell'
+  }
+
+  static clone (node) {
+    return new SNTableCellNode(
+      node.__headerState,
+      node.__colSpan,
+      node.__width,
+      node.__key
+    )
+  }
+
+  static importJSON (serializedNode) {
+    return $createSNTableCellNode(
+      serializedNode.headerState,
+      serializedNode.colSpan,
+      serializedNode.width
+    ).updateFromJSON(serializedNode)
+  }
+
+  exportDOM (editor) {
+    const output = super.exportDOM(editor)
+    if (isHTMLElement(output.element)) {
+      const el = output.element
+      // strip hardcoded inline styles that conflict with theme CSS classes:
+      // - border: '1px solid black' → CSS uses var(--theme-borderColor)
+      // - width: 'Xpx' → CSS uses min-width: 75px
+      // - vertical-align, text-align → CSS handles these
+      // - background-color: '#f2f3f5' for headers → CSS uses var(--theme-commentBg)
+      // preserve any user-set custom background color
+      const customBg = this.getBackgroundColor()
+      el.removeAttribute('style')
+      if (customBg) {
+        el.style.backgroundColor = customBg
+      }
+    }
+    return output
+  }
+}
+
+export function $createSNTableCellNode (headerState, colSpan, width) {
+  return $applyNodeReplacement(new SNTableCellNode(headerState, colSpan, width))
+}
+
+export function $isSNTableCellNode (node) {
+  return node instanceof SNTableCellNode
+}


### PR DESCRIPTION
## Summary

Fixes #2777 — Tables styling is inconsistent between HTML and Lexical.

Lexical's `TableCellNode.exportDOM()` applies hardcoded inline styles (`border: 1px solid black`, `background-color: #f2f3f5`, fixed `width`, etc.) that conflict with SN's CSS theme classes (`var(--theme-borderColor)`, `var(--theme-commentBg)`, etc.). During SSR, the HTML fallback renders with these hardcoded styles, then flashes when Lexical hydrates and theme CSS classes take over.

### Changes

- **New `SNTableCellNode`** (`lib/lexical/nodes/misc/table-cell.js`): Extends `TableCellNode` and overrides `exportDOM` to strip conflicting inline styles from the exported HTML, letting CSS classes handle all styling.
- **Node registration** (`lib/lexical/nodes/index.js`): Registers `SNTableCellNode` as a replacement for `TableCellNode` using the same pattern as `SNHeadingNode`.
- User-set custom background colors are preserved.

### How it works

| Before | After |
|--------|-------|
| SSR HTML has `border: 1px solid black` | SSR HTML uses `.sn-table__cell` class → `var(--theme-borderColor)` |
| Headers flash `#f2f3f5` then switch to theme color | Headers use `.sn-table__cell--header` → `var(--theme-commentBg)` from the start |
| Fixed `width: 75px` inline | CSS `min-width: 75px` from stylesheet |

### Test plan

- [x] `standard` lint passes with no errors
- [x] `npm test` — all 18 tests pass
- [x] Existing table functionality (create, edit, resize, alignment) unaffected — `SNTableCellNode` only overrides `exportDOM`, all other methods inherited from `TableCellNode`
- [x] Node replacement pattern follows established `SNHeadingNode` precedent