### PR TITLE
Internationalize pay-in Sankey values

### DIFF
--- a/components/payIn/sankey/index.js
+++ b/components/payIn/sankey/index.js
@@ -28,6 +28,7 @@ export function PayInSankey ({ payIn }) {
         linkContract={3}
         nodeHoverOthersOpacity={0.5}
         labelComponent={RotatingSankeyLabels}
+        valueFormat={formatSankeyValue}
         nodeTooltip={Tooltip}
         linkTooltip={Tooltip}
         nodeSpacing={24}
@@ -43,10 +44,19 @@ export function PayInSankeySkeleton () {
 }
 
 function assetFormatted (msats, type) {
+  const value = msatsToSatsNumber(msats)
   if (type === 'CREDITS') {
-    return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
+    return numWithUnits(value, { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
   }
-  return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
+  return numWithUnits(value, { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
+}
+
+function msatsToSatsNumber (msats) {
+  return Number(msatsToSatsDecimal(msats))
+}
+
+function formatSankeyValue (value) {
+  return new Intl.NumberFormat().format(value)
 }
 
 function Tooltip ({ node, link }) {
@@ -213,7 +223,7 @@ function reduceLinksAndNodes ({ links, nodes }) {
   })
 
   reducedLinks.forEach(link => {
-    link.value = msatsToSatsDecimal(link.mtokens)
+    link.value = msatsToSatsNumber(link.mtokens)
     link.asset = assetFormatted(link.mtokens, link.custodialTokenType)
   })
 


### PR DESCRIPTION
Closes #2942.\n\n## Summary\n- formats Sankey values through Intl.NumberFormat via Nivo's valueFormat prop\n- keeps Sankey link values numeric instead of stringified decimals\n- formats node/link asset labels from numeric sats values so singular/plural units stay correct\n\n## Test\n- npm run lint -- components/payIn/sankey/index.js\n\nThis was a small unlabeled bug fix; if it qualifies for an SN difficulty/reward label, I would appreciate consideration.