### PR TITLE
Fix LNURLP username casing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,9 @@ const nextJest = require('next/jest')
 const createJestConfig = nextJest({ dir: './' })
 
 // createJestConfig is exported in this way to ensure that next/jest can load the Next.js configuration, which is async
-module.exports = createJestConfig({ testPathIgnorePatterns: ['/payIn/'] })
+module.exports = createJestConfig({
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1'
+  },
+  testPathIgnorePatterns: ['/payIn/']
+})

--- a/pages/api/lnurlp/[username]/index.js
+++ b/pages/api/lnurlp/[username]/index.js
@@ -10,9 +10,9 @@ export default async ({ query: { username } }, res) => {
   }
 
   const url = process.env.NODE_ENV === 'development' ? process.env.SELF_URL : process.env.NEXT_PUBLIC_URL
-  const { metadata } = lnurlPayMetadata(username)
+  const { metadata } = lnurlPayMetadata(user.name)
   return res.status(200).json({
-    callback: lnurlpCallbackUrl(username, url), // The URL from LN SERVICE which will accept the pay request parameters
+    callback: lnurlpCallbackUrl(user.name, url), // The URL from LN SERVICE which will accept the pay request parameters
     minSendable: Number(PROXY_PAYER_MIN_MSATS), // Min amount LN SERVICE is willing to receive, can not be less than 1 or more than `maxSendable`
     maxSendable: Number(PROXY_PAYER_MAX_MSATS), // Max amount LN SERVICE is willing to receive: the largest payer amount whose post-fee payout the wrap pipeline accepts
     metadata, // Metadata json which must be presented as raw string here, this is required to pass signature verification at a later step

--- a/pages/api/lnurlp/[username]/pay.js
+++ b/pages/api/lnurlp/[username]/pay.js
@@ -33,7 +33,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
   try {
     await assertGofacYourself({ models, headers })
     // if nostr, decode, validate sig, check tags, set description hash
-    let { description, descriptionHash } = lnurlPayMetadata(username)
+    let { description, descriptionHash } = lnurlPayMetadata(user.name)
     let noteStr
     let lud18Data
     if (nostr) {
@@ -71,7 +71,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
         return res.status(400).json({ status: 'ERROR', reason: err.toString() })
       }
 
-      descriptionHash = createHash('sha256').update(lnurlPayMetadata(username).metadata + payerData).digest('hex')
+      descriptionHash = createHash('sha256').update(lnurlPayMetadata(user.name).metadata + payerData).digest('hex')
     }
 
     if (comment && characterLength(comment) > LNURLP_COMMENT_MAX_LENGTH) {
@@ -96,7 +96,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
     return res.status(200).json({
       pr: payInBolt11.bolt11,
       routes: [],
-      verify: lnurlpVerifyUrl(username, payInBolt11.hash)
+      verify: lnurlpVerifyUrl(user.name, payInBolt11.hash)
     })
   } catch (error) {
     console.log(error)

--- a/pages/api/lnurlp/[username]/username-case.test.js
+++ b/pages/api/lnurlp/[username]/username-case.test.js
@@ -1,0 +1,106 @@
+/* eslint-env jest */
+
+import { createHash } from 'crypto'
+import models from '@/api/models'
+import assertGofacYourself from '@/api/resolvers/ofac'
+import pay from '@/api/payIn'
+import { lnurlPayMetadata } from '@/lib/lnurl'
+import indexHandler from './index'
+import payHandler from './pay'
+
+jest.mock('@/api/models', () => ({
+  __esModule: true,
+  default: {
+    user: {
+      findUnique: jest.fn()
+    }
+  }
+}))
+
+jest.mock('@/api/resolvers/ofac', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+jest.mock('@/wallets/server', () => ({
+  __esModule: true,
+  walletLogger: jest.fn(() => ({
+    info: jest.fn(() => Promise.resolve()),
+    error: jest.fn(() => Promise.resolve())
+  }))
+}))
+
+jest.mock('@/api/payIn', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+function mockRes () {
+  return {
+    statusCode: undefined,
+    body: undefined,
+    status: jest.fn(function (statusCode) {
+      this.statusCode = statusCode
+      return this
+    }),
+    json: jest.fn(function (body) {
+      this.body = body
+      return this
+    })
+  }
+}
+
+describe('lnurlp username casing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env.NEXT_PUBLIC_URL = 'https://stacker.news'
+    models.user.findUnique.mockResolvedValue({ id: 1, name: 'SwapMarket' })
+    assertGofacYourself.mockResolvedValue()
+    pay.mockResolvedValue({ payInBolt11: { bolt11: 'lnbc1test', hash: 'testhash' } })
+  })
+
+  test('uses the canonical username in metadata and callback urls', async () => {
+    const res = mockRes()
+
+    await indexHandler({ query: { username: 'swapmarket' } }, res)
+
+    expect(models.user.findUnique).toHaveBeenCalledWith({ where: { name: 'swapmarket' } })
+    expect(res.statusCode).toBe(200)
+    expect(res.body.callback).toBe('https://stacker.news/api/lnurlp/SwapMarket/pay')
+    expect(res.body.metadata).toBe(lnurlPayMetadata('SwapMarket').metadata)
+  })
+
+  test('uses the canonical username when creating pay request hashes', async () => {
+    const res = mockRes()
+    const expectedMetadata = lnurlPayMetadata('SwapMarket')
+
+    await payHandler({ query: { username: 'swapmarket', amount: '21000' }, headers: {} }, res)
+
+    expect(pay).toHaveBeenCalledWith('PROXY_PAYMENT', expect.objectContaining({
+      msats: 21000n,
+      description: expectedMetadata.description,
+      descriptionHash: expectedMetadata.descriptionHash
+    }), expect.objectContaining({
+      me: { id: 1, name: 'SwapMarket' }
+    }))
+    expect(res.statusCode).toBe(200)
+    expect(res.body.verify).toBe('https://stacker.news/api/lnurlp/SwapMarket/verify/testhash')
+  })
+
+  test('uses the canonical username when hashing payer data', async () => {
+    const res = mockRes()
+    const payerData = JSON.stringify({ name: 'Alice' })
+    const metadata = lnurlPayMetadata('SwapMarket').metadata
+    const descriptionHash = createHash('sha256').update(metadata + payerData).digest('hex')
+
+    await payHandler({ query: { username: 'swapmarket', amount: '21000', payerdata: payerData }, headers: {} }, res)
+
+    expect(pay).toHaveBeenCalledWith('PROXY_PAYMENT', expect.objectContaining({
+      descriptionHash,
+      lud18Data: { name: 'Alice' }
+    }), expect.objectContaining({
+      me: { id: 1, name: 'SwapMarket' }
+    }))
+    expect(res.statusCode).toBe(200)
+  })
+})


### PR DESCRIPTION
Fixes #3058.

## What changed
- Use the canonical stored username for LNURLP metadata and callback URLs after the user lookup succeeds.
- Use the same canonical username for pay request description hashes, payer-data hashes, and verify URLs, so lowercase wallet callbacks still target the actual account casing.
- Add regression tests for lowercase `swapmarket` resolving to `SwapMarket` in descriptor, payment creation, and payer-data hashing.
- Keep the Jest alias mapper so endpoint tests can resolve `@/` imports consistently.

## Verification
- `npm test -- --runTestsByPath pages/api/lnurlp/[username]/username-case.test.js --runInBand`
- `npx standard pages/api/lnurlp/[username]/index.js pages/api/lnurlp/[username]/pay.js pages/api/lnurlp/[username]/username-case.test.js jest.config.js`
- `git diff --check origin/master...HEAD`

BTC payout address if this is eligible for a sats award: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`