### PR TITLE
formatting: fix footnote-ref superscript

### DIFF
--- a/styles/text.scss
+++ b/styles/text.scss
@@ -870,7 +870,7 @@ span + .sn-link {
   all: unset;
 }
 
-.sn-text__superscript {
+.sn-text__superscript, .sn-footnote-ref {
   vertical-align: super !important;
   font-size: .8em !important;
 }


### PR DESCRIPTION
## Description

After 786d8b0d, footnote refs were no longer superscript and I only just noticed this now. This change treats `.sn-footnote-ref` as `.sn-text__superscript`

## Screenshots

| Before | After |
| --- | --- |
| <img width="168" height="117" alt="before" src="https://github.com/user-attachments/assets/597aec3e-3ce5-4c91-8afd-b6a580294ebb" /> | <img width="196" height="127" alt="after" src="https://github.com/user-attachments/assets/77c3e6b0-68b2-466f-a4d3-a286989a3def" /> |

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No

**Did you use AI for this? If so, how much did it assist you?**

It found me the commit that caused it so that I didn't have to git-blame the tree. Yes, I'm lazy af.