### PR TITLE
css: Improve alignment of badges

### DIFF
--- a/components/badge.js
+++ b/components/badge.js
@@ -58,7 +58,7 @@ export default function Badges ({ user, badge, bot, showWalletBadges, className 
   if (badges.length === 0) return null
 
   return (
-    <span className={classNames(className, 'd-inline-flex align-items-center justify-content-center')}>
+    <span className={classNames(className, 'align-items-center justify-content-center')}>
       {badges.map(({ icon, overlayText, sizeDelta, style }, i) => (
         <SNBadge
           key={i}
@@ -88,7 +88,7 @@ function SNBadge ({ user, badge, overlayText, badgeClassName, IconForBadge, heig
 
   return (
     <Wrapper>
-      <span className='d-inline-flex align-items-center justify-content-center' style={style}><IconForBadge className={badgeClassName} height={height + sizeDelta} width={width + sizeDelta} /></span>
+      <span className='align-items-center justify-content-center' style={style}><IconForBadge className={badgeClassName} height={height + sizeDelta} width={width + sizeDelta} /></span>
     </Wrapper>
   )
 }


### PR DESCRIPTION
## Description

I think this makes the badges slightly more aligned with the nym. WDYT?

https://github.com/user-attachments/assets/028bbcb7-4040-4641-a4b3-53d83992811e

(compare 0:00 with 0:34)

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

1, I used my eyes, see video

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

not relevant

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

no