### PR TITLE
Add 'unsubscribe from thread' option for comments

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -850,6 +850,18 @@ export default {
       }
       return { id }
     },
+    unsubscribeThread: async (parent, { id }, { me, models }) => {
+      // Delete all ThreadSubscription records where the subscribed item
+      // is an ancestor of (or equal to) the given item
+      await models.$executeRaw`
+        DELETE FROM "ThreadSubscription" ts
+        USING "Item" i
+        WHERE ts."userId" = ${me.id}
+        AND ts."itemId" = i.id
+        AND i.path @> (SELECT path FROM "Item" WHERE id = ${Number(id)})
+      `
+      return { id }
+    },
     deleteItem: async (parent, { id }, { me, models }) => {
       const old = await models.item.findUnique({ where: { id: Number(id) } })
       if (Number(old.userId) !== Number(me?.id)) {

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -22,6 +22,7 @@ export default gql`
     bookmarkItem(id: ID): Item
     pinItem(id: ID): Item
     subscribeItem(id: ID): Item
+    unsubscribeThread(id: ID!): Item
     deleteItem(id: ID): Item
     upsertLink(
       id: ID, subNames: [String!], title: String!, url: String!, text: String, boost: Int, forward: [ItemForwardInput],

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -12,7 +12,7 @@ import styles from './item.module.css'
 import { useMe } from './me'
 import DontLikeThisDropdownItem, { OutlawDropdownItem } from './dont-link-this'
 import BookmarkDropdownItem from './bookmark'
-import SubscribeDropdownItem from './subscribe'
+import SubscribeDropdownItem, { UnsubscribeThreadDropdownItem } from './subscribe'
 import { CopyLinkDropdownItem, CrosspostDropdownItem } from './share'
 import Badges from './badge'
 import { USER_ID } from '@/lib/constants'
@@ -187,6 +187,7 @@ export default function ItemInfo ({
                 <Dropdown.Item onClick={onQuoteReply}>quote reply</Dropdown.Item>}
               {me && <BookmarkDropdownItem item={item} />}
               {me && <SubscribeDropdownItem item={item} />}
+              {me && item.parentId && <UnsubscribeThreadDropdownItem item={item} />}
               {item.otsHash &&
                 <Link href={`/items/${item.id}/ots`} className='text-reset dropdown-item'>
                   opentimestamp


### PR DESCRIPTION
## Summary

Adds an **unsubscribe from thread** option to the comment action dropdown that removes all `ThreadSubscription` records for ancestor items in the comment chain. This lets users stop all reply notifications from a busy thread with a single click, without needing to find and unsubscribe from each parent item individually.

Closes #2578

## Changes

**Backend:**
- New `unsubscribeThread(id: ID!)` GraphQL mutation in `api/typeDefs/item.js`
- Resolver in `api/resolvers/item.js` uses ltree `@>` to find all ancestor subscriptions and delete them

**Frontend:**
- New `UnsubscribeThreadDropdownItem` component in `components/subscribe.js`
- Added to comment action dropdown in `components/item-info.js` (shown for comments with a `parentId`)
- Apollo cache update clears `meSubscription` on all ancestor items using dot-delimited path prefix matching

## How it works

The existing `subscribeItem` mutation deletes subscriptions for the target item and its **descendants** (using `<@`). The new `unsubscribeThread` mutation deletes subscriptions for all **ancestors** of the target item (using `@>`), effectively silencing the entire thread above the clicked comment.

## Test plan

- [x] CI passes (all 6 checks)
- [x] New "unsubscribe from thread" appears in comment dropdown for logged-in users
- [x] Clicking it removes all ancestor ThreadSubscription records
- [x] Subsequent replies to those ancestors no longer generate notifications
- [x] Apollo cache correctly clears `meSubscription` on ancestor items
- [x] Option only appears on comments (items with `parentId`), not root posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)