### PR TITLE
Fix localized transaction Sankey amounts

### DIFF
--- a/components/payIn/sankey/index.js
+++ b/components/payIn/sankey/index.js
@@ -1,4 +1,4 @@
-import { msatsToSatsDecimal, numWithUnits } from '@/lib/format'
+import { formatMsatsAsSats, msatsToSatsDecimal } from '@/lib/format'
 import { payTypeShortName } from '@/lib/pay-in'
 import { ResponsiveSankey } from '@nivo/sankey'
 import { RotatingSankeyLabels } from './label'
@@ -43,10 +43,11 @@ export function PayInSankeySkeleton () {
 }
 
 function assetFormatted (msats, type) {
+  const amount = formatMsatsAsSats(msats)
   if (type === 'CREDITS') {
-    return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
+    return `${amount} ${BigInt(msats) === 1000n ? 'CC' : 'CCs'}`
   }
-  return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
+  return `${amount} ${BigInt(msats) === 1000n ? 'sat' : 'sats'}`
 }
 
 function Tooltip ({ node, link }) {

--- a/lib/format.js
+++ b/lib/format.js
@@ -76,6 +76,20 @@ export const msatsToSatsDecimal = msats => {
   return fixedDecimal(Number(msats) / 1000.0, 3)
 }
 
+export const formatMsatsAsSats = (msats, { locale } = {}) => {
+  if (msats === null || msats === undefined) {
+    return null
+  }
+
+  const msatsBigInt = BigInt(msats)
+  const hasFractionalSats = msatsBigInt % 1000n !== 0n
+
+  return new Intl.NumberFormat(locale, {
+    minimumFractionDigits: hasFractionalSats ? 3 : 0,
+    maximumFractionDigits: 3
+  }).format(Number(msatsBigInt) / 1000)
+}
+
 export const formatSats = (sats) => numWithUnits(sats, { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
 export const formatMsats = (msats) => numWithUnits(toPositiveNumber(msats), { unitSingular: 'msat', unitPlural: 'msats', abbreviate: false })
 

--- a/lib/format.spec.js
+++ b/lib/format.spec.js
@@ -1,0 +1,19 @@
+/* eslint-env jest */
+
+import { formatMsatsAsSats } from './format'
+
+describe('formatMsatsAsSats', () => {
+  test('formats integer sats without fractional digits', () => {
+    expect(formatMsatsAsSats(149000, { locale: 'en-US' })).toBe('149')
+  })
+
+  test('formats grouped integer sats for the active locale', () => {
+    expect(formatMsatsAsSats(4856000, { locale: 'en-US' })).toBe('4,856')
+    expect(formatMsatsAsSats(4856000, { locale: 'de-DE' })).toBe('4.856')
+  })
+
+  test('formats fractional sats for the active locale', () => {
+    expect(formatMsatsAsSats(4856, { locale: 'en-US' })).toBe('4.856')
+    expect(formatMsatsAsSats(4856, { locale: 'de-DE' })).toBe('4,856')
+  })
+})


### PR DESCRIPTION
## Summary
- add a locale-aware formatter for displaying millisat values as sats
- use it for transaction Sankey tooltip amounts so fractional sats use the viewer locale decimal separator
- cover integer grouping and fractional sats with formatter tests

Closes #2942.

## Testing
- npm test -- lib/format.spec.js --runInBand
- npm run lint -- --quiet

## Contribution award
This PR closes an existing bug issue. Please apply the Stacker News contribution-award flow from the README after review/merge; happy to provide any payout details needed.