### PR TITLE
fix: expose NEXT_PUBLIC_MDAST_DEBUG env var to service worker

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -271,6 +271,7 @@ module.exports = withPlausibleProxy({ src: 'https://plausible.io/js/pa-EScEhWlTi
             'process.env.NEXT_PUBLIC_NORMAL_POLL_INTERVAL_MS': JSON.stringify(process.env.NEXT_PUBLIC_NORMAL_POLL_INTERVAL_MS),
             'process.env.NEXT_PUBLIC_LONG_POLL_INTERVAL_MS': JSON.stringify(process.env.NEXT_PUBLIC_LONG_POLL_INTERVAL_MS),
             'process.env.NEXT_PUBLIC_EXTRA_LONG_POLL_INTERVAL_MS': JSON.stringify(process.env.NEXT_PUBLIC_EXTRA_LONG_POLL_INTERVAL_MS),
+            'process.env.NEXT_PUBLIC_MDAST_DEBUG': JSON.stringify(process.env.NEXT_PUBLIC_MDAST_DEBUG),
             'process.env.SANCTIONED_COUNTRY_CODES': JSON.stringify(process.env.SANCTIONED_COUNTRY_CODES),
             'process.env.NEXT_IS_EXPORT_WORKER': 'true'
           })


### PR DESCRIPTION
## Description

Context https://stacker.news/items/1471694
The whole `lib/constants.js` gets bundled with the service worker, but `process.env...` doesn't exist in that context. 

Every env var used in `lib/constants.js` must be exposed to the service worker by defining them in `webpack.DefinePlugin` inside `next.config.js`, Webpack will then replace `process.env...` with real values. 
In this case, we are missing `NEXT_PUBLIC_MDAST_DEBUG`

## Screenshots

This bug cannot be reproduced in dev

## Additional Context

I'm pretty sure we pull `lib/constants.js` only because we import `me.js` (which imports `constants.js`), not because we need them.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

4, can't QA, but it's the same bug we patched in #1947 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a single env var to the service worker webpack `DefinePlugin` mapping, affecting only build-time constant substitution for `sw.js`. Potential impact is limited to service worker behavior when this debug flag is used.
> 
> **Overview**
> Makes `NEXT_PUBLIC_MDAST_DEBUG` available inside the service worker bundle by adding it to the `webpack.DefinePlugin` env substitutions used during `InjectManifest`.
> 
> This prevents `process.env.NEXT_PUBLIC_MDAST_DEBUG` lookups from breaking in `sw.js`/bundled imports where `process.env` is not available at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d55f927b2ee771728875fd7dac375a7571df8127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->