### PR TITLE
Sort user feeds by item sats

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -59,11 +59,12 @@ export async function getItemsById (ids, { me, models }) {
   return items.map(({ rank, ...item }) => item)
 }
 
-const orderByClause = (by, me, models, type, sub) => {
+const orderByClause = (by, me, models, type, sub, sort) => {
   switch (by) {
     case 'comments':
       return 'ORDER BY "Item".ncomments DESC'
     case 'sats':
+      if (sort === 'user') return 'ORDER BY "Item".msats DESC, "Item".id DESC'
       return 'ORDER BY "Item".ranktop DESC, "Item".id DESC'
     case 'downsats':
       return 'ORDER BY "Item"."downMsats" DESC'
@@ -431,10 +432,10 @@ export default {
                 typeClause(type),
                 by === 'downsats' && '"Item"."downMsats" > 0',
                 whenClause(when || 'forever', table))}
-              ${orderByClause(by, me, models, type)}
+              ${orderByClause(by, me, models, type, undefined, sort)}
               OFFSET $4
               LIMIT $5`,
-            orderBy: orderByClause(by, me, models, type)
+            orderBy: orderByClause(by, me, models, type, undefined, sort)
           }, ...whenRange(when, from, to || decodedCursor.time), user.id, decodedCursor.offset, limit)
           break
         case 'new':


### PR DESCRIPTION
## Summary
- sort user feeds by the visible item sats value when `by=sats`
- keep top feed sats sorting on `ranktop`, where comments still contribute to the ranking score
- apply the same order to the inner and outer user-feed queries so pagination order stays stable

## Why
Closes #2903.

## Validation
- `npm run lint -- api/resolvers/item.js`
- `npm run lint`
- `git diff --check`

Payout BTC address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`