### PR TITLE
Disallow URI schemes in post titles

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -37,6 +37,7 @@ const titleValidator = string().required('required').trim().max(
   MAX_TITLE_LENGTH,
   ({ max, value }) => `-${Math.abs(max - value.length)} characters remaining`
 ).min(MIN_TITLE_LENGTH, `must be at least ${MIN_TITLE_LENGTH} characters`)
+  .test('no-uri-scheme', "can't contain URI schemes", value => !/\b[a-z][a-z0-9+.-]*:\/\//i.test(value || ''))
 
 const textValidator = (max) => string().trim().max(
   max,

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -1,0 +1,51 @@
+/* eslint-env jest */
+
+import { bountySchema, discussionSchema, jobSchema, linkSchema, pollSchema } from './validate.js'
+
+const models = {
+  sub: {
+    findMany: async ({ where }) => {
+      return where.name.in.map(name => ({
+        name,
+        status: 'ACTIVE',
+        postTypes: ['BOUNTY', 'DISCUSSION', 'LINK', 'POLL']
+      }))
+    }
+  }
+}
+
+const validPost = {
+  title: 'Crypto.com stadium hosts big game',
+  text: '',
+  subNames: ['bitcoin']
+}
+
+const postTitleCases = [
+  ['bounty', bountySchema({ models }), { ...validPost, bounty: 1000 }],
+  ['discussion', discussionSchema({ models }), validPost],
+  ['link', linkSchema({ models }), { ...validPost, url: 'https://example.com' }],
+  ['poll', pollSchema({ models }), { ...validPost, options: ['one', 'two'] }],
+  ['job', jobSchema({}), {
+    title: validPost.title,
+    company: 'Stacker News',
+    text: 'Help build Stacker News',
+    url: 'https://stacker.news',
+    location: 'Austin'
+  }]
+]
+
+describe.each(postTitleCases)('%s title validation', (_, schema, validValues) => {
+  test('allows domains without a URI scheme', async () => {
+    await expect(schema.validate(validValues)).resolves.toBeDefined()
+  })
+
+  test('rejects titles containing a URI scheme', async () => {
+    await expect(schema.validate({
+      ...validValues,
+      title: 'Read https://example.com before posting'
+    })).rejects.toMatchObject({
+      path: 'title',
+      message: "can't contain URI schemes"
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- reject URI schemes like `https://` in the shared post title validator
- keep domain-only titles like `Crypto.com stadium hosts big game` valid
- add coverage for bounty, discussion, link, poll, and job title schemas

## Why
Closes #117.

## Validation
- `npm test -- lib/validate.spec.js`
- `npm run lint -- lib/validate.js lib/validate.spec.js`
- `npm run lint`
- `git diff --check`

Payout BTC address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`