### PR TITLE
Remember editor settings locally

### DIFF
--- a/components/editor/contexts/mode.js
+++ b/components/editor/contexts/mode.js
@@ -3,20 +3,50 @@ import { createContext, useState, useMemo, useContext, useCallback } from 'react
 export const MARKDOWN_MODE = 'markdown'
 export const RICH_MODE = 'rich'
 
+const STORAGE_KEY = 'sn:editor:mode'
+
 const EditorModeContext = createContext()
 
+function isValidMode (mode) {
+  return mode === MARKDOWN_MODE || mode === RICH_MODE
+}
+
+function getInitialMode () {
+  if (typeof window === 'undefined') return MARKDOWN_MODE
+
+  try {
+    const mode = window.localStorage.getItem(STORAGE_KEY)
+    return isValidMode(mode) ? mode : MARKDOWN_MODE
+  } catch {
+    return MARKDOWN_MODE
+  }
+}
+
+function saveMode (mode) {
+  if (typeof window === 'undefined') return
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, mode)
+  } catch {}
+}
+
 export function EditorModeProvider ({ children }) {
-  const [mode, setMode] = useState(MARKDOWN_MODE)
+  const [mode, setMode] = useState(getInitialMode)
 
   const changeMode = useCallback((newMode) => {
-    if (newMode !== MARKDOWN_MODE && newMode !== RICH_MODE) {
+    if (!isValidMode(newMode)) {
       throw new Error(`Invalid mode: ${newMode}`)
     }
     setMode(newMode)
+    saveMode(newMode)
   }, [])
 
   const toggleMode = useCallback(() => {
-    setMode(prev => prev === MARKDOWN_MODE ? RICH_MODE : MARKDOWN_MODE)
+    setMode(prev => {
+      const newMode = prev === MARKDOWN_MODE ? RICH_MODE : MARKDOWN_MODE
+      saveMode(newMode)
+      return newMode
+    })
   }, [])
 
   const value = useMemo(() => ({

--- a/components/editor/contexts/toolbar.js
+++ b/components/editor/contexts/toolbar.js
@@ -23,16 +23,47 @@ const INITIAL_STATE = {
   ...INITIAL_FORMAT_STATE
 }
 
+const STORAGE_KEY = 'sn:editor:show-toolbar'
+
 const ToolbarContext = createContext()
 
+function getInitialShowToolbar (fallback) {
+  if (typeof window === 'undefined') return fallback
+
+  try {
+    const value = window.localStorage.getItem(STORAGE_KEY)
+    if (value === 'true') return true
+    if (value === 'false') return false
+  } catch {}
+
+  return fallback
+}
+
+function saveShowToolbar (value) {
+  if (typeof window === 'undefined') return
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, value ? 'true' : 'false')
+  } catch {}
+}
+
 export function ToolbarContextProvider ({ topLevel, children }) {
-  const [toolbarState, setToolbarState] = useState({ ...INITIAL_STATE, showToolbar: !!topLevel })
+  const [toolbarState, setToolbarState] = useState(() => ({
+    ...INITIAL_STATE,
+    showToolbar: getInitialShowToolbar(!!topLevel)
+  }))
 
   const batchUpdateToolbarState = useCallback((updates) => {
+    if (Object.prototype.hasOwnProperty.call(updates, 'showToolbar')) {
+      saveShowToolbar(updates.showToolbar)
+    }
     setToolbarState((prev) => ({ ...prev, ...updates }))
   }, [])
 
   const updateToolbarState = useCallback((key, value) => {
+    if (key === 'showToolbar') {
+      saveShowToolbar(value)
+    }
     setToolbarState((prev) => ({
       ...prev,
       [key]: value


### PR DESCRIPTION
## Description

Fixes #2858.

Remembers the editor's last selected mode (`write`/`compose`) and toolbar visibility in localStorage. The old defaults are preserved when no preference exists: markdown/write mode by default, and toolbar visibility still falls back to the editor's `topLevel` setting.

The localStorage reads and writes are guarded so unavailable browser storage falls back without breaking the editor.

## QA

- `npm run lint -- components/editor/contexts/mode.js components/editor/contexts/toolbar.js`
- `npm run lint`
- Browser QA attempted at `http://localhost:3000/post`; rendered interaction could not be completed because the local dev environment hit project setup/runtime blockers after startup, including Prisma client/module setup and URLPattern/runtime issues on this machine.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. This only adds local browser preferences and falls back to the existing defaults.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

6/10. Lint passed and the code paths are scoped to editor mode and toolbar state. Rendered browser interaction was attempted but blocked by local environment setup.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

No visual styling changes. Not browser-tested across modes due the local environment blocker above.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes. AI assisted with implementation, repository inspection, and validation.

Bounty payout address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`