### PR TITLE
Format push notification markdown

### DIFF
--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -1,11 +1,11 @@
 import webPush from 'web-push'
-import removeMd from 'remove-markdown'
 import { COMMENT_DEPTH_LIMIT, FOUND_BLURBS, LOST_BLURBS, DEFAULT_POSTS_SATS_FILTER, DEFAULT_COMMENTS_SATS_FILTER } from './constants'
 import { msatsToSats, numWithUnits } from './format'
 import { nextBillingWithGrace } from '@/lib/territory'
 import models from '@/api/models'
 import { isMuted } from '@/lib/user'
 import { Prisma } from '@prisma/client'
+import { formatPushBody } from '@/lib/webPushFormat'
 
 // Check if an item meets a user's sat filter threshold for push notifications
 async function meetsUserSatFilter (userId, item) {
@@ -65,7 +65,7 @@ function createPayload (notification) {
   // https://webkit.org/blog/16535/meet-declarative-web-push/
   // DEV: localhost in URLs is not supported by declarative web push
   let { title, body, ...options } = notification
-  if (body) body = removeMd(body)
+  if (body) body = formatPushBody(body)
   return JSON.stringify({
     web_push: 8030, // Declarative Web Push JSON format
     notification: {

--- a/lib/webPush.test.js
+++ b/lib/webPush.test.js
@@ -1,0 +1,13 @@
+/* eslint-env jest */
+
+import { formatPushBody } from './webPushFormat'
+
+describe('formatPushBody', () => {
+  it('removes markdown formatting from push notification bodies', () => {
+    expect(formatPushBody('**bold** [link](https://stacker.news)')).toBe('bold link')
+  })
+
+  it('removes display math delimiters and punctuation escapes', () => {
+    expect(formatPushBody('$$really\\,cool!$$')).toBe('really,cool!')
+  })
+})

--- a/lib/webPushFormat.js
+++ b/lib/webPushFormat.js
@@ -1,0 +1,9 @@
+import removeMd from 'remove-markdown'
+
+export function formatPushBody (body) {
+  if (!body) return body
+
+  return removeMd(body)
+    .replace(/\$\$([^$]+)\$\$/g, '$1')
+    .replace(/\\([,;:!?.])/g, '$1')
+}


### PR DESCRIPTION
## Summary
- strip markdown from push notification bodies via a side-effect-free formatter
- remove display math delimiters and escaped punctuation so Android notifications do not show raw `$$...$$` text
- add focused coverage for the formatter

Fixes #2852

## Testing
- npm run lint -- lib/webPush.js lib/webPushFormat.js lib/webPush.test.js
- npm test -- lib/webPush.test.js --runInBand