### PR TITLE
trim whitespaces when appending a value to the editor

### DIFF
--- a/components/editor/plugins/core/append-value.js
+++ b/components/editor/plugins/core/append-value.js
@@ -15,7 +15,7 @@ export default function AppendValuePlugin ({ value }) {
     if (value && value !== prevValueRef.current) {
       prevValueRef.current = value
       editor.update(() => {
-        $appendMarkdown(value, false, 2)
+        $appendMarkdown(value, true, 2)
       })
     } else if (!value) {
       // clear on cancel quote


### PR DESCRIPTION
## Description

Fixes #2827 by telling `$appendMarkdown` to trim whitespaces when appending a value (quote replies).

## Additional Context

Quote reply without selection still spawns an extra quote marker `>`, and it depends on the markdown being saved. Should we trim that too?

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior tweak limited to editor append flows; low risk aside from minor formatting changes in appended content.
> 
> **Overview**
> Updates `AppendValuePlugin` to call `$appendMarkdown` with `trimWhitespace=true` when appending quote-reply content, preventing leading/trailing whitespace from creating extra/empty markdown lines (e.g., stray `>` markers) during append operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1923ef6d57c1394dafec4e9f6a040030da89efa5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->