### PR TITLE
Sort profile sats filter by direct item sats

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -32,6 +32,7 @@ import pay, { retry as retryPayIn } from '../payIn'
 import { BOUNTY_ALREADY_PAID_ERROR, BOUNTY_IN_PROGRESS_ERROR, getBountyPaymentTail } from '../payIn/lib/bountyPayment'
 import { lexicalHTMLGenerator } from '@/lib/lexical/server/html'
 import { resolveItemComments } from './comment-tree'
+import { orderByClause, userOrderByClause } from '@/lib/item-order'
 
 export async function getItem (parent, { id }, { me, models }) {
   const [item] = await getItemsById([id], { me, models })
@@ -57,19 +58,6 @@ export async function getItemsById (ids, { me, models }) {
   })
 
   return items.map(({ rank, ...item }) => item)
-}
-
-const orderByClause = (by, me, models, type, sub) => {
-  switch (by) {
-    case 'comments':
-      return 'ORDER BY "Item".ncomments DESC'
-    case 'sats':
-      return 'ORDER BY "Item".ranktop DESC, "Item".id DESC'
-    case 'downsats':
-      return 'ORDER BY "Item"."downMsats" DESC'
-    default:
-      return `ORDER BY ${type === 'bookmarks' ? '"bookmarkCreatedAt"' : '"Item".created_at'} DESC`
-  }
 }
 
 // this grabs all the stuff we need to display the item list and only
@@ -431,10 +419,10 @@ export default {
                 typeClause(type),
                 by === 'downsats' && '"Item"."downMsats" > 0',
                 whenClause(when || 'forever', table))}
-              ${orderByClause(by, me, models, type)}
+              ${userOrderByClause(by, type)}
               OFFSET $4
               LIMIT $5`,
-            orderBy: orderByClause(by, me, models, type)
+            orderBy: userOrderByClause(by, type)
           }, ...whenRange(when, from, to || decodedCursor.time), user.id, decodedCursor.offset, limit)
           break
         case 'new':
@@ -479,10 +467,10 @@ export default {
                 by === 'downsats' && '"Item"."downMsats" > 0',
                 await filterClause(type, sub, 'top', ctx, by),
                 muteClause(me))}
-              ${orderByClause(by || 'sats', me, models, type, sub)}
+              ${orderByClause(by || 'sats', type)}
               OFFSET $3
               LIMIT $4`,
-            orderBy: orderByClause(by || 'sats', me, models, type, sub)
+            orderBy: orderByClause(by || 'sats', type)
           }, ...whenRange(when, from, to || decodedCursor.time), decodedCursor.offset, limit, ...subArr)
           break
         default:

--- a/lib/item-order.js
+++ b/lib/item-order.js
@@ -1,0 +1,20 @@
+export function orderByClause (by, type) {
+  switch (by) {
+    case 'comments':
+      return 'ORDER BY "Item".ncomments DESC'
+    case 'sats':
+      return 'ORDER BY "Item".ranktop DESC, "Item".id DESC'
+    case 'downsats':
+      return 'ORDER BY "Item"."downMsats" DESC'
+    default:
+      return `ORDER BY ${type === 'bookmarks' ? '"bookmarkCreatedAt"' : '"Item".created_at'} DESC`
+  }
+}
+
+export function userOrderByClause (by, type) {
+  if (by === 'sats') {
+    return 'ORDER BY "Item".msats DESC, "Item".id DESC'
+  }
+
+  return orderByClause(by, type)
+}

--- a/lib/item-order.spec.js
+++ b/lib/item-order.spec.js
@@ -1,0 +1,17 @@
+/* eslint-env jest */
+
+import { orderByClause, userOrderByClause } from './item-order'
+
+describe('item order clauses', () => {
+  it('keeps top sats sorting on ranktop', () => {
+    expect(orderByClause('sats', 'posts')).toBe('ORDER BY "Item".ranktop DESC, "Item".id DESC')
+  })
+
+  it('sorts user sats by direct item sats', () => {
+    expect(userOrderByClause('sats', 'posts')).toBe('ORDER BY "Item".msats DESC, "Item".id DESC')
+  })
+
+  it('preserves bookmark created sort for new user bookmarks', () => {
+    expect(userOrderByClause('new', 'bookmarks')).toBe('ORDER BY "bookmarkCreatedAt" DESC')
+  })
+})


### PR DESCRIPTION
Closes #2903

Profile item pages were reusing the top-feed `ranktop` order for `by=sats`, which can include comment sats. This adds a profile-specific order clause so user pages sort by the displayed direct item sats while top feeds keep using `ranktop`.

Tests:
- `npx.cmd standard api\resolvers\item.js lib\item-order.js lib\item-order.spec.js`
- `$env:NODE_OPTIONS=''--experimental-vm-modules''; npx.cmd jest lib/item-order.spec.js --runInBand`

Happy to address any review feedback.