### PR TITLE
feat: improve pagination cursor with keyset pagination

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -59,16 +59,40 @@ export async function getItemsById (ids, { me, models }) {
   return items.map(({ rank, ...item }) => item)
 }
 
+export const getSortField = (by, type) => {
+  switch (by) {
+    case 'comments': return 'ncomments'
+    case 'sats': return 'ranktop'
+    case 'downsats': return 'downMsats'
+    default: return type === 'bookmarks' ? 'bookmarkCreatedAt' : 'created_at'
+  }
+}
+
+export const keysetClause = (decodedCursor, sortField, table = 'Item', op = '<', idField = 'id') => {
+  if (decodedCursor.id && decodedCursor.sortValue !== undefined) {
+    const field = sortField.includes('.') ? sortField : `"${table}"."${sortField}"`
+    const idColumn = `"${table}"."${idField}"`
+    const sortValue = sortField === 'created_at' || sortField === 'bookmarkCreatedAt' || sortField === 'payInStateChangedAt'
+      ? `(TO_TIMESTAMP(${decodedCursor.sortValue / 1000}) AT TIME ZONE 'UTC')`
+      : decodedCursor.sortValue
+
+    const lastId = typeof decodedCursor.id === 'string' ? `'${decodedCursor.id}'` : decodedCursor.id
+
+    return `(${field}, ${idColumn}) ${op} (${sortValue}, ${lastId})`
+  }
+  return null
+}
+
 const orderByClause = (by, me, models, type, sub) => {
   switch (by) {
     case 'comments':
-      return 'ORDER BY "Item".ncomments DESC'
+      return 'ORDER BY "Item".ncomments DESC, "Item".id DESC'
     case 'sats':
       return 'ORDER BY "Item".ranktop DESC, "Item".id DESC'
     case 'downsats':
-      return 'ORDER BY "Item"."downMsats" DESC'
+      return 'ORDER BY "Item"."downMsats" DESC, "Item".id DESC'
     default:
-      return `ORDER BY ${type === 'bookmarks' ? '"bookmarkCreatedAt"' : '"Item".created_at'} DESC`
+      return `ORDER BY ${type === 'bookmarks' ? 'b.created_at' : '"Item".created_at'} DESC, "Item".id DESC`
   }
 }
 
@@ -172,7 +196,7 @@ const relationClause = (type) => {
   let clause = ''
   switch (type) {
     case 'bookmarks':
-      clause += ' FROM "Item" JOIN "Bookmark" ON "Bookmark"."itemId" = "Item"."id" LEFT JOIN "Item" root ON "Item"."rootId" = root.id '
+      clause += ' FROM "Item" JOIN "Bookmark" b ON b."itemId" = "Item"."id" LEFT JOIN "Item" root ON "Item"."rootId" = root.id '
       break
     case 'comments':
     case 'freebies':
@@ -204,7 +228,7 @@ export const payInJoinFilter = me => {
 }
 
 const selectClause = (type) => type === 'bookmarks'
-  ? `${SELECT}, "Bookmark"."created_at" as "bookmarkCreatedAt"`
+  ? `${SELECT}, b."created_at" as "bookmarkCreatedAt"`
   : SELECT
 
 const subClauseTable = (type) => COMMENT_TYPE_QUERY.includes(type) ? 'root' : 'Item'
@@ -418,6 +442,7 @@ export default {
           }
 
           table = type === 'bookmarks' ? 'Bookmark' : 'Item'
+          const userSortField = getSortField(by, type)
           items = await itemQueryWithMeta({
             me,
             models,
@@ -430,9 +455,10 @@ export default {
                 activeOrMine(me),
                 typeClause(type),
                 by === 'downsats' && '"Item"."downMsats" > 0',
-                whenClause(when || 'forever', table))}
+                whenClause(when || 'forever', table),
+                keysetClause(decodedCursor, userSortField, table))}
               ${orderByClause(by, me, models, type)}
-              OFFSET $4
+              ${decodedCursor.id ? '' : 'OFFSET $4'}
               LIMIT $5`,
             orderBy: orderByClause(by, me, models, type)
           }, ...whenRange(when, from, to || decodedCursor.time), user.id, decodedCursor.offset, limit)
@@ -452,15 +478,17 @@ export default {
                 activeOrMine(me),
                 await filterClause(type, sub, 'new', ctx),
                 typeClause(type),
-                muteClause(me)
+                muteClause(me),
+                keysetClause(decodedCursor, 'payInStateChangedAt', 'PayIn')
               )}
-              ORDER BY "PayIn"."payInStateChangedAt" DESC
-              OFFSET $2
+              ORDER BY "PayIn"."payInStateChangedAt" DESC, "Item".id DESC
+              ${decodedCursor.id ? '' : 'OFFSET $2'}
               LIMIT $3`,
-            orderBy: 'ORDER BY "PayIn"."payInStateChangedAt" DESC'
+            orderBy: 'ORDER BY "PayIn"."payInStateChangedAt" DESC, "Item".id DESC'
           }, decodedCursor.time, decodedCursor.offset, limit, ...subArr)
           break
         case 'top':
