### PR TITLE
Add 'unsubscribe from thread' action to Reply notifications

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -750,6 +750,17 @@ export default {
       }
       return { id }
     },
+    unsubscribeThread: async (parent, { id }, { me, models }) => {
+      if (!me) throw new GqlAuthenticationError()
+      await models.$executeRaw`
+        DELETE FROM "ThreadSubscription" ts
+        USING "Item" i
+        WHERE ts."userId" = ${me.id}
+        AND i.path @> (SELECT path FROM "Item" WHERE id = ${Number(id)})
+        AND ts."itemId" = i.id
+      `
+      return { id }
+    },
     deleteItem: async (parent, { id }, { me, models }) => {
       const old = await models.item.findUnique({ where: { id: Number(id) } })
       if (Number(old.userId) !== Number(me?.id)) {

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -22,6 +22,7 @@ export default gql`
     bookmarkItem(id: ID): Item
     pinItem(id: ID): Item
     subscribeItem(id: ID): Item
+    unsubscribeThread(id: ID!): Item
     deleteItem(id: ID): Item
     upsertLink(
       id: ID, subNames: [String!], title: String!, url: String!, text: String, forward: [ItemForwardInput],

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { gql } from '@apollo/client'
-import { useQuery } from '@apollo/client/react'
+import { useMutation, useQuery } from '@apollo/client/react'
 import Comment, { CommentSkeleton } from './comment'
 import Item from './item'
 import ItemJob from './item-job'
@@ -716,7 +716,41 @@ function JobChanged ({ n }) {
 }
 
 function Reply ({ n }) {
-  return <NoteItem item={n.item} />
+  const toaster = useToast()
+  const [unsubscribed, setUnsubscribed] = useState(false)
+  const [unsubscribeThread] = useMutation(
+    gql`
+      mutation unsubscribeThread($id: ID!) {
+        unsubscribeThread(id: $id) {
+          id
+        }
+      }
+    `
+  )
+  return (
+    <>
+      <NoteItem item={n.item} />
+      {!unsubscribed && (
+        <div className='text-end'>
+          <span
+            className='text-muted small pointer'
+            onClick={async () => {
+              try {
+                await unsubscribeThread({ variables: { id: n.item.id } })
+                setUnsubscribed(true)
+                toaster.success('unsubscribed from thread')
+              } catch (err) {
+                console.error(err)
+                toaster.danger('failed to unsubscribe from thread')
+              }
+            }}
+          >
+            unsubscribe from thread
+          </span>
+        </div>
+      )}
+    </>
+  )
 }
 
 function FollowActivity ({ n }) {


### PR DESCRIPTION
Closes #2578

Add unsubscribeThread mutation
Add "unsubscribe from thread" action link under Reply notifications

## Description
This PR adds an "Unsubscribe from thread" feature directly in the notifications page. It allows users to easily stop receiving notifications from long or noisy reply chains by unsubscribing from the current item and all its ancestors in one click.

Key changes:

- Added unsubscribeThread(id: ID!): Item mutation to the GraphQL schema
- Implemented the resolver using PostgreSQL’s ltree @> operator to efficiently delete all ancestor ThreadSubscription records in a single query
- Updated the Reply notification component to display a small “unsubscribe from thread” link with immediate feedback (hides after success + toast message)

## Screenshots
<img width="738" height="76" alt="unsubscribe from thread" src="https://github.com/user-attachments/assets/3b719327-13a3-4652-957d-6dfecc724a3c" />

_“unsubscribe from thread” action visible under Reply notifications_

## Additional Context
The mutation follows the existing tree structure patterns in the codebase using ltree path matching. This provides a much better user experience when dealing with notification spam from active comment threads.
## Checklist
Are your changes backward compatible? Please answer below:

Yes. No breaking changes to the GraphQL API or database schema.

On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:

9/10. Tested full subscription → notification → unsubscribe flow, verified database cleanup, confirmed no new notifications arrive after unsubscribing, and ran linting and tests.

For frontend changes: Tested on mobile, light and dark mode? Please answer below:

Yes. The UI uses existing Bootstrap utility classes and works correctly across mobile, desktop, light, and dark modes.

Did you introduce any new environment variables? If so, call them out explicitly here:

No.

Did you use AI for this? If so, how much did it assist you?

Yes, used for code review