### PR TITLE
fix: prevent accidental image uploads when pasting from rich text editors

### DIFF
--- a/components/editor/plugins/upload.js
+++ b/components/editor/plugins/upload.js
@@ -160,6 +160,13 @@ export default function FileUploadPlugin ({ editorRef }) {
           const items = e.clipboardData?.items || []
           if (items.length === 0) return false
 
+          // rich text editors like Microsoft Word put a rendered bitmap of the selection on the
+          // clipboard alongside the real text/html content. when there is actual text
+          // to paste, prefer it and let the default rich-text/markdown paste handle it
+          // instead of uploading the incidental image.
+          const text = e.clipboardData?.getData('text/plain')?.trim()
+          if (text) return false
+
           const fileList = new window.DataTransfer()
           let hasImages = false
 


### PR DESCRIPTION
## Description

Rich text editors like Microsoft Word can bundle a screenshot of the selected text in the `clipboardData`. Upload's `PASTE_COMMAND` handler will then detect the image, paste it and ignore the text.

This PR fixes this behavior in the upload paste handler, by checking if the `clipboardData` contains `text/plain` data. If it contains such data, the upload paste handler will bail and let other handlers paste the text.

## Screenshots

Prod:

https://github.com/user-attachments/assets/0af2af62-371f-4bf9-9a74-b0c23eb38439

After:


https://github.com/user-attachments/assets/a764c9d6-3a65-4c72-92f5-5223da674fab




## Additional Context

This was discovered in the Lexical 0.45.0 PR

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7, upload paste handler ignores pastes with text clipboard data

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

n/a

**Did you use AI for this? If so, how much did it assist you?**

only to check if a Lexical update did this, turns out it happened in prod too

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in the upload paste path; image-only pastes unchanged, low blast radius.
> 
> **Overview**
> Fixes paste from rich text apps (e.g. **Microsoft Word**) where the clipboard includes both **plain text** and an incidental **screenshot bitmap** of the selection.
> 
> The upload plugin’s **`PASTE_COMMAND`** handler (high priority) used to treat any clipboard image as a file upload. It now **bails out** when trimmed **`text/plain`** is present, so default rich-text/markdown paste runs instead of uploading the extra image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a97f55bf2515fafe555c059cd79ed6a993da5b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->