### PR TITLE
lazy import Lexical's Shiki code highlighter

### DIFF
--- a/components/editor/contexts/toolbar.js
+++ b/components/editor/contexts/toolbar.js
@@ -14,8 +14,7 @@ export const INITIAL_FORMAT_STATE = {
   isSuperscript: false,
   isLowercase: false,
   isUppercase: false,
-  isCapitalize: false,
-  codeLanguage: null
+  isCapitalize: false
 }
 
 const INITIAL_STATE = {

--- a/components/editor/plugins/toolbar/index.js
+++ b/components/editor/plugins/toolbar/index.js
@@ -38,8 +38,6 @@ import { COMMAND_PRIORITY_CRITICAL, $getSelection, $isRangeSelection, $isNodeSel
 import { mergeRegister, $getNearestNodeOfType } from '@lexical/utils'
 import { $snGetBlockType, $snGetElementFormat, $snHasLink } from '@/lib/lexical/commands/formatting/utils'
 import { $findTopLevelElement } from '@/lib/lexical/commands/utils'
-import { $isCodeNode } from '@lexical/code'
-import { normalizeCodeLanguage } from '@lexical/code-shiki'
 import { ListNode } from '@lexical/list'
 import { SN_INSERT_MATH_COMMAND } from '@/lib/lexical/commands/math'
 import MathIcon from '@/svgs/editor/toolbar/inserts/formula.svg'
@@ -190,10 +188,6 @@ export function ToolbarPlugin ({ name, topLevel }) {
         const parentList = $getNearestNodeOfType(selectedNode, ListNode)
         if (!parentList) {
           const selectedElement = $findTopLevelElement(selectedNode)
-          if ($isCodeNode(selectedElement)) {
-            const language = selectedElement.getLanguage()
-            updates.codeLanguage = language ? normalizeCodeLanguage(language) || language : ''
-          }
           if ($isElementNode(selectedElement)) {
             updates.elementFormat = selectedElement.getFormatType()
           }

--- a/lib/lexical/exts/shiki.js
+++ b/lib/lexical/exts/shiki.js
@@ -1,30 +1,50 @@
 import { $nodesOfType, createCommand, COMMAND_PRIORITY_EDITOR, defineExtension } from 'lexical'
-import { registerCodeHighlighting, ShikiTokenizer } from '@lexical/code-shiki'
 import { CodeExtension, CodeNode } from '@lexical/code'
 
 export const UPDATE_CODE_THEME_COMMAND = createCommand()
 
+const DEFAULT_THEME = 'github-dark-default'
+
 export const CodeShikiSNExtension = defineExtension({
   name: 'CodeShikiSNExtension',
-  config: { tokenizer: { ...ShikiTokenizer, defaultLanguage: 'text', defaultTheme: 'github-dark-default' } },
   dependencies: [CodeExtension],
-  register: (editor, { tokenizer }) => {
-    let cleanup = registerCodeHighlighting(editor, tokenizer)
+  register (editor, _config, state) {
+    let currentTheme = DEFAULT_THEME
+    let cleanup = () => {}
+    let shiki = null
 
-    const unregister = editor.registerCommand(
+    const applyHighlighting = (theme) => {
+      // clean up previous highlighting
+      cleanup()
+      // register new highlighting
+      cleanup = shiki.registerCodeHighlighting(editor, {
+        ...shiki.ShikiTokenizer,
+        defaultLanguage: 'text',
+        defaultTheme: theme
+      })
+    }
+
+    // theme updates are queued and applied once shiki is loaded
+    const unregisterTheme = editor.registerCommand(
       UPDATE_CODE_THEME_COMMAND,
       (newTheme) => {
-        // remove previous registration
-        cleanup()
+        currentTheme = newTheme
         // set theme on all code nodes
         $nodesOfType(CodeNode).forEach(node => node.setTheme(newTheme))
-
-        cleanup = registerCodeHighlighting(editor, { ...tokenizer, defaultTheme: newTheme })
+        // apply new highlighting if shiki is already loaded
+        if (shiki) applyHighlighting(newTheme)
         return true
       }, COMMAND_PRIORITY_EDITOR)
 
+    import('@lexical/code-shiki').then((mod) => {
+      if (state.getSignal().aborted) return
+      shiki = mod
+      // load shiki with current theme
+      applyHighlighting(currentTheme)
+    })
+
     return () => {
-      unregister()
+      unregisterTheme()
       cleanup()
     }
   }

--- a/styles/text.scss
+++ b/styles/text.scss
@@ -25,7 +25,7 @@
   padding-bottom: calc(var(--grid-gap) * 0.5);
 }
 
-.sn-text code, .sn-text blockquote {
+.sn-text .sn-code-block, .sn-text blockquote {
   margin-top: calc(var(--grid-gap) * 0.5);
   margin-bottom: calc(var(--grid-gap) * 0.5);
 }
@@ -885,6 +885,7 @@ span + .sn-link {
 .sn-code-block {
   position: relative;
   background-color: var(--theme-commentBg);
+  color: var(--bs-body-color);
   font-family: Menlo, Consolas, Monaco, monospace;
   display: block;
   line-height: 1.53;


### PR DESCRIPTION
## Description

Part of #1832, after 4 slop PRs

Lazily loads Lexical's Shiki code highlighter reducing the main `_app` bundle size by over 50%.

This is not a huge win: Editor/Reader is used for territory descriptions and, of course, items. As soon as Editor/Reader loads, Shiki is loaded too.
That's because Lexical doesn't support runtime configuration changes, we either load it while loading Lexical or we don't load it at all.


## Screenshots

Pre-patch

<img width="1084" height="685" alt="image" src="https://github.com/user-attachments/assets/4f1ff57e-fe2d-4003-81ee-036f6d46be65" />

Post-patch

<img width="1083" height="564" alt="image" src="https://github.com/user-attachments/assets/059e5df3-f2f6-4a62-a50a-b6542a81a0f6" />

## Additional Context

We're using Shiki because it's insanely fast compared to Prism, and has better community support. If we really want to reduce Shiki's size we could enable just a few languages, but then what if someone wants to post a `Windows Registry Script` code block? /s

---

code language detection has been removed from toolbar because it was unused and was also making the lazyload harder than necessary

---

This PR also fixes code block vertical layout shift (html->lexical step) and color flicker (`<pre>` rendered before `<code>` while lazy-loading Shiki)

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8, works the same as before, Shiki is loaded only if Editor is loaded.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
Yes, code themes are now queued if Shiki is not loaded yet. Code blocks respect light mode and dark mode instantly.

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
Review, but this pattern comes from Lexical docs: https://lexical.dev/docs/extensions/faq#what-about-lazy-loading


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how code highlighting is initialized (async lazy import) and re-applied on theme changes, which could impact code block rendering/timing in the editor/reader.
> 
> **Overview**
> **Lazy-loads Lexical’s Shiki code highlighter** by moving `@lexical/code-shiki` to a dynamic import in `CodeShikiSNExtension`, queuing `UPDATE_CODE_THEME_COMMAND` updates until Shiki is available and re-registering highlighting when the theme changes.
> 
> Removes unused toolbar `codeLanguage` tracking (and related imports/state) to simplify the toolbar update path, and adjusts `.sn-code-block` spacing/styling so code blocks get consistent margins and inherit `--bs-body-color`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d5fd6509afafb01a0523b5234a9f24e297fbc4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->