### PR TITLE
fix: accept NIP-46 connect responses from signers that echo the URI secret

### DIFF
--- a/lib/nostr.js
+++ b/lib/nostr.js
@@ -193,11 +193,68 @@ export function nostrZapDetails (zap) {
   return { npub, content, note }
 }
 
-// workaround NDK url parsing issue (see https://github.com/stackernews/stacker.news/pull/1636)
+// Workarounds for NDK NIP-46 bugs that prevent connecting to spec-compliant signers.
+//
+// 1. URL parsing — the original workaround (see PR #1636). NDK uses
+//    `new URL(token)` which on some browsers returns empty `searchParams` for
+//    non-special schemes like `bunker://`. Rewriting to `http://` makes the
+//    URL parser populate hostname + searchParams correctly.
+//
+// 2. Connect handshake — NDK's `blockUntilReady` violates NIP-46 in two ways:
+//      a. It sends `connect([userPubkey ?? "", secret])`. For bunker URIs
+//         without `?pubkey=` (the typical single-user signer case), this
+//         passes an empty first param. NIP-46 says the first param is the
+//         remote-signer-pubkey, not the user-pubkey. Some signers reject the
+//         empty string; others (e.g., Clave) tolerate it but the override
+//         sends the spec-correct value defensively.
+//      b. It only accepts `response.result === "ack"` and rejects everything
+//         else with `response.error` — which is `undefined` when a signer
+//         returns the spec-allowed alternative (the URI secret echoed back).
+//         Spec-compliant signers like Clave (LightSigner.swift) and any
+//         signer matching nostr-tools' `BunkerSigner.fromURI` return the
+//         secret-echo form, so NDK's `await blockUntilReady()` rejects with
+//         `undefined` and our `setError(e)` later throws on `e.message`.
+//
+//    Bugs 2a and 2b are present in every released NDK from 2.12.2 through
+//    3.0.3. This override accepts both response forms per NIP-46 and sends
+//    the bunker pubkey when `userPubkey` is missing. Delete this override
+//    once we bump to an NDK version that fixes them upstream.
 class NDKNip46SignerURLPatch extends NDKNip46Signer {
   connectionTokenInit (connectionToken) {
     connectionToken = connectionToken.replace('bunker://', 'http://')
     return super.connectionTokenInit(connectionToken)
+  }
+
+  async blockUntilReady () {
+    // NIP-05 path is unaffected — defer to NDK.
+    if (this.nip05 && !this.userPubkey) return super.blockUntilReady()
+
+    if (!this.bunkerPubkey) throw new Error('Bunker pubkey not set')
+
+    await this.startListening()
+    this.rpc.on('authUrl', (...args) => this.emit('authUrl', ...args))
+
+    await new Promise((resolve, reject) => {
+      // Fix (a): send the remote-signer-pubkey as the first param.
+      const connectParams = [this.userPubkey || this.bunkerPubkey]
+      if (this.secret) connectParams.push(this.secret)
+
+      this.rpc.sendRequest(
+        this.bunkerPubkey, 'connect', connectParams, 24133,
+        (response) => {
+          // Fix (b): accept "ack" OR the URI secret echoed back, per NIP-46.
+          const ok = response.result === 'ack' ||
+                     (this.secret && response.result === this.secret)
+          if (ok) resolve()
+          else reject(new Error(response.error || `unexpected NIP-46 connect response: ${response.result}`))
+        }
+      )
+    })
+
+    // Resolve user pubkey via get_public_key — same as NDK's normal flow.
+    const pubkey = await this.getPublicKey()
+    this.userPubkey = pubkey
+    return this.user()
   }
 }
 

