### PR TITLE
feat: add user setting to convert x.com links to xcancel.com

### DIFF
--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -80,6 +80,7 @@ export default gql`
   input SettingsInput {
     autoDropBolt11s: Boolean!
     noReferralLinks: Boolean!
+    nitterize: Boolean!
     fiatCurrency: String!
     postsSatsFilter: Int
     commentsSatsFilter: Int
@@ -148,6 +149,7 @@ export default gql`
     """
     autoDropBolt11s: Boolean!
     noReferralLinks: Boolean!
+    nitterize: Boolean!
     fiatCurrency: String!
     postsSatsFilter: Int
     commentsSatsFilter: Int

--- a/components/item.js
+++ b/components/item.js
@@ -19,7 +19,7 @@ import { DownZap } from './dont-link-this'
 import { timeLeft } from '@/lib/time'
 import classNames from 'classnames'
 import removeMd from 'remove-markdown'
-import { decodeProxyUrl, IMGPROXY_URL_REGEXP, parseInternalLinks } from '@/lib/url'
+import { decodeProxyUrl, IMGPROXY_URL_REGEXP, parseInternalLinks, nitterizeUrl } from '@/lib/url'
 import ItemPopover from './item-popover'
 import { useMe } from './me'
 import Boost from './boost-button'
@@ -60,6 +60,9 @@ function mediaType ({ url, imgproxyUrls }) {
 }
 
 function ItemLink ({ url, rel }) {
+  const { me } = useMe()
+  const nitterize = me?.privates?.nitterize
+
   try {
     const { linkText } = parseInternalLinks(url)
     if (linkText) {
@@ -70,13 +73,15 @@ function ItemLink ({ url, rel }) {
       )
     }
 
+    const displayUrl = nitterize ? nitterizeUrl(url) : url
+
     return (
       // eslint-disable-next-line
       <a
-        className={styles.link} target='_blank' href={url}
+        className={styles.link} target='_blank' href={displayUrl}
         rel={rel ?? UNKNOWN_LINK_REL}
       >
-        {url.replace(/(^https?:|^)\/\//, '')}
+        {displayUrl.replace(/(^https?:|^)\/\//, '')}
       </a>
     )
   } catch {

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -24,6 +24,7 @@ ${STREAK_FIELDS}
     privates {
       autoDropBolt11s
       noReferralLinks
+      nitterize
       fiatCurrency
       postsSatsFilter
       commentsSatsFilter
@@ -89,6 +90,7 @@ export const SETTINGS_FIELDS = gql`
       imgproxyOnly
       showImagesAndVideos
       noReferralLinks
+      nitterize
       nostrPubkey
       nostrCrossposting
       nostrRelays

--- a/lib/lexical/exts/item-context.js
+++ b/lib/lexical/exts/item-context.js
@@ -3,7 +3,7 @@ import { LinkNode, AutoLinkNode } from '@lexical/link'
 import { mergeRegister } from '@lexical/utils'
 import { MediaNode } from '@/lib/lexical/nodes/content/media'
 import { EmbedNode } from '@/lib/lexical/nodes/content/embed'
-import { IMGPROXY_URL_REGEXP, decodeProxyUrl } from '@/lib/url'
+import { IMGPROXY_URL_REGEXP, decodeProxyUrl, nitterizeUrl } from '@/lib/url'
 import { UNKNOWN_LINK_REL } from '@/lib/constants'
 import { $replaceNodeWithLink } from '@/lib/lexical/nodes/utils'
 
@@ -85,18 +85,38 @@ export const processSrcSetInitial = (srcSetInitial, src) => {
  */
 export const ItemContextExtension = defineExtension({
   name: 'item-context',
-  register: (editor, { imgproxyUrls, outlawed, rel, showImagesAndVideos, imgproxyOnly } = {}) => {
+  register: (editor, { imgproxyUrls, outlawed, rel, showImagesAndVideos, imgproxyOnly, nitterize } = {}) => {
     // handle filters and outlawed content
     const unregisterFilters = mergeRegister(
       editor.registerNodeTransform(AutoLinkNode, (node) => {
         if (outlawed) replaceWithText(node, node.getURL())
+        else if (nitterize) {
+          const url = node.getURL()
+          const converted = nitterizeUrl(url)
+          if (converted !== url) {
+            node.setURL(converted)
+            // update the text node to match the new URL for bare links
+            const firstChild = node.getFirstChild()
+            if (firstChild && firstChild.getTextContent() === url) {
+              firstChild.setTextContent(converted)
+            }
+          }
+        }
       }),
       editor.registerNodeTransform(LinkNode, (node) => {
         // handle rel
         if ((rel || UNKNOWN_LINK_REL) !== node.getRel()) {
           node.setRel(rel || UNKNOWN_LINK_REL)
         }
-        if (outlawed) replaceWithText(node, node.getURL())
+        if (outlawed) {
+          replaceWithText(node, node.getURL())
+        } else if (nitterize) {
+          const url = node.getURL()
+          const converted = nitterizeUrl(url)
+          if (converted !== url) {
+            node.setURL(converted)
+          }
+        }
       }),
       editor.registerNodeTransform(MediaNode, (node) => {
         const src = node.getSrc()
@@ -128,6 +148,12 @@ export const ItemContextExtension = defineExtension({
         }
         if (showImagesAndVideos === false) {
           $replaceNodeWithLink(node, src)
+          return
+        }
+        // convert twitter/x.com embeds to xcancel.com links
+        if (nitterize && node.getProvider() === 'twitter') {
+          const converted = nitterizeUrl(src)
+          $replaceNodeWithLink(node, converted)
         }
       })
     )

--- a/lib/lexical/server/loader.js
+++ b/lib/lexical/server/loader.js
@@ -23,7 +23,8 @@ export function lexicalStateLoader ({ me, userLoader } = {}) {
         postsSatsFilter: DEFAULT_POSTS_SATS_FILTER,
         commentsSatsFilter: DEFAULT_COMMENTS_SATS_FILTER,
         imgproxyOnly: false,
-        showImagesAndVideos: true
+        showImagesAndVideos: true,
+        nitterize: false
       }
     }
     const user = await userLoader.load(me.id)
@@ -31,7 +32,8 @@ export function lexicalStateLoader ({ me, userLoader } = {}) {
       postsSatsFilter: user ? user.postsSatsFilter : DEFAULT_POSTS_SATS_FILTER,
       commentsSatsFilter: user ? user.commentsSatsFilter : DEFAULT_COMMENTS_SATS_FILTER,
       imgproxyOnly: user?.imgproxyOnly ?? false,
-      showImagesAndVideos: user?.showImagesAndVideos ?? true
+      showImagesAndVideos: user?.showImagesAndVideos ?? true,
+      nitterize: user?.nitterize ?? false
     }
   }
 
@@ -49,9 +51,10 @@ export function lexicalStateLoader ({ me, userLoader } = {}) {
           // filter out media if the user has disabled them
           const showImagesAndVideos = userFilters.showImagesAndVideos
           const imgproxyOnly = userFilters.imgproxyOnly
+          const nitterize = userFilters.nitterize
 
           try {
-            const lexicalState = prepareLexicalState({ text, context: { ...rest, outlawed, showImagesAndVideos, imgproxyOnly } })
+            const lexicalState = prepareLexicalState({ text, context: { ...rest, outlawed, showImagesAndVideos, imgproxyOnly, nitterize } })
             return lexicalState
           } catch (error) {
             console.error('error preparing Lexical State:', error)

--- a/lib/url.js
+++ b/lib/url.js
@@ -220,6 +220,32 @@ export function stripTrailingSlash (uri) {
   return uri.endsWith('/') ? uri.slice(0, -1) : uri
 }
 
+/**
+ * converts x.com and twitter.com URLs to xcancel.com
+ * preserves the rest of the URL path and query string
+ * @param {string} url - the URL to convert
+ * @returns {string} the converted URL, or the original if not an x.com/twitter.com URL
+ */
+export function nitterizeUrl (url) {
+  try {
+    const parsed = new URL(url)
+    if (
+      parsed.hostname === 'x.com' ||
+      parsed.hostname === 'www.x.com' ||
+      parsed.hostname === 'twitter.com' ||
+      parsed.hostname === 'www.twitter.com' ||
+      parsed.hostname === 'mobile.twitter.com' ||
+      parsed.hostname === 'mobile.x.com'
+    ) {
+      parsed.hostname = 'xcancel.com'
+      return parsed.toString()
+    }
+  } catch {
+    // not a valid URL, return as-is
+  }
+  return url
+}
+
 export class ResponseAssertError extends Error {
   constructor (res, { message, method } = {}) {
     const urlPart = method ? `${method} ${res.url}` : res.url

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -424,6 +424,7 @@ export const settingsSchema = object().shape({
   hideNostr: boolean(),
   hideTwitter: boolean(),
   noReferralLinks: boolean(),
+  nitterize: boolean(),
   postsSatsFilter: intValidator.nullable().min(-1000, 'must be at least -1000').max(1000, 'must be at most 1000'),
   commentsSatsFilter: intValidator.nullable().min(-100, 'must be at least -100').max(100, 'must be at most 100'),
   zapUndos: intValidator.nullable().min(0, 'must be greater or equal to 0')

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -133,7 +133,8 @@ export default function Settings ({ ssrData }) {
             nostrCrossposting: settings?.nostrCrossposting,
             nostrRelays: settings?.nostrRelays?.length ? settings?.nostrRelays : [''],
             hideBookmarks: settings?.hideBookmarks,
-            noReferralLinks: settings?.noReferralLinks
+            noReferralLinks: settings?.noReferralLinks,
+            nitterize: settings?.nitterize
           }}
           schema={settingsSchema}
           onSubmit={async ({
@@ -410,6 +411,21 @@ export default function Settings ({ ssrData }) {
           <Checkbox
             label={<>don't create referral links on copy</>}
             name='noReferralLinks'
+            groupClassName='mb-0'
+          />
+          <Checkbox
+            label={
+              <div className='d-flex align-items-center'>use xcancel.com for x.com links
+                <Info>
+                  <ul>
+                    <li>automatically convert x.com and twitter.com links to xcancel.com</li>
+                    <li>xcancel.com is a privacy-preserving alternative frontend for Twitter/X</li>
+                    <li>no JavaScript, no ads, no tracking</li>
+                  </ul>
+                </Info>
+              </div>
+            }
+            name='nitterize'
           />
           <h4 className='mt-5'>content</h4>
           <Range

--- a/prisma/migrations/20260510000000_nitterize_setting/migration.sql
+++ b/prisma/migrations/20260510000000_nitterize_setting/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "nitterize" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -97,6 +97,7 @@ model User {
   hideNostr                 Boolean                @default(true)
   hideTwitter               Boolean                @default(true)
   noReferralLinks           Boolean                @default(false)
+  nitterize                 Boolean                @default(false)
   githubId                  String?
   twitterId                 String?
   followers                 UserSubscription[]     @relation("follower")


### PR DESCRIPTION
## Summary
- Fixes #2664
- Adds a `nitterize` boolean user setting (default off) that converts `x.com`/`twitter.com` URLs to `xcancel.com`, a privacy-preserving Nitter frontend
- Handles all variants: `x.com`, `www.x.com`, `twitter.com`, `mobile.twitter.com`, etc.
- Server-side conversion in the Lexical pipeline for inline links, auto-links, and Twitter embeds
- Client-side conversion for item header URLs
- Settings UI checkbox in the Privacy section with an Info tooltip explaining xcancel.com
- Includes Prisma migration for the new `nitterize` column