### PR TITLE
feat: load Lexical Reader in SSR with a fake DOM

### DIFF
--- a/components/editor/index.js
+++ b/components/editor/index.js
@@ -1,9 +1,8 @@
-import { createContext, useContext } from 'react'
-import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 import Editor from './editor'
 import { ToolbarContextProvider } from './contexts/toolbar'
 import { EditorModeProvider } from './contexts/mode'
+import Reader from './reader'
 
 export function SNEditor ({ ...props }) {
   return (
@@ -15,27 +14,11 @@ export function SNEditor ({ ...props }) {
   )
 }
 
-const HTMLContext = createContext('')
-
-function HTMLFallback () {
-  const html = useContext(HTMLContext)
-  return <div data-sn-reader dangerouslySetInnerHTML={{ __html: html }} />
-}
-
-const Reader = dynamic(() => import('./reader'), {
-  ssr: false,
-  loading: HTMLFallback
-})
-
 export function SNReader ({ html, ...props }) {
   const router = useRouter()
   const debug = router.isReady && router.query.html
 
   if (debug) return <div data-sn-reader dangerouslySetInnerHTML={{ __html: html }} />
 
-  return (
-    <HTMLContext.Provider value={html}>
-      <Reader {...props} />
-    </HTMLContext.Provider>
-  )
+  return <Reader {...props} />
 }

--- a/components/editor/reader.js
+++ b/components/editor/reader.js
@@ -1,7 +1,6 @@
 import { useMemo } from 'react'
 import { defineExtension, configExtension } from 'lexical'
 import { RichTextExtension } from '@lexical/rich-text'
-import { ContentEditable } from '@lexical/react/LexicalContentEditable'
 import { LexicalExtensionComposer } from '@lexical/react/LexicalExtensionComposer'
 import { ReactExtension } from '@lexical/react/ReactExtension'
 import { TableExtension } from '@lexical/table'
@@ -15,8 +14,27 @@ import { AutoLinkExtension } from '@/lib/lexical/exts/autolink'
 import NextLinkPlugin from './plugins/patch/next-link'
 import { MuteLexicalExtension } from '@/lib/lexical/exts/mute-lexical'
 import theme from '@/lib/lexical/theme'
+import { withDOM } from '@/lib/lexical/server/dom'
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { ContentEditable } from '@lexical/react/LexicalContentEditable'
 
-const initiateLexical = (editor, state, text) => {
+/** creates a fake DOM to load Lexical in SSR */
+const initialContentEditableSSR = (editor) => {
+  if (typeof window !== 'undefined') return ''
+
+  return withDOM(() => {
+    // attach a temporary root element to the editor
+    // and let lexical render its content into it
+    const root = document.createElement('div')
+    editor.setRootElement(root)
+    const { innerHTML } = root
+    editor.setRootElement(null)
+    // return the rendered content as HTML
+    return innerHTML
+  })
+}
+
+const initiateEditorState = (editor, state, text) => {
   if (text) {
     markdownToLexical(editor, text)
     return
@@ -33,6 +51,19 @@ const initiateLexical = (editor, state, text) => {
       console.error(error)
     }
   }
+}
+
+function SSRContentEditable (props) {
+  const [editor] = useLexicalComposerContext()
+
+  return (
+    <ContentEditable
+      {...props}
+      // client-side Lexical will replace the server HTML once it has mounted
+      suppressHydrationWarning
+      dangerouslySetInnerHTML={{ __html: initialContentEditableSSR(editor) }}
+    />
+  )
 }
 
 export default function Reader ({ topLevel, state, text, readerRef, innerClassName }) {
@@ -55,17 +86,16 @@ export default function Reader ({ topLevel, state, text, readerRef, innerClassNa
         ...theme,
         topLevel: topLevel && 'topLevel'
       },
-      $initialEditorState: (editor) => initiateLexical(editor, state, text),
+      $initialEditorState: (editor) => initiateEditorState(editor, state, text),
       onError: (error) => console.error('reader has encountered an error:', error)
     }), [topLevel, state, text])
 
   return (
-    <LexicalExtensionComposer extension={reader} contentEditable={null}>
+    <LexicalExtensionComposer
+      extension={reader}
+      contentEditable={<SSRContentEditable data-sn-reader='true' className={innerClassName} />}
+    >
       <EditorRefPlugin editorRef={readerRef} />
-      <ContentEditable
-        data-sn-reader='true'
-        className={innerClassName}
-      />
       <CodeThemePlugin />
       <NextLinkPlugin />
     </LexicalExtensionComposer>

--- a/lib/lexical/server/dom.js
+++ b/lib/lexical/server/dom.js
@@ -17,17 +17,26 @@ export function withDOM (fn) {
   }
 
   // save previous global state
+  const prevComputedStyle = global.getComputedStyle
+  const prevDOMParser = global.DOMParser
+  const prevMutationObserver = global.MutationObserver
   const prevDocument = global.document
 
   // create new DOM environment
   const { window: newWindow, document: newDocument } = createLinkeDOM()
   global.window = newWindow
   global.document = newDocument
+  global.getComputedStyle = newWindow.getComputedStyle
+  global.DOMParser = newWindow.DOMParser
+  global.MutationObserver = newWindow.MutationObserver
 
   try {
     return fn(newWindow)
   } finally {
     // restore previous state and clean up
+    global.getComputedStyle = prevComputedStyle
+    global.DOMParser = prevDOMParser
+    global.MutationObserver = prevMutationObserver
     global.window = prevWindow
     global.document = prevDocument
   }


### PR DESCRIPTION
## Description

Server-renders the Lexical Reader by briefly giving Lexical a fake DOM.

`initialContentEditableSSR` temporarily creates a fake `document` via `withDOM` (linkedom), then attaches it as Lexical's root element, allowing Lexical to render its `EditorState` into a valid root. The resulting HTML is used as the content editable (what gets rendered) for Lexical during SSR.

## Screenshots

Lexical loads instantly

https://github.com/user-attachments/assets/e2704776-80f9-4177-bf26-15a067aa0fe5

## Additional Context

Should we remove HTML support at this point? We don't have another use for it and it's just wasted bandwidth.
I can see it being really useful for exports or no-js environments (`html` param) but nothing we currently support.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes, HTML is intact and still accessible via `html` param

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

6, in QA

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Yes, still light QA in background

**Did you use AI for this? If so, how much did it assist you?**

No, although I got the idea from an example made by Claude online.