### PR TITLE
sndev https and secure cookies

### DIFF
--- a/.cursor/rules/dev-environment.mdc
+++ b/.cursor/rules/dev-environment.mdc
@@ -44,7 +44,7 @@ Use `required_permissions: ["all"]` for shell commands that need Docker access.
 
 ## Compose Profiles
 
-Services are grouped into profiles: `minimal`, `payments`, `wallets`, `email`, `search`, `images`, `capture`, `domains`.
+Services are grouped into profiles: `minimal`, `payments`, `wallets`, `email`, `search`, `images`, `capture`, `domains`, `domains-caddy`.
 Not all services run by default — only those in the active `COMPOSE_PROFILES`.
 
 ## Database Access

--- a/.env.development
+++ b/.env.development
@@ -1,7 +1,7 @@
 PRISMA_SLOW_LOGS_MS=
 GRAPHQL_SLOW_LOGS_MS=
 NODE_ENV=development
-COMPOSE_PROFILES='minimal,images,search,payments,wallets,email,capture,domains'
+COMPOSE_PROFILES='minimal,images,search,payments,wallets,email,capture,domains,domains-caddy'
 
 ############################################################################
 # OPTIONAL SECRETS                                                         #
@@ -59,12 +59,6 @@ LND_CONNECT_ADDRESS=03cc1d0932bb99b0697f5b5e5961b83ab7fd66f1efc4c9f5c7bad66c1bcb
 NEXTAUTH_SECRET=3_0W_PhDRZVanbeJsZZGIEljexkKoGbL6qGIqSwTjjI
 JWT_SIGNING_PRIVATE_KEY={"kty":"oct","kid":"FvD__hmeKoKHu2fKjUrWbRKfhjimIM4IKshyrJG4KSM","alg":"HS512","k":"3_0W_PhDRZVanbeJsZZGIEljexkKoGbL6qGIqSwTjjI"}
 INVOICE_HMAC_KEY=a4c1d9c81edb87b79d28809876a18cf72293eadb39f92f3f4f2f1cfbdf907c91
-
-# comma-separated list of additional allowed origins for webpack HMR in dev
-# wildcards are supported, e.g. **.local for every level, or *.local for the top level
-# full domains are also supported, e.g. sndev.local,linuxpc.local
-# when empty, by default, localhost is allowed
-ALLOWED_DEV_ORIGINS=
 
 # lnd
 # xxd -p -c0 docker/lnd/sn/regtest/admin.macaroon
@@ -212,11 +206,15 @@ DOMAINS_DNS_SERVER=172.30.0.2
 # custom domains debugging
 NEXT_PUBLIC_CUSTOM_DOMAINS_DEBUG=1
 
-# comma-separated list of additional allowed origins for webpack HMR in dev
-# wildcards are supported, e.g. **.local for every level, or *.local for the top level
-# full domains are also supported, e.g. sndev.local,linuxpc.local
-# when empty, by default, localhost is allowed
-ALLOWED_DEV_ORIGINS=
+# comma-separated list of additional allowed origins for webpack HMR, font
+# loading, and other Next.js dev resources. wildcards are supported at the
+# subdomain level (e.g. *.sndev). full domains also work
+# (www.foo.sndev,linuxpc.local). localhost is always allowed.
+#
+# defaults below cover dev custom domains served via the local Caddy proxy
+# (enabled by the domains-caddy profile; see docs/dev/custom-domains.md):
+# RFC-reserved .test, the made-up .sndev TLD wildcarded by dnsmasq.
+ALLOWED_DEV_ORIGINS=**.sndev,**.test
 
 # MDAST pipeline debugging
 NEXT_PUBLIC_MDAST_DEBUG=0

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ COMMANDS
 
 #### Running specific services
 
