### PR TITLE
Preserve Fediverse handles as plain text

### DIFF
--- a/lib/lexical/mdast/transforms/index.js
+++ b/lib/lexical/mdast/transforms/index.js
@@ -1,5 +1,5 @@
 export { mentionTransform } from './mentions.js'
 export { nostrTransform } from './nostr.js'
-export { misleadingLinkTransform, malformedLinkEncodingTransform } from './links.js'
+export { fediverseHandleTransform, misleadingLinkTransform, malformedLinkEncodingTransform } from './links.js'
 export { footnoteTransform } from './footnotes.js'
 export { tocTransform } from './toc.js'

--- a/lib/lexical/mdast/transforms/links.js
+++ b/lib/lexical/mdast/transforms/links.js
@@ -2,6 +2,44 @@ import { visit } from 'unist-util-visit'
 import { toString } from 'mdast-util-to-string'
 import { isMisleadingLink } from '@/lib/url'
 
+const FEDIVERSE_HANDLE_MARKERS = new Set(['@', '!'])
+
+function mailtoLinkText (node) {
+  if (!node.url?.toLowerCase().startsWith('mailto:')) return
+
+  return node.url.slice('mailto:'.length)
+}
+
+/**
+ * gfm autolinks turn @user@host.tld into a text "@" and a mailto:user@host.tld link.
+ * keep fediverse handles as plain text while preserving normal email autolinks.
+ */
+export function fediverseHandleTransform (tree) {
+  visit(tree, 'link', (node, index, parent) => {
+    if (!parent || index === undefined || index === 0) return
+
+    const previous = parent.children[index - 1]
+    if (previous?.type !== 'text') return
+
+    const marker = previous.value?.slice(-1)
+    if (!FEDIVERSE_HANDLE_MARKERS.has(marker)) return
+
+    const text = toString(node)
+    const mailtoText = mailtoLinkText(node)
+    if (!text || text !== mailtoText) return
+
+    const handleNode = { type: 'text', value: `${marker}${text}` }
+    if (previous.value.length === 1) {
+      parent.children.splice(index - 1, 2, handleNode)
+      return index - 1
+    }
+
+    previous.value = previous.value.slice(0, -1)
+    parent.children[index] = handleNode
+    return index
+  })
+}
+
 /**
  * a link is misleading if the text is not the same as the URL.
  *

--- a/lib/lexical/utils/mdast.js
+++ b/lib/lexical/utils/mdast.js
@@ -16,6 +16,7 @@ import {
 import {
   mentionTransform,
   nostrTransform,
+  fediverseHandleTransform,
   misleadingLinkTransform,
   malformedLinkEncodingTransform,
   footnoteTransform,
@@ -51,6 +52,7 @@ export function $markdownToLexical (markdown, { splitInParagraphs = false, appen
     mdastTransforms: [
       mentionTransform,
       nostrTransform,
+      fediverseHandleTransform,
       misleadingLinkTransform,
       malformedLinkEncodingTransform,
       footnoteTransform,


### PR DESCRIPTION
## Summary
- Preserve Fediverse-style handles like `@user@instance.tld` and `!group@instance.tld` as plain text after GFM autolink parsing.
- Keep normal email autolinks such as `alice@example.com` as `mailto:` links.

## Why
Closes #93.

## Validation
- Ran a focused MDAST transform pipeline assertion for `@Cointastical@BitcoinHackers.org`, `!group@BitcoinHackers.org`, prefixed handle text, and a normal email autolink.
- `./node_modules/.bin/standard lib/lexical/mdast/transforms/links.js lib/lexical/mdast/transforms/index.js lib/lexical/utils/mdast.js`

## Payout
BTC address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`