### PR TITLE
Preserve expanded text across back navigation

### DIFF
--- a/components/text-expansion.js
+++ b/components/text-expansion.js
@@ -1,0 +1,26 @@
+export const SHOW_FULL_TEXT_QUERY_PARAM = 'showFullText'
+
+function normalizeQueryValue (value) {
+  if (Array.isArray(value)) return value
+  if (value === undefined) return []
+  return [value]
+}
+
+export function isTextExpandedInQuery (queryValue, itemId) {
+  if (!itemId) return false
+  const id = String(itemId)
+  return normalizeQueryValue(queryValue).map(String).includes(id)
+}
+
+export function addTextExpansionToQuery (query, itemId) {
+  if (!itemId) return query
+
+  const id = String(itemId)
+  const existing = normalizeQueryValue(query[SHOW_FULL_TEXT_QUERY_PARAM]).map(String)
+  const nextValue = Array.from(new Set([...existing, id]))
+
+  return {
+    ...query,
+    [SHOW_FULL_TEXT_QUERY_PARAM]: nextValue.length === 1 ? nextValue[0] : nextValue
+  }
+}

--- a/components/text-expansion.spec.js
+++ b/components/text-expansion.spec.js
@@ -1,0 +1,29 @@
+/* eslint-env jest */
+
+import { addTextExpansionToQuery, isTextExpandedInQuery, SHOW_FULL_TEXT_QUERY_PARAM } from './text-expansion'
+
+describe('text expansion query state', () => {
+  test('detects an expanded item id in string and array query values', () => {
+    expect(isTextExpandedInQuery('123', 123)).toBe(true)
+    expect(isTextExpandedInQuery(['123', '456'], 456)).toBe(true)
+    expect(isTextExpandedInQuery(['123', '456'], 789)).toBe(false)
+    expect(isTextExpandedInQuery(undefined, 123)).toBe(false)
+  })
+
+  test('adds the expanded item id without mutating existing query state', () => {
+    const query = { nodata: 'true', [SHOW_FULL_TEXT_QUERY_PARAM]: '123' }
+    const nextQuery = addTextExpansionToQuery(query, 456)
+
+    expect(query[SHOW_FULL_TEXT_QUERY_PARAM]).toBe('123')
+    expect(nextQuery).toEqual({
+      nodata: 'true',
+      [SHOW_FULL_TEXT_QUERY_PARAM]: ['123', '456']
+    })
+  })
+
+  test('keeps repeated expansions unique', () => {
+    expect(addTextExpansionToQuery({ [SHOW_FULL_TEXT_QUERY_PARAM]: ['123'] }, '123')).toEqual({
+      [SHOW_FULL_TEXT_QUERY_PARAM]: '123'
+    })
+  })
+})

--- a/components/text.js
+++ b/components/text.js
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router'
 import classNames from 'classnames'
 import { CarouselProvider, useCarousel } from './carousel'
 import { SNReader } from './editor'
+import { addTextExpansionToQuery, isTextExpandedInQuery, SHOW_FULL_TEXT_QUERY_PARAM } from './text-expansion'
 
 export function SearchText ({ text }) {
   return (
@@ -19,27 +20,34 @@ export function SearchText ({ text }) {
   )
 }
 
-export function useOverflow ({ containerRef, truncated = false }) {
+export function useOverflow ({ containerRef, truncated = false, itemId }) {
   const router = useRouter()
   // would the text overflow on the current screen size?
   const [overflowing, setOverflowing] = useState(false)
   // should we show the full text?
   const [show, setShow] = useState(false)
-  const showOverflow = useCallback(() => setShow(true), [setShow])
+  const showOverflow = useCallback(() => {
+    setShow(true)
+
+    if (!itemId) return
+
+    router.replace({
+      pathname: router.pathname,
+      query: addTextExpansionToQuery(router.query, itemId)
+    }, router.asPath, { ...router.options, shallow: true, scroll: false }).catch((e) => {
+      if (!e.cancelled) {
+        console.log(e)
+      }
+    })
+  }, [itemId, router])
 
   // if we are navigating to a hash, show the full text
   useEffect(() => {
-    setShow(router.asPath.includes('#'))
-    const handleRouteChange = (url, { shallow }) => {
-      setShow(url.includes('#'))
-    }
-
-    router.events.on('hashChangeStart', handleRouteChange)
-
-    return () => {
-      router.events.off('hashChangeStart', handleRouteChange)
-    }
-  }, [router.asPath, router.events])
+    setShow(
+      router.asPath.includes('#') ||
+      isTextExpandedInQuery(router.query[SHOW_FULL_TEXT_QUERY_PARAM], itemId)
+    )
+  }, [itemId, router.asPath, router.query])
 
   // clip item and give it a`show full text` button if we are overflowing
   useEffect(() => {
@@ -121,9 +129,9 @@ export default function Text (props) {
   return <TextBody {...props} />
 }
 
-export function TextBody ({ topLevel, children, className, innerClassName, state, html, imgproxyUrls, rel, name, readerRef }) {
+export function TextBody ({ topLevel, children, className, innerClassName, state, html, imgproxyUrls, rel, name, readerRef, itemId }) {
   const containerRef = useRef(null)
-  const { overflowing, show, Overflow } = useOverflow({ containerRef, truncated: !!children })
+  const { overflowing, show, Overflow } = useOverflow({ containerRef, truncated: !!children, itemId })
   const carousel = useCarousel()
 
   const textClassNames = useMemo(() => {


### PR DESCRIPTION
Closes #2818.

This preserves the expanded "show full text" state in the hidden Next router query when a long item is opened. If the user follows an internal link and then uses browser Back, the previous history entry still carries the expanded item id, so the long post renders expanded and the browser can restore the original scroll position.

Tests:
- `NODE_OPTIONS=--experimental-vm-modules npx jest components/text-expansion.spec.js`
- `npx standard components/text.js components/text-expansion.js components/text-expansion.spec.js`

Happy to adjust the query key/name if you prefer a different convention.