### PR TITLE
fix: don't escape `[` bracket in linktext

### DIFF
--- a/lib/lexical/utils/mdast.js
+++ b/lib/lexical/utils/mdast.js
@@ -124,7 +124,9 @@ export function $lexicalToMarkdown (transformerBridge = false) {
         // prevent autolink syntax (<url>), always use [text](url)
         link: (node, _parent, state) => {
           const text = state.containerPhrasing(node, { before: '[', after: ']' })
-          return `[${text}](${node.url || ''}${node.title ? ` "${node.title}"` : ''})`
+          // gfm-footnote extension marks [ as unsafe in phrasing,
+          // but [ can't start footnotes or nested links inside link text, so the escape is unnecessary
+          return `[${text.replace(/\\\[/g, '[')}](${node.url || ''}${node.title ? ` "${node.title}"` : ''})`
         }
       }
     }


### PR DESCRIPTION
## Description

Fixes #2879 

`gfm-footnote` `toMarkdown` extension marks `[` as unsafe in phrasing to protect from unwanted footnotes or nested links, but footnotes or nested links can't start anyway inside of linktext.
This PR unescapes `[` square brackets inside of `linktext` (text node inside of a link node).

## Screenshots


https://github.com/user-attachments/assets/f528bff2-b11d-4c27-bb32-5427b4569b8f



## Additional Context

One of the goals of future stages is to implement a better method for customizing escaping.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._
Yes
**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
review, tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: narrow change to Markdown serialization that only alters escaping behavior inside link text; main risk is minor formatting regressions in edge-case link rendering.
> 
> **Overview**
> Fixes Lexical-to-Markdown export so link text no longer keeps escaped `\[` characters introduced by the `gfm-footnote` phrasing safety rules. The `link` `toMarkdown` handler now unescapes `[` within link text while still emitting standard `[text](url "title")` syntax.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c307919e426eab5a985e7c4666311a53b16f0a6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->