### PR TITLE
feat: web push notifications for custom domains

### DIFF
--- a/api/resolvers/notifications.js
+++ b/api/resolvers/notifications.js
@@ -423,22 +423,27 @@ export default {
     }
   },
   Mutation: {
-    savePushSubscription: async (parent, { endpoint, p256dh, auth, oldEndpoint }, { me, models }) => {
+    savePushSubscription: async (parent, { endpoint, p256dh, auth, oldEndpoint }, { me, models, getDomain }) => {
       if (!me) {
         throw new GqlAuthenticationError()
       }
 
       await validateSchema(pushSubscriptionSchema, { endpoint, p256dh, auth })
 
+      // the origin the browser subscribed from determines the subscription's branding.
+      // null domainId means the subscription belongs to Stacker News.
+      const domainMapping = await getDomain()
+      const domainId = domainMapping?.id ?? null
+
       let dbPushSubscription
       if (oldEndpoint) {
         dbPushSubscription = await models.pushSubscription.update({
-          data: { userId: me.id, endpoint, p256dh, auth }, where: { endpoint: oldEndpoint }
+          data: { userId: me.id, endpoint, p256dh, auth, domainId }, where: { endpoint: oldEndpoint }
         })
         console.log(`[webPush] updated subscription of user ${me.id}: old=${oldEndpoint} new=${endpoint}`)
       } else {
         dbPushSubscription = await models.pushSubscription.create({
-          data: { userId: me.id, endpoint, p256dh, auth }
+          data: { userId: me.id, endpoint, p256dh, auth, domainId }
         })
         console.log(`[webPush] created subscription for user ${me.id}: endpoint=${endpoint}`)
       }

--- a/lib/domains/index.js
+++ b/lib/domains/index.js
@@ -82,6 +82,15 @@ export const getDomainMapping = async (domain) => {
   return domainsMappings?.[parsedDomain.hostname] ?? null
 }
 
+/** same as getDomainMapping but keyed by Domain.id, for callers (e.g. web push)
+ * that persist a domainId rather than a hostname */
+export const getDomainMappingById = async (id) => {
+  if (!id) return null
+
+  const domainsMappings = await domainsMappingsCache()
+  return Object.values(domainsMappings ?? {}).find(m => m.id === id) ?? null
+}
+
 /** returns render-ready domain branding (theme + SEO with fallbacks), keyed by subName */
 export const getDomainBranding = async (domain) => {
   const domainMapping = await getDomainMapping(domain)

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -1,11 +1,13 @@
 import webPush from 'web-push'
 import removeMd from 'remove-markdown'
-import { COMMENT_DEPTH_LIMIT, FOUND_BLURBS, LOST_BLURBS, DEFAULT_POSTS_SATS_FILTER, DEFAULT_COMMENTS_SATS_FILTER } from './constants'
+import { COMMENT_DEPTH_LIMIT, FOUND_BLURBS, LOST_BLURBS, DEFAULT_POSTS_SATS_FILTER, DEFAULT_COMMENTS_SATS_FILTER, PUBLIC_MEDIA_URL } from './constants'
 import { msatsToSats, numWithUnits } from './format'
 import { nextBillingWithGrace } from '@/lib/territory'
 import models from '@/api/models'
 import { isMuted } from '@/lib/user'
 import { Prisma } from '@prisma/client'
+import { getDomainMappingById, SN_MAIN_DOMAIN } from '@/lib/domains'
+import { getSeoWithFallback } from '@/lib/domains/seo'
 
 // Check if an item meets a user's sat filter threshold for push notifications
 async function meetsUserSatFilter (userId, item) {
@@ -60,20 +62,45 @@ function log (...args) {
   console.log('[webPush]', ...args)
 }
 
-function createPayload (notification) {
+// resolves the branding for a subscription's origin so payloads point icons and
+// links at the right domain. null means the subscription belongs to the main SN
+// site (or its custom domain is no longer ACTIVE), which falls back to SN defaults.
+// returns { origin, brand, faviconId }.
+async function brandingForSubscription (subscription) {
+  const mapping = await getDomainMappingById(subscription?.domainId)
+  if (!mapping) return null
+  const { title, faviconId } = getSeoWithFallback(mapping)
+  return {
+    origin: `${SN_MAIN_DOMAIN.protocol}//${mapping.domainName}`,
+    brand: title,
+    faviconId
+  }
+}
+
+function createPayload (notification, branding) {
   // https://web.dev/push-notifications-display-a-notification/#visual-options
   // https://webkit.org/blog/16535/meet-declarative-web-push/
   // DEV: localhost in URLs is not supported by declarative web push
+  const origin = branding?.origin ?? process.env.NEXT_PUBLIC_URL
+  const icon = branding?.faviconId
+    ? `${PUBLIC_MEDIA_URL}/${branding.faviconId}`
+    : origin + '/icons/icon_x96.png'
+
   let { title, body, ...options } = notification
   if (body) body = removeMd(body)
+  // navigate is required and Declarative Web Push can't use relative paths, so we
+  // resolve the notification's relative target (data.url) against the subscription's
+  // origin. this keeps clicks on the right domain (main SN or custom domain) and
+  // falls back to the notifications page.
+  const navigate = origin + (options.data?.url ?? '/notifications')
   return JSON.stringify({
     web_push: 8030, // Declarative Web Push JSON format
     notification: {
       title,
       body,
       timestamp: Date.now(),
-      icon: process.env.NEXT_PUBLIC_URL + '/icons/icon_x96.png',
-      navigate: process.env.NEXT_PUBLIC_URL + '/notifications', // navigate is required
+      icon,
+      navigate,
       app_badge: 1, // TODO: establish a proper badge count system
       ...options
     }
@@ -152,20 +179,23 @@ async function sendUserNotification (userId, notification) {
     notification.data ??= {}
     if (notification.itemId) {
       // legacy Push API notificationclick event needs data.url as the navigate key is consumed by the browser
+      // keep it relative so createPayload can resolve it against each subscription's origin
       notification.data.url ??= await createItemUrl(notification.itemId)
-      // Declarative Web Push can't use relative paths
-      notification.navigate ??= process.env.NEXT_PUBLIC_URL + notification.data.url
       delete notification.itemId
     }
 
     const filterFragment = userFilterFragment(notification.setting)
 
-    const payload = createPayload(notification)
     const subscriptions = await models.pushSubscription.findMany({
       where: { userId, ...filterFragment }
     })
+    // build the payload per subscription so each one is branded for the origin
+    // (main SN or a custom domain) the browser subscribed from
     await Promise.allSettled(
-      subscriptions.map(subscription => sendNotification(subscription, payload))
+      subscriptions.map(async (subscription) => {
+        const branding = await brandingForSubscription(subscription)
+        return sendNotification(subscription, createPayload(notification, branding))
+      })
     )
   } catch (err) {
     log('error sending user notification:', err)
@@ -174,7 +204,9 @@ async function sendUserNotification (userId, notification) {
 
 export async function sendPushSubscriptionReply (subscription) {
   try {
-    const payload = createPayload({ title: 'Stacker News notifications are now active' })
+    const branding = await brandingForSubscription(subscription)
+    const brand = branding?.brand ?? 'Stacker News'
+    const payload = createPayload({ title: `${brand} notifications are now active` }, branding)
     await sendNotification(subscription, payload)
   } catch (err) {
     log('error sending subscription reply:', err)

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -71,7 +71,9 @@ async function brandingForSubscription (subscription) {
   if (!mapping) return null
   const { title, faviconId } = getSeoWithFallback(mapping)
   return {
-    origin: `${SN_MAIN_DOMAIN.protocol}//${mapping.domainName}`,
+    // XXX: DEV hack, we're using the main domain's protocol as custom domains are based on it
+    // this breaks notifications for custom domains served via Caddy when the NEXT_PUBLIC_URL is HTTP
+    origin: `${SN_MAIN_DOMAIN.protocol}//${mapping.domainName}${SN_MAIN_DOMAIN.port ? `:${SN_MAIN_DOMAIN.port}` : ''}`,
     brand: title,
     faviconId
   }

--- a/pages/api/graphql.js
+++ b/pages/api/graphql.js
@@ -14,6 +14,7 @@ import { ApolloServerPluginLandingPageDisabled } from '@apollo/server/plugin/dis
 import PgBoss from 'pg-boss'
 import { lexicalStateLoader } from '@/lib/lexical/server/loader'
 import { createUserLoader, createSubLoader } from '@/api/loaders'
+import { getDomainMapping } from '@/lib/domains'
 
 const apolloServer = new ApolloServer({
   typeDefs,
@@ -85,6 +86,13 @@ const apolloHandler = startServerAndCreateNextHandler(apolloServer, {
       : null
     const userLoader = createUserLoader(models)
     const subLoader = createSubLoader(models)
+    // lazily resolves the request's custom domain mapping (ACTIVE domains only),
+    // repeat reads within a request hit the cache once.
+    let domainMappingPromise
+    const getDomain = () => {
+      domainMappingPromise ??= getDomainMapping(req.headers.host)
+      return domainMappingPromise
+    }
     return {
       models,
       headers: req.headers,
@@ -94,6 +102,7 @@ const apolloHandler = startServerAndCreateNextHandler(apolloServer, {
       boss,
       userLoader,
       subLoader,
+      getDomain,
       lexicalStateLoader: lexicalStateLoader({ me, userLoader })
     }
   }

--- a/prisma/migrations/20260604145045_custom_domains_webpush/migration.sql
+++ b/prisma/migrations/20260604145045_custom_domains_webpush/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "PushSubscription" ADD COLUMN     "domainId" INTEGER;
+
+-- CreateIndex
+CREATE INDEX "PushSubscription_domainId_idx" ON "PushSubscription"("domainId");
+
+-- AddForeignKey
+ALTER TABLE "PushSubscription" ADD CONSTRAINT "PushSubscription_domainId_fkey" FOREIGN KEY ("domainId") REFERENCES "Domain"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -909,10 +909,13 @@ model PushSubscription {
   endpoint  String
   p256dh    String
   auth      String
+  domainId  Int?
   createdAt DateTime @default(now()) @map("created_at")
   user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  domain    Domain?  @relation(fields: [domainId], references: [id], onDelete: SetNull)
 
   @@index([userId], map: "PushSubscription.userId_index")
+  @@index([domainId])
 }
 
 model TerritoryTransfer {
@@ -952,6 +955,7 @@ model Domain {
   tokenVersion            Int                         @default(0)
 
   sub                     Sub                         @relation(fields: [subName], references: [name], onDelete: Cascade, onUpdate: Cascade)
+  pushSubscriptions       PushSubscription[]
   attempts                DomainVerificationAttempt[]
   records                 DomainVerificationRecord[]
   authRequests            DomainAuthRequest[]


### PR DESCRIPTION
## Description

Push notifications on custom domains _work_ out of the box, but they have a couple of issues:

1. They’re essentially duplicating the Stacker News push notifications; this causes users of both SN and custom domain PWA to receive the same notifications twice.
2. Notifications are Stacker News branded
3. Clicking on a notification redirects to `stacker.news` because of the hardcoded `notification.navigate` URL

This PR handles (2) and (3), the first issue is instead something we need to explore in-depth.

## Screenshots

Branded push subscription:

<img width="360" height="85" alt="image" src="https://github.com/user-attachments/assets/9efa8a34-b5df-4b85-9f4d-6da20a190a33" />

Navigation to custom domain:


https://github.com/user-attachments/assets/2740444d-7d04-4997-a19f-9cdc725bae5a



## Additional Context



## Checklist

**Are your changes backward compatible? Please answer below:**

Yes, `PushSubscription` table now has the `domainId` foreign key to carry the domain context across web push.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

6, push notifications for custom domains work great, and SN push notifications work as expected. Didn't test navigation on mobile devices.

**Did you use AI for this? If so, how much did it assist you?**

Yes, review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible push behavior (URLs and branding) for all subscriptions; schema migration is backward compatible but per-subscription payload logic is new surface area for regressions on main SN and custom domains.
> 
> **Overview**
> Push subscriptions now record **which host** the user subscribed from via optional `domainId` on `PushSubscription`, resolved at save time through a new lazy `getDomain()` on GraphQL context (from `req.headers.host`).
> 
> **Sending** builds notification payloads **per subscription**: custom-domain favicon/title, absolute `navigate` URLs on the territory’s domain (not hardcoded `NEXT_PUBLIC_URL`), and a branded “notifications are now active” reply. `getDomainMappingById` supports lookup when only `domainId` is stored.
> 
> Existing rows keep `domainId` null and behave like main Stacker News. Duplicate notifications across SN and a custom-domain PWA are **not** addressed here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6121d55802b93f6299d22547b965e0e3738c50f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->