### PR TITLE
fix: exclude down-zapped items from FWD recipient notifications

### DIFF
--- a/api/resolvers/notifications.js
+++ b/api/resolvers/notifications.js
@@ -215,6 +215,7 @@ export default {
             JOIN "ItemForward" ON "ItemForward"."itemId" = "Item".id AND "ItemForward"."userId" = $1
             WHERE "Item"."userId" <> $1
             AND "Item"."lastZapAt" < $2
+            AND "Item".msats > 0
             ORDER BY "sortTime" DESC
             LIMIT ${LIMIT})`
         )


### PR DESCRIPTION
## Problem

Fixes #861

When a forwarded item gets down-zapped (outlawed), its `msats` drops to 0 or below. However, the `ForwardedVotification` notification query in the inbox still includes these items because it only filters on `lastZapAt` — not on whether the item actually has positive sats. This causes FWD recipients to see notifications saying they "stacked 0 sats" from outlawed/down-zapped items.

## Solution

Add `AND "Item".msats > 0` to the `ForwardedVotification` query's WHERE clause. This ensures FWD recipients only see notifications for items that currently have positive earned sats.

The push notification path (`notifyZapped` in `lib/webPush.js`) is already correct — it's only called from `zap.js`'s `onPaidSideEffects`, and `downZap.js` does not export `onPaidSideEffects`, so down-zaps never trigger push notifications. The bug is only in the notification inbox query.

## Test Plan

- [x] All CI checks pass (lint, unit tests, shellcheck)
- [x] Verified `lastZapAt` is only updated by positive zaps (in `api/payIn/types/zap.js`), not by down-zaps
- [x] Verified `notifyZapped` push notification is only called from `zap.js`, not `downZap.js`
- [x] Confirmed the `ForwardedVotification` query now correctly filters out items with `msats <= 0`

## Changes

- `api/resolvers/notifications.js`: Add `AND "Item".msats > 0` filter to `ForwardedVotification` query