### PR TITLE
Preserve nested blocks when toggling quote off

### DIFF
--- a/lib/lexical/commands/formatting/blocks.js
+++ b/lib/lexical/commands/formatting/blocks.js
@@ -8,10 +8,12 @@ import {
 } from '@lexical/list'
 import {
   createCommand, $getSelection, $isRangeSelection,
-  COMMAND_PRIORITY_EDITOR, $createParagraphNode
+  COMMAND_PRIORITY_EDITOR, $createParagraphNode,
+  $isElementNode, $isDecoratorNode, $isLineBreakNode
 } from 'lexical'
 import { $setBlocksType } from '@lexical/selection'
-import { $createQuoteNode } from '@lexical/rich-text'
+import { $createQuoteNode, $isQuoteNode } from '@lexical/rich-text'
+import { $findMatchingParent } from '@lexical/utils'
 import { $createSNHeadingNode } from '@/lib/lexical/nodes/misc/heading'
 import { USE_TRANSFORMER_BRIDGE } from '@/components/editor/plugins/core/transformer-bridge'
 import { MD_INSERT_BLOCK_COMMAND } from '@/lib/lexical/commands/formatting/markdown'
@@ -25,6 +27,63 @@ export const SN_FORMAT_BLOCK_COMMAND = createCommand('SN_FORMAT_BLOCK_COMMAND')
 
 const $formatParagraph = (selection) => {
   $setBlocksType(selection, () => $createParagraphNode())
+}
+
+function $findQuoteParent (node) {
+  return $isQuoteNode(node) ? node : $findMatchingParent(node, $isQuoteNode)
+}
+
+function $unwrapQuoteNode (quoteNode) {
+  let paragraph = null
+
+  const appendParagraphBeforeQuote = () => {
+    if (paragraph?.getChildrenSize() > 0) {
+      quoteNode.insertBefore(paragraph)
+    }
+    paragraph = null
+  }
+
+  for (const child of quoteNode.getChildren()) {
+    if ($isLineBreakNode(child)) {
+      appendParagraphBeforeQuote()
+      continue
+    }
+
+    const isBlock = ($isElementNode(child) || $isDecoratorNode(child)) && !child.isInline()
+    if (isBlock) {
+      appendParagraphBeforeQuote()
+      quoteNode.insertBefore(child)
+      continue
+    }
+
+    paragraph ??= $createParagraphNode()
+    paragraph.append(child)
+  }
+
+  appendParagraphBeforeQuote()
+  quoteNode.remove()
+}
+
+function $unwrapSelectedQuotes (selection) {
+  const quotes = new Map()
+
+  for (const node of selection.getNodes()) {
+    const quote = $findQuoteParent(node)
+    if (quote) quotes.set(quote.getKey(), quote)
+  }
+
+  if ($isRangeSelection(selection)) {
+    for (const point of [selection.anchor, selection.focus]) {
+      const quote = $findQuoteParent(point.getNode())
+      if (quote) quotes.set(quote.getKey(), quote)
+    }
+  }
+
+  for (const quote of quotes.values()) {
+    $unwrapQuoteNode(quote)
+  }
+
+  return quotes.size > 0
 }
 
 const $formatHeading = (activeBlock, block, selection) => {
@@ -48,7 +107,10 @@ const $formatCheckList = (editor, activeBlock, block, selection) => {
 }
 
 const $formatBlockQuote = (activeBlock, block, selection) => {
-  if (activeBlock === block) return $formatParagraph(selection)
+  if (activeBlock === block) {
+    if (selection && $unwrapSelectedQuotes(selection)) return
+    return $formatParagraph(selection)
+  }
   if (!selection) return
   $setBlocksType(selection, () => $createQuoteNode())
 }

--- a/lib/lexical/commands/formatting/blocks.spec.js
+++ b/lib/lexical/commands/formatting/blocks.spec.js
@@ -1,0 +1,80 @@
+/* eslint-env jest */
+jest.mock('../../nodes/misc/heading', () => {
+  const { $createParagraphNode } = jest.requireActual('lexical')
+  return {
+    $createSNHeadingNode: () => $createParagraphNode()
+  }
+}, { virtual: true })
+
+jest.mock('../../../../components/editor/plugins/core/transformer-bridge.js', () => {
+  const { createCommand } = jest.requireActual('lexical')
+  return {
+    __esModule: true,
+    default: () => null,
+    USE_TRANSFORMER_BRIDGE: createCommand('USE_TRANSFORMER_BRIDGE')
+  }
+})
+
+jest.mock('./markdown', () => {
+  const { createCommand } = jest.requireActual('lexical')
+  return {
+    MD_INSERT_BLOCK_COMMAND: createCommand('MD_INSERT_BLOCK_COMMAND')
+  }
+})
+
+const { createHeadlessEditor } = require('@lexical/headless')
+const { $createCodeNode, CodeNode } = require('@lexical/code')
+const { $createQuoteNode, QuoteNode } = require('@lexical/rich-text')
+const { $createTextNode, $getRoot, $isElementNode } = require('lexical')
+const { $formatBlock } = require('./blocks')
+
+function createEditor () {
+  return createHeadlessEditor({
+    namespace: 'sn-format-block-test',
+    nodes: [CodeNode, QuoteNode],
+    onError: error => {
+      throw error
+    }
+  })
+}
+
+function readRootJSON (editor) {
+  let root
+  editor.getEditorState().read(() => {
+    const serialize = node => {
+      const json = node.exportJSON()
+      if ($isElementNode(node)) {
+        json.children = node.getChildren().map(serialize)
+      }
+      return json
+    }
+    root = serialize($getRoot())
+  })
+  return root
+}
+
+describe('$formatBlock', () => {
+  test('turning off quote preserves nested code blocks imported from markdown', () => {
+    const editor = createEditor()
+
+    editor.update(() => {
+      const code = $createCodeNode('js').append($createTextNode('console.log(hello)'))
+      const quote = $createQuoteNode().append(code)
+      $getRoot().append(quote)
+    }, { discrete: true })
+
+    editor.update(() => {
+      const quote = $getRoot().getFirstChild()
+      const code = quote.getFirstChild()
+      const text = code.getFirstChild()
+
+      text.select(0, text.getTextContentSize())
+      $formatBlock(editor, 'quote')
+    }, { discrete: true })
+
+    const root = readRootJSON(editor)
+    expect(root.children).toHaveLength(1)
+    expect(root.children[0].type).toBe('code')
+    expect(root.children[0].children[0].text).toBe('console.log(hello)')
+  })
+})


### PR DESCRIPTION
Closes #2862

## Summary
- unwrap selected quote nodes directly when toggling quote off instead of converting the nested selected block to a paragraph
- preserve nested block children such as code blocks while converting inline quote content back into paragraphs
- add a focused headless editor regression test for a markdown-imported quote containing a code block

## Verification
- $env:NODE_OPTIONS='--experimental-vm-modules'; npx.cmd jest lib/lexical/commands/formatting/blocks.spec.js
- npx.cmd standard lib/lexical/commands/formatting/blocks.js lib/lexical/commands/formatting/blocks.spec.js
- git diff --check

Happy to address any review feedback.