### PR TITLE
seo: use territory description for OG meta tags

### DIFF
--- a/components/layout.js
+++ b/components/layout.js
@@ -9,12 +9,12 @@ import styles from './layout.module.css'
 import PullToRefresh from './pull-to-refresh'
 
 export default function Layout ({
-  sub, contain = true, footer = true, footerLinks = true,
+  sub, subInfo, contain = true, footer = true, footerLinks = true,
   containClassName = '', seo = true, item, user, children
 }) {
   return (
     <>
-      {seo && <Seo sub={sub} item={item} user={user} />}
+      {seo && <Seo sub={sub} subInfo={subInfo} item={item} user={user} />}
       <Navigation sub={sub} />
       {contain
         ? (

--- a/components/seo.js
+++ b/components/seo.js
@@ -36,13 +36,13 @@ export function SeoSearch ({ sub }) {
 // index page seo
 // recent page seo
 
-export default function Seo ({ sub, item, user }) {
+export default function Seo ({ sub, subInfo, item, user }) {
   const router = useRouter()
   const pathNoQuery = router.asPath.split('?')[0]
   const defaultTitle = pathNoQuery.slice(1)
   const snStr = `stacker news${sub ? ` ~${sub}` : ''}`
   let fullTitle = `${defaultTitle && `${defaultTitle} \\ `}stacker news`
-  let desc = 'moderating forums with money'
+  let desc = subInfo?.desc || 'moderating forums with money'
   if (item) {
     if (item.title) {
       fullTitle = `${item.title} \\ ${snStr}`

--- a/pages/~/edit.js
+++ b/pages/~/edit.js
@@ -21,7 +21,7 @@ export default function TerritoryPage ({ ssrData }) {
   const { sub } = data || ssrData
 
   return (
-    <CenterLayout sub={sub?.name}>
+    <CenterLayout sub={sub?.name} subInfo={sub}>
       <TerritoryPaymentDue sub={sub} />
       <h1 className='mt-5'>edit territory</h1>
       <TerritoryForm sub={sub} />

--- a/pages/~/index.js
+++ b/pages/~/index.js
@@ -22,7 +22,7 @@ export default function Sub ({ ssrData }) {
   const { sub } = data || ssrData
 
   return (
-    <Layout sub={sub?.name}>
+    <Layout sub={sub?.name} subInfo={sub}>
       {sub
         ? <TerritoryHeader sub={sub} />
         : (

--- a/pages/~/new/[type].js
+++ b/pages/~/new/[type].js
@@ -40,7 +40,7 @@ export default function Index ({ ssrData }) {
   const { sub } = data || ssrData
 
   return (
-    <Layout sub={sub?.name}>
+    <Layout sub={sub?.name} subInfo={sub}>
       <NewHeader sub={sub} />
       <Items
         ssrData={ssrData}

--- a/pages/~/top/[type]/[when].js
+++ b/pages/~/top/[type]/[when].js
@@ -20,10 +20,11 @@ export default function Index ({ ssrData }) {
   const router = useRouter()
   const variables = variablesFunc(router.query)
 
-  const sub = ssrData?.sub?.name || variables.sub
+  const subObj = ssrData?.sub
+  const sub = subObj?.name || variables.sub
 
   return (
-    <Layout sub={sub}>
+    <Layout sub={sub} subInfo={subObj}>
       <TopHeader sub={variables.sub} cat={variables.type} />
       <Items
         ssrData={ssrData}


### PR DESCRIPTION
## Summary
- Fixes #2363
- Territory pages now use the territory's description for the OG meta description instead of the generic site-wide default
- Added `subInfo` prop to `Layout` and `Seo` components to forward the full territory object
- Updated 4 territory page files to pass `subInfo={sub}`
- Item and user pages still override with their own content as before