### PR TITLE
don't outline and track muted comments

### DIFF
--- a/components/comment.js
+++ b/components/comment.js
@@ -162,6 +162,9 @@ export default function Comment ({
   }, [item.id, cache, router.query.commentId])
 
   useEffect(() => {
+    // don't outline muted comments
+    const isMuted = item.user?.meMute
+    if (isMuted) return
     // checking navigator because outlining should happen only on item pages
     if (!navigator || me?.id === item.user?.id) return
 


### PR DESCRIPTION
## Description

#2842 
Checks if the author of the new comment is not muted before outlining it (and tracking it via navigator).

## Screenshots


https://github.com/user-attachments/assets/f7932d7f-50de-4827-a28e-d1423368340d



## Additional Context

Maybe muted comments should appear at the bottom rather than the top!

## Checklist

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/UX logic change gated by a mute flag; minimal blast radius and no security or data-handling impact.
> 
> **Overview**
> Prevents muted users’ comments from being treated as “new” on item pages.
> 
> `Comment` now bails out of the outlining/`navigator.trackNewComment` effect when `item.user.meMute` is set, so muted comments won’t be highlighted or counted in the new-comment navigator flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d0098ab72c8c99036e69b366d530de0a8201f3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->