### PR TITLE
Make chain fee URL configurable

### DIFF
--- a/api/resolvers/chainFee.js
+++ b/api/resolvers/chainFee.js
@@ -1,9 +1,10 @@
 import { cachedFetcher, snFetch } from '@/lib/fetch'
 
+const CHAIN_FEE_URL = process.env.CHAIN_FEE_URL || 'https://mempool.space/api/v1/fees/recommended'
+
 const getChainFeeRate = cachedFetcher(async function fetchChainFeeRate () {
-  const url = 'https://mempool.space/api/v1/fees/recommended'
   try {
-    const res = await snFetch(url)
+    const res = await snFetch(CHAIN_FEE_URL)
     const body = await res.json()
     return body.hourFee
   } catch (err) {


### PR DESCRIPTION
## Summary

This keeps Stacker News using mempool.space by default, but allows operators to override the chain-fee endpoint with `CHAIN_FEE_URL`.

The resolver only needs the existing mempool-style fields and currently returns `hourFee`, so compatible fee endpoints can be used without changing the GraphQL API or default behavior.

Example compatible URL:

`https://bitcoinsapi.com/api/v1/compat/mempool/fees/recommended`

## Validation

- `node --check api/resolvers/chainFee.js`
- `git diff --check`
- Live compatible endpoint check returned `fastestFee`, `halfHourFee`, `hourFee`, `economyFee`, and `minimumFee`

I also tried `npx --no-install standard api/resolvers/chainFee.js`, but this checkout does not have dependencies installed, so npm refused to run the missing `standard` package without installing it.