### PR TITLE
Strip Lexical table cell inline export styles

### DIFF
--- a/lib/lexical/nodes/index.js
+++ b/lib/lexical/nodes/index.js
@@ -9,6 +9,7 @@ import { EmbedNode } from './content/embed'
 import { MathNode } from './formatting/math'
 import { TableOfContentsNode } from './content/toc'
 import { SNHeadingNode, $createSNHeadingNode } from './misc/heading'
+import { SNTableCellNode, $createSNTableCellNode } from './misc/table-cell'
 import {
   UserMentionNode,
   TerritoryMentionNode,
@@ -35,7 +36,15 @@ const DefaultNodes = [
   CodeNode,
   CodeHighlightNode,
   TableNode,
-  TableCellNode,
+  SNTableCellNode,
+  {
+    replace: TableCellNode,
+    with: (node) => $createSNTableCellNode(node.getHeaderStyles(), node.getColSpan(), node.getWidth())
+      .setRowSpan(node.getRowSpan())
+      .setBackgroundColor(node.getBackgroundColor())
+      .setVerticalAlign(node.getVerticalAlign()),
+    withKlass: SNTableCellNode
+  },
   TableRowNode,
   AutoLinkNode,
   LinkNode,

--- a/lib/lexical/nodes/misc/table-cell.js
+++ b/lib/lexical/nodes/misc/table-cell.js
@@ -1,0 +1,54 @@
+import { TableCellNode } from '@lexical/table'
+import { $applyNodeReplacement, isHTMLElement } from 'lexical'
+
+export class SNTableCellNode extends TableCellNode {
+  static getType () {
+    return 'sn-tablecell'
+  }
+
+  static clone (node) {
+    return new SNTableCellNode(node.__headerState, node.__colSpan, node.__width, node.__key)
+  }
+
+  static importDOM () {
+    return TableCellNode.importDOM()
+  }
+
+  static importJSON (serializedNode) {
+    return $createSNTableCellNode(serializedNode.headerState, serializedNode.colSpan, serializedNode.width)
+      .updateFromJSON(serializedNode)
+  }
+
+  exportDOM (editor) {
+    const output = super.exportDOM(editor)
+    const { element } = output
+
+    if (isHTMLElement(element)) {
+      const width = this.getWidth()
+      const verticalAlign = this.getVerticalAlign()
+      const backgroundColor = this.getBackgroundColor()
+
+      element.removeAttribute('style')
+
+      if (width) {
+        element.style.width = `${width}px`
+      }
+      if (verticalAlign) {
+        element.style.verticalAlign = verticalAlign
+      }
+      if (backgroundColor) {
+        element.style.backgroundColor = backgroundColor
+      }
+    }
+
+    return output
+  }
+}
+
+export function $createSNTableCellNode (headerState, colSpan, width) {
+  return $applyNodeReplacement(new SNTableCellNode(headerState, colSpan, width))
+}
+
+export function $isSNTableCellNode (node) {
+  return node instanceof SNTableCellNode
+}

--- a/lib/lexical/nodes/misc/table-cell.spec.js
+++ b/lib/lexical/nodes/misc/table-cell.spec.js
@@ -1,0 +1,94 @@
+/* eslint-env jest */
+
+import { createHeadlessEditor } from '@lexical/headless'
+import { $createTableCellNode, $createTableNode, $createTableRowNode, TableCellHeaderStates, TableCellNode, TableNode, TableRowNode } from '@lexical/table'
+import { $generateHtmlFromNodes } from '@lexical/html'
+import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical'
+import { SNTableCellNode, $createSNTableCellNode } from './table-cell'
+import { withDOM } from '@/lib/lexical/server/dom'
+
+function createEditor () {
+  return createHeadlessEditor({
+    namespace: 'sn-table-cell-test',
+    nodes: [
+      TableNode,
+      SNTableCellNode,
+      {
+        replace: TableCellNode,
+        with: (node) => $createSNTableCellNode(node.getHeaderStyles(), node.getColSpan(), node.getWidth())
+          .setRowSpan(node.getRowSpan())
+          .setBackgroundColor(node.getBackgroundColor())
+          .setVerticalAlign(node.getVerticalAlign()),
+        withKlass: SNTableCellNode
+      },
+      TableRowNode
+    ],
+    theme: {
+      paragraph: 'sn-paragraph',
+      table: 'sn-table',
+      tableCell: 'sn-table__cell',
+      tableCellHeader: 'sn-table__cell--header'
+    },
+    onError: (error) => {
+      throw error
+    }
+  })
+}
+
+function createTableHtml ({ configureCell } = {}) {
+  return withDOM(() => {
+    const editor = createEditor()
+    let html
+
+    editor.update(() => {
+      const table = $createTableNode()
+      const row = $createTableRowNode()
+      const cell = $createTableCellNode(TableCellHeaderStates.ROW)
+
+      configureCell?.(cell)
+      cell.append($createParagraphNode().append($createTextNode('header')))
+      row.append(cell)
+      table.append(row)
+
+      const root = $getRoot()
+      root.clear()
+      root.append(table)
+    }, { discrete: true })
+
+    editor.getEditorState().read(() => {
+      html = $generateHtmlFromNodes(editor)
+    })
+
+    return html
+  })
+}
+
+describe('SNTableCellNode', () => {
+  test('does not export Lexical default inline cell styles', () => {
+    const html = createTableHtml()
+
+    expect(html).toContain('sn-table__cell')
+    expect(html).toContain('sn-table__cell--header')
+    expect(html).not.toContain('1px solid black')
+    expect(html).not.toMatch(/width:\s*75px/)
+    expect(html).not.toMatch(/vertical-align:\s*top/)
+    expect(html).not.toMatch(/text-align:\s*start/)
+    expect(html).not.toMatch(/background-color:\s*rgb\(242,\s*243,\s*245\)/)
+    expect(html).not.toContain('#f2f3f5')
+  })
+
+  test('keeps intentional cell export styles', () => {
+    const html = createTableHtml({
+      configureCell: (cell) => {
+        cell
+          .setWidth(120)
+          .setVerticalAlign('middle')
+          .setBackgroundColor('rgb(1, 2, 3)')
+      }
+    })
+
+    expect(html).toMatch(/width:\s*120px/)
+    expect(html).toMatch(/vertical-align:\s*middle/)
+    expect(html).toMatch(/background-color:\s*rgb\(1,\s*2,\s*3\)/)
+  })
+})


### PR DESCRIPTION
Fixes #2777

This removes Lexical's hardcoded inline table-cell export styles from SN-rendered table cells so exported/SSR HTML can use the existing `.sn-table__cell` and `.sn-table__cell--header` theme CSS instead of black borders, fixed 75px widths, top vertical alignment, and the default gray header fill.

The patch adds an `SNTableCellNode` replacement for `TableCellNode`. It strips the default export-only inline styles, while preserving intentional cell styles that are stored on the node such as explicit width, vertical alignment, and custom background color.

Tested:
- `npx.cmd standard lib\lexical\nodes\index.js lib\lexical\nodes\misc\table-cell.js lib\lexical\nodes\misc\table-cell.spec.js`
- `$env:NODE_OPTIONS='--experimental-vm-modules'; npx.cmd jest lib/lexical/nodes/misc/table-cell.spec.js --runInBand`

Notes:
- This intentionally keeps the change scoped to HTML export/SSR behavior.
- Prior attempt #2789 was closed for insufficient local testing; this version includes a focused regression test for the exported HTML.
- Happy to adjust the preservation rules if table export should also drop explicit width/vertical-align.

AI assistance: Yes. Codex helped trace the export path, implement the patch, and run the focused tests.