### PR TITLE
fix: move aspect ratio declarations to video embed placeholders

### DIFF
--- a/styles/text.scss
+++ b/styles/text.scss
@@ -573,7 +573,6 @@ span + .sn-link {
 .sn-embed--youtube {
   width: 100%;
   max-width: 320px;
-  aspect-ratio: 16 / 9;
 }
 
 .topLevel .sn-embed--youtube {
@@ -584,7 +583,6 @@ span + .sn-link {
 .sn-embed--rumble {
   width: 100%;
   max-width: 320px;
-  aspect-ratio: 16 / 9;
 }
 
 .topLevel .sn-embed--rumble {
@@ -595,11 +593,19 @@ span + .sn-link {
 .sn-embed--peertube {
   width: 100%;
   max-width: 320px;
-  aspect-ratio: 16 / 9;
 }
 
 .topLevel .sn-embed--peertube {
   max-width: 640px;
+}
+
+// aspect-ratio only on HTML placeholders
+// this way embeds get aspect-ratio from their inner components,
+// and Safari won't break because of nested aspect-ratio declarations
+.sn-embed-placeholder.sn-embed--youtube,
+.sn-embed-placeholder.sn-embed--rumble,
+.sn-embed-placeholder.sn-embed--peertube {
+  aspect-ratio: 16 / 9;
 }
 
 // wavlake embed


### PR DESCRIPTION
## Description

Context: https://stacker.news/items/1464331 YouTube embed on Safari extends outside of its container
This PR fixes this bug by getting rid of `aspect-ratio` declarations on embed containers, avoiding conflicts with the child iframe's declarations on Safari.

The embed `aspect-ratio` declarations are moved to the respective HTML placeholders to maintain parity between SSR HTML and Lexical.

## Screenshots

Before:
<img width="1066" height="1111" alt="image" src="https://github.com/user-attachments/assets/40ae1e42-a34a-40b3-9ba3-5cbfe00dae57" />


After:
<img width="1103" height="1190" alt="image" src="https://github.com/user-attachments/assets/4518325e-c135-409a-a2f9-c9d0255ff541" />

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7, works on Safari, Chrome and Firefox. Tested with YouTube and Rumble embeds (peertube not available atm)

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
no