### PR TITLE
fix: don't check for links when pasting into a CodeNode

### DIFF
--- a/components/editor/plugins/link/index.js
+++ b/components/editor/plugins/link/index.js
@@ -11,6 +11,7 @@ import LinkEditor from './editor'
 import { getSelectedNode } from '@/lib/lexical/commands/utils'
 import { SN_TOGGLE_LINK_COMMAND } from '@/lib/lexical/commands/links'
 import { ensureProtocol, removeTracking, URL_REGEXP } from '@/lib/url'
+import { $isCodeNode } from '@lexical/code'
 
 export default function LinkEditorPlugin ({ anchorElem }) {
   const [isLinkEditable, setIsLinkEditable] = useState(false)
@@ -86,6 +87,14 @@ export default function LinkEditorPlugin ({ anchorElem }) {
         (event) => {
           const selection = $getSelection()
           if (!$isRangeSelection(selection)) return false
+
+          // check if we're inside a CodeNode
+          const anchorNode = selection.anchor.getNode()
+          const codeNode = $findMatchingParent(anchorNode, $isCodeNode)
+          if (codeNode) {
+            // let default paste behavior handle it (plain text)
+            return false
+          }
 
           const text = event.clipboardData?.getData('text/plain')?.trim()
           if (!text || !URL_REGEXP.test(text)) return false


### PR DESCRIPTION
## Description

Our own Link plugin intercepts pastes via `PASTE_COMMAND` and places an `AutoLinkNode` if the content contains a URL. Naively this also happens inside `CodeNode`s, when it shouldn't.

This PR fixes this by checking if we're inside of a `CodeNode` before even running our own custom `PASTE_COMMAND` to search for links.

## Screenshots

## Additional Context

Thankfully `CodeNode` cleans up any unwanted nodes by itself, but selection was anyway hindered and pasting item links would result in pasting something like `#123456`.

## Checklist

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, can paste normally in `CodeNode` and the link detection still works outside of it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to paste handling that only bypasses URL auto-linking when the cursor is within a `CodeNode`.
> 
> **Overview**
> Prevents the link plugin’s `PASTE_COMMAND` handler from auto-wrapping pasted URLs as links when the selection is inside a `CodeNode`, letting Lexical’s default plain-text paste behavior run instead.
> 
> This adds a `@lexical/code` dependency and a parent-node check before running the URL detection/`AutoLinkNode` insertion logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94145dc7f4199dfda00aad40192bf0c6c57627b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->