### PR TITLE
Reduce home initial load blank state

### DIFF
--- a/pages/~/index.js
+++ b/pages/~/index.js
@@ -9,17 +9,18 @@ import PageLoading from '@/components/page-loading'
 import TerritoryHeader from '@/components/territory-header'
 
 export const getServerSideProps = getGetServerSideProps({
-  query: SUB_ITEMS,
+  query: vars => vars.sub ? SUB_ITEMS : null,
   notFound: (data, vars) => vars.sub && !data.sub
 })
 
 export default function Sub ({ ssrData }) {
   const router = useRouter()
   const variables = { ...router.query }
-  const { data } = useQuery(SUB_FULL, { variables })
+  const hasSub = !!variables.sub
+  const { data } = useQuery(SUB_FULL, { variables, skip: !hasSub })
 
-  if (!data && !ssrData) return <PageLoading />
-  const { sub } = data || ssrData
+  if (hasSub && !data && !ssrData) return <PageLoading />
+  const { sub } = data || ssrData || {}
 
   return (
     <Layout sub={sub?.name}>


### PR DESCRIPTION
This PR reduces the first-load blank state reported in #2970 for the public home page.

The home route currently waits for the full `SUB_ITEMS` SSR query before returning the page. On high-latency or low-upload connections, that can leave users looking at a blank white page and wondering whether the site is down.

This change keeps territory pages SSR-backed, but lets the public home page return the app frame immediately:

- Home SSR no longer waits on `SUB_ITEMS`.
- Territory pages still use `SUB_ITEMS` SSR and preserve the existing `notFound` behavior.
- Home skips the `SUB_FULL` query that is only needed for territory headers.
- Existing `Items` fallback behavior renders the item skeleton while the client loads the feed.

This should give users visible progress on slow first loads instead of a stagnant blank page.

Closes #2970.

## Local verification

- `npm run lint -- pages/~/index.js`
- `npm run lint`

Note: local Node is v24.3.0 while the project declares Node 22.21.1, so npm emitted an engine warning during dependency install. Lint passed.

## Award / payout

If this qualifies for a contribution award, please pay sats/BTC to:

`bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`
