### PR TITLE
fix: remove references to old markdown rich paste plugin from Editor

### DIFF
--- a/components/editor/editor.js
+++ b/components/editor/editor.js
@@ -27,7 +27,6 @@ import { SoftkeyEmptyGuardPlugin } from '@/components/editor/plugins/patch/softk
 import { MarkdownTextExtension } from '@/lib/lexical/exts/markdown'
 import AppendValuePlugin from '@/components/editor/plugins/core/append-value'
 import TransformerBridgePlugin from '@/components/editor/plugins/core/transformer-bridge'
-import MarkdownRichPastePlugin from '@/components/editor/plugins/core/markdown-paste'
 import { useEditorMode } from './contexts/mode'
 import { $markdownToLexical } from '@/lib/lexical/utils/mdast'
 import { RichTextExtension } from '@lexical/rich-text'
@@ -185,12 +184,7 @@ function EditorContent ({
           <LinkEditorPlugin anchorElem={containerRef} />
         </>
       )}
-      {isMarkdown && (
-        <>
-          <TransformerBridgePlugin />
-          <MarkdownRichPastePlugin />
-        </>
-      )}
+      {isMarkdown && <TransformerBridgePlugin />}
       {hint && <BootstrapForm.Text>{hint}</BootstrapForm.Text>}
       {warn && <BootstrapForm.Text className='text-warning'>{warn}</BootstrapForm.Text>}
     </div>


### PR DESCRIPTION
Missed this in #2896
This PR removes stale references to the old `MarkdownRichPastePlugin` that causes the editor to throw.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: deletes an unused/obsolete plugin import and render path in the editor, with minimal behavioral change beyond no longer attempting the old rich-paste handling in markdown mode.
> 
> **Overview**
> Stops the markdown editor mode from importing/rendering the deprecated `MarkdownRichPastePlugin`, leaving markdown mode to only use `TransformerBridgePlugin`.
> 
> This removes stale references that could cause the editor to throw at runtime when markdown mode is active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fa94e8bc2842b03e8760c9bc6ae3c9f273bdf82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->