### PR TITLE
fix: allow re-selecting the same zap suggestion amount

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -308,7 +308,7 @@ function FormGroup ({ className, label, children }) {
 }
 
 function InputInner ({
-  prepend, append, hint, warn, showValid, onChange, onBlur, overrideValue, appendValue,
+  prepend, append, hint, warn, showValid, onChange, onBlur, overrideValue, overrideNonce, appendValue,
   innerRef, noForm, clear, onKeyDown, inputGroupClassName, debounce: debounceTime, maxLength, hideError,
   AppendColumn, ...props
 }) {
@@ -363,7 +363,7 @@ function InputInner ({
         onChange && onChange(formik, { target: { value: draft } })
       }
     }
-  }, [overrideValue])
+  }, [overrideValue, overrideNonce])
 
   useEffect(() => {
     if (appendValue) {

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -27,7 +27,7 @@ const Tips = ({ setOValue }) => {
     <Button
       size='sm'
       key={num}
-      onClick={() => { setOValue(num) }}
+      onClick={() => { setOValue(prev => ({ value: num, nonce: ((prev?.nonce) || 0) + 1 })) }}
     >
       <UpBolt
         className='me-1'
@@ -129,7 +129,8 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
         name='amount'
         type='number'
         innerRef={inputRef}
-        overrideValue={oValue}
+        overrideValue={oValue?.value}
+        overrideNonce={oValue?.nonce}
         step={step}
         required
         autoFocus


### PR DESCRIPTION
## Summary

Fixes #2703 — Zap suggestion buttons couldn't be clicked more than once with the same value. For example, selecting "100", manually changing to another amount, then selecting "100" again had no effect.

## Root cause

The `Tips` component calls `setOValue(num)` which sets React state to a primitive number. The `InputInner` component in `form.js` applies the override value via a `useEffect` with `[overrideValue]` in its dependency array. When the same number is set twice (e.g., `100` → `100`), React sees no state change and skips the effect entirely.

## Fix

- Changed `setOValue` in `Tips` to store `{ value, nonce }` objects, where `nonce` increments on every click, ensuring React always sees a new state reference
- Added `overrideNonce` prop to `InputInner` and included it in the `useEffect` dependency array
- `overrideNonce` is optional and backward-compatible — existing callers that don't pass it are unaffected

## Test plan

- [x] `npm run lint` passes
- [ ] Long-press zap → select 100 → manually change to 50 → select 100 again → input should update to 100
- [ ] Selecting different suggestion values still works normally
- [ ] Custom tip amounts work correctly
- [ ] Other `overrideValue` consumers (search filters, sub select, link form) still work