### PR TITLE
fix: move eclair env_file to service level on docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -594,8 +594,8 @@ services:
     restart: unless-stopped
     depends_on:
       <<: *depends_on_bitcoin
+    env_file: *env_file
     environment:
-      <<: *env_file
       JAVA_OPTS:
         -Declair.printToConsole
         -Dakka.loglevel=DEBUG


### PR DESCRIPTION
## Description

`./sndev start` was not working:

```
failed to parse docker-compose.yml: yaml: construct errors:
  line 1: yaml: map merge requires map or sequence of maps as the value
```

The `eclair` service was doing `<<: *env_file` under `environment:` but every other service uses `env_file: *env_file` at the service level so I figured that could be the fix (claude helped me).

Claude said this:
"Older Docker Compose tolerated it silently. The newer one (v5) has a stricter YAML parser and straight up refuses to parse the whole file — so it broke every profile, even `minimal`."

And TBH, I didn't find evidence to back this claim up except for the fact that moving it one level up to match the rest worked. I also tested sndev start with the other profile options and everything seems to working properly.

## Screenshots

Before fix:

<img width="901" height="161" alt="image" src="https://github.com/user-attachments/assets/114802a6-d0ab-4750-aaf5-f2a68248d19e" />

After fix:

<img width="1009" height="329" alt="image" src="https://github.com/user-attachments/assets/70c90b33-a03e-400d-b31a-03de166b6757" />

## Additional Context

No. I just cloned the repo and tried to run it from the master branch with sndev start.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

Claude helped me on this one too:

"8. Ran `docker compose config -q` across all profiles (`minimal`, `payments`, `wallets`, full stack, `*`) — all parse now. Then booted the full dev stack for real: eclair comes up, peers with `sn_lnd`, and `printenv` confirms `DATABASE_URL`/`NODE_ENV` are injected with no junk merge keys."

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

N/A

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No

**Did you use AI for this? If so, how much did it assist you?**

Yes. I used Claude Opus 4.8 to help me find the parse error, propose a fix and then I used it again to smoke test all profiles and analyze the results.