### PR TITLE
feat: download analytics as CSV

### DIFF
--- a/components/download-csv.js
+++ b/components/download-csv.js
@@ -1,0 +1,14 @@
+import Button from 'react-bootstrap/Button'
+
+export function DownloadCsvButton ({ onClick }) {
+  return (
+    <Button
+      variant='link'
+      className='text-muted fw-bold ms-auto py-0 mb-2'
+      size='sm'
+      onClick={onClick}
+    >
+      download csv
+    </Button>
+  )
+}

--- a/lib/csv.js
+++ b/lib/csv.js
@@ -1,0 +1,108 @@
+/**
+ * Convert an array of objects into a CSV string.
+ * Each object key becomes a column header.
+ *
+ * @param {Object[]} rows - Array of flat objects
+ * @param {string[]} [columns] - Optional ordered list of column keys. If omitted, uses all keys from the first row.
+ * @returns {string} CSV-formatted string
+ */
+export function toCSV (rows, columns) {
+  if (!rows || rows.length === 0) return ''
+
+  const cols = columns || Object.keys(rows[0]).filter(k => k !== '__typename')
+
+  const escape = (val) => {
+    if (val === null || val === undefined) return ''
+    const str = String(val)
+    // wrap in quotes if the value contains a comma, quote, or newline
+    if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+      return `"${str.replace(/"/g, '""')}"`
+    }
+    return str
+  }
+
+  const header = cols.map(escape).join(',')
+  const body = rows.map(row =>
+    cols.map(col => escape(row[col])).join(',')
+  ).join('\n')
+
+  return header + '\n' + body
+}
+
+/**
+ * Trigger a browser download of a CSV string.
+ *
+ * @param {string} csvString - The CSV content
+ * @param {string} filename - The download filename (should end in .csv)
+ */
+export function downloadCSV (csvString, filename) {
+  const blob = new Blob([csvString], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  link.style.display = 'none'
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+  URL.revokeObjectURL(url)
+}
+
+/**
+ * Convert chart growth data (the shape returned by GraphQL growth queries)
+ * into a flat array suitable for CSV export.
+ *
+ * The input shape is: [{ time, data: [{ name, value }] }]
+ * The output shape is: [{ time, name1: value1, name2: value2, ... }]
+ *
+ * @param {Object[]} data - Raw growth data from GraphQL
+ * @param {Function} [nameTransform] - Optional function to transform data point names
+ * @returns {Object[]} Flat array of objects
+ */
+export function flattenGrowthData (data, nameTransform) {
+  if (!data || data.length === 0) return []
+
+  return data.map(entry => {
+    const obj = { time: entry.time }
+    entry.data.forEach(d => {
+      const key = nameTransform ? nameTransform(d.name) : d.name
+      obj[key] = d.value
+    })
+    return obj
+  })
+}
+
+/**
+ * Merge multiple named growth datasets into a single array of rows
+ * keyed by time. Each dataset's columns are prefixed with the dataset label
+ * to avoid collisions (e.g. "stacked: zaps", "spent: posts").
+ *
+ * @param {Array<{label: string, data: Object[]}>} datasets - Named datasets with raw GraphQL growth data
+ * @param {Function} [nameTransform] - Optional function to transform data point names
+ * @returns {Object[]} Merged flat array of objects with time + prefixed columns
+ */
+export function mergeGrowthDatasets (datasets, nameTransform) {
+  // build a map of time -> merged row
+  const timeMap = new Map()
+
+  for (const { label, data } of datasets) {
+    if (!data || data.length === 0) continue
+
+    for (const entry of data) {
+      if (!timeMap.has(entry.time)) {
+        timeMap.set(entry.time, { time: entry.time })
+      }
+      const row = timeMap.get(entry.time)
+      for (const d of entry.data) {
+        const baseName = nameTransform ? nameTransform(d.name) : d.name
+        const key = `${label}: ${baseName}`
+        row[key] = d.value
+      }
+    }
+  }
+
+  // sort by time and return
+  return Array.from(timeMap.values()).sort((a, b) =>
+    new Date(a.time) - new Date(b.time)
+  )
+}

--- a/pages/satistics/graphs/[when].js
+++ b/pages/satistics/graphs/[when].js
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { gql } from '@apollo/client'
 import { useQuery } from '@apollo/client/react'
 import { getGetServerSideProps } from '@/api/ssrApollo'
@@ -11,6 +12,9 @@ import PageLoading from '@/components/page-loading'
 import { WhenAreaChartSkeleton, WhenLineChartSkeleton } from '@/components/charts-skeletons'
 import { UserAnalyticsHeader } from '@/components/user-analytics-header'
 import { numWithUnits } from '@/lib/format'
+import { DownloadCsvButton } from '@/components/download-csv'
+import { payTypeShortName } from '@/lib/pay-in'
+import { mergeGrowthDatasets, toCSV, downloadCSV } from '@/lib/csv'
 
 const WhenAreaChart = dynamic(() => import('@/components/charts').then(mod => mod.WhenAreaChart), {
   loading: () => <WhenAreaChartSkeleton />
@@ -90,10 +94,23 @@ export default function Growth ({ ssrData }) {
     stackingGrowth
   } = data || ssrData
 
+  const handleDownloadCsv = useCallback(() => {
+    const rows = mergeGrowthDatasets([
+      { label: 'sats stacked', data: stackingGrowth },
+      { label: 'sats spent', data: spendingGrowth },
+      { label: 'spend counts', data: itemGrowth }
+    ], payTypeShortName)
+    if (rows.length === 0) return
+    downloadCSV(toCSV(rows), `satistics_${when || 'day'}.csv`)
+  }, [stackingGrowth, spendingGrowth, itemGrowth, when])
+
   return (
     <Layout>
       <SatisticsHeader />
-      <UserAnalyticsHeader pathname='satistics/graphs' />
+      <div className='d-flex align-items-center flex-wrap'>
+        <UserAnalyticsHeader pathname='satistics/graphs' />
+        <DownloadCsvButton onClick={handleDownloadCsv} />
+      </div>
       <UserGrowthTotals totals={growthTotals} />
       <Row>
         <Col className='mt-3'>

--- a/pages/stackers/[sub]/[when].js
+++ b/pages/stackers/[sub]/[when].js
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { gql } from '@apollo/client'
 import { useQuery } from '@apollo/client/react'
 import { getGetServerSideProps } from '@/api/ssrApollo'
@@ -10,6 +11,9 @@ import dynamic from 'next/dynamic'
 import PageLoading from '@/components/page-loading'
 import { WhenAreaChartSkeleton, WhenLineChartSkeleton } from '@/components/charts-skeletons'
 import { numWithUnits } from '@/lib/format'
+import { DownloadCsvButton } from '@/components/download-csv'
+import { payTypeShortName } from '@/lib/pay-in'
+import { mergeGrowthDatasets, toCSV, downloadCSV } from '@/lib/csv'
 
 const WhenAreaChart = dynamic(() => import('@/components/charts').then(mod => mod.WhenAreaChart), {
   loading: () => <WhenAreaChartSkeleton />
@@ -121,9 +125,26 @@ export default function Growth ({ ssrData }) {
     stackerGrowth
   } = data || ssrData
 
+  const handleDownloadCsv = useCallback(() => {
+    const rows = mergeGrowthDatasets([
+      { label: 'sats stacked', data: stackingGrowth },
+      { label: 'sats spent', data: spendingGrowth },
+      { label: 'unique stackers', data: stackerGrowth },
+      { label: 'unique spenders', data: spenderGrowth },
+      { label: 'spend counts', data: itemGrowth },
+      ...(sub === 'all' ? [{ label: 'registrations', data: registrationGrowth }] : [])
+    ], payTypeShortName)
+    if (rows.length === 0) return
+    const prefix = sub && sub !== 'all' ? `${sub}_` : ''
+    downloadCSV(toCSV(rows), `${prefix}analytics_${when || 'day'}.csv`)
+  }, [stackingGrowth, spendingGrowth, stackerGrowth, spenderGrowth, itemGrowth, registrationGrowth, when, sub])
+
   return (
     <Layout>
-      <SubAnalyticsHeader />
+      <div className='d-flex align-items-center flex-wrap'>
+        <SubAnalyticsHeader />
+        <DownloadCsvButton onClick={handleDownloadCsv} />
+      </div>
       <GrowthTotals totals={growthTotals} sub={sub} />
       <Row>
         <Col className='mt-3'>


### PR DESCRIPTION
## Summary
- Fixes #2612
- Adds a "download csv" button to the personal satistics graphs page and the territory/stacker analytics page
- All chart datasets are merged by time into one wide CSV with column names prefixed by chart label
- Client-side only — no server changes needed
- New files: `lib/csv.js` (CSV utilities), `components/download-csv.js` (button component)