### PR TITLE
Set math horizontal overflow to auto

### DIFF
--- a/styles/text.scss
+++ b/styles/text.scss
@@ -850,6 +850,9 @@ span + .sn-link {
 .sn-math {
   cursor: default;
   user-select: none;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--theme-borderColor) var(--theme-commentBg);
 }
 
 .sn-math.focused {


### PR DESCRIPTION
## Description

Fixes #2810 
Adds `overflow-x: auto` to the MathNode CSS style, with a thin scrollbar (only WebKit)

## Screenshots
<img width="548" height="375" alt="image" src="https://github.com/user-attachments/assets/f0f1a6f9-3443-4030-b07a-4c6015c4a0b7" />

## Additional Context

n/a

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

9

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only change scoped to math rendering and a minor formatting fix; low risk aside from potential layout/scrollbar appearance differences across browsers.
> 
> **Overview**
> Math nodes (`.sn-math`) now use `overflow-x: auto` with thin, themed scrollbars so long equations can be scrolled horizontally instead of overflowing.
> 
> Also fixes a missing newline/brace at the end of `styles/text.scss`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a7895450bd26766c6bb4d14ce31e46536deed74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->