### PR TITLE
Preserve formatting on internal item links

### DIFF
--- a/lib/lexical/mdast/visitors/mentions.js
+++ b/lib/lexical/mdast/visitors/mentions.js
@@ -82,6 +82,10 @@ function extractText (children) {
   }).join('')
 }
 
+export function hasOnlyPlainTextChildren (children) {
+  return children?.every(child => child.type === 'text') ?? true
+}
+
 export const MdastItemMentionLinkVisitor = {
   testNode: 'link',
   priority: 20,
@@ -89,6 +93,10 @@ export const MdastItemMentionLinkVisitor = {
     try {
       const { itemId, commentId, linkText } = parseInternalLinks(mdastNode.url)
       if (itemId || commentId) {
+        if (!hasOnlyPlainTextChildren(mdastNode.children)) {
+          actions.nextVisitor()
+          return
+        }
         const text = extractText(mdastNode.children) || linkText
         const mentionNode = $createItemMentionNode({
           id: commentId || itemId,

--- a/lib/lexical/mdast/visitors/mentions.spec.js
+++ b/lib/lexical/mdast/visitors/mentions.spec.js
@@ -1,0 +1,46 @@
+/* eslint-env jest */
+
+import { MdastItemMentionLinkVisitor, hasOnlyPlainTextChildren } from './mentions.js'
+
+describe('item mention links', () => {
+  test('converts plain internal link text to item mentions', () => {
+    expect(hasOnlyPlainTextChildren([
+      { type: 'text', value: 'High Risk, Low Reward' }
+    ])).toBe(true)
+  })
+
+  test('preserves formatted internal link text as regular links', () => {
+    expect(hasOnlyPlainTextChildren([
+      {
+        type: 'emphasis',
+        children: [{ type: 'text', value: 'High Risk, Low Reward' }]
+      }
+    ])).toBe(false)
+  })
+
+  test('falls through to the regular link visitor for formatted internal links', () => {
+    process.env.NEXT_PUBLIC_URL = 'https://stacker.news'
+
+    const actions = {
+      nextVisitor: jest.fn(),
+      addAndStepInto: jest.fn()
+    }
+
+    MdastItemMentionLinkVisitor.visitNode({
+      mdastNode: {
+        type: 'link',
+        url: 'https://stacker.news/items/778491',
+        children: [
+          {
+            type: 'emphasis',
+            children: [{ type: 'text', value: 'High Risk, Low Reward' }]
+          }
+        ]
+      },
+      actions
+    })
+
+    expect(actions.nextVisitor).toHaveBeenCalledTimes(1)
+    expect(actions.addAndStepInto).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Description

Fixes #2767.

Internal Stacker item links with formatted markdown text, like [_High Risk, Low Reward_](https://stacker.news/items/778491), were converted into ItemMentionNodes before the regular link visitor could preserve the child emphasis nodes. This keeps the item-mention conversion for plain text links, but falls through to the normal link visitor when the link text contains mdast formatting.

## Screenshots

N/A - parser/import behavior covered by a focused unit test.

## Additional Context

This is intentionally smaller than the older proof-of-concept in #2768: it preserves formatting by avoiding decorator conversion for formatted link children instead of adding formatting state to the decorator node.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. Plain internal item links still become item mentions; only formatted custom link text takes the existing regular link path.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7. Ran 
px.cmd standard lib/lexical/mdast/visitors/mentions.js lib/lexical/mdast/visitors/mentions.spec.js and $env:NODE_OPTIONS='--experimental-vm-modules'; npx.cmd jest lib/lexical/mdast/visitors/mentions.spec.js --runInBand.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

N/A. This is a markdown import decision with no visual styling changes.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes. Codex helped trace the markdown import path, make the patch, and run the focused tests.