### PR TITLE
fix: improve error handling of Lexical generators

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -100,9 +100,12 @@ export function useOverflow ({ containerRef, truncated = false }) {
   return { overflowing, show, setShow, Overflow }
 }
 
-export default function Text ({ topLevel, children, className, innerClassName, state, html, imgproxyUrls, rel, name, readerRef }) {
+export default function Text ({ topLevel, children: text, className, innerClassName, state, html, imgproxyUrls, rel, name, readerRef }) {
+  // if we don't have anything to render, bail
+  if (!state && !text?.trim()) return null
+
   const containerRef = useRef(null)
-  const { overflowing, show, Overflow } = useOverflow({ containerRef, truncated: !!children })
+  const { overflowing, show, Overflow } = useOverflow({ containerRef, truncated: !!text })
   const carousel = useCarousel()
 
   const textClassNames = useMemo(() => {
@@ -119,7 +122,7 @@ export default function Text ({ topLevel, children, className, innerClassName, s
       <SNReader
         topLevel={topLevel}
         state={state}
-        text={children} // if children is provided, markdown will be parsed and rendered
+        text={text} // if text is provided, markdown will be parsed and rendered
         html={html}
         imgproxyUrls={imgproxyUrls}
         rel={rel}
@@ -128,7 +131,7 @@ export default function Text ({ topLevel, children, className, innerClassName, s
         innerClassName={innerClassName}
       />
     )
-  }, [children, topLevel, state, html, imgproxyUrls, rel, readerRef, name, innerClassName])
+  }, [text, topLevel, state, html, imgproxyUrls, rel, readerRef, name, innerClassName])
 
   return (
     <div className={textClassNames} ref={containerRef}>

--- a/components/text.js
+++ b/components/text.js
@@ -100,12 +100,30 @@ export function useOverflow ({ containerRef, truncated = false }) {
   return { overflowing, show, setShow, Overflow }
 }
 
-export default function Text ({ topLevel, children: text, className, innerClassName, state, html, imgproxyUrls, rel, name, readerRef }) {
+/**
+ * Renders rich content from Markdown or Lexical state
+ *
+ * @param {object} props - props object
+ * @param {boolean} props.topLevel - whether to render as top-level content
+ * @param {string} props.children - Markdown text
+ * @param {string} props.className - container class name
+ * @param {string} props.innerClassName - Lexical contenteditable className
+ * @param {string} props.state - serialized Lexical state
+ * @param {string} props.html - pre-Lexical SSR HTML content
+ * @param {object} props.imgproxyUrls - imgproxy data object
+ * @param {string} props.rel - link rel attribute
+ * @param {string} props.name - link name attribute
+ * @param {object} props.readerRef - reader ref
+ */
+export default function Text (props) {
   // if we don't have anything to render, bail
-  if (!state && !text?.trim()) return null
+  if (!props.state && !props.children?.trim()) return null
+  return <TextBody {...props} />
+}
 
+export function TextBody ({ topLevel, children, className, innerClassName, state, html, imgproxyUrls, rel, name, readerRef }) {
   const containerRef = useRef(null)
-  const { overflowing, show, Overflow } = useOverflow({ containerRef, truncated: !!text })
+  const { overflowing, show, Overflow } = useOverflow({ containerRef, truncated: !!children })
   const carousel = useCarousel()
 
   const textClassNames = useMemo(() => {
@@ -122,7 +140,7 @@ export default function Text ({ topLevel, children: text, className, innerClassN
       <SNReader
         topLevel={topLevel}
         state={state}
-        text={text} // if text is provided, markdown will be parsed and rendered
+        text={children} // if children is provided, markdown will be parsed and rendered
         html={html}
         imgproxyUrls={imgproxyUrls}
         rel={rel}
@@ -131,7 +149,7 @@ export default function Text ({ topLevel, children: text, className, innerClassN
         innerClassName={innerClassName}
       />
     )
-  }, [text, topLevel, state, html, imgproxyUrls, rel, readerRef, name, innerClassName])
+  }, [children, topLevel, state, html, imgproxyUrls, rel, readerRef, name, innerClassName])
 
   return (
     <div className={textClassNames} ref={containerRef}>

--- a/lib/lexical/server/html.js
+++ b/lib/lexical/server/html.js
@@ -44,7 +44,7 @@ export function lexicalHTMLGenerator (lexicalState, options = {}, editorOptions 
         // if the html conversion fails, we'll use the lexicalState directly
         // this might be a problem for instant content
         console.error('error generating HTML in SSR from Lexical State: ', error)
-        return 'Error generating HTML, content will be loaded in a moment.'
+        html = 'Error generating HTML, content will be loaded in a moment.'
       }
     })
 

--- a/lib/lexical/server/html.js
+++ b/lib/lexical/server/html.js
@@ -30,7 +30,7 @@ export function lexicalHTMLGenerator (lexicalState, options = {}, editorOptions 
     try {
       editor.setEditorState(editor.parseEditorState(lexicalState))
     } catch (error) {
-      return 'error generating HTML, another attempt will be made. the text will be hydrated in a moment.'
+      return 'Error generating rich content, another attempt will be made. Mention an admin if this persists.'
     }
     let html = ''
 
@@ -44,7 +44,7 @@ export function lexicalHTMLGenerator (lexicalState, options = {}, editorOptions 
         // if the html conversion fails, we'll use the lexicalState directly
         // this might be a problem for instant content
         console.error('error generating HTML in SSR from Lexical State: ', error)
-        html = null
+        return 'Error generating HTML, content will be loaded in a moment.'
       }
     })
 

--- a/lib/lexical/server/interpolator.js
+++ b/lib/lexical/server/interpolator.js
@@ -7,15 +7,13 @@ import { ItemContextExtension } from '@/lib/lexical/exts/item-context'
 import { mergeRegister } from '@lexical/utils'
 
 /**
- * converts markdown to Lexical state or processes existing state
+ * converts markdown to a serialized Lexical state
  * @param {string} [params.text] - markdown text to convert
  * @param {Object} [params.context] - context object
- * @returns {Promise<Object>} object with text and lexicalState properties
+ * @returns {string|null} serialized lexical state or null for empty content
  */
-export async function prepareLexicalState ({ text, context = {} }) {
-  if (!text) {
-    throw new Error('text is required')
-  }
+export function prepareLexicalState ({ text, context = {} }) {
+  if (!text?.trim()) return null
 
   const editor = createSNHeadlessEditor()
   // register extensions, must be registerable

--- a/lib/lexical/server/loader.js
+++ b/lib/lexical/server/loader.js
@@ -49,11 +49,14 @@ export function lexicalStateLoader ({ me, userLoader } = {}) {
           // filter out media if the user has disabled them
           const showImagesAndVideos = userFilters.showImagesAndVideos
           const imgproxyOnly = userFilters.imgproxyOnly
-          return prepareLexicalState({ text, context: { ...rest, outlawed, showImagesAndVideos, imgproxyOnly } })
-            .catch(error => {
-              console.error('error preparing Lexical State:', error)
-              return null
-            })
+
+          try {
+            const lexicalState = prepareLexicalState({ text, context: { ...rest, outlawed, showImagesAndVideos, imgproxyOnly } })
+            return lexicalState
+          } catch (error) {
+            console.error('error preparing Lexical State:', error)
+            return null
+          }
         })
       )
     },


### PR DESCRIPTION
## Description

Fixes #2911 
This PR instructs `prepareLexicalState` to handle missing/empty `text`, and enhances the error handling of the Lexical State and HTML generators.

## Changes

- `prepareLexicalState` never returned a promise/did any async work, its signature has been corrected.
- HTML generation now shows two different errors to the user
  - lexical state is invalid (primary error, cannot show any content)
    - `Error generating rich content, another attempt will be made. Mention an admin if this persists.`
  - cannot generate HTML nodes from a lexical state (secondary error, can show lexical content afterwards)
    - `Error generating HTML, content will be loaded in a moment.`

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7, tested on `null` text, `\n` text, normal text.

**Did you use AI for this? If so, how much did it assist you?**

no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes server-side rich-text generation paths and introduces early-return behavior that could hide content if inputs are unexpectedly empty or malformed.
> 
> **Overview**
> Improves robustness of rich-text rendering/generation by treating empty/whitespace Markdown as no content and by tightening error handling for Lexical SSR.
> 
> `Text` now bails out when both `state` and trimmed `children` are missing, and rich-content generation distinguishes between invalid Lexical state (user-facing “rich content” error) vs HTML node generation failures (fallback message while client hydration loads). `prepareLexicalState` is corrected to be synchronous, return `null` for empty input, and `lexicalStateLoader` is updated to handle errors without async `.catch`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5900f5411e7aadc6a8b4fbd8602cff6058362fc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->