### PR TITLE
fix transaction sankey number formatting

### DIFF
--- a/components/__tests__/payInSankey.test.js
+++ b/components/__tests__/payInSankey.test.js
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+
+jest.mock('@nivo/sankey', () => ({
+  ResponsiveSankey: () => null
+}))
+
+const { formatSankeyValue, getSankeyData } = require('../payIn/sankey')
+
+describe('PayInSankey formatting', () => {
+  let numberFormat
+
+  beforeEach(() => {
+    numberFormat = jest.spyOn(Intl, 'NumberFormat').mockImplementation(function () {
+      return {
+        format: value => `formatted ${value}`
+      }
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('formats Nivo Sankey values with Intl.NumberFormat', () => {
+    expect(formatSankeyValue(1234567.89)).toBe('formatted 1234567.89')
+    expect(numberFormat).toHaveBeenCalled()
+  })
+
+  test('formats Sankey node and link assets with localized full values', () => {
+    const data = getSankeyData({
+      mcost: 1234567890
+    })
+
+    const satsNode = data.nodes.find(node => node.id === 'sats')
+    expect(satsNode.asset).toBe('formatted 1234567.89 sats')
+
+    expect(data.links).toEqual([
+      expect.objectContaining({
+        source: 'sats',
+        target: '',
+        value: 1234567.89,
+        asset: 'formatted 1234567.89 sats'
+      })
+    ])
+  })
+})

--- a/components/payIn/sankey/index.js
+++ b/components/payIn/sankey/index.js
@@ -27,6 +27,7 @@ export function PayInSankey ({ payIn }) {
         layout='vertical'
         linkContract={3}
         nodeHoverOthersOpacity={0.5}
+        valueFormat={formatSankeyValue}
         labelComponent={RotatingSankeyLabels}
         nodeTooltip={Tooltip}
         linkTooltip={Tooltip}
@@ -42,11 +43,20 @@ export function PayInSankeySkeleton () {
   )
 }
 
+function msatsToSankeyValue (msats) {
+  return Number(msatsToSatsDecimal(msats))
+}
+
+export function formatSankeyValue (value) {
+  return new Intl.NumberFormat().format(value)
+}
+
 function assetFormatted (msats, type) {
+  const value = msatsToSankeyValue(msats)
   if (type === 'CREDITS') {
-    return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
+    return numWithUnits(value, { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
   }
-  return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
+  return numWithUnits(value, { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
 }
 
 function Tooltip ({ node, link }) {
@@ -57,7 +67,7 @@ function Tooltip ({ node, link }) {
   return <div style={{ whiteSpace: 'nowrap', backgroundColor: 'var(--bs-body-bg)', padding: '4px 8px', borderRadius: '4px', border: '1px solid var(--bs-border-color)' }}>{node.asset}</div>
 }
 
-function getSankeyData (payIn) {
+export function getSankeyData (payIn) {
   const nodes = []
   const links = []
 
@@ -213,7 +223,7 @@ function reduceLinksAndNodes ({ links, nodes }) {
   })
 
   reducedLinks.forEach(link => {
-    link.value = msatsToSatsDecimal(link.mtokens)
+    link.value = msatsToSankeyValue(link.mtokens)
     link.asset = assetFormatted(link.mtokens, link.custodialTokenType)
   })
 


### PR DESCRIPTION
Fixes #2942

## Description

The transaction Sankey chart now passes an `Intl.NumberFormat` value formatter to Nivo, so its generated node/link values use localized separators instead of raw number strings. The Sankey data now stores numeric link values and reuses the same localized full-value formatting for sat/CC tooltip assets.

## Screenshots

N/A. I could not run the documented local UI stack in this environment because Docker is not installed (`docker: command not found`).

## Additional Context

#2942 currently has no difficulty label. If this fix is eligible for award handling, would you like to assign a difficulty label to the issue?

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. This only changes presentation formatting for existing Sankey values and does not change API/data contracts.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7/10. I ran focused and full automated checks:

- `npm test -- components/__tests__/payInSankey.test.js --runInBand`
- `npm run lint -- components/payIn/sankey/index.js components/__tests__/payInSankey.test.js`
- `npm test -- --runInBand`
- `npm run lint`
- `git diff --check`

I also tried `npm run build`; compilation succeeded, then page data collection failed on local production infrastructure/config (`DATABASE_URL`/OpenSearch), before any Sankey page-specific validation.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

No. The local UI path requires `./sndev start`, and Docker is not installed in this environment. The formatter behavior is covered by a focused Jest regression test.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes. AI assisted with identifying the formatting path, writing the focused patch/test, and running validation. I reviewed the diff and test results before opening this PR.
