### PR TITLE
editor: persist mode and toolbar visibility in localStorage

### DIFF
--- a/components/editor/contexts/mode.js
+++ b/components/editor/contexts/mode.js
@@ -1,23 +1,26 @@
-import { createContext, useState, useMemo, useContext, useCallback } from 'react'
+import { createContext, useMemo, useContext, useCallback } from 'react'
+import useLocalState from '@/components/use-local-state'
 
 export const MARKDOWN_MODE = 'markdown'
 export const RICH_MODE = 'rich'
 
+const STORAGE_KEY = 'editor:mode'
+
 const EditorModeContext = createContext()
 
 export function EditorModeProvider ({ children }) {
-  const [mode, setMode] = useState(MARKDOWN_MODE)
+  const [mode, setMode] = useLocalState(STORAGE_KEY, MARKDOWN_MODE)
 
   const changeMode = useCallback((newMode) => {
     if (newMode !== MARKDOWN_MODE && newMode !== RICH_MODE) {
       throw new Error(`Invalid mode: ${newMode}`)
     }
     setMode(newMode)
-  }, [])
+  }, [setMode])
 
   const toggleMode = useCallback(() => {
-    setMode(prev => prev === MARKDOWN_MODE ? RICH_MODE : MARKDOWN_MODE)
-  }, [])
+    setMode(mode === MARKDOWN_MODE ? RICH_MODE : MARKDOWN_MODE)
+  }, [mode, setMode])
 
   const value = useMemo(() => ({
     mode,

--- a/components/editor/contexts/toolbar.js
+++ b/components/editor/contexts/toolbar.js
@@ -1,4 +1,5 @@
 import { createContext, useContext, useMemo, useState, useCallback } from 'react'
+import { SSR } from '@/lib/constants'
 
 export const INITIAL_FORMAT_STATE = {
   blockType: 'paragraph',
@@ -18,6 +19,8 @@ export const INITIAL_FORMAT_STATE = {
   codeLanguage: null
 }
 
+const STORAGE_KEY = 'editor:showToolbar'
+
 const INITIAL_STATE = {
   showToolbar: false,
   ...INITIAL_FORMAT_STATE
@@ -25,14 +28,27 @@ const INITIAL_STATE = {
 
 const ToolbarContext = createContext()
 
+function getInitialShowToolbar (topLevel) {
+  if (!SSR) {
+    const stored = window.localStorage.getItem(STORAGE_KEY)
+    if (stored !== null) {
+      return JSON.parse(stored)
+    }
+  }
+  return !!topLevel
+}
+
 export function ToolbarContextProvider ({ topLevel, children }) {
-  const [toolbarState, setToolbarState] = useState({ ...INITIAL_STATE, showToolbar: !!topLevel })
+  const [toolbarState, setToolbarState] = useState(() => ({ ...INITIAL_STATE, showToolbar: getInitialShowToolbar(topLevel) }))
 
   const batchUpdateToolbarState = useCallback((updates) => {
     setToolbarState((prev) => ({ ...prev, ...updates }))
   }, [])
 
   const updateToolbarState = useCallback((key, value) => {
+    if (key === 'showToolbar' && !SSR) {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value))
+    }
     setToolbarState((prev) => ({
       ...prev,
       [key]: value


### PR DESCRIPTION
## Summary
- Fixes #2858
- Editor mode (write vs compose) and toolbar visibility are now persisted to localStorage
- Uses the project's existing `useLocalState` hook for mode persistence
- Toolbar visibility reads from `localStorage` on init, writes on change
- Settings survive page reloads — editor opens in the same mode you left it