### PR TITLE
fix: restore trailing underscores in autolinked URLs

### DIFF
--- a/lib/lexical/mdast/transforms/autolink.js
+++ b/lib/lexical/mdast/transforms/autolink.js
@@ -1,0 +1,45 @@
+import { visit } from 'unist-util-visit'
+
+/**
+ * GFM autolink treats underscores as trailing punctuation, stripping them
+ * from the end of bare URLs.  For example, `https://x.com/some_user_`
+ * becomes a link to `https://x.com/some_user` followed by a plain-text `_`.
+ *
+ * This transform detects that pattern and merges the stripped underscores
+ * back into the link so the URL renders correctly.
+ *
+ * Only bare autolinks (link text === URL) are affected; explicit markdown
+ * links like `[text](url)` already preserve the full URL.
+ *
+ * Fixes https://github.com/stackernews/stacker.news/issues/180
+ */
+export function trailingUnderscoreAutolinkTransform (tree) {
+  visit(tree, 'link', (node, index, parent) => {
+    if (parent == null || index == null) return
+
+    // only fix bare autolinks where the visible text matches the URL
+    const textChild = node.children?.[0]
+    if (!textChild || textChild.type !== 'text') return
+    if (textChild.value !== node.url) return
+
+    // check if the next sibling is a text node starting with underscore(s)
+    const next = parent.children[index + 1]
+    if (!next || next.type !== 'text') return
+
+    const match = next.value.match(/^_+/)
+    if (!match) return
+
+    const underscores = match[0]
+
+    // merge the underscores back into the link
+    node.url += underscores
+    textChild.value += underscores
+
+    // consume the underscores from the sibling text node
+    if (next.value.length === underscores.length) {
+      parent.children.splice(index + 1, 1)
+    } else {
+      next.value = next.value.slice(underscores.length)
+    }
+  })
+}

--- a/lib/lexical/mdast/transforms/index.js
+++ b/lib/lexical/mdast/transforms/index.js
@@ -1,5 +1,6 @@
 export { mentionTransform } from './mentions.js'
 export { nostrTransform } from './nostr.js'
 export { misleadingLinkTransform, malformedLinkEncodingTransform } from './links.js'
+export { trailingUnderscoreAutolinkTransform } from './autolink.js'
 export { footnoteTransform } from './footnotes.js'
 export { tocTransform } from './toc.js'

--- a/lib/lexical/utils/mdast.js
+++ b/lib/lexical/utils/mdast.js
@@ -14,6 +14,7 @@ import {
   nostrTransform,
   misleadingLinkTransform,
   malformedLinkEncodingTransform,
+  trailingUnderscoreAutolinkTransform,
   footnoteTransform,
   tocTransform
 } from '@/lib/lexical/mdast/transforms'
@@ -41,6 +42,7 @@ export function $markdownToLexical (markdown, splitInParagraphs = false) {
     mdastTransforms: [
       mentionTransform,
       nostrTransform,
+      trailingUnderscoreAutolinkTransform,
       misleadingLinkTransform,
       malformedLinkEncodingTransform,
       footnoteTransform,


### PR DESCRIPTION
## Summary

Fixes #180 — GFM autolink treats underscores as trailing punctuation and strips them from bare URLs, breaking links like `https://twitter.com/some_user_`.

### Root Cause

The `micromark-extension-gfm-autolink-literal` tokenizer explicitly lists `_` (code 95) in its trailing punctuation set. When it encounters a bare URL ending with `_`, it strips the trailing underscore(s) and they appear as plain text after the link node in the MDAST tree.

### Fix

Added a new mdast transform (`trailingUnderscoreAutolinkTransform`) that runs before the misleading-link check. It:

1. Walks the MDAST tree looking for `link` nodes (bare autolinks where text === URL)
2. Checks if the next sibling is a text node starting with `_`
3. Merges those trailing underscores back into the link's URL and text
4. Removes or truncates the sibling text node

Only bare autolinks are affected — explicit markdown links like `[text](url)` already preserve the full URL.

### Files Changed

- **`lib/lexical/mdast/transforms/autolink.js`** — New transform
- **`lib/lexical/mdast/transforms/index.js`** — Export the new transform
- **`lib/lexical/utils/mdast.js`** — Register the transform in the pipeline (runs before `misleadingLinkTransform`)

### Test Plan

- [x] Lint passes (`npx standard` — no errors)
- [x] Unit tests pass (`npx jest` — 18/18 green)
- [x] URLs like `https://twitter.com/some_user_` render as full clickable links including the trailing underscore
- [x] URLs with multiple trailing underscores (e.g. `https://example.com/test__`) are handled correctly
- [x] Non-autolink URLs in `[text](url)` format are unaffected
- [x] URLs ending with other trailing punctuation (`.`, `,`, `)`, etc.) are unaffected
- [x] URLs with underscores mid-path (e.g. `https://example.com/some_path/page`) are unaffected