### PR TITLE
Localize PayIn Sankey number formatting

### DIFF
--- a/components/payIn-sankey-format.spec.js
+++ b/components/payIn-sankey-format.spec.js
@@ -1,0 +1,16 @@
+/* eslint-env jest */
+
+import { formatSankeyAsset, formatSankeyValue } from './payIn/sankey/format'
+
+describe('PayIn Sankey formatting', () => {
+  test('localizes chart values', () => {
+    expect(formatSankeyValue('1234.567')).toBe(new Intl.NumberFormat().format(1234.567))
+  })
+
+  test('localizes assets while preserving their unit labels', () => {
+    const formatted = new Intl.NumberFormat().format(1234.567)
+
+    expect(formatSankeyAsset(1234567, 'SATS')).toBe(`${formatted} sats`)
+    expect(formatSankeyAsset(1234567, 'CREDITS')).toBe(`${formatted} CCs`)
+  })
+})

--- a/components/payIn/sankey/format.js
+++ b/components/payIn/sankey/format.js
@@ -1,0 +1,13 @@
+import { msatsToSatsDecimal, numWithUnits } from '@/lib/format'
+
+export function formatSankeyValue (value) {
+  return new Intl.NumberFormat().format(value)
+}
+
+export function formatSankeyAsset (msats, type) {
+  const sats = msatsToSatsDecimal(msats)
+  if (type === 'CREDITS') {
+    return numWithUnits(sats, { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false, format: true })
+  }
+  return numWithUnits(sats, { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false, format: true })
+}

--- a/components/payIn/sankey/index.js
+++ b/components/payIn/sankey/index.js
@@ -1,6 +1,7 @@
-import { msatsToSatsDecimal, numWithUnits } from '@/lib/format'
+import { msatsToSatsDecimal } from '@/lib/format'
 import { payTypeShortName } from '@/lib/pay-in'
 import { ResponsiveSankey } from '@nivo/sankey'
+import { formatSankeyAsset, formatSankeyValue } from './format'
 import { RotatingSankeyLabels } from './label'
 
 export function PayInSankey ({ payIn }) {
@@ -9,6 +10,7 @@ export function PayInSankey ({ payIn }) {
     <div className='position-relative' style={{ width: '100%', maxWidth: '600px', height: '460px' }}>
       <ResponsiveSankey
         data={data}
+        valueFormat={formatSankeyValue}
         margin={{ top: 60, right: 60, bottom: 160, left: 60 }}
         align='justify'
         labelPosition='outside'
@@ -40,13 +42,6 @@ export function PayInSankeySkeleton () {
   return (
     <div style={{ width: '100%', maxWidth: '600px', height: '360px' }} className='clouds' />
   )
-}
-
-function assetFormatted (msats, type) {
-  if (type === 'CREDITS') {
-    return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
-  }
-  return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
 }
 
 function Tooltip ({ node, link }) {
@@ -199,7 +194,7 @@ function reduceLinksAndNodes ({ links, nodes }) {
 
   reducedNodes.forEach(node => {
     if (node.mtokens) {
-      node.asset = assetFormatted(node.mtokens, node.custodialTokenType)
+      node.asset = formatSankeyAsset(node.mtokens, node.custodialTokenType)
     }
   })
 
@@ -214,7 +209,7 @@ function reduceLinksAndNodes ({ links, nodes }) {
 
   reducedLinks.forEach(link => {
     link.value = msatsToSatsDecimal(link.mtokens)
-    link.asset = assetFormatted(link.mtokens, link.custodialTokenType)
+    link.asset = formatSankeyAsset(link.mtokens, link.custodialTokenType)
   })
 
   return { links: reducedLinks, nodes: reducedNodes }


### PR DESCRIPTION
## Description

Fixes #2942.

Localizes the PayIn transaction Sankey numeric values with `Intl.NumberFormat()` instead of leaving raw chart values unformatted. The Sankey asset labels are now routed through a small formatter helper that keeps the existing `sat`/`CC` unit labels while using locale-aware grouping for the number itself.

## Screenshots

N/A - formatting helper change covered by unit test.

## Additional Context

The production build compiled successfully, then failed during page-data collection because local env has an undefined URL value:

```text
unhandledRejection TypeError: Invalid URL
code: 'ERR_INVALID_URL'
input: 'undefined'
```

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. This only changes presentation formatting for existing Sankey values.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7/10. Ran targeted formatter tests, targeted StandardJS lint, full `npm run lint`, `git diff --check`, and attempted `npm run build`. Build compiled, then failed on an unrelated local env URL issue during page-data collection.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Not visually tested. The change is limited to number formatting for existing Sankey values and has unit coverage.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes. AI assisted with locating the Sankey code path, making the small formatter patch, and running validation commands.
