### PR TITLE
fix: sticky header horizontal shift caused by scrollbar width

### DIFF
--- a/components/header.module.css
+++ b/components/header.module.css
@@ -114,7 +114,8 @@
 .sticky {
     position: fixed;
     border-bottom: 1px solid var(--theme-toolbarActive);
-    width: 100vw;
+    left: 0;
+    right: 0;
     top: -1px;
     padding-top: 1px;
     background-color: var(--bs-body-bg);


### PR DESCRIPTION
## Summary
- Fixes #2346
- The `.sticky` header used `width: 100vw` which includes the scrollbar width, causing a slight horizontal shift compared to the non-sticky header
- Replaced with `left: 0; right: 0` which correctly excludes scrollbar width for `position: fixed` elements