### PR TITLE
Preserve markdown paste stages in history

### DIFF
--- a/lib/lexical/exts/markdown.js
+++ b/lib/lexical/exts/markdown.js
@@ -8,23 +8,27 @@ import {
   DROP_COMMAND,
   DRAGOVER_COMMAND,
   defineExtension,
+  $addUpdateTag,
+  $createRangeSelection,
   $getSelection,
   $isRangeSelection,
   $getRoot,
+  $setSelection,
   PASTE_COMMAND,
   COPY_COMMAND,
   CUT_COMMAND,
-  PASTE_TAG
+  PASTE_TAG,
+  HISTORY_PUSH_TAG
 } from 'lexical'
 import { registerRichText } from '@lexical/rich-text'
 import { mergeRegister, objectKlassEquals } from '@lexical/utils'
-import { $insertText } from '@/lib/lexical/utils'
+import { $getNodesFromText } from '@/lib/lexical/utils'
 import { $lexicalToMarkdown } from '@/lib/lexical/utils/mdast'
 import { withDisposableBridge } from '@/components/editor/hooks/use-headless-bridge'
 
 /** redirects a paste event to a disposable rich text bridge,
  *  and exports the resulting EditorState as markdown via MDAST */
-const getMarkdownFromPaste = withDisposableBridge((bridge, event) => {
+const getMarkdownVersionsFromPaste = withDisposableBridge((bridge, event) => {
   try {
     bridge.update(() => {
       const root = $getRoot()
@@ -34,16 +38,60 @@ const getMarkdownFromPaste = withDisposableBridge((bridge, event) => {
 
     bridge.dispatchCommand(PASTE_COMMAND, event)
 
-    let markdown = null
+    let escaped = null
+    let unescaped = null
     bridge.update(() => {
-      markdown = $lexicalToMarkdown(true)
+      escaped = $lexicalToMarkdown()
+      unescaped = $lexicalToMarkdown(true)
     }, { discrete: true })
 
-    return markdown
+    return { escaped, unescaped }
   } catch {
     return null
   }
 }, { name: 'sn-markdown-paste-bridge' })
+
+export function pasteStages ({ plainText, markdownVersions }) {
+  return [
+    plainText,
+    markdownVersions?.unescaped,
+    markdownVersions?.escaped
+  ].filter((text, index, stages) => text && text !== stages[index - 1])
+}
+
+function $selectInsertedNodes (nodes) {
+  if (nodes.length === 0) return
+
+  const first = nodes[0]
+  const last = nodes[nodes.length - 1]
+  const selection = $createRangeSelection()
+  selection.anchor.set(first.getKey(), 0, 'element')
+  selection.focus.set(last.getKey(), last.getChildrenSize(), 'element')
+  $setSelection(selection)
+}
+
+function $replaceSelectionWithText (text, selectInserted = false) {
+  const selection = $getSelection()
+  if (!$isRangeSelection(selection)) return
+
+  const nodes = $getNodesFromText(text, true)
+  selection.insertNodes(nodes)
+
+  if (selectInserted) {
+    $selectInsertedNodes(nodes)
+  } else {
+    nodes[nodes.length - 1]?.selectEnd()
+  }
+}
+
+export function insertPasteStages (editor, stages) {
+  stages.forEach((text, index) => {
+    editor.update(() => {
+      $addUpdateTag(PASTE_TAG)
+      $replaceSelectionWithText(text, index < stages.length - 1)
+    }, { tag: HISTORY_PUSH_TAG, discrete: true })
+  })
+}
 
 function onPasteForMarkdown (event, editor) {
   event.preventDefault()
@@ -55,13 +103,14 @@ function onPasteForMarkdown (event, editor) {
 
   // check for rich content (lexical or HTML)
   const hasRichContent = clipboardData.getData('application/x-lexical-editor') || clipboardData.getData('text/html')
-  // if we have rich content, get the markdown from the paste
-  // otherwise, use plain text
-  const text = (hasRichContent && getMarkdownFromPaste(event)) ||
-    clipboardData.getData('text/plain') || clipboardData.getData('text/uri-list')
+  const plainText = clipboardData.getData('text/plain') || clipboardData.getData('text/uri-list')
+  const stages = pasteStages({
+    plainText,
+    markdownVersions: hasRichContent ? getMarkdownVersionsFromPaste(event) : null
+  })
 
-  if (!text) return
-  editor.update(() => $insertText(text, true), { tag: PASTE_TAG })
+  if (stages.length === 0) return
+  insertPasteStages(editor, stages)
 }
 
 /** rich text extension that handles plain text only */


### PR DESCRIPTION
## Summary
- Build markdown paste history as staged updates: plain clipboard text, unescaped markdown, then escaped final markdown.
- Force each paste stage into its own history entry so undo can step back through the alternatives while the final visible paste stays escaped.

## Why
Closes #2996.

## Validation
- headless Lexical paste-history assertion for final escaped text, first undo to unescaped text, and second undo to plain text
- `./node_modules/.bin/standard lib/lexical/exts/markdown.js`
- `git diff --check`
- `npm run lint`

## Payout
BTC address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`