-By default all services will be run. If you want to exclude specific services from running, set `COMPOSE_PROFILES` in a `.env.local` file to one or more of `minimal,images,search,payments,wallets,email,capture`. To only run mininal necessary without things like payments in `.env.local`:
+By default all services will be run. If you want to exclude specific services from running, set `COMPOSE_PROFILES` in a `.env.local` file to one or more of `minimal,images,search,payments,wallets,email,capture,domains,domains-caddy`. To only run minimal necessary without things like payments in `.env.local`:
 
 ```.env
 COMPOSE_PROFILES=minimal
@@ -189,6 +189,8 @@ To enable dnsmasq:
     ```
 
 To add/remove DNS records you can now use `./sndev domains dns`. More on this [here](#add-or-remove-dns-records-in-local).
+
+The `domains` profile enables dnsmasq and custom-domain worker jobs. The bundled Caddy HTTPS proxy is separate in `domains-caddy`, so you can keep local domain verification while omitting Caddy if an external TLS-terminating load balancer handles your dev domains.
 
 <br>
 
@@ -494,6 +496,8 @@ To enable Web Push locally, you will need to set the `VAPID_*` env vars. `VAPID_
 ### Add or remove DNS records in local
 
 A worker dedicated to verifying custom domains, checks, among other things, if a domain has the correct DNS records and values. This would normally require a real domain and access to its DNS configuration. Therefore we use dnsmasq to have local DNS, make sure you have [enabled it](#local-dns-via-dnsmasq).
+
+If you access local custom domains through the bundled Caddy proxy, keep `domains-caddy` enabled too. If you use your own TLS-terminating load balancer, it should forward `X-Forwarded-Proto: https` so dev cookies that depend on secure requests are marked `Secure`.
 
 To add a DNS record the syntax is the following:
 

--- a/components/login.js
+++ b/components/login.js
@@ -9,7 +9,6 @@ import { NostrAuthWithExplainer } from './nostr-auth'
 import LoginButton, { LoginWithNymButton } from './login-button'
 import { emailSchema } from '@/lib/validate'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
-import { datePivot } from '@/lib/time'
 import * as cookie from 'cookie'
 import { cookieOptions, MULTI_AUTH_ANON, MULTI_AUTH_POINTER } from '@/lib/auth'
 import Link from 'next/link'
@@ -91,13 +90,9 @@ export default function Login ({ providers, callbackUrl, multiAuth, error, text,
 
   // signup/signin awareness cookie
   useEffect(() => {
-    // expire cookie if we're on /signup instead of /login
+    // clear the cookie if we're on /signup instead of /login
     // since the server will only check if the cookie is set, not its value
-    const options = cookieOptions({
-      expires: signin ? datePivot(new Date(), { hours: 24 }) : 0,
-      maxAge: signin ? 86400 : 0,
-      httpOnly: false
-    })
+    const options = cookieOptions({ httpOnly: false, maxAge: signin ? 86400 : 0 })
     document.cookie = cookie.serialize('signin', signin, options)
   }, [signin])
 

--- a/components/use-cookie.js
+++ b/components/use-cookie.js
@@ -41,7 +41,9 @@ export default function useCookie (name) {
   }, [name])
 
   const remove = useCallback(() => {
-    document.cookie = cookie.serialize(name, '', { expires: 0, maxAge: 0 })
+    // path must match the SET (cookieOptions defaults path to '/'); without it
+    // the browser uses the current URL's directory and the clear silently misses.
+    document.cookie = cookie.serialize(name, '', cookieOptions({ httpOnly: false, maxAge: 0 }))
     setValue(null)
   }, [name])
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -914,7 +914,12 @@ services:
       - "5353:53/udp"
     command:
       - --no-daemon
+      # Wildcard A records for dev test TLDs. Both .sndev and .test are RFC
+      # 2606 / 6761 reserved (.test) or invented for sndev (.sndev), so they
+      # never collide with real internet hostnames. Pair with macOS
+      # /etc/resolver/<tld> to get zero-/etc/hosts dev DNS.
       - --address=/.sndev/127.0.0.1
+      - --address=/.test/127.0.0.1
       - --conf-file=/etc/dnsmasq.conf
       - --conf-dir=/etc/dnsmasq.d
     volumes:
@@ -924,6 +929,27 @@ services:
     networks:
       domains-network:
         ipv4_address: 172.30.0.2
+  caddy:
+    # ALB-equivalent: terminates TLS for custom domains and forwards plain
+    # HTTP to the next.js app, so dev mirrors the prod traffic shape and
+    # browsers treat custom domains as secure contexts.
+    image: caddy:2.10-alpine
+    container_name: caddy
+    profiles:
+      - domains-caddy
+    restart: unless-stopped
+    depends_on:
+      app:
+        condition: service_healthy
+        restart: true
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./docker/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    cpu_shares: "${CPU_SHARES_LOW}"
 
 volumes:
   db:
@@ -940,6 +966,8 @@ volumes:
   eclair:
   dnsmasq:
   lnpub:
+  caddy_data:
+  caddy_config:
 
 networks:
   default: {}

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,0 +1,56 @@
+# Local TLS terminator for custom-domain dev. Mirrors prod, where the AWS ALB
+# terminates HTTPS via ACM and forwards plain HTTP to the app.
+#
+# On-demand TLS with `tls internal` mints a per-SNI cert from Caddy's local CA
+# the first time a hostname is hit, so any dev custom domain (whatever
+# /etc/hosts or dnsmasq points at 127.0.0.1) works without per-domain config.
+#
+# Run `./sndev domains trust` once to install Caddy's local root CA into the
+# host trust store; after that browsers see a real green padlock and the page
+# is treated as a secure context (window.crypto.subtle, secure cookies, etc.).
+{
+	auto_https disable_redirects
+	local_certs
+
+	# Caddy refuses on-demand TLS without an "ask" endpoint, to prevent SNI
+	# floods from forcing it to mint unbounded certs. In dev we self-host a
+	# loopback-only allow-all ask on :5555 so any SNI is allowed without
+	# wiring up an external service.
+	on_demand_tls {
+		ask http://127.0.0.1:5555/
+	}
+
+	log {
+		output stderr
+		level WARN
+	}
+}
+
+# Loopback-only ask endpoint: any GET /?domain=<sni> returns 200, so Caddy
+# mints a cert for any incoming SNI. Bound to localhost so nothing outside the
+# container can reach it.
+http://127.0.0.1:5555 {
+	respond 200
+}
+
+# HTTPS catch-all: terminate TLS with the local CA, reverse-proxy to Next.js.
+:443 {
+	tls internal {
+		on_demand
+	}
+	encode zstd gzip
+
+	reverse_proxy app:3000 {
+		# preserve the original Host so proxy.js's getDomainMapping(host) sees
+		# the user-facing custom domain, not "app:3000"
+		header_up Host {host}
+		# Tell Next.js the browser-facing request was HTTPS so dev cookies that
+		# depend on Secure, like sn_referrer, match the TLS-terminated origin.
+		header_up X-Forwarded-Proto https
+	}
+}
+
+# HTTP -> HTTPS, mirroring the prod ALB redirect.
+:80 {
+	redir https://{host}{uri} 308
+}

--- a/docs/dev/custom-domains.md
+++ b/docs/dev/custom-domains.md
@@ -283,3 +283,66 @@ Two variants worth walking through, since they exercise different parts of the d
 3. Weeks later, the owner re-adds `pizza.com`. A fresh row is created, `id=43`, `tokenVersion` defaulted to `0`.
 4. Verification succeeds, the `PENDING -> ACTIVE` trigger bumps `tokenVersion` to `1`.
 5. The attacker tries their stolen cookie again. The domain is `ACTIVE` (so `!mapping` passes) and the new `tokenVersion=1` happens to collide with the stolen JWT's `tokenVersion=1`. Without `domainId`, **this would resurrect the stolen token**. With `domainId` in place: `mapping.id` is `43`, the JWT claims `42`, `43 !== 42` -> rejected.
+
+# Local dev: end-to-end HTTPS
+
+Custom domains in production sit behind the AWS ALB, which terminates HTTPS
+using ACM-issued certs and forwards plain HTTP to the app. The dev environment
+mirrors that with a `caddy` container in the `domains-caddy` compose profile that
+reverse-proxies `:80` and `:443` on the host into `app:3000`.
+
+This matters for QA because browsers only treat HTTPS (and `localhost`) as
+[secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts).
+On a plain-HTTP custom-domain origin like `http://www.foo.sndev`, anything
+that depends on `window.crypto.subtle` (the wallet vault key derivation) or on
+`Secure` cookies will silently degrade or break in dev — but work fine in prod
+behind the ALB. Running through Caddy closes that gap.
+
+`domains` and `domains-caddy` are separate profiles: keep `domains` enabled for
+dnsmasq and custom-domain worker jobs, and enable `domains-caddy` only when you
+want the bundled local HTTPS proxy. If your dev environment already sits behind
+another TLS-terminating load balancer (for example one that enforces mTLS), omit
+`domains-caddy` and have that load balancer forward `X-Forwarded-Proto: https`
+to the app so dev `Secure` cookies follow the browser-facing protocol.
+
+#### Setup
+
+1. Make sure nothing else is using host ports 80 and 443 (a local nginx /
+   Apache / Caddy will conflict). Stop them before starting the dev env.
+2. Start the env with the `domains` and `domains-caddy` profiles enabled (both
+   are already part of the default `COMPOSE_PROFILES` if you've been working
+   on custom domains):
+   ```sh
+   ./sndev start
+   ```
+3. Resolve your test domain to `127.0.0.1`. Either:
+   - add it to `/etc/hosts`, e.g. `127.0.0.1 www.foo.sndev`, or
+   - use the dnsmasq flow: `./sndev domains dns add cname www.foo.sndev sn.sndev`
+     (`*.sndev` already resolves to `127.0.0.1` via dnsmasq).
+4. **One-time:** install Caddy's local root CA into the host trust store so
+   browsers trust the auto-generated certs:
+   ```sh
+   ./sndev domains trust
+   ```
+   This shells out to `security add-trusted-cert` on macOS or
+   `update-ca-certificates` on Linux (both require sudo). Restart Chrome /
+   Safari to pick up the new root. Firefox uses its own NSS trust store —
+   import the cert manually via Settings if you use Firefox.
+5. Open `https://www.foo.sndev` (or whatever domain you set up). Real
+   green-padlock HTTPS, `crypto.subtle` defined, HMR over `wss://`, secure
+   cookies, the works.
+
+`./sndev domains trust` is idempotent and persists in the `caddy_data` named
+volume across container restarts; you don't need to re-run it after
+`./sndev restart` or `./sndev stop`.
+
+#### Caveats
+
+- The Caddy local CA is **only** trusted on the machine that ran
+  `./sndev domains trust`. Other devices on your network won't trust it.
+- `./sndev delete` (which wipes volumes) destroys the Caddy CA. The next
+  `./sndev domains trust` will install a fresh one; you'll want to remove the
+  old one from your trust store first to avoid clutter.
+- The `customDomainSchema` requires ≥3 labels (`www.foo.sndev`), so 2-label
+  test names like `aaa.test` won't pass `setDomain` validation — use
+  `www.aaa.test` or similar.

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,4 +1,3 @@
-import { datePivot } from '@/lib/time'
 import * as cookie from 'cookie'
 import { NodeNextRequest } from 'next/dist/server/base-http/node'
 import { encode as encodeJWT, decode as decodeJWT } from 'next-auth/jwt'
@@ -6,10 +5,41 @@ import { encode as encodeJWT, decode as decodeJWT } from 'next-auth/jwt'
 const b64Encode = obj => Buffer.from(JSON.stringify(obj)).toString('base64')
 const b64Decode = s => JSON.parse(Buffer.from(s, 'base64'))
 
-export const HTTPS = process.env.NODE_ENV === 'production'
+const isProd = process.env.NODE_ENV === 'production'
 
+// True iff the current request was served over HTTPS. In prod this is always
+// true (the ALB terminates TLS). In dev it depends on whether the request
+// came in via a TLS-terminating proxy (https) or directly to localhost:3000
+// (http) — used to gate the Secure cookie attribute so localhost dev still
+// works while the custom-domain HTTPS path exercises the full secure-cookie
+// codepath.
+//
+// Accepts either an edge NextRequest, a Node IncomingMessage, or undefined.
+// When called in the browser with no req, derives from window.location.
+export function isSecureRequest (req) {
+  if (isProd) return true
+  if (!req) {
+    if (typeof window !== 'undefined') return window.location.protocol === 'https:'
+    return false
+  }
+  // X-Forwarded-Proto wins: it's the authoritative client protocol when a
+  // TLS-terminating proxy (Caddy/external LB in dev, ALB in prod) is in
+  // front. On edge NextRequest, req.nextUrl.protocol reflects the inbound hop
+  // to the app (plain http behind Caddy), so we must consult the header first.
+  const headers = req.headers
+  const xfp = typeof headers?.get === 'function' ? headers.get('x-forwarded-proto') : headers?.['x-forwarded-proto']
+  if (xfp) return xfp === 'https'
+  // No proxy in front: fall back to the actual inbound protocol (edge only;
+  // bare Node IncomingMessage has no equivalent and stays false).
+  if (req.nextUrl?.protocol) return req.nextUrl.protocol === 'https:'
+  return false
+}
+
+// Cookie names get the __Secure- prefix only in prod, where the prefix is
+// guaranteed honor-able. Keeping names stable in dev lets the same imported
+// constant work whether the request came in via HTTP localhost or HTTPS proxy.
 export const secureCookie = (name) =>
-  HTTPS
+  isProd
     ? `__Secure-${name}`
     : name
 
@@ -23,20 +53,25 @@ export const MULTI_AUTH_JWT = id => secureCookie(`multi_auth.${id}`)
 const MULTI_AUTH_REGEXP = /^(__Secure-)?multi_auth/
 const MULTI_AUTH_JWT_REGEXP = /^(__Secure-)?multi_auth\.\d+$/
 
-export const cookieOptions = (args) => ({
+// Pass `req` to make `secure` per-request. `secure` may also be overridden
+// directly. `maxAge` defaults to 30 days; pass 0 to clear. `expires` is
+// derived from `maxAge` (skipped on clear so `Max-Age=0` is unambiguous).
+// All other args spread onto the result.
+export const cookieOptions = ({ req, secure, maxAge = 2592000, ...rest } = {}) => ({
   path: '/',
-  secure: HTTPS,
-  // httpOnly cookies by default
+  secure: secure ?? isSecureRequest(req),
   httpOnly: true,
   sameSite: 'lax',
-  // default expiration for next-auth JWTs is in 30 days
-  expires: datePivot(new Date(), { days: 30 }),
-  maxAge: 2592000, // 30 days in seconds
-  ...args
+  maxAge,
+  expires: maxAge > 0 ? new Date(Date.now() + maxAge * 1000) : undefined,
+  ...rest
 })
 
-export function buildMultiAuthCookies (existingMultiAuth, { id, jwt, name, photoId }) {
-  const httpOnlyOptions = cookieOptions()
+// `req` is optional and only used to derive the per-request `Secure` flag.
+// Pass it whenever you have one so dev custom-domain HTTPS gets `Secure`
+// cookies and plain-HTTP localhost dev does not.
+export function buildMultiAuthCookies (existingMultiAuth, { id, jwt, name, photoId }, req) {
+  const httpOnlyOptions = cookieOptions({ req })
   const jsOptions = { ...httpOnlyOptions, httpOnly: false }
 
   const cookies = [
@@ -59,7 +94,7 @@ export function buildMultiAuthCookies (existingMultiAuth, { id, jwt, name, photo
 
 export function setMultiAuthCookies (req, res, entry) {
   const existingMultiAuth = req.cookies[MULTI_AUTH_LIST]
-  const newCookies = buildMultiAuthCookies(existingMultiAuth, entry)
+  const newCookies = buildMultiAuthCookies(existingMultiAuth, entry, req)
 
   for (const { name, value, options } of newCookies) {
     res.appendHeader('Set-Cookie', cookie.serialize(name, value, options))
@@ -128,7 +163,7 @@ async function checkMultiAuthCookies (req, res) {
 }
 
 async function resetMultiAuthCookies (req, res) {
-  const httpOnlyOptions = cookieOptions({ expires: 0, maxAge: 0 })
+  const httpOnlyOptions = cookieOptions({ req, maxAge: 0 })
   const jsOptions = { ...httpOnlyOptions, httpOnly: false }
 
   // remove all multi_auth cookies ...
@@ -154,7 +189,7 @@ class JwtExpiredError extends Error {
 }
 
 async function refreshMultiAuthCookies (req, res) {
-  const httpOnlyOptions = cookieOptions()
+  const httpOnlyOptions = cookieOptions({ req })
   const jsOptions = { ...httpOnlyOptions, httpOnly: false }
 
   const refreshCookie = (name) => {

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -11,7 +11,7 @@ import { getToken, encode as encodeJWT } from 'next-auth/jwt'
 import { schnorr } from '@noble/curves/secp256k1'
 import { notifyReferral } from '@/lib/webPush'
 import { hashEmail } from '@/lib/crypto'
-import { multiAuthMiddleware, setMultiAuthCookies } from '@/lib/auth'
+import { multiAuthMiddleware, setMultiAuthCookies, cookieOptions } from '@/lib/auth'
 import { getDomainMapping } from '@/lib/domains'
 import { isSafeRedirectPath, parseSafeHost } from '@/lib/safe-url'
 import { BECH32_CHARSET } from '@/lib/constants'
@@ -97,7 +97,7 @@ function getCallbacks (req, res) {
     async jwt ({ token, user, account, profile, isNewUser }) {
       if (user) {
         // reset signup cookie if any
-        res.appendHeader('Set-Cookie', cookie.serialize('signin', '', { path: '/', expires: 0, maxAge: 0 }))
+        res.appendHeader('Set-Cookie', cookie.serialize('signin', '', cookieOptions({ req, httpOnly: false, maxAge: 0 })))
         // token won't have an id on it for new logins, we add it
         // note: token is what's kept in the jwt
         token.id = Number(user.id)

--- a/pages/api/auth/domains/verify.js
+++ b/pages/api/auth/domains/verify.js
@@ -38,7 +38,7 @@ export default async function handler (req, res) {
     // exchange the code for a session token
     const tokenData = await exchangeCode(parsedDomain.hostname, code, verifier)
     // set the session cookie
-    res.appendHeader('Set-Cookie', cookie.serialize(SESSION_COOKIE, tokenData.sessionToken, cookieOptions()))
+    res.appendHeader('Set-Cookie', cookie.serialize(SESSION_COOKIE, tokenData.sessionToken, cookieOptions({ req })))
 
     // mirror multi-auth state on the custom domain so the account picker also works here.
     // each per-user JWT is the domain-bound session token minted for THIS domain (not the
@@ -52,7 +52,8 @@ export default async function handler (req, res) {
           jwt: tokenData.sessionToken,
           name: tokenData.user.name,
           photoId: tokenData.user.photoId
-        }
+        },
+        req
       )
       for (const { name, value, options } of multiAuthCookies) {
         res.appendHeader('Set-Cookie', cookie.serialize(name, value, options))

--- a/pages/api/next-account.js
+++ b/pages/api/next-account.js
@@ -1,6 +1,5 @@
 import * as cookie from 'cookie'
-import { datePivot } from '@/lib/time'
-import { HTTPS, MULTI_AUTH_JWT, MULTI_AUTH_LIST, MULTI_AUTH_POINTER, SESSION_COOKIE } from '@/lib/auth'
+import { cookieOptions as baseCookieOptions, MULTI_AUTH_JWT, MULTI_AUTH_LIST, MULTI_AUTH_POINTER, SESSION_COOKIE } from '@/lib/auth'
 
 /**
  * @param  {NextApiRequest}  req
@@ -22,23 +21,18 @@ export default (req, res) => {
 
   const cookies = []
 
-  const cookieOptions = {
-    path: '/',
-    secure: HTTPS,
-    httpOnly: true,
-    sameSite: 'lax',
-    expires: datePivot(new Date(), { months: 1 })
-  }
+  const cookieOptions = baseCookieOptions({ req })
+  const clearOptions = baseCookieOptions({ req, maxAge: 0 })
   // remove JWT pointed to by cookie pointer
-  cookies.push(cookie.serialize(MULTI_AUTH_JWT(userId), '', { ...cookieOptions, expires: 0, maxAge: 0 }))
+  cookies.push(cookie.serialize(MULTI_AUTH_JWT(userId), '', clearOptions))
 
   // update multi_auth cookie and check if there are more accounts available
   const oldMultiAuth = req.cookies[MULTI_AUTH_LIST] ? b64Decode(req.cookies[MULTI_AUTH_LIST]) : undefined
   const newMultiAuth = oldMultiAuth?.filter(({ id }) => id !== Number(userId))
   if (!oldMultiAuth || newMultiAuth?.length === 0) {
     // no next account available. cleanup: remove multi_auth + pointer cookie
-    cookies.push(cookie.serialize(MULTI_AUTH_LIST, '', { ...cookieOptions, httpOnly: false, expires: 0, maxAge: 0 }))
-    cookies.push(cookie.serialize(MULTI_AUTH_POINTER, '', { ...cookieOptions, httpOnly: false, expires: 0, maxAge: 0 }))
+    cookies.push(cookie.serialize(MULTI_AUTH_LIST, '', { ...clearOptions, httpOnly: false }))
+    cookies.push(cookie.serialize(MULTI_AUTH_POINTER, '', { ...clearOptions, httpOnly: false }))
     res.setHeader('Set-Cookie', cookies)
     res.status(204).end()
     return

--- a/proxy.js
+++ b/proxy.js
@@ -1,7 +1,7 @@
 import 'urlpattern-polyfill'
 import { NextRequest, NextResponse } from 'next/server'
 import { randomBytes } from 'node:crypto'
-import { HTTPS } from '@/lib/auth'
+import { cookieOptions } from '@/lib/auth'
 import {
   deriveChallenge,
   DOMAINS_AUTH_VERIFIER_COOKIE,
@@ -10,13 +10,7 @@ import {
 } from '@/lib/domains/auth'
 import { getDomainMapping, createDomainsDebugLogger } from '@/lib/domains'
 
-const verifierCookieOptions = {
-  httpOnly: true,
-  sameSite: 'lax',
-  secure: HTTPS,
-  path: '/',
-  maxAge: DOMAINS_AUTH_VERIFIER_TTL_S
-}
+const REFERRER_TTL_S = 60 * 60 * 24
 
 const referrerPattern = new URLPattern({ pathname: ':pathname(*)/r/:referrer([\\w_]+)' })
 const itemPattern = new URLPattern({ pathname: '/items/:id(\\d+){/:other(\\w+)}?' })
@@ -108,7 +102,11 @@ async function redirectToAuth (request, searchParams, domain, signup) {
   }
 
   const response = NextResponse.redirect(redirectUrl)
-  response.cookies.set(DOMAINS_AUTH_VERIFIER_COOKIE, verifier, verifierCookieOptions)
+  response.cookies.set(
+    DOMAINS_AUTH_VERIFIER_COOKIE,
+    verifier,
+    cookieOptions({ req: request, maxAge: DOMAINS_AUTH_VERIFIER_TTL_S })
+  )
   return response
 }
 
@@ -133,6 +131,11 @@ function getContentReferrer (request, url) {
 // we store the referrers in cookies for a future signup event
 // we pass the referrers in the request headers so we can use them in referral rewards for logged in stackers
 function referrerMiddleware (request) {
+  // referrer cookies are read only by middleware/SSR — keep them httpOnly.
+  // Secure follows isSecureRequest(req); TLS-terminating dev proxies must send
+  // X-Forwarded-Proto: https or sn_referrer stays non-Secure.
+  const referrerOptions = (maxAge) => cookieOptions({ req: request, maxAge })
+
   if (referrerPattern.test(request.url)) {
     const { pathname, referrer } = referrerPattern.exec(request.url).pathname.groups
 
@@ -144,20 +147,20 @@ function referrerMiddleware (request) {
     // explicit referrers are set for a day and can only be overriden by other explicit
     // referrers. Content referrers do not override explicit referrers because
     // explicit referees might click around before signing up.
-    response.cookies.set(SN_REFERRER, referrer, { maxAge: 60 * 60 * 24 })
+    response.cookies.set(SN_REFERRER, referrer, referrerOptions(REFERRER_TTL_S))
 
     // we record the first page the user lands on and keep it for 24 hours
     // in addition to the explicit referrer, this allows us to tell the referrer
     // which share link the user clicked on
     const contentReferrer = getContentReferrer(request, url)
     if (contentReferrer) {
-      response.cookies.set(SN_REFEREE_LANDING, contentReferrer, { maxAge: 60 * 60 * 24 })
+      response.cookies.set(SN_REFEREE_LANDING, contentReferrer, referrerOptions(REFERRER_TTL_S))
     }
     // store the explicit referrer for one page load
     // this allows us to attribute both explicit and implicit referrers after the redirect
     // e.g. items/<num>/r/<referrer> links should attribute both the item op and the referrer
     // without this the /r/<referrer> would be lost on redirect
-    response.cookies.set(SN_REFERRER_NONCE, referrer, { maxAge: 1 })
+    response.cookies.set(SN_REFERRER_NONCE, referrer, referrerOptions(1))
     return response
   }
 
@@ -178,23 +181,17 @@ function referrerMiddleware (request) {
 
   // if we don't already have an explicit referrer, give them the content referrer as one
   if (!request.cookies.has(SN_REFERRER) && contentReferrer) {
-    response.cookies.set(SN_REFERRER, contentReferrer, { maxAge: 60 * 60 * 24 })
+    response.cookies.set(SN_REFERRER, contentReferrer, referrerOptions(REFERRER_TTL_S))
   }
 
   return response
 }
 
 function applyReferrerCookies (response, referrer) {
-  for (const cookie of referrer.cookies.getAll()) {
-    response.cookies.set(
-      cookie.name,
-      cookie.value,
-      {
-        maxAge: cookie.maxAge,
-        expires: cookie.expires,
-        path: cookie.path
-      }
-    )
+  for (const { name, value, ...options } of referrer.cookies.getAll()) {
+    // forward all attributes (secure, httpOnly, sameSite, ...), not just timing,
+    // so referrer cookies inherit the security flags set by referrerMiddleware.
+    response.cookies.set(name, value, options)
   }
   return response
 }

--- a/sndev
+++ b/sndev
@@ -59,7 +59,7 @@ sndev__dmenu_profile() {
   # dmenu allows to select multiple profiles with CTRL+Enter in which case it will
   # immediately write the selected profile to stdout even if it was already selected
   # so we use sort+uniq to remove duplicates
-  profiles="minimal payments wallets tor cln eclair nwc lnbits litd lndk lnpub email search images capture"
+  profiles="minimal payments wallets tor cln eclair nwc lnbits litd lndk lnpub email search images capture domains domains-caddy"
   echo "$profiles" | tr ' ' '\n' | dmenu | sort | uniq | tr '\n' ',' | sed 's/,$//'
 }
 
@@ -354,11 +354,84 @@ sndev__domains() {
       fi
     fi
     ;;
+  trust)
+    case $2 in
+      -h|--help|help)
+        sndev__help_domains_trust
+        exit 0
+        ;;
+    esac
+    sndev__domains_trust
+    ;;
   # PLACEHOLDER for domain verification management
   *)
     sndev__help_domains
     exit 0
   esac
+}
+
+sndev__domains_trust() {
+  if ! docker ps --format '{{.Names}}' | grep -q '^caddy$'; then
+    echo "caddy is not running."
+    echo "start it with: ./sndev start (with the 'domains-caddy' profile in COMPOSE_PROFILES)"
+    exit 1
+  fi
+
+  ca_path="/data/caddy/pki/authorities/local/root.crt"
+  tmp_ca=$(mktemp -t sn-caddy-root.XXXXXX 2>/dev/null || mktemp /tmp/sn-caddy-root.XXXXXX)
+  if ! docker__exec caddy cat "$ca_path" > "$tmp_ca" 2>/dev/null; then
+    rm -f "$tmp_ca"
+    echo "could not read caddy local CA at $ca_path."
+    echo "the cert is generated lazily on the first https request — try hitting"
+    echo "any https://*.sndev URL once and re-run, or check 'sndev logs caddy'."
+    exit 1
+  fi
+
+  case "$(uname)" in
+    Darwin)
+      echo "installing caddy local CA into the macOS System keychain (requires sudo)"
+      sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$tmp_ca"
+      ;;
+    Linux)
+      if command -v update-ca-trust >/dev/null 2>&1; then
+        # Fedora / RHEL / CentOS / Rocky / Alma
+        dest=/etc/pki/ca-trust/source/anchors/sndev-caddy-root.crt
+        echo "installing caddy local CA into $dest (requires sudo)"
+        sudo cp "$tmp_ca" "$dest"
+        sudo update-ca-trust
+      elif command -v update-ca-certificates >/dev/null 2>&1; then
+        # Debian / Ubuntu / openSUSE
+        if [ -d /etc/pki/trust/anchors ]; then
+          dest=/etc/pki/trust/anchors/sndev-caddy-root.crt
+        else
+          dest=/usr/local/share/ca-certificates/sndev-caddy-root.crt
+        fi
+        echo "installing caddy local CA into $dest (requires sudo)"
+        sudo cp "$tmp_ca" "$dest"
+        sudo update-ca-certificates
+      elif command -v trust >/dev/null 2>&1; then
+        # Arch and other p11-kit based systems
+        echo "installing caddy local CA via 'trust anchor' (requires sudo)"
+        sudo trust anchor "$tmp_ca"
+      else
+        echo "no supported trust store tool found (update-ca-trust, update-ca-certificates, trust)."
+        echo "the CA cert is at: $tmp_ca"
+        echo "import it manually into your system trust store."
+        exit 1
+      fi
+      ;;
+    *)
+      echo "automatic install not supported on $(uname). the CA cert is at: $tmp_ca"
+      echo "import it into your system trust store manually."
+      exit 1
+      ;;
+  esac
+
+  rm -f "$tmp_ca"
+  echo
+  echo "trust installed. restart Chrome/Safari to pick up the new root CA."
+  echo "Firefox uses its own NSS trust store — import the cert manually via"
+  echo "Settings > Privacy & Security > Certificates > Import."
 }
 
 sndev__help_domains() {
@@ -370,6 +443,31 @@ USAGE
 
 COMMANDS
   dns             [add|remove|list]
+  trust           install the caddy local CA into the host trust store
+"
+
+  echo "$help"
+}
+
+sndev__help_domains_trust() {
+  help="
+install the caddy local CA into the host trust store
+
+USAGE
+  $ sndev domains trust
+
+DESCRIPTION
+  Pulls the auto-generated Caddy local root CA out of the running caddy
+  container and installs it into the host trust store, so HTTPS to any
+  custom dev domain (https://*.sndev, https://*.test, etc.) shows a green
+  padlock and is treated as a secure context — which
+  unlocks window.crypto.subtle, Secure cookies, and matches prod behavior.
+
+  One-time per machine. The CA is persisted in the caddy_data docker volume.
+
+REQUIREMENTS
+  - the 'domains-caddy' compose profile must be enabled and 'caddy' running
+  - sudo (to write to the system keychain on macOS / ca-certificates on Linux)
 "
 
   echo "$help"
@@ -669,6 +767,10 @@ USAGE
 }
 
 sndev__help() {
+    if [ $# -eq 3 ]; then
+      call "sndev__$1_$2_$3" "$@"
+      exit 0
+    fi
     if [ $# -eq 2 ]; then
       call "sndev__$1_$2" "$@"
       exit 0

--- a/wallets/client/components/page-shells.js
+++ b/wallets/client/components/page-shells.js
@@ -118,10 +118,13 @@ export function WalletRouteGateShell ({ children, errorTitle, loadingMessage }) 
 }
 
 export function WalletKeyStorageUnavailableShell () {
+  const insecureContext = typeof window !== 'undefined' && window.isSecureContext === false
   return (
     <WalletErrorShell
       title='wallets unavailable'
-      message='this device does not support storage of cryptographic keys via IndexedDB'
+      message={insecureContext
+        ? 'wallets require a secure (HTTPS) connection on this device'
+        : 'this device does not support storage of cryptographic keys via IndexedDB'}
     />
   )
 }

--- a/wallets/client/hooks/global.js
+++ b/wallets/client/hooks/global.js
@@ -151,15 +151,23 @@ function useKeyInit () {
 
   const logger = useWalletLogger()
 
+  // browsers only expose window.crypto.subtle in secure contexts (HTTPS, localhost, *.localhost).
+  // dev custom domains served over plain HTTP fail this check, which would otherwise crash
+  // PBKDF2 key derivation in deriveKey().
+  const keyStorageAvailable = typeof window !== 'undefined' &&
+    typeof window.indexedDB !== 'undefined' &&
+    window.isSecureContext &&
+    !!window.crypto?.subtle
+
   useEffect(() => {
-    if (typeof window.indexedDB === 'undefined') {
+    if (!keyStorageAvailable) {
       dispatch({ type: KEY_STORAGE_UNAVAILABLE })
     } else if (!keySyncInProgress && wrongKey) {
       dispatch({ type: WRONG_KEY })
     } else {
       dispatch({ type: KEY_MATCH })
     }
-  }, [wrongKey, keySyncInProgress, dispatch])
+  }, [keyStorageAvailable, wrongKey, keySyncInProgress, dispatch])
 
   const generateRandomKey = useGenerateRandomKey()
   const setKey = useSetKey()
@@ -167,7 +175,7 @@ function useKeyInit () {
   const { open } = useVaultLocalStore()
 
   useEffect(() => {
-    if (!me?.id) return
+    if (!me?.id || !keyStorageAvailable) return
     let db
 
     async function openDb () {
@@ -185,7 +193,7 @@ function useKeyInit () {
       db?.close()
       setDb(null)
     }
-  }, [me?.id, open])
+  }, [me?.id, keyStorageAvailable, open])
 
   useEffect(() => {
     if (!me?.id || !db) return

--- a/wallets/client/hooks/query.js
+++ b/wallets/client/hooks/query.js
@@ -200,7 +200,7 @@ export function useWalletsQuery () {
       })
       .catch(err => {
         if (cancelled) return
-        console.error('failed to decrypt wallets:', err)
+        console.warn('failed to decrypt wallets:', err)
         setWallets([])
         // OperationError from the Web Crypto API does not have a message
         setError(new Error('decryption error: ' + (err.message || err.name)))


### PR DESCRIPTION
This was motivated by wallets not working on custom domains in `sndev` (because `window.crypto.subtle` is unavailable in insecure contexts). While we may be able to just use `*.localhost` custom domains in dev to achieve the same (depending on the browser), it was a small lift toward achieving more fidelity.

It's four commits:

- adds a Caddy server to `sndev` that serves self-signed certs
    - also adds `sndev domains trust` to import/trust the certs
- auth: derive cookie Secure flag per request
    - this is a bit invasive, but it allows use of secure cookies in dev 
    - before this was gated on `process.env.NODE_ENV === 'production'`
- wallets: fail key init gracefully on insecure-context dev domains
    - attempting to use wallets on custom domain without https would throw
- wallets: console.warn when local key fails to decrypt remote
    - this was a side effect of #2904 (console errors in `useEffect`) and is only an annoyance in dev

TODO
- still needs human touch (claude is a yapper)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/cookie issuance logic and adds a TLS-terminating proxy path in dev, which can affect session persistence and cross-domain auth if misconfigured (e.g., missing `X-Forwarded-Proto`).
> 
> **Overview**
> Adds an optional `domains-caddy` dev profile that runs a local Caddy TLS terminator (ports 80/443) for custom domains, plus `sndev domains trust` to install Caddy’s local CA; dnsmasq is updated to wildcard `*.sndev` and `*.test`, and docs/env defaults are adjusted accordingly.
> 
> Refactors cookie handling so the `Secure` attribute is derived **per request** (via `X-Forwarded-Proto`/protocol) instead of being gated only by `NODE_ENV`, and threads this through NextAuth, multi-auth cookies, domain-auth verification, referrer middleware, and cookie clearing paths.
> 
> Improves wallet behavior on insecure origins by detecting non-secure contexts (missing `crypto.subtle`/secure context) and failing key init gracefully with a clearer error message; also downgrades a noisy decrypt failure log from `console.error` to `console.warn`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5385814dbf266204d817b7c73f137154f946136. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->