--- a/lib/nostr.js
+++ b/lib/nostr.js
@@ -235,8 +235,16 @@ class NDKNip46SignerURLPatch extends NDKNip46Signer {
     this.rpc.on('authUrl', (...args) => this.emit('authUrl', ...args))
 
     await new Promise((resolve, reject) => {
-      // Fix (a): send the remote-signer-pubkey as the first param.
-      const connectParams = [this.userPubkey || this.bunkerPubkey]
+      // Fix (a): send the remote-signer-pubkey as the first connect param, per
+      // NIP-46 (`connect: [<remote-signer-pubkey>, <optional_secret>, ...]`).
+      // This is always bunkerPubkey (the URI host) — even when the URI carries
+      // `?pubkey=<user-pubkey>` (multi-user signers), that value is the user
+      // identity, not the connect target, and is resolved separately via
+      // get_public_key below. Sending userPubkey here breaks signers that
+      // validate connect.params[0] against their own signer pubkey. (nostr-tools'
+      // BunkerSigner sends `this.bp.pubkey` likewise.) bunkerPubkey is
+      // guaranteed set by the guard above.
+      const connectParams = [this.bunkerPubkey]
       if (this.secret) connectParams.push(this.secret)
 
       this.rpc.sendRequest(


### PR DESCRIPTION
## Summary

Fixes the NIP-46 bunker login hanging forever on the "Waiting for authorization" spinner when paired with spec-compliant signers like [Clave](https://github.com/DocNR/clave). The root cause is two NIP-46 spec violations in NDK's `NDKNip46Signer.blockUntilReady` — present in every released NDK from 2.12.2 (this repo's pinned version) through 3.0.3.

Per the [NIP-46 spec](https://github.com/nostr-protocol/nips/blob/master/46.md):

```
connect: [<remote-signer-pubkey>, <optional_secret>, <optional_requested_perms>]
result: "ack" OR <required-secret-value>
```

NDK violates both:

1. Sends `connect([userPubkey ?? "", secret])`. For `bunker://...` URIs without `?pubkey=` (the typical single-user signer case — Clave, etc.) `userPubkey` is null, so an empty string lands as the first param.
2. Only accepts `response.result === "ack"`, rejecting the spec-allowed alternative (the URI secret echoed back) with `response.error` — which is `undefined` when the bunker returned a successful-shaped response. Our `setError(e)` in [components/nostr-auth.js](https://github.com/stackernews/stacker.news/blob/master/components/nostr-auth.js#L87-L94) then throws on `e.message || e.toString()`, leaving the spinner stuck.

This PR extends the existing `NDKNip46SignerURLPatch` (from #1636) with an overridden `blockUntilReady` that:

- Sends `bunkerPubkey` as the first connect param when `userPubkey` is null (per spec)
- Accepts both `"ack"` and the URI secret echoed back (per spec)
- Defers to `super.blockUntilReady()` for the NIP-05 path (unchanged)
- Wraps unexpected-result rejections in a real `Error` so the catch handler doesn't `TypeError` on undefined

The override can be deleted once we bump to an NDK that fixes both bugs upstream — companion PR filed at [nostr-dev-kit/ndk#390](https://github.com/nostr-dev-kit/ndk/pull/390).

## Test plan

Verified end-to-end against `@nostr-dev-kit/ndk@2.12.2` (the version pinned here) using a Clave-emulating mock NIP-46 bunker on a local `nak serve` relay, plus a real Clave bunker URI from a TestFlight device:

| Mode | Bunker response | Outcome |
|---|---|---|
| Unpatched NDK 2.12.2 | secret echo (Clave-style) | ❌ rejects in 39ms with `undefined` (the bug) |
| Patched override | secret echo (Clave-style) | ✅ resolves in 112ms |
| Patched override | `"ack"` (nsec.app-style) | ✅ resolves in 110ms |
| Patched override | real Clave URI on `relay.powr.build` | ✅ resolves in 1990ms |

- [x] Reproduces the original hang against unpatched NDK
- [x] Patched override completes the connect handshake against a Clave-style secret-echo response
- [x] Patched override still works with `"ack"` responses (regression — no breakage for nsec.app etc.)
- [x] Live test against a real Clave TestFlight build's bunker URI on `relay.powr.build`
- NIP-05 login path is unchanged — defers to `super.blockUntilReady()` explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
