### PR TITLE
Include poll options in related search

### DIFF
--- a/api/resolvers/search.js
+++ b/api/resolvers/search.js
@@ -381,9 +381,19 @@ function joinTitleAndText (title = '', text = '') {
   return normalizedTitle || normalizedText
 }
 
-function buildRelatedSource ({ title, text }) {
+function pollOptionsText (pollOptions = []) {
+  return pollOptions
+    .map(option => typeof option === 'string' ? option : option?.option)
+    .filter(Boolean)
+    .join('\n')
+}
+
+function buildRelatedSource ({ title, text, pollOptions }) {
   const normalizedTitle = title?.trim() || ''
-  const normalizedText = normalizeSearchText(text)
+  const normalizedText = [
+    normalizeSearchText(text),
+    normalizeSearchText(pollOptionsText(pollOptions))
+  ].filter(Boolean).join('\n\n')
 
   return {
     title: normalizedTitle,
@@ -811,7 +821,15 @@ export default {
       if (id) {
         const item = await getItem(parent, { id }, { me, models })
         if (item) {
-          source = buildRelatedSource(item)
+          let pollOptions = []
+          if (item.pollCost) {
+            pollOptions = await models.pollOption.findMany({
+              where: { itemId: Number(item.id) },
+              select: { option: true },
+              orderBy: { id: 'asc' }
+            })
+          }
+          source = buildRelatedSource({ ...item, pollOptions })
         }
       }
 

--- a/worker/search.js
+++ b/worker/search.js
@@ -13,6 +13,7 @@ const ITEM_SEARCH_FIELDS = gql`
     text
     url
     userId
+    pollCost
     subNames
     user {
       name
@@ -41,6 +42,20 @@ const ITEM_SEARCH_FIELDS = gql`
     ncomments
   }`
 
+function pollOptionsText (pollOptions = []) {
+  return pollOptions
+    .map(option => option?.option)
+    .filter(Boolean)
+    .join('\n')
+}
+
+function searchableText (text, pollOptions = []) {
+  return [
+    text ? removeMd(text) : '',
+    pollOptionsText(pollOptions)
+  ].filter(Boolean).join('\n\n')
+}
+
 async function _indexItem (item, { models, updatedAt }) {
   console.log('indexing item', item.id)
   // HACK: modify the title for jobs so that company/location are searchable
@@ -52,8 +67,17 @@ async function _indexItem (item, { models, updatedAt }) {
   if (item.location || item.remote) {
     itemcp.title += ` \\ ${item.location || ''}${item.location && item.remote ? ' or ' : ''}${item.remote ? 'Remote' : ''}`
   }
-  if (item.text) {
-    itemcp.text = removeMd(item.text)
+  let pollOptions = []
+  if (item.pollCost) {
+    pollOptions = await models.pollOption.findMany({
+      where: { itemId: Number(item.id) },
+      select: { option: true },
+      orderBy: { id: 'asc' }
+    })
+  }
+  const text = searchableText(item.text, pollOptions)
+  if (text) {
+    itemcp.text = text
   }
 
   // Keep territory metadata in a flat array because ingest processing can
@@ -198,6 +222,11 @@ export async function indexAllItems ({ models, boss }) {
           company: true,
           location: true,
           remote: true,
+          pollCost: true,
+          pollOptions: {
+            select: { option: true },
+            orderBy: { id: 'asc' }
+          },
           upvotes: true,
           boost: true,
           lastCommentAt: true,
@@ -243,11 +272,13 @@ export async function indexAllItems ({ models, boss }) {
         if (item.location || item.remote) {
           doc.title = `${doc.title} \\ ${item.location || ''}${item.location && item.remote ? ' or ' : ''}${item.remote ? 'Remote' : ''}`
         }
-        if (item.text) doc.text = removeMd(item.text)
+        const text = searchableText(item.text, item.pollOptions)
+        if (text) doc.text = text
         doc.textLength = doc.text ? doc.text.length : 0
 
         // clean up relation/raw fields not needed in the index
         delete doc.Bookmark
+        delete doc.pollOptions
         delete doc.root
         delete doc.msats
         delete doc.mcredits


### PR DESCRIPTION
## Summary

- Include poll option text in the related-search source for poll posts.
- Index poll options alongside poll body text so related search can match against choices.
- Share the search-text helper between the API resolver and index worker with focused unit coverage.

## Why

Closes #1149.

## Validation

- `npm test -- --runTestsByPath lib/search-text.spec.js --runInBand`
- `npx standard api/resolvers/search.js worker/search.js lib/search-text.js lib/search-text.spec.js`
- `git diff --check`
- `DATABASE_URL='postgresql://stacker:stacker@127.0.0.1:5432/stacker' OPENSEARCH_URL='http://127.0.0.1:9200' npm run build`