### PR TITLE
Fix invalid re-selection of placeholder url when toggling a link via Transformer Bridge

### DIFF
--- a/components/editor/plugins/core/append-value.js
+++ b/components/editor/plugins/core/append-value.js
@@ -15,7 +15,7 @@ export default function AppendValuePlugin ({ value }) {
     if (value && value !== prevValueRef.current) {
       prevValueRef.current = value
       editor.update(() => {
-        $appendMarkdown(value, 2)
+        $appendMarkdown(value, false, 2)
       })
     } else if (!value) {
       // clear on cancel quote

--- a/components/editor/plugins/core/transformer-bridge.js
+++ b/components/editor/plugins/core/transformer-bridge.js
@@ -79,7 +79,8 @@ export default function TransformerBridgePlugin () {
       if (!newMarkdown) return false
 
       // insert the new markdown into the original editor
-      $insertMarkdown(newMarkdown)
+      // trim whitespaces to avoid extra newlines
+      $insertMarkdown(newMarkdown, true)
       return true
     }, COMMAND_PRIORITY_EDITOR)
   }, [editor, bridgeRef])

--- a/lib/lexical/commands/formatting/markdown.js
+++ b/lib/lexical/commands/formatting/markdown.js
@@ -60,7 +60,7 @@ function handleCodeblockCommand ({ language = 'text' } = {}) {
   if (!$isRangeSelection(selection)) return false
 
   const selectedText = selection.getTextContent()
-  $insertMarkdown(`\`\`\`${language}\n${selectedText}\n\`\`\``, { line: 0, anchorOffset: 1 })
+  $insertMarkdown(`\`\`\`${language}\n${selectedText}\n\`\`\``, false, { line: 0, anchorOffset: 1 })
   return true
 }
 

--- a/lib/lexical/utils/index.js
+++ b/lib/lexical/utils/index.js
@@ -36,19 +36,21 @@ export function $isMarkdownEmpty () {
 /** inserts markdown content at the current selection,
  * or appends to the root if no selection
  *
+ * optionally trims whitespace from the markdown content
  * optionally sets the cursor position after insertion
  *
  * @param {string} markdown - the markdown content to insert
+ * @param {boolean} trimWhitespace - whether to trim whitespace from the markdown content
  * @param {Object} cursor - the cursor position to set
  * @param {number} cursor.line - the line number to set the cursor at
  * @param {number} cursor.anchorOffset - the anchor offset to set the cursor at
  * @param {number} cursor.focusOffset - the focus offset to set the cursor at
  */
-export function $insertMarkdown (markdown, cursor) {
+export function $insertMarkdown (markdown, trimWhitespace = false, cursor) {
   const selection = $getSelection()
-  if (!$isRangeSelection(selection)) return $appendMarkdown(markdown)
+  if (!$isRangeSelection(selection)) return $appendMarkdown(markdown, trimWhitespace)
 
-  const nodes = $getNodesFromMarkdown(markdown)
+  const nodes = $getNodesFromMarkdown(markdown, trimWhitespace)
   selection.insertNodes(nodes)
 
   if (cursor) {
@@ -57,9 +59,9 @@ export function $insertMarkdown (markdown, cursor) {
 }
 
 /** appends markdown content to the root */
-export function $appendMarkdown (markdown, spacing = 0) {
+export function $appendMarkdown (markdown, trimWhitespace = false, spacing = 0) {
   const root = $getRoot()
-  const nodes = $getNodesFromMarkdown(markdown)
+  const nodes = $getNodesFromMarkdown(markdown, trimWhitespace)
   // if root is not empty but its content is (e.g. empty paragraphs), clear it
   if (!root.isEmpty() && $isMarkdownEmpty()) root.clear()
   root.append(...nodes)


### PR DESCRIPTION
## Description

RE #2776

Adds `trimWhitespace` option to `insertMarkdown` and `appendMarkdown` utilities.
Transformer Bridge now trims its markdown result, fixing incorrect re-selection of the link placeholder/alt text.

## Screenshots

Before (prod)

https://github.com/user-attachments/assets/9a384120-7839-4a2f-a34d-4f10e40f2215

After


https://github.com/user-attachments/assets/ae0cd331-ee9a-43bf-9024-87ad6c11700b



## Additional Context

This is a consequence of arbitrary selections and how fragile they are ... other than my fault for not QAing correctly #2779
In markdown mode, there's not a real way to position the cursor, let's say, inside a link node's URL field, because there's no `LinkNode` to begin with, so it's like playing with `textarea` selections.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, QA done on every transformer bridge insertion, and simple markdown insertions on collapsed selections are not affected because insertion still doesn't trim whitespaces by default

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared Lexical markdown insertion utilities and changes call signatures, so subtle whitespace/cursor-position regressions are possible across editor insertion paths; however defaults preserve prior behavior unless explicitly enabled.
> 
> **Overview**
> Fixes a selection/cursor bug when applying transformations via the Markdown Transformer Bridge by trimming the bridge-produced markdown before reinserting it (avoiding extra newlines/whitespace that caused incorrect reselection of link placeholder text).
> 
> Extends `$insertMarkdown` and `$appendMarkdown` to accept a new `trimWhitespace` boolean (defaulting to `false`) and threads it through node generation; updates call sites (`TransformerBridgePlugin`, `AppendValuePlugin`, and markdown codeblock insertion) to use the new signature and enable trimming only where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be29029724d9c61124a26b7b7ec4725538061496. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->