### PR TITLE
Preserve formatting on item mentions

### DIFF
--- a/components/editor/nodes/mentions.js
+++ b/components/editor/nodes/mentions.js
@@ -8,7 +8,7 @@ import { $isItemMentionNode } from '@/lib/lexical/nodes/decorative/mentions/item
 import { getLinkAttributes } from '@/lib/url'
 import { $createLinkNode } from '@lexical/link'
 
-export default function MentionsComponent ({ nodeKey, href, text }) {
+export default function MentionsComponent ({ nodeKey, href, text, className }) {
   const [editor] = useLexicalComposerContext()
   const isEditable = useLexicalEditable()
 
@@ -24,8 +24,10 @@ export default function MentionsComponent ({ nodeKey, href, text }) {
         const url = node.getURL()
         const displayText = node.getText()
         const { target, rel } = getLinkAttributes(url)
+        const textNode = $createTextNode(displayText || url)
+        textNode.setFormat(node.getFormat())
         newNode = $createLinkNode(url, { target, rel })
-          .append($createTextNode(displayText || url))
+          .append(textNode)
       } else {
         // other mention types become plain text
         // cursor will land on the text node triggering mentions menu
@@ -43,7 +45,7 @@ export default function MentionsComponent ({ nodeKey, href, text }) {
     onDoubleClick: breakMention
   })
 
-  if (!isEditable) return <Link href={href}>{text}</Link>
+  if (!isEditable) return <Link className={className} href={href}>{text}</Link>
 
-  return <span title='double click to edit'>{text}</span>
+  return <span className={className} title='double click to edit'>{text}</span>
 }

--- a/lib/lexical/mdast/visitors/mentions.js
+++ b/lib/lexical/mdast/visitors/mentions.js
@@ -5,6 +5,60 @@ import {
 } from '@/lib/lexical/nodes/decorative/mentions'
 import { parseInternalLinks } from '@/lib/url'
 import { $createItemMentionNode, isCustomText } from '@/lib/lexical/nodes/decorative/mentions/item'
+import {
+  IS_BOLD,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_HIGHLIGHT,
+  IS_SUPERSCRIPT,
+  IS_SUBSCRIPT,
+  IS_UNDERLINE
+} from '../format-constants.js'
+
+const HTML_FORMATS = [
+  { flag: IS_SUPERSCRIPT, openTag: '<sup>', closeTag: '</sup>' },
+  { flag: IS_SUBSCRIPT, openTag: '<sub>', closeTag: '</sub>' },
+  { flag: IS_UNDERLINE, openTag: '<ins>', closeTag: '</ins>' }
+]
+
+const MDAST_FORMATS = [
+  { flag: IS_ITALIC, mdastType: 'emphasis' },
+  { flag: IS_BOLD, mdastType: 'strong' },
+  { flag: IS_STRIKETHROUGH, mdastType: 'delete' },
+  { flag: IS_HIGHLIGHT, mdastType: 'highlight' }
+]
+
+function appendWithFormatting (node, format, mdastParent, actions) {
+  if (!format) {
+    actions.appendToParent(mdastParent, node)
+    return
+  }
+
+  for (const { flag, openTag } of HTML_FORMATS) {
+    if (format & flag) {
+      actions.appendToParent(mdastParent, { type: 'html', value: openTag })
+    }
+  }
+
+  let localParentNode = mdastParent
+  for (const { flag, mdastType } of MDAST_FORMATS) {
+    if (format & flag) {
+      localParentNode = actions.appendToParent(localParentNode, {
+        type: mdastType,
+        children: []
+      })
+    }
+  }
+
+  actions.appendToParent(localParentNode, node)
+
+  for (let i = HTML_FORMATS.length - 1; i >= 0; i--) {
+    const { flag, closeTag } = HTML_FORMATS[i]
+    if (format & flag) {
+      actions.appendToParent(mdastParent, { type: 'html', value: closeTag })
+    }
+  }
+}
 
 // user mentions (@user, @user/path)
 // uses transforms to parse mentions
@@ -93,7 +147,8 @@ export const MdastItemMentionLinkVisitor = {
         const mentionNode = $createItemMentionNode({
           id: commentId || itemId,
           text,
-          url: mdastNode.url
+          url: mdastNode.url,
+          format: actions.getParentFormatting()
         })
         actions.addAndStepInto(mentionNode)
         return
@@ -111,22 +166,25 @@ export const LexicalItemMentionVisitor = {
     const url = lexicalNode.getURL()
     const text = lexicalNode.getText()
     const id = lexicalNode.getItemMentionId()
+    let node
 
     // check if custom text
     if (isCustomText(text, id)) {
       // export as a LinkNode
-      actions.appendToParent(mdastParent, {
+      node = {
         type: 'link',
         url,
         children: [{ type: 'text', value: text }]
-      })
+      }
     } else {
       // export as text node
-      actions.appendToParent(mdastParent, {
+      node = {
         type: 'text',
         value: url,
         data: { url: true }
-      })
+      }
     }
+
+    appendWithFormatting(node, lexicalNode.getFormat(), mdastParent, actions)
   }
 }

--- a/lib/lexical/nodes/decorative/mentions/item.jsx
+++ b/lib/lexical/nodes/decorative/mentions/item.jsx
@@ -1,12 +1,35 @@
 import { DecoratorNode, $applyNodeReplacement } from 'lexical'
+import classNames from 'classnames'
+import {
+  DEFAULT_FORMAT,
+  IS_BOLD,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_HIGHLIGHT,
+  IS_SUPERSCRIPT,
+  IS_SUBSCRIPT,
+  IS_UNDERLINE
+} from '@/lib/lexical/mdast/format-constants'
+
+const DEFAULT_TEXT_THEME = {
+  bold: 'sn-text__bold',
+  italic: 'sn-text__italic',
+  highlight: 'sn-text__highlight',
+  underline: 'sn-text__underline',
+  strikethrough: 'sn-text__strikethrough',
+  underlineStrikethrough: 'sn-text__underline-strikethrough',
+  superscript: 'sn-text__superscript',
+  subscript: 'sn-text__subscript'
+}
 
 function $convertItemMentionElement (domNode) {
   const id = domNode.getAttribute('data-lexical-item-mention-id')
   const text = domNode.querySelector('a')?.textContent
   const url = domNode.querySelector('a')?.getAttribute('href')
+  const format = getTextFormatFromClassName(domNode)
 
   if (id) {
-    const node = $createItemMentionNode({ id, text, url })
+    const node = $createItemMentionNode({ id, text, url, format })
     return { node }
   }
 
@@ -17,10 +40,61 @@ export function isCustomText (text, id) {
   return text && text !== `#${id}`
 }
 
+function textClass (theme, key) {
+  return theme?.[key] || DEFAULT_TEXT_THEME[key]
+}
+
+function hasTextClass (domNode, key) {
+  return domNode.classList.contains(DEFAULT_TEXT_THEME[key])
+}
+
+function getTextFormatFromClassName (domNode) {
+  let format = DEFAULT_FORMAT
+
+  if (hasTextClass(domNode, 'bold')) format |= IS_BOLD
+  if (hasTextClass(domNode, 'italic')) format |= IS_ITALIC
+  if (hasTextClass(domNode, 'highlight')) format |= IS_HIGHLIGHT
+  if (hasTextClass(domNode, 'superscript')) format |= IS_SUPERSCRIPT
+  if (hasTextClass(domNode, 'subscript')) format |= IS_SUBSCRIPT
+
+  if (hasTextClass(domNode, 'underlineStrikethrough')) {
+    format |= IS_UNDERLINE | IS_STRIKETHROUGH
+  } else {
+    if (hasTextClass(domNode, 'underline')) format |= IS_UNDERLINE
+    if (hasTextClass(domNode, 'strikethrough')) format |= IS_STRIKETHROUGH
+  }
+
+  return format
+}
+
+export function getTextFormatClassName (format = DEFAULT_FORMAT, theme) {
+  const underlined = format & IS_UNDERLINE
+  const struck = format & IS_STRIKETHROUGH
+
+  return classNames({
+    [textClass(theme, 'bold')]: format & IS_BOLD,
+    [textClass(theme, 'italic')]: format & IS_ITALIC,
+    [textClass(theme, 'highlight')]: format & IS_HIGHLIGHT,
+    [textClass(theme, 'underline')]: underlined && !struck,
+    [textClass(theme, 'strikethrough')]: struck && !underlined,
+    [textClass(theme, 'underlineStrikethrough')]: underlined && struck,
+    [textClass(theme, 'superscript')]: format & IS_SUPERSCRIPT,
+    [textClass(theme, 'subscript')]: format & IS_SUBSCRIPT
+  })
+}
+
+function getItemMentionClassName (theme, text, id, format) {
+  return classNames(
+    isCustomText(text, id) ? theme?.link : theme?.itemMention,
+    getTextFormatClassName(format, theme?.text)
+  )
+}
+
 export class ItemMentionNode extends DecoratorNode {
   __itemMentionId
   __text
   __url
+  __format
 
   static getType () {
     return 'item-mention'
@@ -38,19 +112,29 @@ export class ItemMentionNode extends DecoratorNode {
     return this.__url
   }
 
+  getFormat () {
+    return this.__format
+  }
+
   static clone (node) {
-    return new ItemMentionNode(node.__itemMentionId, node.__text, node.__url, node.__key)
+    return new ItemMentionNode(node.__itemMentionId, node.__text, node.__url, node.__format, node.__key)
   }
 
   static importJSON (serializedNode) {
-    return $createItemMentionNode({ id: serializedNode.itemMentionId, text: serializedNode.text, url: serializedNode.url })
+    return $createItemMentionNode({
+      id: serializedNode.itemMentionId,
+      text: serializedNode.text,
+      url: serializedNode.url,
+      format: serializedNode.format ?? DEFAULT_FORMAT
+    })
   }
 
-  constructor (itemMentionId, text, url, key) {
+  constructor (itemMentionId, text, url, format = DEFAULT_FORMAT, key) {
     super(key)
     this.__itemMentionId = itemMentionId
     this.__text = text
     this.__url = url
+    this.__format = format
   }
 
   exportJSON () {
@@ -59,14 +143,15 @@ export class ItemMentionNode extends DecoratorNode {
       version: 1,
       itemMentionId: this.__itemMentionId,
       text: this.__text,
-      url: this.__url
+      url: this.__url,
+      format: this.__format
     }
   }
 
   createDOM (config) {
     const domNode = document.createElement('span')
     const theme = config.theme
-    const className = isCustomText(this.__text, this.__itemMentionId) ? theme.link : theme.itemMention
+    const className = getItemMentionClassName(theme, this.__text, this.__itemMentionId, this.__format)
     if (className !== undefined) {
       domNode.className = className
     }
@@ -80,7 +165,7 @@ export class ItemMentionNode extends DecoratorNode {
     const wrapper = document.createElement('span')
     wrapper.setAttribute('data-lexical-item-mention', true)
     const theme = editor._config.theme
-    const className = isCustomText(this.__text, this.__itemMentionId) ? theme.link : theme.itemMention
+    const className = getItemMentionClassName(theme, this.__text, this.__itemMentionId, this.__format)
     if (className !== undefined) {
       wrapper.className = className
     }
@@ -113,22 +198,23 @@ export class ItemMentionNode extends DecoratorNode {
     return this.__text || `#${this.__itemMentionId}`
   }
 
-  decorate () {
+  decorate (_editor, config) {
     const ItemPopover = require('@/components/item-popover').default
     const MentionsComponent = require('@/components/editor/nodes/mentions').default
     const id = this.__itemMentionId
     const href = this.__url
     const text = this.__text || `#${this.__itemMentionId}`
+    const className = getItemMentionClassName(config?.theme, this.__text, this.__itemMentionId, this.__format)
     return (
       <ItemPopover id={id}>
-        <MentionsComponent nodeKey={this.getKey()} href={href} text={text} />
+        <MentionsComponent nodeKey={this.getKey()} href={href} text={text} className={className} />
       </ItemPopover>
     )
   }
 }
 
-export function $createItemMentionNode ({ id, text, url }) {
-  return $applyNodeReplacement(new ItemMentionNode(id, text, url))
+export function $createItemMentionNode ({ id, text, url, format = DEFAULT_FORMAT }) {
+  return $applyNodeReplacement(new ItemMentionNode(id, text, url, format))
 }
 
 export function $isItemMentionNode (node) {


### PR DESCRIPTION
## Summary
- Store text formatting on `ItemMentionNode` when internal links are imported through the MDAST pipeline.
- Apply the same formatting classes when item mentions render, export to DOM, or break back into regular links.
- Preserve formatted item mentions when exporting back to Markdown.

## Why
Closes #2767.

## Validation
- Headless MDAST/Lexical roundtrip assertion for bold and italic internal item links.
- `./node_modules/.bin/standard lib/lexical/nodes/decorative/mentions/item.jsx components/editor/nodes/mentions.js lib/lexical/mdast/visitors/mentions.js`
- `git diff --check`
- `npm run lint`

## Payout
BTC address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`