### PR TITLE
fix: carousel nav arrows obscuring images

### DIFF
--- a/components/carousel.js
+++ b/components/carousel.js
@@ -6,6 +6,33 @@ import styles from './carousel.module.css'
 import { useShowModal } from './modal'
 import { Dropdown } from 'react-bootstrap'
 
+const NAV_FADE_TIMEOUT = 2000
+
+function useNavVisibility () {
+  const [visible, setVisible] = useState(true)
+  const timerRef = useRef(null)
+
+  const resetTimer = useCallback(() => {
+    setVisible(true)
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => setVisible(false), NAV_FADE_TIMEOUT)
+  }, [])
+
+  useEffect(() => {
+    // start the initial fade-out timer
+    timerRef.current = setTimeout(() => setVisible(false), NAV_FADE_TIMEOUT)
+
+    const onMouseMove = () => resetTimer()
+    document.addEventListener('mousemove', onMouseMove)
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove)
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [resetTimer])
+
+  return visible
+}
+
 function useSwiping ({ moveLeft, moveRight }) {
   const [touchStartX, setTouchStartX] = useState(null)
 
@@ -77,11 +104,12 @@ function Carousel ({ close, mediaArr, src, setOptions }) {
 
   useSwiping({ moveLeft, moveRight })
   useArrowKeys({ moveLeft, moveRight })
+  const navVisible = useNavVisibility()
 
   return (
     <div className={styles.fullScreenContainer} onClick={close}>
       <img className={styles.fullScreen} src={currentSrc} />
-      <div className={styles.fullScreenNavContainer}>
+      <div className={classNames(styles.fullScreenNavContainer, navVisible && styles.visible)}>
         <div
           className={classNames(styles.fullScreenNav, !canGoLeft && 'invisible', styles.left)}
           onClick={(e) => {

--- a/components/carousel.module.css
+++ b/components/carousel.module.css
@@ -9,6 +9,13 @@ div.fullScreenNavContainer {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+div.fullScreenNavContainer:hover,
+div.fullScreenNavContainer.visible {
+    opacity: 1;
 }
 
 img.fullScreen {
@@ -31,7 +38,7 @@ img.fullScreen {
 }
 
 div.fullScreenNav:hover > svg {
-    background-color: rgba(0, 0, 0, .5);
+    background-color: rgba(0, 0, 0, 0.5);
 }
 
 div.fullScreenNav  {
@@ -54,10 +61,11 @@ div.fullScreenNav.right {
 div.fullScreenNav > svg {
     border-radius: 50%;
     backdrop-filter: blur(4px);
-    background-color: rgba(0, 0, 0, 0.7);
+    background-color: rgba(0, 0, 0, 0.3);
     fill: white;
     max-height: 34px;
     max-width: 34px;
     padding: 0.35rem;
     margin: .75rem;
+    transition: background-color 0.2s ease;
 }


### PR DESCRIPTION
## Summary
- Fixes #2500
- Nav arrows had opaque dark backgrounds (`rgba(0,0,0,0.7)`) that obscured image content
- Reduced arrow background opacity to `rgba(0,0,0,0.3)` so images are visible through them
- Added auto-fade behavior: arrows show on open, fade out after 2s of mouse inactivity, reappear on mouse movement
- Added smooth CSS transitions for both arrow visibility and hover states