### PR TITLE
deps: flatted to 3.4.2, sjcl to 1.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18986,9 +18986,10 @@
       "dev": true
     },
     "node_modules/sjcl": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.8.tgz",
-      "integrity": "sha512-LzIjEQ0S0DpIgnxMEayM1rq9aGwGRG4OnZhCdjx7glTaJtf4zRfpg87ImfjSJjoW9vKpagd82McDOwbRT5kQKQ==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.9.tgz",
+      "integrity": "sha512-dWM71tkSHxe7zEZj0/COjtJdmErIxp7UMp8a6D4xx8dTTtJLc4lFL+HAX8s6lvASyQQ2iYMHwa7rhhQq7MT5MA==",
+      "license": "(BSD-2-Clause OR GPL-2.0-only)",
       "engines": {
         "node": "*"
       }


### PR DESCRIPTION
## Description

Very minor bumps from `npm audit`:

#### dev-only:

- bump flatted to 3.4.2 (again, sigh) 
  - fixes GHSA-rf6f-7fwh-wjgh 
  - no impact outside of linter

#### dependency-of-dependency

- bump sjcl to 1.0.9
  - `macaroon` depends on this.
  - fixes `CVE-2026-4258` 
  - no direct use of this, just another lib that bundles too much in one place.

I separated them into a commit each, due to the different nature of both issues (despite the fix being `npm audit fix` for both) in case I messed up and there's some future rollback need.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

- Code review (of [`macaroon`](https://github.com/go-macaroon/js-macaroon)) revealed no active paths for the `sjcl` issues
- Tested linter.
- Tested invoices.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No

**Did you use AI for this? If so, how much did it assist you?**

No
