### PR TITLE
Reduce initial bundle by dynamically loading rich editor

### DIFF
--- a/components/editor/index.js
+++ b/components/editor/index.js
@@ -1,9 +1,13 @@
 import { createContext, useContext } from 'react'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
-import Editor from './editor'
 import { ToolbarContextProvider } from './contexts/toolbar'
 import { EditorModeProvider } from './contexts/mode'
+
+const Editor = dynamic(() => import('./editor'), {
+  ssr: false,
+  loading: () => <div className='form-control clouds' style={{ minHeight: '6rem' }} />
+})
 
 export function SNEditor ({ ...props }) {
   return (


### PR DESCRIPTION
## Description

Addresses #1832.

This keeps the rich Lexical editor out of the app-wide initial bundle by loading `components/editor/editor.js` dynamically from `SNEditor`. `components/form.js` is imported across the app, so the previous static import pulled the rich editor stack, including Shiki syntax highlighting, into the global `_app` chunk even on read-only pages.

The editor still renders inside the existing editor mode and toolbar providers. While the editor chunk is loading, the field shows the same cloud loading treatment used elsewhere in forms.

## Bundle measurement

Measured with `npm run build` on current `master` (`64afb581`) using local build env placeholders for `DATABASE_URL` and `OPENSEARCH_*`.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| `_app` JS chunk | 12,381,692 B | 2,756,405 B | -9,625,287 B (-77.7%) |
| `_app` entrypoint incl. webpack/framework/main | 12,722,902 B | 3,099,098 B | -9,623,804 B (-75.6%) |

The extracted editor/Shiki code remains available as async chunks for pages that actually render the editor, instead of being loaded by every page.

## QA

- `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/stackernews OPENSEARCH_URL=http://127.0.0.1:9200 OPENSEARCH_USERNAME=admin OPENSEARCH_PASSWORD=admin npm run build`
- `XDG_CACHE_HOME=/private/tmp/codex-cache npm run lint`
- `git diff --check`

## Bounty payment

BTC address if needed: `39Q34P8A7g375yqEr8buvNJkUbRgKfbKQZ`
