### PR TITLE
Fix msat decimal formatting

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -73,7 +73,7 @@ export const msatsToSatsDecimal = msats => {
   if (msats === null || msats === undefined) {
     return null
   }
-  return fixedDecimal(Number(msats) / 1000.0, 3)
+  return Number(fixedDecimal(Number(msats) / 1000.0, 3))
 }
 
 export const formatSats = (sats) => numWithUnits(sats, { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })

--- a/lib/format.test.js
+++ b/lib/format.test.js
@@ -1,0 +1,16 @@
+/* eslint-env jest */
+
+import { msatsToSatsDecimal, numWithUnits } from './format'
+
+describe('msatsToSatsDecimal', () => {
+  test('returns a number so unit labels and locale formatting work', () => {
+    const sats = msatsToSatsDecimal(1000)
+
+    expect(sats).toBe(1)
+    expect(numWithUnits(sats, { abbreviate: false })).toBe('1 sat')
+  })
+
+  test('preserves sub-sat precision', () => {
+    expect(msatsToSatsDecimal(1234)).toBe(1.234)
+  })
+})


### PR DESCRIPTION
## What changed
- Return a number from msatsToSatsDecimal instead of a fixed-decimal string.
- Add coverage for singular unit formatting and sub-sat precision.

## Why
This lets transaction Sankey amounts go through Intl.NumberFormat and unit pluralization correctly. For example, 1000 msats now formats as 1 sat instead of treating "1.000" as a string.

Fixes #2942

## Testing
- npm run lint -- lib/format.js lib/format.test.js
- npm test -- lib/format.test.js --runInBand