### PR TITLE
Fix Blixt Wallet Lightning Address integration

### DIFF
--- a/wallets/lib/wallets.json
+++ b/wallets/lib/wallets.json
@@ -128,7 +128,7 @@
         "name": "BLIXT",
         "displayName": "Blixt",
         "image": "/wallets/blixt.svg",
-        "url": "https://blixtwallet.github.io/"
+        "url": "https://blixtwallet.com/"
     },
     {
         "name": "NPUB_CASH",


### PR DESCRIPTION
Hi, we use `@blixtwallet.com`  for our Lightning Address support in Blixt.

Cheers
Hampus