### PR TITLE
fix: scale hybrid search pagination_depth with offset

### DIFF
--- a/api/resolvers/search.js
+++ b/api/resolvers/search.js
@@ -119,7 +119,7 @@ export default {
 
         osQuery = {
           hybrid: {
-            pagination_depth: LIMIT * 2,
+            pagination_depth: decodedCursor.offset + LIMIT * 2,
             queries: [
               {
                 bool: {
@@ -449,7 +449,7 @@ export default {
         if (process.env.OPENSEARCH_MODEL_ID) {
           osQuery = {
             hybrid: {
-              pagination_depth: LIMIT * 2,
+              pagination_depth: decodedCursor.offset + LIMIT * 2,
               queries: [
                 {
                   bool: {


### PR DESCRIPTION
## Summary

Fixes #2528 — related posts pagination returns duplicate results when clicking "more".

The `pagination_depth` parameter in hybrid search queries (both `related` and `search` resolvers) was fixed at `LIMIT * 2` (42) regardless of the current pagination offset. When the user requests page 2+ (`from: 21`, `from: 42`, etc.), OpenSearch's hybrid scorer could not reach past the static depth, causing it to return the same results as earlier pages.

**Fix**: Scale `pagination_depth` to `decodedCursor.offset + LIMIT * 2` so the hybrid merge window always extends past the requested page. This matches how the `neural.k` parameter is already scaled (`decodedCursor.offset + LIMIT`).

## Changes

- `api/resolvers/search.js` line 122: `related` resolver — `pagination_depth: decodedCursor.offset + LIMIT * 2`
- `api/resolvers/search.js` line 452: `search` resolver — same fix (had the same bug)

## Test Plan

- [x] All 6 CI checks passing (lint, shellcheck, unit tests, GitGuardian, Socket Security)
- [x] Verified `decodedCursor.offset` is 0 on first page, so first-page behavior is unchanged (`0 + 21*2 = 42`)
- [x] On subsequent pages, `pagination_depth` now grows to cover the requested range (e.g., page 2: `21 + 42 = 63`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)