### PR TITLE
fix: strip math/LaTeX syntax from push notification body

### DIFF
--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -60,12 +60,28 @@ function log (...args) {
   console.log('[webPush]', ...args)
 }
 
+// Strip extended markdown syntax not handled by remove-markdown (e.g. math, footnotes, HTML tags)
+function stripExtendedMd (text) {
+  return text
+    // display math blocks: $$...$$ (may span multiple lines)
+    .replace(/\$\$[\s\S]*?\$\$/g, '')
+    // inline math: $...$
+    .replace(/\$[^\s$][^$]*?\$/g, '')
+    // footnote references: [^1]
+    .replace(/\[\^\w+\]/g, '')
+    // remaining HTML tags (sub, sup, etc.)
+    .replace(/<\/?[a-z][^>]*>/gi, '')
+    // collapse multiple whitespace/newlines into a single space
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
 function createPayload (notification) {
   // https://web.dev/push-notifications-display-a-notification/#visual-options
   // https://webkit.org/blog/16535/meet-declarative-web-push/
   // DEV: localhost in URLs is not supported by declarative web push
   let { title, body, ...options } = notification
-  if (body) body = removeMd(body)
+  if (body) body = stripExtendedMd(removeMd(body))
   return JSON.stringify({
     web_push: 8030, // Declarative Web Push JSON format
     notification: {


### PR DESCRIPTION
## Summary
- Fixes #2852
- Push notifications showed raw unformatted text like `$$really\,cool.$$` because `remove-markdown` doesn't handle Stacker News extended markdown
- Added `stripExtendedMd()` that runs after `removeMd()` to clean up display math (`$$...$$`), inline math (`$...$`), footnote references, and residual HTML tags
- Collapses whitespace for clean notification text