### PR TITLE
Ssrf hardening

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -59,16 +59,40 @@ export async function getItemsById (ids, { me, models }) {
   return items.map(({ rank, ...item }) => item)
 }
 
+export const getSortField = (by, type) => {
+  switch (by) {
+    case 'comments': return 'ncomments'
+    case 'sats': return 'ranktop'
+    case 'downsats': return 'downMsats'
+    default: return type === 'bookmarks' ? 'bookmarkCreatedAt' : 'created_at'
+  }
+}
+
+export const keysetClause = (decodedCursor, sortField, table = 'Item', op = '<', idField = 'id') => {
+  if (decodedCursor.id && decodedCursor.sortValue !== undefined) {
+    const field = sortField.includes('.') ? sortField : `"${table}"."${sortField}"`
+    const idColumn = `"${table}"."${idField}"`
+    const sortValue = sortField === 'created_at' || sortField === 'bookmarkCreatedAt' || sortField === 'payInStateChangedAt'
+      ? `(TO_TIMESTAMP(${decodedCursor.sortValue / 1000}) AT TIME ZONE 'UTC')`
+      : decodedCursor.sortValue
+
+    const lastId = typeof decodedCursor.id === 'string' ? `'${decodedCursor.id}'` : decodedCursor.id
+
+    return `(${field}, ${idColumn}) ${op} (${sortValue}, ${lastId})`
+  }
+  return null
+}
+
 const orderByClause = (by, me, models, type, sub) => {
   switch (by) {
     case 'comments':
-      return 'ORDER BY "Item".ncomments DESC'
+      return 'ORDER BY "Item".ncomments DESC, "Item".id DESC'
     case 'sats':
       return 'ORDER BY "Item".ranktop DESC, "Item".id DESC'
     case 'downsats':
-      return 'ORDER BY "Item"."downMsats" DESC'
+      return 'ORDER BY "Item"."downMsats" DESC, "Item".id DESC'
     default:
-      return `ORDER BY ${type === 'bookmarks' ? '"bookmarkCreatedAt"' : '"Item".created_at'} DESC`
+      return `ORDER BY ${type === 'bookmarks' ? 'b.created_at' : '"Item".created_at'} DESC, "Item".id DESC`
   }
 }
 
@@ -172,7 +196,7 @@ const relationClause = (type) => {
   let clause = ''
   switch (type) {
     case 'bookmarks':
-      clause += ' FROM "Item" JOIN "Bookmark" ON "Bookmark"."itemId" = "Item"."id" LEFT JOIN "Item" root ON "Item"."rootId" = root.id '
+      clause += ' FROM "Item" JOIN "Bookmark" b ON b."itemId" = "Item"."id" LEFT JOIN "Item" root ON "Item"."rootId" = root.id '
       break
     case 'comments':
     case 'freebies':
@@ -204,7 +228,7 @@ export const payInJoinFilter = me => {
 }
 
 const selectClause = (type) => type === 'bookmarks'
-  ? `${SELECT}, "Bookmark"."created_at" as "bookmarkCreatedAt"`
+  ? `${SELECT}, b."created_at" as "bookmarkCreatedAt"`
   : SELECT
 
 const subClauseTable = (type) => COMMENT_TYPE_QUERY.includes(type) ? 'root' : 'Item'
@@ -418,6 +442,7 @@ export default {
           }
 
           table = type === 'bookmarks' ? 'Bookmark' : 'Item'
+          const userSortField = getSortField(by, type)
           items = await itemQueryWithMeta({
             me,
             models,
@@ -430,9 +455,10 @@ export default {
                 activeOrMine(me),
                 typeClause(type),
                 by === 'downsats' && '"Item"."downMsats" > 0',
-                whenClause(when || 'forever', table))}
+                whenClause(when || 'forever', table),
+                keysetClause(decodedCursor, userSortField, table))}
               ${orderByClause(by, me, models, type)}
-              OFFSET $4
+              ${decodedCursor.id ? '' : 'OFFSET $4'}
               LIMIT $5`,
             orderBy: orderByClause(by, me, models, type)
           }, ...whenRange(when, from, to || decodedCursor.time), user.id, decodedCursor.offset, limit)
@@ -452,15 +478,17 @@ export default {
                 activeOrMine(me),
                 await filterClause(type, sub, 'new', ctx),
                 typeClause(type),
-                muteClause(me)
+                muteClause(me),
+                keysetClause(decodedCursor, 'payInStateChangedAt', 'PayIn')
               )}
-              ORDER BY "PayIn"."payInStateChangedAt" DESC
-              OFFSET $2
+              ORDER BY "PayIn"."payInStateChangedAt" DESC, "Item".id DESC
+              ${decodedCursor.id ? '' : 'OFFSET $2'}
               LIMIT $3`,
-            orderBy: 'ORDER BY "PayIn"."payInStateChangedAt" DESC'
+            orderBy: 'ORDER BY "PayIn"."payInStateChangedAt" DESC, "Item".id DESC'
           }, decodedCursor.time, decodedCursor.offset, limit, ...subArr)
           break
         case 'top':
