### PR TITLE
don't show sub select on custom domains on mobile

### DIFF
--- a/components/nav/mobile/top-bar.js
+++ b/components/nav/mobile/top-bar.js
@@ -15,13 +15,13 @@ export default function TopBar ({ prefix, sub, path, pathname, topNavKey, dropNa
         activeKey={topNavKey}
       >
         <Back className='d-flex d-md-none' />
-        {hasNavSelect({ path, pathname })
+        {!branding && hasNavSelect({ path, pathname })
           ? <NavSelect sub={sub} className='w-100' />
           : (
             <>
               <NavPrice className='flex-shrink-1' />
               <CommentsNavigator navigator={navigator} commentCount={commentCount} className='px-2' />
-              {me ? <NavWalletSummary /> : <SignUpButton width='fit-content' />}
+              {me ? <NavWalletSummary /> : branding ? null : <SignUpButton width='fit-content' />}
             </>)}
       </Nav>
     </Navbar>

--- a/components/nav/mobile/top-bar.js
+++ b/components/nav/mobile/top-bar.js
@@ -5,19 +5,34 @@ import { useMe } from '@/components/me'
 import { useCommentsNavigatorContext, CommentsNavigator } from '@/components/use-comments-navigator'
 import { useBranding } from '@/components/territory-branding'
 
-export default function TopBar ({ prefix, sub, path, pathname, topNavKey, dropNavKey }) {
+function NavContent ({ sub, path, pathname }) {
   const { me } = useMe()
   const { navigator, commentCount } = useCommentsNavigatorContext()
   const branding = useBranding()
 
-  // on mobile, we don't show the top bar if it contains a nav select on custom domains
-  // on mobile, the top bar with nav select is only shown on ~/, ~/new/*, ~/top/*
-  // as a consquence, those three paths will not have a back button on custom domains
-  // but, they continue to have a back button on the sticky bar when scrolling down
-  if (branding && hasNavSelect({ path, pathname })) {
-    return null
+  if (!hasNavSelect({ path, pathname })) {
+    return (
+      <>
+        <NavPrice className='flex-shrink-1' />
+        <CommentsNavigator navigator={navigator} commentCount={commentCount} className='px-2' />
+        {me ? <NavWalletSummary /> : <SignUpButton width='fit-content' />}
+      </>
+    )
   }
 
+  if (branding) {
+    return (
+      <>
+        <NavPrice className='flex-shrink-1' />
+        {me && <NavWalletSummary />}
+      </>
+    )
+  }
+
+  return <NavSelect sub={sub} className='w-100' />
+}
+
+export default function TopBar ({ prefix, sub, path, pathname, topNavKey, dropNavKey }) {
   return (
     <Navbar>
       <Nav
@@ -25,14 +40,7 @@ export default function TopBar ({ prefix, sub, path, pathname, topNavKey, dropNa
         activeKey={topNavKey}
       >
         <Back className='d-flex d-md-none' />
-        {hasNavSelect({ path, pathname })
-          ? <NavSelect sub={sub} className='w-100' />
-          : (
-            <>
-              <NavPrice className='flex-shrink-1' />
-              <CommentsNavigator navigator={navigator} commentCount={commentCount} className='px-2' />
-              {me ? <NavWalletSummary /> : <SignUpButton width='fit-content' />}
-            </>)}
+        <NavContent sub={sub} path={path} pathname={pathname} />
       </Nav>
     </Navbar>
   )

--- a/components/nav/mobile/top-bar.js
+++ b/components/nav/mobile/top-bar.js
@@ -5,34 +5,19 @@ import { useMe } from '@/components/me'
 import { useCommentsNavigatorContext, CommentsNavigator } from '@/components/use-comments-navigator'
 import { useBranding } from '@/components/territory-branding'
 
-function NavContent ({ sub, path, pathname }) {
+export default function TopBar ({ prefix, sub, path, pathname, topNavKey, dropNavKey }) {
   const { me } = useMe()
   const { navigator, commentCount } = useCommentsNavigatorContext()
   const branding = useBranding()
 
-  if (!hasNavSelect({ path, pathname })) {
-    return (
-      <>
-        <NavPrice className='flex-shrink-1' />
-        <CommentsNavigator navigator={navigator} commentCount={commentCount} className='px-2' />
-        {me ? <NavWalletSummary /> : <SignUpButton width='fit-content' />}
-      </>
-    )
+  // on mobile, we don't show the top bar if it contains a nav select on custom domains
+  // on mobile, the top bar with nav select is only shown on ~/, ~/new/*, ~/top/*
+  // as a consquence, those three paths will not have a back button on custom domains
+  // but, they continue to have a back button on the sticky bar when scrolling down
+  if (branding && hasNavSelect({ path, pathname })) {
+    return null
   }
 
-  if (branding) {
-    return (
-      <>
-        <NavPrice className='flex-shrink-1' />
-        {me && <NavWalletSummary />}
-      </>
-    )
-  }
-
-  return <NavSelect sub={sub} className='w-100' />
-}
-
-export default function TopBar ({ prefix, sub, path, pathname, topNavKey, dropNavKey }) {
   return (
     <Navbar>
       <Nav
@@ -40,7 +25,14 @@ export default function TopBar ({ prefix, sub, path, pathname, topNavKey, dropNa
         activeKey={topNavKey}
       >
         <Back className='d-flex d-md-none' />
-        <NavContent sub={sub} path={path} pathname={pathname} />
+        {hasNavSelect({ path, pathname })
+          ? <NavSelect sub={sub} className='w-100' />
+          : (
+            <>
+              <NavPrice className='flex-shrink-1' />
+              <CommentsNavigator navigator={navigator} commentCount={commentCount} className='px-2' />
+              {me ? <NavWalletSummary /> : <SignUpButton width='fit-content' />}
+            </>)}
       </Nav>
     </Navbar>
   )

--- a/components/nav/mobile/top-bar.js
+++ b/components/nav/mobile/top-bar.js
@@ -3,10 +3,20 @@ import styles from '../../header.module.css'
 import { Back, NavPrice, NavSelect, NavWalletSummary, SignUpButton, hasNavSelect } from '../common'
 import { useMe } from '@/components/me'
 import { useCommentsNavigatorContext, CommentsNavigator } from '@/components/use-comments-navigator'
+import { useBranding } from '@/components/territory-branding'
 
 export default function TopBar ({ prefix, sub, path, pathname, topNavKey, dropNavKey }) {
   const { me } = useMe()
   const { navigator, commentCount } = useCommentsNavigatorContext()
+  const branding = useBranding()
+
+  // on mobile, we don't show the top bar if it contains a nav select on custom domains
+  // on mobile, the top bar with nav select is only shown on ~/, ~/new/*, ~/top/*
+  // as a consquence, those three paths will not have a back button on custom domains
+  // but, they continue to have a back button on the sticky bar when scrolling down
+  if (branding && hasNavSelect({ path, pathname })) {
+    return null
+  }
 
   return (
     <Navbar>
@@ -15,13 +25,13 @@ export default function TopBar ({ prefix, sub, path, pathname, topNavKey, dropNa
         activeKey={topNavKey}
       >
         <Back className='d-flex d-md-none' />
-        {!branding && hasNavSelect({ path, pathname })
+        {hasNavSelect({ path, pathname })
           ? <NavSelect sub={sub} className='w-100' />
           : (
             <>
               <NavPrice className='flex-shrink-1' />
               <CommentsNavigator navigator={navigator} commentCount={commentCount} className='px-2' />
-              {me ? <NavWalletSummary /> : branding ? null : <SignUpButton width='fit-content' />}
+              {me ? <NavWalletSummary /> : <SignUpButton width='fit-content' />}
             </>)}
       </Nav>
     </Navbar>


### PR DESCRIPTION
## Description

Removes sub select from the mobile top bar on custom domains, places `NavWalletSummary` instead.

## Screenshots

<img width="481" height="765" alt="image" src="https://github.com/user-attachments/assets/78dc1866-f313-41fe-b853-a29c2df551e6" />


## Additional Context

Maybe the sorts could be merged with `NavWalletSummary` but it requires heavy refactor and it's probably better to move this decision to the polishing PR.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

9

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

n/a

**Did you use AI for this? If so, how much did it assist you?**

no

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mobile-only navigation layout on branded domains; no auth, data, or API changes.
> 
> **Overview**
> On **custom domains** (territory branding), the **mobile top bar** no longer renders on territory feed routes where it would have shown **`NavSelect`** (`~/`, `~/new/*`, `~/top/*`). Those views rely on the existing **mobile second bar** (`Sorts` + **`NavWalletSummary`** / sign-up) instead of duplicating the sub picker in the top bar.
> 
> **Tradeoff:** On branded domains, those three path families lose the top-bar **Back** control; back navigation remains available via the sticky bar when scrolling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 511083a23694bffabb249f82732aa7ec9280c44a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->