### PR TITLE
email magic code autocomplete

### DIFF
--- a/pages/email.js
+++ b/pages/email.js
@@ -76,7 +76,8 @@ export const MagicCodeForm = ({ onSubmit, disabled }) => {
         groupClassName='d-flex flex-column justify-content-center gap-2'
         inputType='text'
         hideError // hide error message on every input, allow custom error message
-        autocomplete='one-time-code'
+        disabled={disabled}
+        autoComplete='one-time-code'
       />
       <SubmitButton variant='primary' className='ps-4 pe-3' disabled={disabled}>enter <ArrowRightLineIcon height={20} width={20} className='ms-2' /></SubmitButton>
     </Form>

--- a/pages/email.js
+++ b/pages/email.js
@@ -76,7 +76,7 @@ export const MagicCodeForm = ({ onSubmit, disabled }) => {
         groupClassName='d-flex flex-column justify-content-center gap-2'
         inputType='text'
         hideError // hide error message on every input, allow custom error message
-        disabled={disabled} // disable the form if no callback is provided
+        autocomplete='one-time-code'
       />
       <SubmitButton variant='primary' className='ps-4 pe-3' disabled={disabled}>enter <ArrowRightLineIcon height={20} width={20} className='ms-2' /></SubmitButton>
     </Form>


### PR DESCRIPTION
## Description

This PR adds support for magic code autocomplete in the email form via `autocomplete='one-time-code'`, browsers (and email clients/operating systems) that support this will retrieve the magic code from the email we send.

## Screenshots

https://github.com/user-attachments/assets/232f3b6e-d448-4e44-9472-c5a73d15191f



## Additional Context

- [x] check if other forms need autocomplete support

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

9, minimal change


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds an `autocomplete` hint to the email magic-code input; no auth logic or data handling is modified.
> 
> **Overview**
> Adds `autoComplete='one-time-code'` to the magic-code `MultiInput` on `pages/email.js` so supporting browsers/OSes can autofill the emailed verification code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82fd2ddd2f18b86da7f2ac1a7830ebea1a02a99d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->