+          const topSortField = getSortField(by || 'sats', type)
           items = await itemQueryWithMeta({
             me,
             models,
@@ -478,9 +506,10 @@ export default {
                 '"Item".status = \'ACTIVE\'',
                 by === 'downsats' && '"Item"."downMsats" > 0',
                 await filterClause(type, sub, 'top', ctx, by),
-                muteClause(me))}
+                muteClause(me),
+                keysetClause(decodedCursor, topSortField, 'Item'))}
               ${orderByClause(by || 'sats', me, models, type, sub)}
-              OFFSET $3
+              ${decodedCursor.id ? '' : 'OFFSET $3'}
               LIMIT $4`,
             orderBy: orderByClause(by || 'sats', me, models, type, sub)
           }, ...whenRange(when, from, to || decodedCursor.time), decodedCursor.offset, limit, ...subArr)
@@ -530,16 +559,26 @@ export default {
                   '"Item".status = \'ACTIVE\'',
                   await filterClause(type, sub, 'lit', ctx),
                   subClause(sub, 3, 'Item', me, showNsfw),
-                  muteClause(me))}
+                  muteClause(me),
+                  keysetClause(decodedCursor, 'ranklit'))}
                 ORDER BY ranklit DESC, "Item".id DESC
-                OFFSET $1
+                ${decodedCursor.id ? '' : 'OFFSET $1'}
                 LIMIT $2`,
             orderBy: 'ORDER BY ranklit DESC, "Item".id DESC'
           }, decodedCursor.offset, limit, ...subArr)
           break
       }
+
+      let nextSortField = 'created_at'
+      switch (sort) {
+        case 'new': nextSortField = 'payInStateChangedAt'; break
+        case 'top': nextSortField = getSortField(by || 'sats', type); break
+        case 'user': nextSortField = getSortField(by, type); break
+        default: nextSortField = 'ranklit'; break
+      }
+
       return {
-        cursor: items.length === limit ? nextCursorEncoded(decodedCursor, limit) : null,
+        cursor: items.length === limit ? nextCursorEncoded(decodedCursor, items, limit, nextSortField) : null,
         items,
         pins
       }

--- a/api/resolvers/sub.js
+++ b/api/resolvers/sub.js
@@ -1,6 +1,7 @@
 import { timeUnitForRange, whenRange } from '@/lib/time'
 import { validateSchema, territorySchema } from '@/lib/validate'
 import { decodeCursor, LIMIT, nextCursorEncoded } from '@/lib/cursor'
+import { keysetClause } from './item'
 import { notifyTerritoryTransfer } from '@/lib/webPush'
 import pay from '../payIn'
 import { GqlAuthenticationError, GqlInputError } from '@/lib/error'
