### PR TITLE
feat: retry ots jobs when they fail

### DIFF
--- a/api/payIn/types/itemCreate.js
+++ b/api/payIn/types/itemCreate.js
@@ -233,8 +233,14 @@ export async function onPaid (tx, payInId) {
   // If this is a freebie comment, increment the free comment counter
   await incrementFreeCommentCount(tx, { item, userId: payIn.userId })
 
-  await tx.$executeRaw`INSERT INTO pgboss.job (name, data, startafter, priority)
-    VALUES ('timestampItem', jsonb_build_object('id', ${item.id}::INTEGER), now() + interval '10 minutes', -2)`
+  // retry OpenTimestamps stamp up to 12x with 10 minutes spacing
+  //
+  // NOTE: we cannot use pgboss' backoff mechanism as its jitter is up to an entire
+  // `retrydelay` period, and thus would make it possible for a parent to be
+  // consistently processed after a child, making this fragile; we have to maintain
+  // item creation order for this.
+  await tx.$executeRaw`INSERT INTO pgboss.job (name, data, startafter, priority, retrylimit, retrydelay, retrybackoff)
+    VALUES ('timestampItem', jsonb_build_object('id', ${item.id}::INTEGER), now() + interval '10 minutes', -2, 12, 600, false)`
   await tx.$executeRaw`
     INSERT INTO pgboss.job (name, data, retrylimit, retrybackoff, startafter)
     VALUES ('imgproxy', jsonb_build_object('id', ${item.id}::INTEGER), 21, true, now() + interval '5 seconds')`

--- a/worker/index.js
+++ b/worker/index.js
@@ -85,6 +85,9 @@ async function work () {
   function jobWrapper (fn) {
     return async function (job) {
       console.log(`running ${job.name} with args`, job.data)
+      if (job.retrycount > 0) {
+        console.log(`  ... retry #${job.retrycount}/${job.retrylimit}`)
+      }
       try {
         await fn({ ...job, ...args })
       } catch (error) {
@@ -132,7 +135,7 @@ async function work () {
   await boss.work('payWeeklyPostBounty', jobWrapper(payWeeklyPostBounty))
   await boss.work('repin-*', jobWrapper(repin))
   await boss.work('trust', jobWrapper(trust))
-  await boss.work('timestampItem', jobWrapper(timestampItem))
+  await boss.work('timestampItem', { includeMetadata: true }, jobWrapper(timestampItem))
   await boss.work('earn', jobWrapper(earn))
   await boss.work('earnRefill', jobWrapper(earnRefill))
   await boss.work('streak', jobWrapper(computeStreaks))

--- a/worker/ots.js
+++ b/worker/ots.js
@@ -24,14 +24,21 @@ export async function timestampItem ({ data: { id }, apollo, models }) {
   })
 
   if (parentId && !parentOtsHash) {
-    console.log('no parent hash available ... skipping')
-    return
+    throw new Error('no parent hash available ... retrying later')
   }
 
-  // SHA256 hash item using a canonical serialization format { parentHash, title, text, url }
-  const itemString = stringifyCanon({ parentHash: parentOtsHash, title, text, url })
-  const otsHash = createHash('sha256').update(itemString).digest()
-  const detached = DetachedTimestampFile.fromHash(new OpSHA256(), otsHash)
+  let otsHash
+  let detached
+  try {
+    // SHA256 hash item using a canonical serialization format { parentHash, title, text, url }
+    const itemString = stringifyCanon({ parentHash: parentOtsHash, title, text, url })
+    otsHash = createHash('sha256').update(itemString).digest()
+    detached = DetachedTimestampFile.fromHash(new OpSHA256(), otsHash)
+  } catch (e) {
+    // if any of this errors out, it's non-recoverable: do not retry
+    console.error('Fatal error while generating ots timestamp data:', e)
+    return
+  }
 
   // timestamp it
   await Notary.stamp(detached)


### PR DESCRIPTION
fixes #2882

## Description

Small extension to the OTS job scheduler.

1. Retry every 10 minutes for a total of 120 minutes
2. Do not backoff, as pgboss backoff jitter has t*2 scope, this would lead to issues with children being posted rapidly after their parents during calendar downtime
3. Logs retries explicitly
4. Be precise about what gets retried:
    - Missing parent, retry (low cost)
    - Errors during stringification, hashing or serialization, do not
      retry. This is fatal because the content won't change next run
    - Failures with remotes or posting to database are retryable

Note: If this turns out to be triggered often (I've yet to experience the scenario where all calendars are down) we can evolve this into a batch retry system and reduce the number of jobs.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

I performed the following:

1. Agent-assisted code review on all data paths
2. Testing with a chain of comments-upon-comments and hardcoded erroring calendars (added `{ calendars: [...<failing_endpoints>] }` to `Notary.stamp()` call
  - Check that after the parent failed, all children fail too (because they want parent hash) but are retried
  - Check that item creation order is preserved (no jitter is applied to timing)
  - Check that retries also happen in order (no jitter is applied to retry timing)
  - Check that when "magically" urls work again, jobs succeed
  - Check that when jobs succeed, they aren't retried

**Did you use AI for this? If so, how much did it assist you?**

Only for finding the job post location under `api/` and code review