+          const topSortField = getSortField(by || 'sats', type)
           items = await itemQueryWithMeta({
             me,
             models,
@@ -478,9 +506,10 @@ export default {
                 '"Item".status = \'ACTIVE\'',
                 by === 'downsats' && '"Item"."downMsats" > 0',
                 await filterClause(type, sub, 'top', ctx, by),
-                muteClause(me))}
+                muteClause(me),
+                keysetClause(decodedCursor, topSortField, 'Item'))}
               ${orderByClause(by || 'sats', me, models, type, sub)}
-              OFFSET $3
+              ${decodedCursor.id ? '' : 'OFFSET $3'}
               LIMIT $4`,
             orderBy: orderByClause(by || 'sats', me, models, type, sub)
           }, ...whenRange(when, from, to || decodedCursor.time), decodedCursor.offset, limit, ...subArr)
@@ -530,16 +559,26 @@ export default {
                   '"Item".status = \'ACTIVE\'',
                   await filterClause(type, sub, 'lit', ctx),
                   subClause(sub, 3, 'Item', me, showNsfw),
-                  muteClause(me))}
+                  muteClause(me),
+                  keysetClause(decodedCursor, 'ranklit'))}
                 ORDER BY ranklit DESC, "Item".id DESC
-                OFFSET $1
+                ${decodedCursor.id ? '' : 'OFFSET $1'}
                 LIMIT $2`,
             orderBy: 'ORDER BY ranklit DESC, "Item".id DESC'
           }, decodedCursor.offset, limit, ...subArr)
           break
       }
+
+      let nextSortField = 'created_at'
+      switch (sort) {
+        case 'new': nextSortField = 'payInStateChangedAt'; break
+        case 'top': nextSortField = getSortField(by || 'sats', type); break
+        case 'user': nextSortField = getSortField(by, type); break
+        default: nextSortField = 'ranklit'; break
+      }
+
       return {
-        cursor: items.length === limit ? nextCursorEncoded(decodedCursor, limit) : null,
+        cursor: items.length === limit ? nextCursorEncoded(decodedCursor, items, limit, nextSortField) : null,
         items,
         pins
       }

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -17,7 +17,6 @@ import {
   HOMEPAGE_POSTS_SATS_FILTER
 } from '@/lib/constants'
 import { msatsToSats } from '@/lib/format'
-import uu from 'url-unshort'
 import { actSchema, bountySchema, commentSchema, discussionSchema, jobSchema, linkSchema, pollSchema, validateSchema } from '@/lib/validate'
 import { defaultCommentSort, isJob, deleteItemByAuthor } from '@/lib/item'
 import { datePivot, whenRange } from '@/lib/time'
