### PR TITLE
Add aria/testids to zap button for automation

### DIFF
--- a/components/upvote.js
+++ b/components/upvote.js
@@ -250,7 +250,14 @@ export default function UpVote ({ item, className, collapsed }) {
         onShortPress={handleShortPress}
       >
         <ActionTooltip notForm disable={disabled} overlayText={overlayText}>
-          <div className={classNames(disabled && styles.noSelfTips, styles.upvoteWrapper)}>
+          <div
+            className={classNames(disabled && styles.noSelfTips, styles.upvoteWrapper)}
+            role='button'
+            tabIndex={0}
+            aria-label={meSats ? 'zapped' : 'zap'}
+            aria-pressed={meSats ? 'true' : 'false'}
+            data-testid='btn-zap'
+          >
             <UpBolt
               width={26}
               height={26}


### PR DESCRIPTION
## Description

Added small accessibility + automation hooks to the zap (bolt) control in `components/upvote.js`:

- Added `data-testid="btn-zap"` so headless/automation can reliably target the correct element (instead of guessing which SVG/icon was clicked).
- Added `aria-label` and `aria-pressed` to expose state (zapped vs not zapped) to assistive tech and to make automated checks deterministic.
- Added `role="button"` + `tabIndex={0}` to make the interactive wrapper more semantically correct.

Why: In headless/mobile-style UIs it’s easy to click the wrong icon (share/menu/etc.). These attributes reduce ambiguity and make it safer to automate flows (e.g., future NWC/zap testing) without changing existing zap behavior.

No behavior changes to zap amounts, tipping logic, or payment flows.

## Screenshots

N/A (attribute-only change; no visible UI changes)

## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_

- This PR intentionally avoids adding any new buttons or hardcoded zap amounts. It only adds semantics/test selectors.
- If we want to fully automate “custom zap amount” flows later, the next minimal step would be adding `data-testid` attributes to the zap modal input + submit button (in `ItemAct`), but that’s out of scope here.

## Checklist

Are your changes backward compatible? Please answer below:

Yes. Additive attribute changes only; no API/db changes.

On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:

6/10 — ran `npm run lint` and `npm test`. No visible UI change expected; did not do full manual browser testing.

For frontend changes: Tested on mobile, light and dark mode? Please answer below:

Not visually tested (no UI changes expected). Attributes should be mode-independent.

Did you introduce any new environment variables? If so, call them out explicitly here:

No.

Did you use AI for this? If so, how much did it assist you?

Yes — AI assisted with identifying minimal, low-risk attribute additions and implementing the patch (~70–80% assist).
