### PR TITLE
Show pay bounty button on top-level comment view

### DIFF
--- a/components/reply.js
+++ b/components/reply.js
@@ -104,7 +104,7 @@ export default forwardRef(function Reply ({
   return (
     <div>
       {replyOpen
-        ? <div className='p-3' />
+        ? <div className='d-flex align-items-center p-3'>{children}</div>
         : (
           <div className={styles.replyButtons}>
             <div


### PR DESCRIPTION
## Summary

Fixes #2635

When a comment is viewed as a top-level item (e.g. navigated to directly from a notification at `/items/:commentId`), the "pay bounty" button is missing. This means bounty posters can't pay a bounty without first navigating to the full post and scrolling to find the comment.

## Root cause

In `components/reply.js`, when `replyOpen` is `true` (which it is for top-level comment views via `item-full.js` line 185), the Reply component renders only a spacer `<div className='p-3' />` and skips its `children` — which includes the `PayBounty` button passed from `comment.js` line 311.

## Fix

Render `children` inside the `replyOpen` spacer div so PayBounty (and any future toolbar children) are visible in the top-level comment view.

**Before:** `<div className='p-3' />`
**After:** `<div className='d-flex align-items-center p-3'>{children}</div>`

## Test plan

- [x] Lint passes (`npm run lint` — zero errors)
- [x] Tests pass (`npm test` — 18/18)
- [x] When viewing a bounty comment as top-level (`/items/:commentId`), the "pay bounty" button appears
- [x] When viewing the same comment in the comment section, the button still appears as before
- [x] Non-bounty comments are unaffected (children is empty/null)