### PR TITLE
fix: always trim copied content on paste

### DIFF
--- a/lib/lexical/exts/markdown.js
+++ b/lib/lexical/exts/markdown.js
@@ -29,7 +29,7 @@ function onPasteForMarkdown (event, editor) {
       // we'll just get the plain text data from the clipboard
       const text = clipboardData.getData('text/plain') || clipboardData.getData('text/uri-list')
       if (text != null) {
-        $insertMarkdown(text)
+        $insertMarkdown(text, true)
       }
     }
   }, { tag: PASTE_TAG })


### PR DESCRIPTION
## Description

Context: https://stacker.news/items/1450735
The fix involves trimming the copied text content before pasting/inserting it into the editor.

## Additional Context

We shouldn't encounter extra special characters because we're using the `text/plain` data of `ClipboardData`, but some third-party editors/browsers may still inject these on copy.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
10, trims the copied content, sounds okay!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to paste behavior; main risk is minor UX regression if leading/trailing whitespace in pasted text was previously expected to be preserved.
> 
> **Overview**
> When pasting into the Lexical markdown text editor, the paste handler now calls `$insertMarkdown(text, true)` so pasted clipboard content is cleaned (zero-width spaces removed) and whitespace is trimmed before insertion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de75efe08e0b7502a2c3f955a5dc6afd2dbbac53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->