### PR TITLE
Limit `api/graphql` requests to recognized origins.

### DIFF
--- a/lib/domains.js
+++ b/lib/domains.js
@@ -46,6 +46,25 @@ export const getDomainMapping = async (domain) => {
   return domainsMappings?.[domainName.toLowerCase()] ?? null
 }
 
+// checks if the given Origin header value matches an allowed origin
+// e.g. main domain or a verified custom domain
+export const isAllowedOrigin = async (origin) => {
+  if (!origin) return false
+
+  let originUrl
+  try {
+    originUrl = new URL(origin)
+  } catch {
+    return false
+  }
+
+  const originHost = originUrl.host
+  if (originHost === SN_MAIN_DOMAIN.host) return true
+
+  const mapping = await getDomainMapping(originHost)
+  return !!mapping
+}
+
 export function createDomainsDebugLogger (domainName, debug = CUSTOM_DOMAINS_DEBUG) {
   const noop = () => {}
 

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -14,6 +14,7 @@ import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/dis
 import PgBoss from 'pg-boss'
 import { lexicalStateLoader } from '@/lib/lexical/server/loader'
 import { createUserLoader, createSubLoader } from '@/api/loaders'
+import { isAllowedOrigin } from '@/lib/domains'
 
 const apolloServer = new ApolloServer({
   typeDefs,
@@ -99,9 +100,37 @@ const apolloHandler = startServerAndCreateNextHandler(apolloServer, {
   }
 })
 
+// CORS allowlist for /api/graphql: only the main domain and any
+// ACTIVE custom domain mapping may make cross-origin calls.
+async function applyGraphqlCORS (req, res) {
+  // vary on Origin so shared caches never serve a response intended for
+  // a different (or no) origin
+  res.setHeader('Vary', 'Origin')
+
+  const origin = req.headers.origin
+  if (!origin) return
+
+  const isAllowed = await isAllowedOrigin(origin)
+  if (!isAllowed) return
+
+  res.setHeader('Access-Control-Allow-Origin', origin)
+  res.setHeader('Access-Control-Allow-Credentials', 'true')
+  res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, x-api-key, Authorization')
+  res.setHeader('Access-Control-Max-Age', '86400')
+}
+
 // Reject GET requests with non-standard Content-Type headers (e.g. message/*)
 // to prevent cross-site timing attacks that bypass CORS preflight checks.
-export default function protectedContentTypeHandler (req, res) {
+export default async function protectedContentTypeHandler (req, res) {
+  await applyGraphqlCORS(req, res)
+
+  // short-circuit preflights so that if the origin was not allowlisted above, the
+  // response simply lacks the CORS headers and the browser will reject it
+  if (req.method === 'OPTIONS') {
+    return res.status(204).end()
+  }
+
   // Check raw headers so duplicate Content-Type headers can't hide an invalid value.
   const invalidGetContentType = req.method === 'GET' &&
     req.rawHeaders.some((name, i, headers) =>


### PR DESCRIPTION
## Description

Adds a dynamic CORS to `api/graphql`. If the current `origin` of the request is the main domain (`stacker.news`) or a valid `ACTIVE` custom domain, `Access-Control-Allow-Origin` will feature the current `origin`. If not, CORS won't be injected and the browser won't make the request. 

## Additional Context

This doesn't serve any real purpose at the moment, imo. Cross-origin requests are already prohibited due to missing CORS, and we only make same-origin requests in-app (`stacker.news/api/graphql`, `customdomain.com/api/graphql`). At most it enables future cross-origin requests.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

6, works correctly, cross-origin is prevented on non-recognized domains as expected.

**Did you use AI for this? If so, how much did it assist you?**

CORS review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the GraphQL API edge surface and cross-origin behavior; a mistake could unintentionally block legitimate clients or overly broaden allowed origins if domain mapping validation is wrong.
> 
> **Overview**
> Adds an origin allowlist for `/api/graphql` by injecting CORS response headers only when the request `Origin` matches the main site domain or an `ACTIVE` custom domain mapping.
> 
> Introduces `isAllowedOrigin` in `lib/domains.js` to validate/parse the `Origin` URL and check it against cached domain mappings, and updates the GraphQL API handler to set `Vary: Origin` and short-circuit `OPTIONS` preflights (returning 204 without CORS headers when not allowlisted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c14d9548ae7e32bb5e46e9bd49668c28e329081b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->