@@ -90,12 +91,13 @@ export async function topSubs (parent, { query, cursor, when, from, to, limit, b
     )
     SELECT * FROM sub_stats
     JOIN "Sub" ON sub_stats.name = "Sub".name
-    ORDER BY ${column} DESC NULLS LAST, "Sub".created_at ASC
-    OFFSET ${decodedCursor.offset}
+    ${decodedCursor.id ? Prisma.sql`WHERE ${Prisma.raw(keysetClause(decodedCursor, column.values[0], 'Sub', '<', 'name'))}` : Prisma.empty}
+    ORDER BY ${column} DESC NULLS LAST, "Sub".name DESC
+    ${decodedCursor.id ? Prisma.empty : Prisma.sql`OFFSET ${decodedCursor.offset}`}
     LIMIT ${limit}`
 
   return {
-    cursor: subs.length === limit ? nextCursorEncoded(decodedCursor, limit) : null,
+    cursor: subs.length === limit ? nextCursorEncoded(decodedCursor, subs, limit, column.values[0], 'name') : null,
     subs
   }
 }

--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -3,7 +3,7 @@ import { join, resolve } from 'path'
 import { decodeCursor, LIMIT, nextCursorEncoded } from '@/lib/cursor'
 import { msatsToSats } from '@/lib/format'
 import { bioSchema, emailSchema, settingsSchema, validateSchema, userSchema } from '@/lib/validate'
-import { getItem, updateItem, filterClause, createItem, whereClause, muteClause, activeOrMine, payInJoinFilter } from './item'
+import { getItem, updateItem, filterClause, createItem, whereClause, muteClause, activeOrMine, payInJoinFilter, keysetClause } from './item'
 import { USER_ID, PAY_IN_NOTIFICATION_TYPES, WALLET_RETRY_BEFORE_MS, WALLET_MAX_RETRIES, SN_SYSTEM_ONLY_IDS, FREE_COMMENTS_PER_MONTH } from '@/lib/constants'
 import { timeUnitForRange, whenRange } from '@/lib/time'
 import assertApiKeyNotPermitted from './apiKey'
@@ -118,15 +118,16 @@ export async function topUsers (parent, { cursor, when, by = 'stacked', from, to
     SELECT * FROM user_stats
     JOIN users ON user_stats."userId" = users.id
     WHERE users.id NOT IN (${Prisma.join([...SN_SYSTEM_ONLY_IDS, USER_ID.anon])})
-    ORDER BY ${column} DESC NULLS LAST, users.created_at ASC
-    OFFSET ${decodedCursor.offset}
+    ${decodedCursor.id ? Prisma.sql`AND ${Prisma.raw(keysetClause(decodedCursor, column.values[0], 'users'))}` : Prisma.empty}
+    ORDER BY ${column} DESC NULLS LAST, users.id DESC
+    ${decodedCursor.id ? Prisma.empty : Prisma.sql`OFFSET ${decodedCursor.offset}`}
     LIMIT ${limit}`
   ).map(
     u => u.hideFromTopUsers && (!me || me.id !== u.id) ? null : u
   )
 
   return {
-    cursor: users.length === limit ? nextCursorEncoded(decodedCursor, limit) : null,
+    cursor: users.length === limit ? nextCursorEncoded(decodedCursor, users, limit, column.values[0]) : null,
     users
   }
 }

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -4,15 +4,28 @@ export function decodeCursor (cursor) {
   if (!cursor) {
     return { offset: 0, time: new Date() }
   } else {
-    const res = JSON.parse(Buffer.from(cursor, 'base64'))
-    res.offset = Number(res.offset)
-    res.time = new Date(res.time)
-    return res
+    try {
+      const res = JSON.parse(Buffer.from(cursor, 'base64'))
+      res.offset = res.offset ? Number(res.offset) : 0
+      res.time = res.time ? new Date(res.time) : new Date()
+      return res
+    } catch (e) {
+      return { offset: 0, time: new Date() }
+    }
   }
 }
 
-export function nextCursorEncoded (cursor, limit = LIMIT) {
+export function nextCursorEncoded (cursor, items = [], limit = LIMIT, sortField = null, idField = 'id') {
   const nextCursor = { ...cursor }
+  if (items.length > 0 && sortField) {
+    const lastItem = items[items.length - 1]
+    nextCursor.id = lastItem[idField]
+    nextCursor.sortValue = lastItem[sortField]
+    // handle date objects
+    if (nextCursor.sortValue instanceof Date) {
+      nextCursor.sortValue = nextCursor.sortValue.getTime()
+    }
+  }
   nextCursor.offset += limit
   return Buffer.from(JSON.stringify(nextCursor)).toString('base64')
 }


### PR DESCRIPTION
 1 ## Problem
    2 The current `OFFSET`-based pagination causes several issues:
    3 1. **Inconsistency:** If new items are added or old ones are deleted while a user is scrolling, items can be skipped or duplicated.
    4 2. **Performance:** As the `OFFSET` grows (deep pagination), the database queries become significantly slower.
    5
    6 ## Solution
    7 I implemented a **hybrid keyset pagination** strategy (`sort_value`, `id`) which provides stable and performant pagination.
    8
    9 ### Changes:
   10 - **`lib/cursor.js`**: Updated to encode/decode `id` and `sortValue` within the cursor object while maintaining backward compatibility with
      `offset`.
   11 - **`api/resolvers/item.js`**:
   12     - Added `keysetClause` and `getSortField` helpers.
   13     - Updated `Query.items` (`new`, `top`, `user`, and `lit` sorts) to use keyset comparisons.
   14     - Added an explicit `id` tie-breaker to all `ORDER BY` clauses to ensure deterministic results.
   15 - **`api/resolvers/user.js` & `api/resolvers/sub.js`**: Migrated `topUsers` and `topSubs` to the keyset approach.
   16 - **Backward Compatibility**: If a cursor only contains an `offset` (e.g., from an old bookmark), the system gracefully falls back to `OFFSET`
      pagination.
   17
   18 ## Verification
   19 - Verified cursor encoding/decoding logic with standalone tests.
   20 - Verified SQL generation for numeric, date, and string-based keysets.
   21
   22 Closes #2880
   23 wallet address Ö bc1qs4rr5prccv63fsws2yx6c8pctx50uzkvc8yyhj