### PR TITLE
fix: misleading urls false positives

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -262,6 +262,16 @@ export function decodeProxyUrl (imgproxyUrl) {
 export function isMisleadingLink (text, href) {
   let misleading = false
 
+  // texts with non-trailing spaces are never urls
+  if (/\s/.test(text.trim())) {
+    return false
+  }
+
+  // numeric texts with periods that have less than 4 elements aren't hosts
+  if (/^\d+\.(\d+)(\.\d)?$/.test(text.trim())) {
+    return false
+  }
+
   try {
     const hrefUrl = new URL(href)
 

--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -44,7 +44,15 @@ const misleadingLinkCases = [
   ['innocent.text', 'https://stacker.news/items/1234', true],
   ['https://google.com', 'https://bing.com', true],
   ['www.google.com', 'https://bing.com', true],
-  ['s-tacker.news', 'https://snacker.news', true]
+  ['s-tacker.news', 'https://snacker.news', true],
+  // don't catch edge cases with spaces
+  ['11.1 percent', 'https://example.com', false],
+  ['for 11.1 percent', 'https://example.com', false],
+  ['v11.1', 'https://example.com', false],
+  // don't catch numeric-only, except for IP addresses
+  ['11.1', 'https://example.com', false],
+  ['11.1.0', 'https://example.com', false],
+  ['11.1.0.0', 'https://example.com', true]
 ]
 
 describe('misleading links', () => {


### PR DESCRIPTION
Fixes #2889 

## Description

- Fix cases where numeric labels in markdown urls are recognized as misleading when they contain a period, up until 3 segments, to still consider IP addresses as misleading.
- Fix chromium specific case where URLs with spaces are deemed valid.
- Added tests to lib/url.spec.js to fixate behavior

## Additional Context

I made a choice to keep any pattern `\d\.\d\.\d\.\d` or more digits as "misleading", even though I'm not sure how much use that is.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

Tested in Chrome, Brave, Vanadium and Safari to make sure that the following patterns do not get flagged as "misleading":

- `[1.](https://example.com)`
- `[1.1](https://example.com)`
- `[1.1.1](https://example.com)`
- `[11.1 percent](https://example.com)`
- `[v1.1](https://example.com)`

But that - `[1.1.1.1](https://example.com)` does get flagged as misleading.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Yes.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

No.