### PR TITLE
enhance: keep SubmitButton's appendText even if disabled

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -63,7 +63,7 @@ export function SubmitButton ({
         : onClick}
       {...props}
     >
-      {formik.isSubmitting ? submittingText : children}{!disabled && appendText && <small> {appendText}</small>}
+      {formik.isSubmitting ? submittingText : children}{appendText && <small> {appendText}</small>}
     </Button>
   )
 }

--- a/components/form.js
+++ b/components/form.js
@@ -63,7 +63,14 @@ export function SubmitButton ({
         : onClick}
       {...props}
     >
-      {formik.isSubmitting ? submittingText : children}{appendText && <small> {appendText}</small>}
+      {formik.isSubmitting
+        ? submittingText
+        : (
+          <>
+            {children}
+            {appendText && <small> {appendText}</small>}
+          </>
+          )}
     </Button>
   )
 }


### PR DESCRIPTION
## Description

Closes #2902
Keeps the fee text on `SubmitButton` even if it's disabled.

## Screenshots


https://github.com/user-attachments/assets/8f3d75ed-e64e-4247-9656-ea15579177c5



## Additional Context

No user of `FeeButton` specifies another `ChildButton` so the change has been applied only to `SubmitButton`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to button rendering; no data handling or behavioral changes beyond display of the appended text.
> 
> **Overview**
> Ensures `SubmitButton` always displays its `appendText` alongside the label whenever it is *not* submitting, even if the button is disabled.
> 
> This replaces the prior conditional that hid `appendText` when `disabled` and restructures the render to show only `submittingText` during `formik.isSubmitting`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82e967153e11c77ffe3c9273620086d23bccbec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->