### PR TITLE
Fix wallet delete transaction closure

### DIFF
--- a/wallets/server/resolvers/wallet.js
+++ b/wallets/server/resolvers/wallet.js
@@ -215,9 +215,30 @@ async function deleteWallet (parent, { id }, { me, models }) {
   if (!me) throw new GqlAuthenticationError()
 
   await models.$transaction(async tx => {
+    const wallet = await tx.wallet.findUnique({
+      where: { id: Number(id), userId: me.id },
+      select: {
+        protocols: {
+          select: { id: true }
+        }
+      }
+    })
+
+    if (!wallet) throw new GqlInputError('wallet not found')
+
+    const protocolIds = wallet.protocols.map(({ id }) => id)
+    if (protocolIds.length > 0) {
+      await tx.walletLog.deleteMany({
+        where: {
+          userId: me.id,
+          protocolId: { in: protocolIds }
+        }
+      })
+    }
+
     await tx.wallet.delete({ where: { id: Number(id), userId: me.id } })
     await updateWalletBadges({ userId: me.id, tx })
-  })
+  }, { timeout: 20000 })
 
   return true
 }


### PR DESCRIPTION
## Summary

Fixes #2629.

Deletes wallet logs for the wallet's protocols explicitly before removing the wallet, then recalculates wallet badges in the same transaction. This avoids relying on a large cascading delete of old protocol logs before `updateWalletBadges` runs, which matches the reported `Transaction already closed` failure on older wallets.

I also extended this specific interactive transaction timeout to 20s so older wallets with large log histories have room to finish the delete and badge update together.

## Verification

- `node --check wallets/server/resolvers/wallet.js`
- `git diff --check -- wallets/server/resolvers/wallet.js`
- `XDG_CACHE_HOME=/private/tmp/codex-cache npm_config_cache=/private/tmp/codex-npm-cache npx --yes --package standard@17.1.2 --package @next/eslint-plugin-next@16.2.6 standard wallets/server/resolvers/wallet.js`
