### PR TITLE
Highlight 'view all N replies' when hidden comments are new

### DIFF
--- a/components/comment.js
+++ b/components/comment.js
@@ -337,6 +337,8 @@ export default function Comment ({
 
 export function ViewMoreReplies ({ item, threadContext = false }) {
   const root = useRoot()
+  const { me } = useMe()
+  const router = useRouter()
   const id = threadContext ? commentSubTreeRootId(item, root) : item.id
 
   // if threadContext is true, we travel to some comments before the current comment, focusing on the comment itself
@@ -347,13 +349,23 @@ export function ViewMoreReplies ({ item, threadContext = false }) {
     ? 'reply on another page'
     : `view all ${item.ncomments} replies`
 
+  // check if hidden replies contain new comments
+  const hasNewComments = useMemo(() => {
+    if (!item.lastCommentAt) return false
+    const meViewedAt = new Date(root.meCommentsViewedAt).getTime()
+    const viewedAt = me?.id ? meViewedAt : router.query.commentsViewedAt
+    if (!viewedAt) return false
+    return new Date(item.lastCommentAt).getTime() > viewedAt
+  }, [item.lastCommentAt, root.meCommentsViewedAt, me?.id, router.query.commentsViewedAt])
+
   return (
     <Link
       href={href}
       as={`/items/${id}`}
-      className='fw-bold d-flex align-items-center gap-2 text-muted'
+      className={classNames('fw-bold d-flex align-items-center gap-2', hasNewComments ? 'text-info' : 'text-muted')}
     >
       {text}
+      {hasNewComments && <span className={styles.newCommentDot} />}
     </Link>
   )
 }

--- a/fragments/comments.js
+++ b/fragments/comments.js
@@ -60,6 +60,7 @@ export const COMMENT_FIELDS = gql`
     otsHash
     ncomments
     nDirectComments
+    lastCommentAt
     live @client
     imgproxyUrls
     rel


### PR DESCRIPTION
## Summary

Fixes #2127

When nested comments are hidden behind a "view all N replies" link, there's no indication that new comments exist in the hidden subtree. Users have to click through every collapsed thread to find new replies.

This PR adds a visual indicator (blue dot + `text-info` color) to the "view all N replies" link when the hidden comments include ones newer than the user's last view.

## Changes

- **`fragments/comments.js`**: Add `lastCommentAt` to `COMMENT_FIELDS` — this field is already denormalized on all ancestor items when new comments are created, but wasn't being queried for comments
- **`components/comment.js`**: Update `ViewMoreReplies` to compare `item.lastCommentAt` against `root.meCommentsViewedAt` (logged-in) or `commentsViewedAt` query param (anon) and show indicator when new comments are hidden

## How it works

Every item in the database has a `lastCommentAt` timestamp that gets updated via `GREATEST()` whenever a descendant comment is created (see `api/payIn/types/itemCreate.js`). By comparing this against the user's last viewed timestamp, we can detect whether hidden replies contain new comments without loading them.

## Test plan

- [x] Lint passes (`npm run lint` — zero errors)
- [x] Tests pass (`npm test` — 18/18)
- [x] When a post has new nested comments hidden behind "view all N replies", the link shows blue text and a blue dot
- [x] When all nested comments have been viewed, the link shows normal muted text with no dot
- [x] Works for both logged-in users (via `meCommentsViewedAt`) and anon users (via `commentsViewedAt` query param)