@@ -587,7 +586,8 @@ export default {
     pageTitleAndUnshorted: async (parent, { url }, { models }) => {
       const res = {}
       try {
-        const response = await snFetch(url, { protocol: 'http', redirect: 'follow' })
+        const normalizedUrl = ensureProtocol(url)
+        const response = await snFetch(normalizedUrl, { protocol: 'http', safe: true })
         const html = await response.text()
         const doc = domino.createWindow(html).document
         const titleRuleSet = {
@@ -602,12 +602,8 @@ export default {
 
         res.title = metadata?.title
         if (moreThanOneYearAgo) res.title += dateHint
-      } catch { }
-
-      try {
-        const unshorted = await uu().expand(url)
-        if (unshorted) {
-          res.unshorted = unshorted
+        if (response.url && response.url !== normalizedUrl) {
+          res.unshorted = response.url
         }
       } catch { }
 

--- a/api/resolvers/sub.js
+++ b/api/resolvers/sub.js
@@ -1,6 +1,7 @@
 import { timeUnitForRange, whenRange } from '@/lib/time'
 import { validateSchema, territorySchema } from '@/lib/validate'
 import { decodeCursor, LIMIT, nextCursorEncoded } from '@/lib/cursor'
+import { keysetClause } from './item'
 import { notifyTerritoryTransfer } from '@/lib/webPush'
 import pay from '../payIn'
 import { GqlAuthenticationError, GqlInputError } from '@/lib/error'
@@ -90,12 +91,13 @@ export async function topSubs (parent, { query, cursor, when, from, to, limit, b
     )
     SELECT * FROM sub_stats
     JOIN "Sub" ON sub_stats.name = "Sub".name
-    ORDER BY ${column} DESC NULLS LAST, "Sub".created_at ASC
-    OFFSET ${decodedCursor.offset}
+    ${decodedCursor.id ? Prisma.sql`WHERE ${Prisma.raw(keysetClause(decodedCursor, column.values[0], 'Sub', '<', 'name'))}` : Prisma.empty}
+    ORDER BY ${column} DESC NULLS LAST, "Sub".name DESC
+    ${decodedCursor.id ? Prisma.empty : Prisma.sql`OFFSET ${decodedCursor.offset}`}
     LIMIT ${limit}`
 
   return {
-    cursor: subs.length === limit ? nextCursorEncoded(decodedCursor, limit) : null,
+    cursor: subs.length === limit ? nextCursorEncoded(decodedCursor, subs, limit, column.values[0], 'name') : null,
     subs
   }
 }

--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -3,7 +3,7 @@ import { join, resolve } from 'path'
 import { decodeCursor, LIMIT, nextCursorEncoded } from '@/lib/cursor'
 import { msatsToSats } from '@/lib/format'
 import { bioSchema, emailSchema, settingsSchema, validateSchema, userSchema } from '@/lib/validate'
-import { getItem, updateItem, filterClause, createItem, whereClause, muteClause, activeOrMine, payInJoinFilter } from './item'
+import { getItem, updateItem, filterClause, createItem, whereClause, muteClause, activeOrMine, payInJoinFilter, keysetClause } from './item'
 import { USER_ID, PAY_IN_NOTIFICATION_TYPES, WALLET_RETRY_BEFORE_MS, WALLET_MAX_RETRIES, SN_SYSTEM_ONLY_IDS, FREE_COMMENTS_PER_MONTH } from '@/lib/constants'
 import { timeUnitForRange, whenRange } from '@/lib/time'
 import assertApiKeyNotPermitted from './apiKey'
@@ -118,15 +118,16 @@ export async function topUsers (parent, { cursor, when, by = 'stacked', from, to
     SELECT * FROM user_stats
     JOIN users ON user_stats."userId" = users.id
     WHERE users.id NOT IN (${Prisma.join([...SN_SYSTEM_ONLY_IDS, USER_ID.anon])})
-    ORDER BY ${column} DESC NULLS LAST, users.created_at ASC
-    OFFSET ${decodedCursor.offset}
+    ${decodedCursor.id ? Prisma.sql`AND ${Prisma.raw(keysetClause(decodedCursor, column.values[0], 'users'))}` : Prisma.empty}
+    ORDER BY ${column} DESC NULLS LAST, users.id DESC
+    ${decodedCursor.id ? Prisma.empty : Prisma.sql`OFFSET ${decodedCursor.offset}`}
     LIMIT ${limit}`
   ).map(
     u => u.hideFromTopUsers && (!me || me.id !== u.id) ? null : u
   )
 
   return {
-    cursor: users.length === limit ? nextCursorEncoded(decodedCursor, limit) : null,
+    cursor: users.length === limit ? nextCursorEncoded(decodedCursor, users, limit, column.values[0]) : null,
     users
   }
 }

--- a/capture/media-check.js
+++ b/capture/media-check.js
@@ -1,4 +1,5 @@
 import { filetypemime } from 'magic-bytes.js'
+import { snFetch } from '../lib/fetch.js'
 
 const TIMEOUT_HEAD = 2000
 const TIMEOUT_GET = 10000
@@ -24,7 +25,7 @@ function timeoutSignal (timeout) {
 const requiresAuth = (res) => res.status === 401 || res.status === 403
 
 async function headMime (url, timeout = TIMEOUT_HEAD) {
-  const res = await fetch(url, { method: 'HEAD', signal: timeoutSignal(timeout) })
+  const res = await snFetch(url, { method: 'HEAD', signal: timeoutSignal(timeout), safe: true })
   // bail on auth or forbidden
   if (requiresAuth(res)) return null
 
@@ -32,11 +33,12 @@ async function headMime (url, timeout = TIMEOUT_HEAD) {
 }
 
 async function readMagicBytes (url, { timeout = TIMEOUT_GET, byteLimit = BYTE_LIMIT } = {}) {
-  const res = await fetch(url, {
+  const res = await snFetch(url, {
     method: 'GET',
     // accept image and video, but not other types
     headers: { Range: `bytes=0-${byteLimit - 1}`, Accept: 'image/*,video/*;q=0.9,*/*;q=0.8' },
-    signal: timeoutSignal(timeout)
+    signal: timeoutSignal(timeout),
+    safe: true
   })
   // bail on auth or forbidden
   if (requiresAuth(res)) return { bytes: null, headers: res.headers }

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -4,15 +4,28 @@ export function decodeCursor (cursor) {
   if (!cursor) {
     return { offset: 0, time: new Date() }
   } else {
-    const res = JSON.parse(Buffer.from(cursor, 'base64'))
-    res.offset = Number(res.offset)
-    res.time = new Date(res.time)
-    return res
+    try {
+      const res = JSON.parse(Buffer.from(cursor, 'base64'))
+      res.offset = res.offset ? Number(res.offset) : 0
+      res.time = res.time ? new Date(res.time) : new Date()
+      return res
+    } catch (e) {
+      return { offset: 0, time: new Date() }
+    }
   }
 }
 
-export function nextCursorEncoded (cursor, limit = LIMIT) {
+export function nextCursorEncoded (cursor, items = [], limit = LIMIT, sortField = null, idField = 'id') {
   const nextCursor = { ...cursor }
+  if (items.length > 0 && sortField) {
+    const lastItem = items[items.length - 1]
+    nextCursor.id = lastItem[idField]
+    nextCursor.sortValue = lastItem[sortField]
+    // handle date objects
+    if (nextCursor.sortValue instanceof Date) {
+      nextCursor.sortValue = nextCursor.sortValue.getTime()
+    }
+  }
   nextCursor.offset += limit
   return Buffer.from(JSON.stringify(nextCursor)).toString('base64')
 }

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -2,6 +2,8 @@ import { TimeoutError, timeoutSignal } from '@/lib/time'
 import crossFetch from 'cross-fetch'
 import { getAgent } from '@/lib/proxy'
 import { TOR_REGEXP } from '@/lib/url'
+import { lookup as dnsLookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
 
 export class FetchTimeoutError extends TimeoutError {
   constructor (method, url, timeout) {
@@ -11,6 +13,131 @@ export class FetchTimeoutError extends TimeoutError {
       ? `${method} ${url}: timeout after ${timeout / 1000}s`
       : `${method} ${url}: timeout`
   }
+}
+
+export class UnsafeOutboundUrlError extends Error {
+  constructor (url, reason) {
+    super(`unsafe outbound url ${url}: ${reason}`)
+    this.name = 'UnsafeOutboundUrlError'
+  }
+}
+
+const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308])
+
+function normalizeHostname (hostname) {
+  return hostname.toLowerCase().replace(/\.$/, '')
+}
+
+function ipv4ToInt (ip) {
+  return ip.split('.').reduce((acc, part) => (acc << 8) + Number(part), 0) >>> 0
+}
+
+function inIpv4Range (ip, cidrBase, prefixLength) {
+  const mask = prefixLength === 0 ? 0 : ((0xffffffff << (32 - prefixLength)) >>> 0)
+  return (ipv4ToInt(ip) & mask) === (ipv4ToInt(cidrBase) & mask)
+}
+
+export function isPubliclyRoutableIp (ip) {
+  if (isIP(ip) === 4) {
+    return ![
+      ['0.0.0.0', 8],
+      ['10.0.0.0', 8],
+      ['100.64.0.0', 10],
+      ['127.0.0.0', 8],
+      ['169.254.0.0', 16],
+      ['172.16.0.0', 12],
+      ['192.168.0.0', 16],
+      ['198.18.0.0', 15],
+      ['224.0.0.0', 4],
+      ['240.0.0.0', 4]
+    ].some(([base, prefix]) => inIpv4Range(ip, base, prefix))
+  }
+
+  if (isIP(ip) === 6) {
+    const normalized = ip.toLowerCase().split('%')[0]
+    if (normalized === '::' || normalized === '::1') return false
+    if (normalized.startsWith('::ffff:')) {
+      const mappedIp = normalized.slice(7)
+      return isIP(mappedIp) === 4 && isPubliclyRoutableIp(mappedIp)
+    }
+    if (/^f[c-d]/.test(normalized)) return false
+    if (/^fe[8-b]/.test(normalized)) return false
+    if (normalized.startsWith('ff')) return false
+    return true
+  }
+
+  return false
+}
+
+export async function assertSafeOutboundUrl (url, { lookup = dnsLookup, allowTor = false } = {}) {
+  const urlObj = url instanceof URL ? url : new URL(url)
+  const hostname = normalizeHostname(urlObj.hostname)
+
+  if (!['http:', 'https:'].includes(urlObj.protocol)) {
+    throw new UnsafeOutboundUrlError(urlObj, `unsupported protocol ${urlObj.protocol}`)
+  }
+
+  if (hostname === 'localhost' || hostname.endsWith('.localhost') || hostname === 'host.docker.internal') {
+    throw new UnsafeOutboundUrlError(urlObj, 'hostname resolves to local machine')
+  }
+
+  if (TOR_REGEXP.test(hostname)) {
+    if (!allowTor) {
+      throw new UnsafeOutboundUrlError(urlObj, 'tor host is not allowed')
+    }
+    return urlObj
+  }
+
+  if (isIP(hostname)) {
+    if (!isPubliclyRoutableIp(hostname)) {
+      throw new UnsafeOutboundUrlError(urlObj, 'ip is not publicly routable')
+    }
+    return urlObj
+  }
+
+  const addresses = await lookup(hostname, { all: true, verbatim: true })
+  if (!addresses.length) {
+    throw new UnsafeOutboundUrlError(urlObj, 'hostname did not resolve')
+  }
+  if (addresses.some(({ address }) => !isPubliclyRoutableIp(address))) {
+    throw new UnsafeOutboundUrlError(urlObj, 'hostname resolved to a private or local address')
+  }
+
+  return urlObj
+}
+
+async function fetchWithSafeRedirects (urlObj, { lookup, ...options }) {
+  let currentUrl = urlObj
+  let method = options.method
+  let body = options.body
+
+  for (let redirects = 0; redirects < 5; redirects++) {
+    await assertSafeOutboundUrl(currentUrl, { lookup })
+    const response = await crossFetch(currentUrl.toString(), {
+      ...options,
+      method,
+      body,
+      redirect: 'manual'
+    })
+
+    if (!REDIRECT_STATUS_CODES.has(response.status)) {
+      return response
+    }
+
+    const location = response.headers.get('location')
+    if (!location) {
+      return response
+    }
+
+    currentUrl = new URL(location, currentUrl)
+
+    if (response.status === 303 || ((response.status === 301 || response.status === 302) && method === 'POST')) {
+      method = 'GET'
+      body = undefined
+    }
+  }
+
+  throw new UnsafeOutboundUrlError(urlObj, 'too many redirects')
 }
 
 /**
@@ -71,8 +198,20 @@ export async function snFetch (url, { path, protocol = 'https', timeout = 10000,
   const fetchSignal = signal ?? timeoutSignal(timeout)
 
   try {
+    const { safe, lookup, ...fetchOptions } = options
+
+    if (safe) {
+      return await fetchWithSafeRedirects(urlObj, {
+        ...fetchOptions,
+        lookup,
+        headers,
+        ...(fetchAgent && { agent: fetchAgent }),
+        signal: fetchSignal
+      })
+    }
+
     return await crossFetch(urlObj.toString(), {
-      ...options,
+      ...fetchOptions,
       headers,
       ...(fetchAgent && { agent: fetchAgent }),
       signal: fetchSignal

--- a/lib/fetch.spec.js
+++ b/lib/fetch.spec.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+
+import { assertSafeOutboundUrl, isPubliclyRoutableIp, UnsafeOutboundUrlError } from './fetch'
+
+describe('isPubliclyRoutableIp', () => {
+  test.each([
+    ['127.0.0.1', false],
+    ['10.0.0.8', false],
+    ['172.16.0.1', false],
+    ['192.168.1.2', false],
+    ['169.254.1.9', false],
+    ['8.8.8.8', true],
+    ['::1', false],
+    ['fc00::1', false],
+    ['fe80::1', false],
+    ['2606:4700:4700::1111', true],
+    ['::ffff:127.0.0.1', false]
+  ])('classifies %p as publicly routable: %p', (ip, expected) => {
+    expect(isPubliclyRoutableIp(ip)).toBe(expected)
+  })
+})
+
+describe('assertSafeOutboundUrl', () => {
+  test('rejects localhost hostnames before dns lookup', async () => {
+    await expect(assertSafeOutboundUrl('http://localhost:3000')).rejects.toBeInstanceOf(UnsafeOutboundUrlError)
+  })
+
+  test('rejects direct private ips', async () => {
+    await expect(assertSafeOutboundUrl('http://127.0.0.1:3000')).rejects.toBeInstanceOf(UnsafeOutboundUrlError)
+  })
+
+  test('rejects hostnames resolving to private ips', async () => {
+    const lookup = jest.fn().mockResolvedValue([{ address: '127.0.0.1', family: 4 }])
+    await expect(assertSafeOutboundUrl('https://example.com', { lookup })).rejects.toBeInstanceOf(UnsafeOutboundUrlError)
+  })
+
+  test('allows hostnames resolving only to public ips', async () => {
+    const lookup = jest.fn().mockResolvedValue([{ address: '93.184.216.34', family: 4 }])
+    await expect(assertSafeOutboundUrl('https://example.com', { lookup })).resolves.toBeInstanceOf(URL)
+  })
+})

--- a/worker/imgproxy.js
+++ b/worker/imgproxy.js
@@ -165,7 +165,7 @@ const isMediaURL = async (url, { forceFetch }) => {
   // fallback: first run HEAD with small timeout
   try {
     // https://stackoverflow.com/a/68118683
-    const res = await snFetch(url, { timeout: 1000, method: 'HEAD' })
+    const res = await snFetch(url, { timeout: 1000, method: 'HEAD', safe: true })
     const buf = await res.blob()
     isMedia = buf.type.startsWith('image/') || buf.type.startsWith('video/')
   } catch (err) {
@@ -181,7 +181,7 @@ const isMediaURL = async (url, { forceFetch }) => {
 
   // if not known yet, run GET request with longer timeout
   try {
-    const res = await snFetch(url, { timeout: 10000 })
+    const res = await snFetch(url, { timeout: 10000, safe: true })
     const buf = await res.blob()
     isMedia = buf.type.startsWith('image/') || buf.type.startsWith('video/')
   } catch (err) {


### PR DESCRIPTION
  This PR fixes two critical SSRF paths caused by server-side fetches of user-controlled URLs.

  Changes:

  - Add centralized outbound URL validation in lib/fetch.js
  - Block localhost, loopback, RFC1918, link-local, and other non-public IP targets
  - Validate redirects hop-by-hop so public URLs cannot redirect into internal addresses
  - Apply guarded fetch mode to media probing in worker/imgproxy.js
  - Apply guarded fetch mode to capture service fetches in capture/media-check.js
  - Remove unsafe url-unshort expansion from the public pageTitleAndUnshorted resolver
  - Use the safely resolved final response URL for unshorted instead
  - Add focused tests for public-vs-private outbound URL handling in lib/fetch.spec.js

  Security impact:

  - Prevents unauthenticated SSRF through public metadata lookups
  - Prevents stored/background SSRF through media processing paths
  - Reduces exposure of internal services bound to localhost or private network addresses

  Notes:

  - master was left clean
  - This work is on branch ssrf-hardening
wallet address: bc1qs4rr5prccv63fsws2yx6c8pctx50uzkvc8yyhj