### PR TITLE
Store email magic code callback in a short-lived cookie

### DIFF
--- a/components/login.js
+++ b/components/login.js
@@ -10,7 +10,7 @@ import LoginButton, { LoginWithNymButton } from './login-button'
 import { emailSchema } from '@/lib/validate'
 import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 import * as cookie from 'cookie'
-import { cookieOptions, MULTI_AUTH_ANON, MULTI_AUTH_POINTER } from '@/lib/auth'
+import { cookieOptions, EMAIL_AUTH_CALLBACK, MULTI_AUTH_ANON, MULTI_AUTH_POINTER } from '@/lib/auth'
 import Link from 'next/link'
 import useCookie from './use-cookie'
 
@@ -24,7 +24,8 @@ export function EmailLoginForm ({ text, callbackUrl, multiAuth }) {
       }}
       schema={emailSchema}
       onSubmit={async ({ email }) => {
-        window.sessionStorage.setItem('callback', JSON.stringify({ email, callbackUrl }))
+        const options = cookieOptions({ httpOnly: false, maxAge: 300 })
+        document.cookie = cookie.serialize(EMAIL_AUTH_CALLBACK, JSON.stringify({ email, callbackUrl }), options)
         signIn('email', { email, callbackUrl, multiAuth })
       }}
     >

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -20,6 +20,7 @@ export const SESSION_COOKIE = secureCookie('next-auth.session-token')
 export const MULTI_AUTH_LIST = secureCookie('multi_auth')
 export const MULTI_AUTH_POINTER = secureCookie('multi_auth.user-id')
 export const MULTI_AUTH_ANON = 'anonymous'
+export const EMAIL_AUTH_CALLBACK = secureCookie('email_auth_callback')
 
 export const MULTI_AUTH_JWT = id => secureCookie(`multi_auth.${id}`)
 

--- a/pages/email.js
+++ b/pages/email.js
@@ -7,9 +7,18 @@ import { Form, SubmitButton, MultiInput } from '@/components/form'
 import { emailTokenSchema } from '@/lib/validate'
 import ArrowRightLineIcon from '@/svgs/arrow-right-line.svg'
 import LoopVideo from '@/components/loop-video'
+import { cookieOptions, EMAIL_AUTH_CALLBACK } from '@/lib/auth'
 
 // force SSR to include CSP nonces
 export const getServerSideProps = getGetServerSideProps({ query: null })
+
+function emailCallbackFromCookie (cookies) {
+  try {
+    return JSON.parse(cookies[EMAIL_AUTH_CALLBACK])
+  } catch {
+    return null
+  }
+}
 
 export default function Email () {
   const router = useRouter()
@@ -17,8 +26,9 @@ export default function Email () {
   const [signin, setSignin] = useState(false)
 
   useEffect(() => {
-    setSignin(!!cookie.parse(document.cookie).signin)
-    setCallback(JSON.parse(window.sessionStorage.getItem('callback')))
+    const cookies = cookie.parse(document.cookie)
+    setSignin(!!cookies.signin)
+    setCallback(emailCallbackFromCookie(cookies))
   }, [])
 
   // build and push the final callback URL
@@ -27,6 +37,7 @@ export default function Email () {
     if (callback.callbackUrl) params.set('callbackUrl', callback.callbackUrl)
     params.set('token', token)
     params.set('email', callback.email.toLowerCase())
+    document.cookie = cookie.serialize(EMAIL_AUTH_CALLBACK, '', cookieOptions({ httpOnly: false, maxAge: 0 }))
     const url = `/api/auth/callback/email?${params.toString()}`
     router.push(url)
   }, [callback, router])

--- a/pages/settings/logins.js
+++ b/pages/settings/logins.js
@@ -24,7 +24,7 @@ import { useMe } from '@/components/me'
 import { SettingsHeader, hasOnlyOneAuthMethod } from './index'
 import { AuthBanner } from '@/components/banners'
 import * as cookie from 'cookie'
-import { cookieOptions } from '@/lib/auth'
+import { cookieOptions, EMAIL_AUTH_CALLBACK } from '@/lib/auth'
 
 export const getServerSideProps = getGetServerSideProps({ query: SETTINGS, authRequired: true })
 
@@ -261,8 +261,7 @@ function EmailLinkForm ({ callbackUrl }) {
         // can't be repurposed to link an email to a different account.
         const options = cookieOptions({ httpOnly: false, maxAge: 300 })
         document.cookie = cookie.serialize('link', String(me.id), options)
-
-        window.sessionStorage.setItem('callback', JSON.stringify({ email, callbackUrl }))
+        document.cookie = cookie.serialize(EMAIL_AUTH_CALLBACK, JSON.stringify({ email, callbackUrl }), options)
         signIn('email', { email, callbackUrl })
       }}
     >


### PR DESCRIPTION
## Summary
- Store the email magic-code callback payload in a short-lived first-party cookie instead of sessionStorage.
- Read and clear that cookie on `/email` when building the final email callback URL.
- Apply the same storage path to email login/signup and email account linking.

## Why
Closes #2984.

## Validation
- `./node_modules/.bin/standard pages/email.js components/login.js pages/settings/logins.js lib/auth.js`
- `git diff --check`
- `npm run lint`
- `rg -n "sessionStorage\.setItem\('callback'|sessionStorage\.getItem\('callback'|email_auth_callback|EMAIL_AUTH_CALLBACK" components pages lib -g "*.js" -g "*.jsx"`

## Payout
BTC address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`