### PR TITLE
Fix payin sankey value formatting

### DIFF
--- a/components/payIn/sankey/index.js
+++ b/components/payIn/sankey/index.js
@@ -25,6 +25,7 @@ export function PayInSankey ({ payIn }) {
         linkHoverOthersOpacity={0.5}
         labelPadding={16}
         layout='vertical'
+        valueFormat={formatSankeyValue}
         linkContract={3}
         nodeHoverOthersOpacity={0.5}
         labelComponent={RotatingSankeyLabels}
@@ -43,10 +44,19 @@ export function PayInSankeySkeleton () {
 }
 
 function assetFormatted (msats, type) {
+  const sats = msatsToSatsNumber(msats)
   if (type === 'CREDITS') {
-    return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
+    return numWithUnits(sats, { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
   }
-  return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
+  return numWithUnits(sats, { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
+}
+
+function formatSankeyValue (sats) {
+  return new Intl.NumberFormat().format(sats)
+}
+
+function msatsToSatsNumber (msats) {
+  return Number(msatsToSatsDecimal(msats))
 }
 
 function Tooltip ({ node, link }) {
@@ -213,7 +223,7 @@ function reduceLinksAndNodes ({ links, nodes }) {
   })
 
   reducedLinks.forEach(link => {
-    link.value = msatsToSatsDecimal(link.mtokens)
+    link.value = msatsToSatsNumber(link.mtokens)
     link.asset = assetFormatted(link.mtokens, link.custodialTokenType)
   })
 


### PR DESCRIPTION
## Description
Fixes #2942.

The pay-in Sankey now passes a locale-aware `valueFormat` to Nivo and gives Nivo numeric values instead of decimal strings, so Nivo-generated formatted values use `Intl.NumberFormat`. The existing custom asset tooltips continue to show localized sat/CC labels.

## Screenshots
N/A

## Additional Context
None.

## Checklist
**Are your changes backward compatible? Please answer below:**
Yes. This only changes client-side formatting for the transaction Sankey diagram.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
7/10. Ran `npm.cmd run lint -- components/payIn/sankey/index.js` and `npm.cmd run lint`.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
No visual mode testing; the change is limited to formatting values passed to the Sankey component.

**Did you introduce any new environment variables? If so, call them out explicitly here:**
No.

**Did you use AI for this? If so, how much did it assist you?**
Yes. AI assisted with finding the issue path and preparing the patch; I reviewed the code and ran lint.
