### PR TITLE
fix: reserve placeholder space for unsized media to prevent layout shift

### DIFF
--- a/lib/lexical/nodes/content/media.jsx
+++ b/lib/lexical/nodes/content/media.jsx
@@ -169,8 +169,12 @@ export class MediaNode extends DecoratorNode {
     }
 
     const { width, height } = this.getWidthAndHeight() || {}
-    width && span.style.setProperty('--width', width)
-    height && span.style.setProperty('--height', height)
+    if (width && height) {
+      span.style.setProperty('--width', width)
+      span.style.setProperty('--height', height)
+    } else {
+      span.classList.add('sn-media--unsized')
+    }
 
     const loading = document.createElement('span')
     loading.className = 'sn-media__loading'
@@ -185,8 +189,12 @@ export class MediaNode extends DecoratorNode {
     span.setAttribute('data-sn-media-kind', this.getKind())
     span.setAttribute('data-sn-media-src', this.__src)
     const { width, height } = this.getWidthAndHeight() || {}
-    width && span.style.setProperty('--width', width)
-    height && span.style.setProperty('--height', height)
+    if (width && height) {
+      span.style.setProperty('--width', width)
+      span.style.setProperty('--height', height)
+    } else {
+      span.classList.add('sn-media--unsized')
+    }
     return span
   }
 

--- a/styles/text.scss
+++ b/styles/text.scss
@@ -182,6 +182,13 @@
   overflow: hidden;
 }
 
+.sn-media--unsized {
+  // reserve placeholder space for images without known dimensions (unproxied)
+  // to reduce layout shift when they load, especially during scroll-to-comment
+  width: 200px;
+  aspect-ratio: 4 / 3;
+}
+
 .sn-media:has(.sn-media__error) {
   min-width: 50px;
   min-height: 50px;


### PR DESCRIPTION
## Summary

Fixes #2581

When unproxied images without known dimensions (e.g., autolinked images not yet processed by imgproxy) load inside comments, the `.sn-media` container collapses to zero height. When the image finally loads, the layout shifts and breaks scroll-to-comment navigation — the user lands at the wrong position.

### Root Cause

In `createDOM()` and `exportDOM()`, when `width`/`height` are not available, the CSS custom properties `--width` and `--height` are never set. This makes the container's `aspect-ratio: var(--width) / var(--height)` and `width: min(...)` declarations invalid, causing the container to collapse until the lazy-loaded image renders.

### Fix

- Added `sn-media--unsized` CSS class to media containers in `createDOM()` and `exportDOM()` when dimensions are unknown
- Added CSS rules for `.sn-media--unsized` that reserve a 200×150px (4:3 aspect ratio) placeholder — matching the existing `MediaLoading` component's dimensions
- This ensures the container occupies space before the image loads, significantly reducing layout shift magnitude
- The existing `preserveScroll` mechanism handles any remaining shift from the placeholder→actual size transition

### Changes

| File | Change |
|------|--------|
| `lib/lexical/nodes/content/media.jsx` | Add `sn-media--unsized` class when dimensions are unknown in `createDOM()` and `exportDOM()` |
| `styles/text.scss` | Add `.sn-media--unsized` CSS rule with placeholder dimensions |

## Test Plan

- [x] `npm run lint` passes (standard)
- [x] `npm test` passes (18/18 tests)
- [x] Verified that sized media containers (with `--width`/`--height`) are unaffected — they don't get the `--unsized` class
- [x] Verified that unsized media containers get `sn-media--unsized` class and reserve 200×150px placeholder space
- [x] The fix is backwards-compatible: existing content with saved Lexical state gets the class via `createDOM()`, and new SSR HTML gets it via `exportDOM()`