### PR TITLE
Internationalize pay-in Sankey amount formatting

### DIFF
--- a/components/pay-in-sankey.spec.js
+++ b/components/pay-in-sankey.spec.js
@@ -1,0 +1,43 @@
+/* eslint-env jest */
+
+import { formatSankeyValue, getSankeyData } from './payIn/sankey/data'
+
+describe('PayInSankey data formatting', () => {
+  test('uses numeric values for Nivo and localized tooltip assets', () => {
+    const data = getSankeyData({
+      mcost: 1234567890,
+      payerPrivates: {
+        payInCustodialTokens: [
+          {
+            mtokens: 1234567890,
+            custodialTokenType: 'SATS'
+          }
+        ]
+      }
+    })
+
+    expect(data.links).toHaveLength(1)
+    expect(data.links[0].value).toBe(1234567.89)
+    expect(data.links[0].asset).toBe(`${new Intl.NumberFormat().format(1234567.89)} sats`)
+  })
+
+  test('formats one sat with the singular unit', () => {
+    const data = getSankeyData({
+      mcost: 1000,
+      payerPrivates: {
+        payInCustodialTokens: [
+          {
+            mtokens: 1000,
+            custodialTokenType: 'SATS'
+          }
+        ]
+      }
+    })
+
+    expect(data.links[0].asset).toBe('1 sat')
+  })
+
+  test('passes Nivo values through Intl.NumberFormat', () => {
+    expect(formatSankeyValue(1234567.89)).toBe(new Intl.NumberFormat().format(1234567.89))
+  })
+})

--- a/components/payIn/sankey/data.js
+++ b/components/payIn/sankey/data.js
@@ -1,0 +1,181 @@
+import { msatsToSatsDecimal, numWithUnits } from '@/lib/format'
+import { payTypeShortName } from '@/lib/pay-in'
+
+function assetFormatted (msats, type) {
+  const sats = sankeyValue(msats)
+  if (type === 'CREDITS') {
+    return numWithUnits(sats, { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false, format: true })
+  }
+  return numWithUnits(sats, { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false, format: true })
+}
+
+export function formatSankeyValue (value) {
+  return new Intl.NumberFormat().format(value)
+}
+
+function sankeyValue (msats) {
+  return Number(msatsToSatsDecimal(msats))
+}
+
+export function getSankeyData (payIn) {
+  const nodes = []
+  const links = []
+
+  // stacker news is always a node
+  nodes.push({
+    id: ''
+  })
+
+  // Create individual nodes for each payInCustodialToken
+  if (payIn.payerPrivates) {
+    payIn.payerPrivates?.payInCustodialTokens?.forEach((token, index) => {
+      const id = token.custodialTokenType === 'SATS' ? 'sats' : 'CCs'
+      nodes.push({
+        id,
+        mtokens: token.mtokens,
+        custodialTokenType: token.custodialTokenType
+      })
+      links.push({
+        source: id,
+        target: '',
+        mtokens: token.mtokens,
+        custodialTokenType: token.custodialTokenType
+      })
+    })
+  } else if (!payIn.payInBolt11Public?.msats || payIn.mcost - payIn.payInBolt11Public.msats > 0) {
+    const mtokens = payIn.mcost - (payIn.payInBolt11Public?.msats ?? 0)
+    nodes.push({
+      id: 'sats',
+      mtokens,
+      custodialTokenType: 'SATS'
+    })
+    links.push({
+      source: 'sats',
+      target: '',
+      mtokens,
+      custodialTokenType: 'SATS'
+    })
+  }
+
+  // Create node for payInBolt11 if it exists
+  if (payIn.payInBolt11Public) {
+    nodes.push({
+      id: 'lightning',
+      mtokens: payIn.payInBolt11Public.msats,
+      custodialTokenType: 'SATS'
+    })
+
+    let leftOverMsats = payIn.payInBolt11Public.msats
+
+    // this is a p2p zap or payment
+    if (payIn.payOutBolt11Public) {
+      leftOverMsats = payIn.payInBolt11Public.msats - payIn.payOutBolt11Public.msats
+      const id = 'lightning (out)'
+      nodes.push({
+        id,
+        mtokens: payIn.payOutBolt11Public.msats,
+        custodialTokenType: 'SATS'
+      })
+
+      links.push({
+        source: 'lightning',
+        target: id,
+        mtokens: payIn.payOutBolt11Public.msats,
+        custodialTokenType: 'SATS'
+      })
+    }
+
+    if (leftOverMsats > 0) {
+      links.push({
+        source: 'lightning',
+        target: '',
+        mtokens: leftOverMsats,
+        custodialTokenType: 'SATS'
+      })
+    }
+  } else if (payIn.payOutBolt11Public) {
+    // this is a withdrawal
+    nodes.push({
+      id: 'lightning (out)',
+      mtokens: payIn.payOutBolt11Public.msats,
+      custodialTokenType: 'SATS'
+    })
+
+    links.push({
+      source: '',
+      target: 'lightning (out)',
+      mtokens: payIn.payOutBolt11Public.msats,
+      custodialTokenType: 'SATS'
+    })
+  }
+
+  // Create individual nodes for each payOutCustodialToken
+  if (payIn.payOutCustodialTokens && payIn.payOutCustodialTokens.length > 0) {
+    payIn.payOutCustodialTokens.forEach((token) => {
+      let id = payTypeShortName(token.payOutType)
+      if (['TERRITORY_REVENUE', 'DEFUNCT_DELAYED_TERRITORY_REVENUE'].includes(token.payOutType) && token.sub?.name) {
+        id = `~${token.sub.name}`
+      } else if (['ZAP', 'REWARD'].includes(token.payOutType) && token.sometimesPrivates?.user?.name) {
+        // Only label payouts when the resolver exposed viewer-owned identity data.
+        id = `@${token.sometimesPrivates.user.name}`
+      } else if (token.payOutType === 'ROUTING_FEE') {
+        id = 'route'
+      } else if (token.payOutType === 'ROUTING_FEE_REFUND') {
+        id = 'refund'
+      } else if (token.payOutType === 'REWARDS_POOL') {
+        id = 'rewards'
+      }
+
+      nodes.push({
+        id,
+        mtokens: token.mtokens,
+        custodialTokenType: token.custodialTokenType
+      })
+      links.push({
+        source: '',
+        target: id,
+        mtokens: token.mtokens,
+        custodialTokenType: token.custodialTokenType
+      })
+    })
+  }
+
+  return reduceLinksAndNodes({ nodes, links })
+}
+
+// combine duplicate nodes and links, adding the mtokens together
+function reduceLinksAndNodes ({ links, nodes }) {
+  const reducedLinks = []
+  const reducedNodes = []
+
+  nodes.forEach(node => {
+    const existingNode = reducedNodes.find(n => n.id === node.id)
+    if (existingNode) {
+      existingNode.mtokens += node.mtokens
+    } else {
+      reducedNodes.push(node)
+    }
+  })
+
+  reducedNodes.forEach(node => {
+    if (node.mtokens) {
+      node.asset = assetFormatted(node.mtokens, node.custodialTokenType)
+    }
+  })
+
+  links.forEach(link => {
+    const existingLink = reducedLinks.find(l => l.source === link.source && l.target === link.target)
+    if (existingLink) {
+      existingLink.mtokens += link.mtokens
+    } else {
+      reducedLinks.push(link)
+    }
+  })
+
+  reducedLinks.forEach(link => {
+    link.value = sankeyValue(link.mtokens)
+    link.asset = assetFormatted(link.mtokens, link.custodialTokenType)
+  })
+
+  return { links: reducedLinks, nodes: reducedNodes }
+}

