### PR TITLE
fix: suppress transient network error toasts in forms

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -849,7 +849,11 @@ export function Form ({
       }
     } catch (err) {
       console.log(err.message, err)
-      toaster.danger(err.message ?? err.toString?.())
+      // don't toast transient network errors from background queries
+      // these surface as ApolloErrors with networkError or browser "Failed to fetch"
+      if (!err.networkError && !(err.message || '').match(/^(failed to fetch|response not successful: received status code 5\d{2})$/i)) {
+        toaster.danger(err.message ?? err.toString?.())
+      }
       return
     }
 


### PR DESCRIPTION
## Summary

Fixes #2329 — Users were randomly seeing "Failed to fetch" and "Received status code 504" error toasts without performing any action. These errors originated from transient network failures during background Apollo polling queries (e.g., `ME`, `blockHeight`, `price`), which bubbled up through `Form`'s catch-all error handler and got toasted as persistent danger notifications.

## Changes

- Modified the `catch` block in `onSubmitInner` (`components/form.js`) to skip toasting network-related errors
- Detects network errors via Apollo's `err.networkError` property (set for all network-level `ApolloError`s including 504 `ServerError`s)
- Falls back to message pattern matching for browser-level fetch failures ("Failed to fetch") and 5xx status codes
- Non-network errors (validation, business logic, GraphQL errors) continue to be toasted normally
- The `RetryLink` already retries these queries indefinitely, so the errors resolve on their own

## Test plan

- [x] `npm run lint` passes
- [ ] Verify "Failed to fetch" errors no longer produce toasts (simulate by throttling network in DevTools)
- [ ] Verify 504 errors no longer produce toasts
- [ ] Verify intentional form submission errors (e.g., validation) still toast correctly
- [ ] Verify GraphQL errors (e.g., insufficient funds) still toast correctly