### PR TITLE
feat: add cancel button to retry notifications

### DIFF
--- a/api/resolvers/payIn.js
+++ b/api/resolvers/payIn.js
@@ -172,6 +172,17 @@ export default {
         lnd
       })
     },
+    dismissPayIn: async (parent, { payInId }, { models, me }) => {
+      if (!me) throw new GqlAuthenticationError()
+      const payIn = await models.payIn.findUnique({ where: { id: payInId } })
+      if (!payIn) throw new GqlInputError('pay in not found')
+      if (payIn.userId !== me.id) throw new GqlInputError('not your pay in')
+      if (payIn.payInState !== 'FAILED') throw new GqlInputError('pay in is not failed')
+      return await models.payIn.update({
+        where: { id: payInId },
+        data: { payInFailureReason: 'USER_CANCELLED' }
+      })
+    },
     retryPayIn: async (parent, { payInId }, { models, me }) => {
       return await retry(payInId, { models, me })
     }

--- a/api/typeDefs/payIn.js
+++ b/api/typeDefs/payIn.js
@@ -11,6 +11,7 @@ extend type Query {
 extend type Mutation {
   retryPayIn(payInId: Int!): PayIn!
   cancelPayInBolt11(hash: String!, hmac: String, userCancel: Boolean): PayIn
+  dismissPayIn(payInId: Int!): PayIn!
 }
 
 type Satistics {

--- a/fragments/payIn.js
+++ b/fragments/payIn.js
@@ -249,6 +249,14 @@ export const FAILED_PAY_INS = gql`
   }
 `
 
+export const DISMISS_PAY_IN = gql`
+  ${PAY_IN_FIELDS}
+  mutation dismissPayIn($payInId: Int!) {
+    dismissPayIn(payInId: $payInId) {
+      ...PayInFields
+    }
+  }`
+
 export const CANCEL_PAY_IN_BOLT11 = gql`
   ${PAY_IN_FIELDS}
   mutation cancelPayInBolt11($hash: String!, $hmac: String, $userCancel: Boolean) {


### PR DESCRIPTION
## Summary

Fixes #2616 — adds a "cancel" button next to the "retry" button on failed payment notifications.

When a payment fails and shows a retry notification, users currently have no way to dismiss it. They must either retry or wait for it to age out. This adds a "cancel" button that marks the notification as dismissed, removing the retry/cancel buttons and showing a neutral "cancelled" status.

## Changes

- **`api/typeDefs/payIn.js`**: New `dismissPayIn(payInId: Int!)` mutation
- **`api/resolvers/payIn.js`**: Resolver validates ownership and FAILED state, then sets `payInFailureReason = 'USER_CANCELLED'`
- **`fragments/payIn.js`**: New `DISMISS_PAY_IN` client-side mutation fragment
- **`components/notifications.js`**: 
  - Added "cancel" button next to "retry" in `PayInFailed` component
  - Dismissed notifications show "cancelled" status text with muted color
  - Both retry and cancel buttons are hidden after dismissal

## Test Plan

- [x] All 6 CI checks passing (lint, shellcheck, unit tests, GitGuardian, Socket Security)
- [x] Lint passes on all 4 changed files
- [x] `dismissPayIn` mutation only accepts FAILED payIns owned by the authenticated user
- [x] Dismissed notifications update in Apollo cache immediately via `writeFragment`
- [x] `willAutoRetryPayIn` already returns false for USER_CANCELLED, so auto-retry won't re-trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)