### PR TITLE
Lazy load rich text editor

### DIFF
--- a/components/editor/index.js
+++ b/components/editor/index.js
@@ -1,9 +1,10 @@
 import { createContext, useContext } from 'react'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
-import Editor from './editor'
 import { ToolbarContextProvider } from './contexts/toolbar'
 import { EditorModeProvider } from './contexts/mode'
+
+const Editor = dynamic(() => import('./editor'))
 
 export function SNEditor ({ ...props }) {
   return (


### PR DESCRIPTION
## Description

Refs #1832

Lazy-load the rich text editor in `components/editor/index.js` so importing `SNReader` no longer also pulls the full editor stack into the shared app bundle. This moves the heavy Lexical/Shiki editor path into a lazy chunk while preserving the reader path.

Measured locally:
- before: `_app` JS chunk was 12,350,370 bytes raw
- after: `_app` JS chunk is 2,756,310 bytes raw / 858,546 bytes gzip

## Screenshots

N/A

## Additional Context

Build completed successfully with local placeholder service envs; it still logs the expected local service connection warnings for the dummy DB/OpenSearch/LND setup.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. This only changes when the editor code is loaded.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

8/10. Ran lint and a production build with local placeholder service envs; checked the emitted chunk sizes before and after.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

No visual UI changes. Build output was verified.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes, lightly. AI helped with a quick scan for similar import/bundle issues across the codebase, sanity-checking the finding, and structuring this comment. The final small lazy-load change and build measurements were verified locally.