### PR TITLE
fix sndev login and correct `useVerificationToken` query

### DIFF
--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -334,7 +334,7 @@ export const getAuthOptions = (req, res) => ({
           FROM (
             SELECT id FROM verification_requests
             WHERE identifier = ${identifier}
-            AND created_at > NOW() - INTERVAL '5 minutes'
+            AND expires > NOW()
             -- we need to find the most recent verification request for this email/identifier
             ORDER BY created_at DESC
             LIMIT 1

--- a/sndev
+++ b/sndev
@@ -508,10 +508,9 @@ sndev__login() {
   docker__exec db psql -U sn -d stackernews -q <<EOF
     INSERT INTO users (name) VALUES ('$1') ON CONFLICT DO NOTHING;
     UPDATE users SET email = '$email', "emailHash" = encode(digest(LOWER('$email')||'$salt', 'sha256'), 'hex') WHERE name = '$1';
+    DELETE FROM verification_requests WHERE token = '$token';
     INSERT INTO verification_requests (identifier, token, expires)
-      VALUES ('$email', '$token', NOW() + INTERVAL '1 day')
-      ON CONFLICT (token) DO UPDATE
-      SET identifier = '$email', expires = NOW() + INTERVAL '1 day';
+      VALUES ('$email', '$token', NOW() + INTERVAL '1 day');
 EOF
 
   echo


### PR DESCRIPTION
Surfaced by @sir-opti 

## Description

Trying to login with another account with `sndev login` can fail because our useVerificationToken in [...nextauth].js only gets verification tokens created in the last 5 minutes, instead of checking the `expires` date.

I propose two changes

- Adjust the `useVerificationToken` query to get unexpired verification requests instead of requests created in the last 5 minutes
  - the query was wrong from the start, it should check for `expires`
- `sndev login` deletes existing verification requests with the same token before inserting a new one.
  - futureproofing

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8e9a61158af879a67147e571fbf2992ebb26ed4a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->