### PR TITLE
fix(nwc): guard against undefined methods in supportedMethods

### DIFF
--- a/wallets/lib/protocols/nwc.js
+++ b/wallets/lib/protocols/nwc.js
@@ -71,5 +71,5 @@ export async function getNwc (nostr, url, { signal }) {
 
 export async function supportedMethods (url, { signal }) {
   const result = await nwcTryRun(nwc => nwc.getInfo(), { url }, { signal })
-  return result.methods
+  return result.methods || []
 }


### PR DESCRIPTION
Hi there\! I noticed a bug reported in #2808 where NWC wallet attachment crashes when the wallet service does not return a `methods` field in its `get_info` response.

## What
When attaching a Nostr Wallet Connect wallet, the UI crashes with `TypeError: Cannot read properties of undefined (reading 'includes')` if the NWC service omits the `methods` field from its `get_info` response.

## Why
The `supportedMethods()` function in `wallets/lib/protocols/nwc.js` returns `result.methods` directly. When the NWC wallet does not include a `methods` field (which is valid per NIP-47 for legacy/minimal implementations), this returns `undefined`. Both `wallets/client/protocols/nwc.js` and `wallets/server/protocols/nwc.js` then call `.includes()` on this undefined value, causing the crash.

## How
Return `result.methods || []` from `supportedMethods()` so that callers can safely call `.includes()` without crashing. An empty array correctly indicates that no methods are explicitly supported, which will cause the appropriate permission errors to be thrown downstream rather than an unhandled TypeError.

Closes #2808