### PR TITLE
fix: re-enable broadcasting cache changes to query watchers

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -37,8 +37,7 @@ function writeQuery (client, apollo, data) {
       query: gql`${apollo.query}`,
       data,
       variables: apollo.variables,
-      overwrite: SSR,
-      broadcast: false
+      overwrite: SSR
     })
   }
 }


### PR DESCRIPTION
## Description

Fixes #2924 
After migrating to Apollo Client 4 and React 19, query watchers no longer react to changes until they are broadcasted to them.

It seems like the only affected query watcher is the Notifications `useQuery`, specifically when reloading the page:
- the destination route is the same we're already on
- we refresh the list via SSR and `writeQuery`

This PR re-enables broadcasting cache changes to query watchers by dropping `broadcast: false`.

## Screenshots

https://github.com/user-attachments/assets/52d42548-1991-43d8-b11b-db3d624e688a


## Additional Context

I didn't find anything else like this, but I may be wrong.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes, `broadcast: true` only re-enables notifications to query watchers. It seems to affect only the Notifications' `useQuery`

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7, works as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a `broadcast: false` suppression so more query watchers will re-render on SSR cache writes, with limited potential for extra UI updates/perf impact.
> 
> **Overview**
> Reverts a previous suppression of Apollo cache broadcasts during SSR hydration by removing `broadcast: false` from the `client.writeQuery` call in `pages/_app.js`.
> 
> This allows active `useQuery` watchers (notably notifications) to react immediately to SSR-refreshed cache data instead of staying stale until a later broadcast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4909296919d3b271a20bbf38630703b2e8efefa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->