### PR TITLE
fix: internationalize Sankey diagram numbers

### DIFF
--- a/components/payIn/sankey/index.js
+++ b/components/payIn/sankey/index.js
@@ -28,6 +28,7 @@ export function PayInSankey ({ payIn }) {
         linkContract={3}
         nodeHoverOthersOpacity={0.5}
         labelComponent={RotatingSankeyLabels}
+        valueFormat={v => new Intl.NumberFormat().format(v)}
         nodeTooltip={Tooltip}
         linkTooltip={Tooltip}
         nodeSpacing={24}
@@ -51,10 +52,11 @@ function assetFormatted (msats, type) {
 
 function Tooltip ({ node, link }) {
   node ??= link
-  if (!node.asset) {
+  const label = node.asset ?? node.formattedValue
+  if (!label) {
     return null
   }
-  return <div style={{ whiteSpace: 'nowrap', backgroundColor: 'var(--bs-body-bg)', padding: '4px 8px', borderRadius: '4px', border: '1px solid var(--bs-border-color)' }}>{node.asset}</div>
+  return <div style={{ whiteSpace: 'nowrap', backgroundColor: 'var(--bs-body-bg)', padding: '4px 8px', borderRadius: '4px', border: '1px solid var(--bs-border-color)' }}>{label}</div>
 }
 
 function getSankeyData (payIn) {


### PR DESCRIPTION
## Summary
- Fixes #2942
- Added `valueFormat` prop using `Intl.NumberFormat` so Nivo's internal formatted values use locale-aware number formatting (thousand separators etc.)
- Tooltip now falls back to `formattedValue` when the custom `asset` property is unavailable, ensuring numbers are always displayed and properly formatted