### PR TITLE
Guard NWC supported methods parsing

### DIFF
--- a/wallets/lib/protocols/nwc.js
+++ b/wallets/lib/protocols/nwc.js
@@ -71,5 +71,12 @@ export async function getNwc (nostr, url, { signal }) {
 
 export async function supportedMethods (url, { signal }) {
   const result = await nwcTryRun(nwc => nwc.getInfo(), { url }, { signal })
-  return result.methods
+  return parseSupportedMethods(result)
+}
+
+export function parseSupportedMethods (info) {
+  const methods = info?.methods ?? info?.supported ?? []
+  if (Array.isArray(methods)) return methods
+  if (typeof methods === 'string') return methods.split(/\s+/).filter(Boolean)
+  return []
 }


### PR DESCRIPTION
## Description

Fixes #2808.

Some NWC `get_info` responses can omit the `methods` array (or return the older `supported` name). The send/receive capability checks call `.includes()` on the value returned by `supportedMethods()`, so an omitted field turns a recoverable wallet capability mismatch into a UI crash.

This normalizes the response from `get_info`:

- prefer `methods`
- fall back to legacy `supported`
- accept space-delimited strings defensively
- return `[]` for missing or malformed values so callers produce the existing `WalletPermissionsError` instead of a `TypeError`

## QA

- `node --check wallets/lib/protocols/nwc.js`
- `standard wallets/lib/protocols/nwc.js wallets/client/protocols/nwc.js wallets/server/protocols/nwc.js`

## Backward compatibility

Backward compatible. Existing wallets returning `methods` keep the same behavior; wallets returning malformed/no capability data now fail validation cleanly instead of crashing.
