### PR TITLE
Reserve space for the sticky bar during auto-scrolls

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -218,8 +218,13 @@ $zindex-sticky: 900;
   --bs-gradient: none;
 }
 
-* {
-  scroll-margin-top: 60px;
+html {
+  scroll-padding-top: 60px;
+
+  /* editor needs more padding to keep its toolbar visible when focused */
+  &:has([data-sn-editor]:focus) {
+    scroll-padding-top: 90px;
+  }
 }
 
 .ms-xs {


### PR DESCRIPTION
## Description

Context: [#1432987](https://stacker.news/items/1432987/?commentId=1433136)
This PR fixes the editor being shadowed by the sticky bar in fixed positioning, by telling the browser we always need 60 to 90px of "breathing room" whenever it wants to scroll.

We had `scroll-margin-top` applied to `*` any element, especially for heading/anchor navigation, and it should've handled scrolling to the `contenteditable`. It didn't work because some browsers are not scrolling to the `contenteditable` element, rather they're scrolling to the **caret** inside of it.

To fix this and to also reserve some space for the toolbar, this PR uses `scroll-padding-top` which lets us decide how much space we want to preserve on every scroll operation, even if the target is not an element.

## Screenshots

tbd

## Additional Context

n/a

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7:
- Headings/anchor navigation: OK
- Scroll to editor: OK

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Tested on Safari mobile and Chrome Android: success

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
Yes, to talk differences between `scroll-margin-top` and `scroll-padding-top`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, global CSS behavior change that only affects scroll positioning/anchor navigation; risk is limited to browser support and potential unexpected offsets on some pages.
> 
> **Overview**
> Reserves space below the fixed sticky bar during browser-driven scrolling by replacing global `scroll-margin-top` on `*` with `html { scroll-padding-top: 60px; }`.
> 
> When a `[data-sn-editor]` is focused, increases the reserved space to `90px` via `html:has([data-sn-editor]:focus)` so the editor and its toolbar remain visible when scrolled into view.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16b40f01027f33324d9cc45d866b84499b405ad5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->