### PR TITLE
fix: make nextjs prefetches aware of custom domains

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -20,6 +20,10 @@ function isTerritoryPath (pathname) {
   return SN_TERRITORY_PATHS.some(p => pathname === p || pathname.startsWith(p + '/'))
 }
 
+function isPrefetchRequest (request) {
+  return request.headers.has('next-router-prefetch') || request.headers.get('purpose') === 'prefetch'
+}
+
 async function customDomainMiddleware (request, domain, subName) {
   // logger is enabled if NEXT_PUBLIC_CUSTOM_DOMAINS_DEBUG == 1
   const logger = createDomainsDebugLogger(domain)
@@ -202,18 +206,27 @@ export async function proxy (req) {
   headers.delete('x-stacker-news-domain')
   const request = new NextRequest(req, { headers })
 
+  // domain can have a port (local dev), so we pass the whole domain to the middleware
+  // instead of the domain retrieved from the mapping
+  const domain = request.headers.get('host')
+  const mapping = await getDomainMapping(domain)
+
+  // prefetches need to be custom-domain aware.
+  // for these requests, we skip referrer attribution and CSP/security headers
+  if (isPrefetchRequest(request)) {
+    return mapping
+      ? customDomainMiddleware(request, domain, mapping.subName)
+      : NextResponse.next()
+  }
+
+  // non-prefetch reqs: referrer + custom domain + security headers
   let resp = referrerMiddleware(request)
   // if resp is a redirect, apply security headers immediately and return
   if (resp.headers.get('Location')) {
     return applySecurityHeaders(resp)
   }
 
-  // if we're on a custom domain, handle it
-  const domain = request.headers.get('host')
-  const mapping = await getDomainMapping(domain)
   if (mapping) {
-    // domain can have a port (local dev), so we pass the whole domain to the middleware
-    // instead of the domain retrieved from the mapping
     const domainResp = await customDomainMiddleware(request, domain, mapping.subName)
     // apply referrer cookies to the custom domain response
     resp = applyReferrerCookies(domainResp, resp)
@@ -225,13 +238,10 @@ export async function proxy (req) {
 export const config = {
   matcher: [
     // NextJS recommends to not add the CSP header to prefetches and static assets
+    // prefetches are handled separately in the middleware for custom domain rewrites
     // See https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy
     {
-      source: '/((?!api|_next/static|_error|404|500|offline|_next/image|_next/webpack-hmr|favicon.ico).*)',
-      missing: [
-        { type: 'header', key: 'next-router-prefetch' },
-        { type: 'header', key: 'purpose', value: 'prefetch' }
-      ]
+      source: '/((?!api|_next/static|_error|404|500|offline|_next/image|_next/webpack-hmr|favicon.ico).*)'
     }
   ]
 }


### PR DESCRIPTION
## Description

Prefetch requests are ignored by our middleware, making custom domains lose their domain status when clicking to links that have been prefetched.
This PR ensures that prefetch requests still go through the custom domain middleware, while still skipping referral and CSP.

## Additional Context

The patch revolves around running the custom domain middleware on prefetches too, on normal `stacker.news` navigation prefetches are still ignored by the middleware.

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7, works correctly, fixes prefetched navigation in prod. Tested in a local production environment.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
local production support

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request handling in edge middleware for prefetch traffic and alters how CSP/security headers are applied, which could affect navigation behavior and caching for custom domains if misdetected.
> 
> **Overview**
> Ensures Next.js *prefetch* requests are custom-domain aware by detecting prefetches (`next-router-prefetch`/`purpose: prefetch`) and routing them through `customDomainMiddleware` when a domain mapping exists.
> 
> Prefetch requests now **skip referrer attribution and CSP/security headers**, and the middleware `matcher` no longer excludes prefetches via `missing` header rules (prefetch handling is done in code instead).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c507723419a153cca4f9b5c8b5380d7c300d2f93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->