### PR TITLE
remove unmaintained bolt11 dep

### DIFF
--- a/api/resolvers/payIn.js
+++ b/api/resolvers/payIn.js
@@ -8,6 +8,7 @@ import { decodeCursor, LIMIT, nextCursorEncoded } from '@/lib/cursor'
 import { getItem, getItemsById } from './item'
 import { getSub } from './sub'
 import { Prisma } from '@prisma/client'
+import { parsePaymentRequest } from 'ln-service'
 
 function payInResultType (payInType) {
   switch (payInType) {
@@ -32,6 +33,18 @@ function payInResultType (payInType) {
 function isMine (payIn, { me }) {
   const meId = me?.id ?? USER_ID.anon
   return Number(meId) === Number(payIn.userId)
+}
+
+function invoiceDescription (bolt11) {
+  if (!bolt11) {
+    return null
+  }
+
+  try {
+    return parsePaymentRequest({ request: bolt11 }).description ?? null
+  } catch {
+    return null
+  }
 }
 
 async function hydratePayInItems (payIns, { me, models }) {
@@ -344,6 +357,14 @@ export default {
         return null
       }
       return payInBolt11.preimage
+    },
+    description: (payInBolt11) => {
+      return invoiceDescription(payInBolt11.bolt11)
+    }
+  },
+  PayOutBolt11: {
+    description: (payOutBolt11) => {
+      return invoiceDescription(payOutBolt11.bolt11)
     }
   },
   PayOutCustodialToken: {

--- a/api/typeDefs/payIn.js
+++ b/api/typeDefs/payIn.js
@@ -105,6 +105,7 @@ type PayInBolt11 {
   preimage: String
   hmac: String
   bolt11: String!
+  description: String
   expiresAt: Date!
   confirmedAt: Date
   cancelledAt: Date
@@ -236,6 +237,7 @@ type PayOutBolt11 {
   hash: String
   preimage: String
   bolt11: String
+  description: String
   expiresAt: Date!
 }
 

--- a/components/invoice.js
+++ b/components/invoice.js
@@ -4,7 +4,7 @@ import AccordianItem from './accordian-item'
 import Qr, { QrSkeleton } from './qr'
 import { CompactLongCountdown } from './countdown'
 import PayerData from './payer-data'
-import Bolt11Info from './bolt11-info'
+import Bolt11Info from './payIn/bolt11-info'
 import { useQuery } from '@apollo/client/react'
 import { INVOICE } from '@/fragments/invoice'
 import { FAST_POLL_INTERVAL_MS, SSR } from '@/lib/constants'
@@ -99,7 +99,7 @@ export default function Invoice ({
     )
   }
 
-  const { bolt11, confirmedPreimage } = invoice
+  const { bolt11, confirmedPreimage, hash, description } = invoice
 
   return (
     <>
@@ -113,7 +113,7 @@ export default function Invoice ({
         <>
           {info && <div className='text-muted fst-italic text-center'>{info}</div>}
           <InvoiceExtras {...invoice} />
-          <Bolt11Info bolt11={bolt11} preimage={confirmedPreimage} />
+          <Bolt11Info bolt11={bolt11} hash={hash} preimage={confirmedPreimage} description={description} />
           {invoice?.item && <ActionInfo invoice={invoice} />}
         </>}
     </>

--- a/components/payIn/bolt11-info.js
+++ b/components/payIn/bolt11-info.js
@@ -1,12 +1,6 @@
 import { CopyInput } from '@/components/form'
-import { bolt11Tags } from '@/lib/bolt11'
 
-export default ({ bolt11, preimage, children }) => {
-  let description, paymentHash
-  if (bolt11) {
-    ({ description, payment_hash: paymentHash } = bolt11Tags(bolt11))
-  }
-
+export default ({ bolt11, hash, preimage, description, children }) => {
   return (
     <div className='d-grid align-items-center w-100' style={{ gridTemplateColumns: 'auto 1fr', gap: '0.5rem' }}>
       {bolt11 &&
@@ -20,7 +14,7 @@ export default ({ bolt11, preimage, children }) => {
             placeholder={bolt11}
           />
         </>}
-      {paymentHash &&
+      {hash &&
         <>
           <div>hash</div>
           <CopyInput
@@ -28,7 +22,7 @@ export default ({ bolt11, preimage, children }) => {
             groupClassName='w-100 mb-0'
             readOnly
             noForm
-            placeholder={paymentHash}
+            placeholder={hash}
           />
         </>}
       {preimage &&

--- a/components/payIn/context.js
+++ b/components/payIn/context.js
@@ -43,7 +43,14 @@ export function PayInContext ({ payIn }) {
       return <div className='w-100'><PayInMetadata payInBolt11={payIn.payerPrivates.payInBolt11} /></div>
     case 'WITHDRAWAL':
     case 'AUTO_WITHDRAWAL':
-      return <Bolt11Info bolt11={payIn.payeePrivates.payOutBolt11.bolt11} preimage={payIn.payeePrivates.payOutBolt11.preimage} />
+      return (
+        <Bolt11Info
+          bolt11={payIn.payeePrivates.payOutBolt11.bolt11}
+          hash={payIn.payeePrivates.payOutBolt11.hash}
+          preimage={payIn.payeePrivates.payOutBolt11.preimage}
+          description={payIn.payeePrivates.payOutBolt11.description}
+        />
+      )
     case 'DONATE':
       return <small className='text-muted d-flex justify-content-center w-100'>Praise be, you donated to the rewards pool.</small>
     case 'BUY_CREDITS':

--- a/components/payIn/index.js
+++ b/components/payIn/index.js
@@ -66,7 +66,14 @@ export default function PayIn ({ id, ssrData }) {
                 <div className='mt-3'>
                   <AccordianItem
                     header='lightning invoice'
-                    body={<Bolt11Info bolt11={payIn.payerPrivates.payInBolt11.bolt11} preimage={payIn.payerPrivates.payInBolt11.preimage} />}
+                    body={(
+                      <Bolt11Info
+                        bolt11={payIn.payerPrivates.payInBolt11.bolt11}
+                        hash={payIn.payerPrivates.payInBolt11.hash}
+                        preimage={payIn.payerPrivates.payInBolt11.preimage}
+                        description={payIn.payerPrivates.payInBolt11.description}
+                      />
+                    )}
                   />
                 </div>
                 )}

--- a/fragments/payIn.js
+++ b/fragments/payIn.js
@@ -27,6 +27,7 @@ export const PAY_IN_BOLT11_FIELDS = gql`
     payInId
     bolt11
     hash
+    description
     hmac
     msatsRequested
     msatsReceived
@@ -178,7 +179,9 @@ export const PAY_IN_STATISTICS_FIELDS = gql`
     payeePrivates {
       payOutBolt11 {
         msats
+        hash
         bolt11
+        description
         preimage
         status
       }

--- a/lib/bolt11.js
+++ b/lib/bolt11.js
@@ -1,5 +1,0 @@
-import { decode } from 'bolt11'
-
-export function bolt11Tags (bolt11) {
-  return decode(bolt11).tagsObject
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "async-retry": "^1.3.3",
         "aws-sdk": "^2.1691.0",
         "bech32": "^2.0.0",
-        "bolt11": "^1.4.1",
         "bootstrap": "^5.3.8",
         "canonical-json": "0.0.4",
         "classnames": "^2.5.1",
@@ -6914,14 +6913,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -8950,26 +8941,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/bolt11": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/bolt11/-/bolt11-1.4.1.tgz",
-      "integrity": "sha512-jR0Y+MO+CK2at1Cg5mltLJ+6tdOwNKoTS/DJOBDdzVkQ+R9D6UgZMayTWOsuzY7OgV1gEqlyT5Tzk6t6r4XcNQ==",
-      "dependencies": {
-        "@types/bn.js": "^4.11.3",
-        "bech32": "^1.1.2",
-        "bitcoinjs-lib": "^6.0.0",
-        "bn.js": "^4.11.8",
-        "create-hash": "^1.2.0",
-        "lodash": "^4.17.11",
-        "safe-buffer": "^5.1.1",
-        "secp256k1": "^4.0.2"
-      }
-    },
-    "node_modules/bolt11/node_modules/bech32": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
-      "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -9015,11 +8986,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
@@ -9390,40 +9356,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cipher-base": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
-      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1",
-        "to-buffer": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/cipher-base/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
@@ -9668,18 +9600,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
       }
     },
     "node_modules/create-jest": {
@@ -10558,21 +10478,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
       "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "license": "ISC"
-    },
-    "node_modules/elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -12536,47 +12441,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hash-base": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
-      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/hash-base/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -12648,16 +12512,6 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
-      }
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -15859,16 +15713,6 @@
         "node": ">= 18"
       }
     },
-    "node_modules/md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
@@ -16746,11 +16590,6 @@
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
-    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -16978,11 +16817,6 @@
       "resolved": "https://registry.npmjs.org/noble-secp256k1/-/noble-secp256k1-1.2.14.tgz",
       "integrity": "sha512-GSCXyoZBUaaPwVWdYncMEmzlSUjF9J/YeEHpklYJCyg8wPuJP3NzDx0BkiwArzINkdX2HJHvUJhL6vVWPOQQcg==",
       "deprecated": "Switch to namespaced @noble/secp256k1 for security and feature updates"
-    },
-    "node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
@@ -18538,19 +18372,6 @@
         "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
@@ -18864,15 +18685,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/ripemd160": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
-      }
-    },
     "node_modules/rollup": {
       "version": "2.80.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
@@ -19050,20 +18862,6 @@
       "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.1.tgz",
       "integrity": "sha512-lwsAIzOPlH8/7IIjjz3K0zYBk7aBVVcvjMwt3M4fLxpjMYyy7i3I97SLHebgn4YBjirkzfp3RvRDWSKsh/+WFw==",
       "license": "MIT"
-    },
-    "node_modules/secp256k1": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.4.tgz",
-      "integrity": "sha512-6JfvwvjUOn8F/jUoBY2Q1v5WY5XS+rj8qSe0v8Y4ezH4InLgTEeOOPQsRll9OV429Pvo6BCHGavIyJfr3TAhsw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "elliptic": "^6.5.7",
-        "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
     },
     "node_modules/secure-json-parse": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "async-retry": "^1.3.3",
     "aws-sdk": "^2.1691.0",
     "bech32": "^2.0.0",
-    "bolt11": "^1.4.1",
     "bootstrap": "^5.3.8",
     "canonical-json": "0.0.4",
     "classnames": "^2.5.1",

--- a/pages/withdraw.js
+++ b/pages/withdraw.js
@@ -14,7 +14,7 @@ import { lnAddrSchema, withdrawlSchema } from '@/lib/validate'
 import { useShowModal } from '@/components/modal'
 import { useField } from 'formik'
 import { useToast } from '@/components/toast'
-import { decode } from 'bolt11'
+import { bech32 } from 'bech32'
 import CameraIcon from '@/svgs/camera-line.svg'
 import useDebounceCallback from '@/components/use-debounce-callback'
 import { lnAddrOptions } from '@/lib/lnurl'
@@ -24,6 +24,19 @@ import PageLoading from '@/components/page-loading'
 import dynamic from 'next/dynamic'
 
 export const getServerSideProps = getGetServerSideProps({ authRequired: true })
+
+// LND and LDK both cap BOLT11 invoice length at 7089 bytes.
+const BOLT11_BECH32_LIMIT = 7089
+const BOLT11_PREFIX = /^ln(?:bc|tb|bcrt|tbs)\d*[munp]?$/i
+
+function isBolt11PaymentRequest (invoice) {
+  try {
+    const { prefix } = bech32.decode(invoice, BOLT11_BECH32_LIMIT)
+    return BOLT11_PREFIX.test(prefix)
+  } catch {
+    return false
+  }
+}
 
 export default function Withdraw () {
   return (
@@ -155,7 +168,7 @@ function InvoiceScanner ({ fieldName }) {
                     result = result.toLowerCase()
                     if (result.split('lightning=')[1]) {
                       helpers.setValue(result.split('lightning=')[1].split(/[&?]/)[0])
-                    } else if (decode(result.replace(/^lightning:/, ''))) {
+                    } else if (isBolt11PaymentRequest(result.replace(/^lightning:/, ''))) {
                       helpers.setValue(result.replace(/^lightning:/, ''))
                     } else {
                       throw new Error('Not a proper lightning payment request')


### PR DESCRIPTION
[bolt11](https://github.com/bitcoinjs/bolt11) isn't maintained and we use it sparingly. The main tradeoffs here are:

1. we can't do full clientside validation of the bolt11 aside from validating the prefix and encoding - but we do serverside still.
2. we can't extract description and hash from the bolt11 on the client.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Lightning invoice parsing/validation paths for withdrawals and invoice display; regressions could affect accepting/scanning payment requests or showing invoice metadata.
> 
> **Overview**
> Removes the unmaintained `bolt11` client dependency and the `lib/bolt11.js` helper, replacing client-side BOLT11 validation in `pages/withdraw.js` with a lightweight bech32 prefix/length check.
> 
> Adds `description` fields to the GraphQL `PayInBolt11` and `PayOutBolt11` types and resolves them server-side via `ln-service`’s `parsePaymentRequest`, then updates invoice/pay-in UIs and GraphQL fragments to consume `hash`/`description` from the API instead of decoding the invoice client-side.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c2f7cb64be801e254623c8f1307db0e4a51106. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->