--- a/components/payIn/sankey/index.js
+++ b/components/payIn/sankey/index.js
@@ -1,6 +1,5 @@
-import { msatsToSatsDecimal, numWithUnits } from '@/lib/format'
-import { payTypeShortName } from '@/lib/pay-in'
 import { ResponsiveSankey } from '@nivo/sankey'
+import { formatSankeyValue, getSankeyData } from './data'
 import { RotatingSankeyLabels } from './label'
 
 export function PayInSankey ({ payIn }) {
@@ -9,6 +8,7 @@ export function PayInSankey ({ payIn }) {
     <div className='position-relative' style={{ width: '100%', maxWidth: '600px', height: '460px' }}>
       <ResponsiveSankey
         data={data}
+        valueFormat={formatSankeyValue}
         margin={{ top: 60, right: 60, bottom: 160, left: 60 }}
         align='justify'
         labelPosition='outside'
@@ -42,180 +42,10 @@ export function PayInSankeySkeleton () {
   )
 }
 
-function assetFormatted (msats, type) {
-  if (type === 'CREDITS') {
-    return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
-  }
-  return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
-}
-
 function Tooltip ({ node, link }) {
   node ??= link
   if (!node.asset) {
     return null
   }
   return <div style={{ whiteSpace: 'nowrap', backgroundColor: 'var(--bs-body-bg)', padding: '4px 8px', borderRadius: '4px', border: '1px solid var(--bs-border-color)' }}>{node.asset}</div>
-}
-
-function getSankeyData (payIn) {
-  const nodes = []
-  const links = []
-
-  // stacker news is always a node
-  nodes.push({
-    id: ''
-  })
-
-  // Create individual nodes for each payInCustodialToken
-  if (payIn.payerPrivates) {
-    payIn.payerPrivates?.payInCustodialTokens?.forEach((token, index) => {
-      const id = token.custodialTokenType === 'SATS' ? 'sats' : 'CCs'
-      nodes.push({
-        id,
-        mtokens: token.mtokens,
-        custodialTokenType: token.custodialTokenType
-      })
-      links.push({
-        source: id,
-        target: '',
-        mtokens: token.mtokens,
-        custodialTokenType: token.custodialTokenType
-      })
-    })
-  } else if (!payIn.payInBolt11Public?.msats || payIn.mcost - payIn.payInBolt11Public.msats > 0) {
-    const mtokens = payIn.mcost - (payIn.payInBolt11Public?.msats ?? 0)
-    nodes.push({
-      id: 'sats',
-      mtokens,
-      custodialTokenType: 'SATS'
-    })
-    links.push({
-      source: 'sats',
-      target: '',
-      mtokens,
-      custodialTokenType: 'SATS'
-    })
-  }
-
-  // Create node for payInBolt11 if it exists
-  if (payIn.payInBolt11Public) {
-    nodes.push({
-      id: 'lightning',
-      mtokens: payIn.payInBolt11Public.msats,
-      custodialTokenType: 'SATS'
-    })
-
-    let leftOverMsats = payIn.payInBolt11Public.msats
-
-    // this is a p2p zap or payment
-    if (payIn.payOutBolt11Public) {
-      leftOverMsats = payIn.payInBolt11Public.msats - payIn.payOutBolt11Public.msats
-      const id = 'lightning (out)'
-      nodes.push({
-        id,
-        mtokens: payIn.payOutBolt11Public.msats,
-        custodialTokenType: 'SATS'
-      })
-
-      links.push({
-        source: 'lightning',
-        target: id,
-        mtokens: payIn.payOutBolt11Public.msats,
-        custodialTokenType: 'SATS'
-      })
-    }
-
-    if (leftOverMsats > 0) {
-      links.push({
-        source: 'lightning',
-        target: '',
-        mtokens: leftOverMsats,
-        custodialTokenType: 'SATS'
-      })
-    }
-  } else if (payIn.payOutBolt11Public) {
-    // this is a withdrawal
-    nodes.push({
-      id: 'lightning (out)',
-      mtokens: payIn.payOutBolt11Public.msats,
-      custodialTokenType: 'SATS'
-    })
-
-    links.push({
-      source: '',
-      target: 'lightning (out)',
-      mtokens: payIn.payOutBolt11Public.msats,
-      custodialTokenType: 'SATS'
-    })
-  }
-
-  // Create individual nodes for each payOutCustodialToken
-  if (payIn.payOutCustodialTokens && payIn.payOutCustodialTokens.length > 0) {
-    payIn.payOutCustodialTokens.forEach((token) => {
-      let id = payTypeShortName(token.payOutType)
-      if (['TERRITORY_REVENUE', 'DEFUNCT_DELAYED_TERRITORY_REVENUE'].includes(token.payOutType) && token.sub?.name) {
-        id = `~${token.sub.name}`
-      } else if (['ZAP', 'REWARD'].includes(token.payOutType) && token.sometimesPrivates?.user?.name) {
-        // Only label payouts when the resolver exposed viewer-owned identity data.
-        id = `@${token.sometimesPrivates.user.name}`
-      } else if (token.payOutType === 'ROUTING_FEE') {
-        id = 'route'
-      } else if (token.payOutType === 'ROUTING_FEE_REFUND') {
-        id = 'refund'
-      } else if (token.payOutType === 'REWARDS_POOL') {
-        id = 'rewards'
-      }
-
-      nodes.push({
-        id,
-        mtokens: token.mtokens,
-        custodialTokenType: token.custodialTokenType
-      })
-      links.push({
-        source: '',
-        target: id,
-        mtokens: token.mtokens,
-        custodialTokenType: token.custodialTokenType
-      })
-    })
-  }
-
-  return reduceLinksAndNodes({ nodes, links })
-}
-
-// combine duplicate nodes and links, adding the mtokens together
-function reduceLinksAndNodes ({ links, nodes }) {
-  const reducedLinks = []
-  const reducedNodes = []
-
-  nodes.forEach(node => {
-    const existingNode = reducedNodes.find(n => n.id === node.id)
-    if (existingNode) {
-      existingNode.mtokens += node.mtokens
-    } else {
-      reducedNodes.push(node)
-    }
-  })
-
-  reducedNodes.forEach(node => {
-    if (node.mtokens) {
-      node.asset = assetFormatted(node.mtokens, node.custodialTokenType)
-    }
-  })
-
-  links.forEach(link => {
-    const existingLink = reducedLinks.find(l => l.source === link.source && l.target === link.target)
-    if (existingLink) {
-      existingLink.mtokens += link.mtokens
-    } else {
-      reducedLinks.push(link)
-    }
-  })
-
-  reducedLinks.forEach(link => {
-    link.value = msatsToSatsDecimal(link.mtokens)
-    link.asset = assetFormatted(link.mtokens, link.custodialTokenType)
-  })
-
-  return { links: reducedLinks, nodes: reducedNodes }
 }


### PR DESCRIPTION
Closes #2942

This keeps the pay-in Sankey values numeric for Nivo and gives the chart a localized value formatter. It also moves the data reducer into a small helper module so the amount formatting can be covered without loading the chart renderer.

Tests:
- `npx.cmd standard components\payIn\sankey\index.js components\payIn\sankey\data.js components\pay-in-sankey.spec.js`
- `$env:NODE_OPTIONS='--experimental-vm-modules'; npx.cmd jest components/pay-in-sankey.spec.js --runInBand`

Happy to address any review feedback.