### PR TITLE
style: show scrollbar on quote node horizontal overflow

### DIFF
--- a/styles/text.scss
+++ b/styles/text.scss
@@ -167,6 +167,9 @@
   > *:last-child {
     margin-bottom: 0;
   }
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--theme-borderColor) var(--theme-commentBg);
 }
 
 .sn-media {


### PR DESCRIPTION
## Description

Fix #2884
Adds an horizontal scrollbar to quote nodes that overflow, which can happen when they contain nodes such as block-level `MathNode`s 

## Screenshots

Quote node with math node with scrollbar

<img width="1349" height="209" alt="image" src="https://github.com/user-attachments/assets/ab5e2702-7107-47e0-a740-ff72cf6e0315" />

## Additional Context

I think this can happen again with other nodes, Lexical styling needs a rework considering it survived all the stages that came after the original PR.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, adds a scrollbar on overflow-x

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
no