### PR TITLE
fix: persist expanded text state of an item with query params

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -1,5 +1,5 @@
 import styles from './text.module.css'
-import React, { useState, useRef, useCallback, useMemo, useEffect } from 'react'
+import React, { useState, useRef, useCallback, useMemo, useEffect, useSyncExternalStore } from 'react'
 import reactStringReplace from 'react-string-replace'
 import { Button } from 'react-bootstrap'
 import { useRouter } from 'next/router'
@@ -19,27 +19,39 @@ export function SearchText ({ text }) {
   )
 }
 
-export function useOverflow ({ containerRef, truncated = false }) {
+export function useOverflow ({ containerRef, itemId, topLevel, truncated = false }) {
   const router = useRouter()
   // would the text overflow on the current screen size?
   const [overflowing, setOverflowing] = useState(false)
-  // always show the full text if the `full` query param is set
-  const [show, setShow] = useState(!!router.query.full)
+
+  // did the user expand the text (show full text button, hash navigation)?
+  const [expanded, setExpanded] = useState(false)
+
+  const storageKey = itemId && `showFullText:${itemId}`
+
+  // was the text expanded earlier in this tab session, or are we on a hash anchor?
+  // scroll restoration measures the first render, so we read this during it;
+  // subscribe is a no-op because sessionStorage doesn't emit same-tab events.
+  const subscribe = useCallback(() => () => {}, [])
+  const storedShow = useSyncExternalStore(
+    subscribe,
+    () => (!!storageKey && window.sessionStorage.getItem(storageKey) === 'true') || window.location.hash !== '',
+    () => false
+  )
+
+  const show = expanded || storedShow || !!(topLevel && router.query.full)
 
   const showOverflow = useCallback(() => {
-    // save the full text state to the query param
-    router.replace({
-      pathname: router.pathname,
-      query: { ...router.query, full: true }
-    }, router.asPath, { shallow: true })
-    setShow(true)
-  }, [router])
+    // remember the expanded state for the rest of the tab session
+    if (storageKey) window.sessionStorage.setItem(storageKey, 'true')
+    setExpanded(true)
+  }, [storageKey])
 
-  // if we are navigating to a hash, show the full text
+  // once we navigate to a hash, keep the full text shown for the rest of this mount,
+  // even if the hash is later removed from the URL
   useEffect(() => {
-    if (router.asPath.includes('#')) setShow(true)
     const handleRouteChange = (url) => {
-      if (url.includes('#')) setShow(true)
+      if (url.includes('#')) setExpanded(true)
     }
 
     router.events.on('hashChangeStart', handleRouteChange)
@@ -47,7 +59,7 @@ export function useOverflow ({ containerRef, truncated = false }) {
     return () => {
       router.events.off('hashChangeStart', handleRouteChange)
     }
-  }, [router.asPath, router.events])
+  }, [router.events])
 
   // clip item and give it a`show full text` button if we are overflowing
   useEffect(() => {
@@ -103,9 +115,9 @@ export function useOverflow ({ containerRef, truncated = false }) {
       )
     }
     return null
-  }, [showOverflow, overflowing, show, setShow])
+  }, [showOverflow, overflowing, show])
 
-  return { overflowing, show, setShow, Overflow }
+  return { overflowing, show, setShow: setExpanded, Overflow }
 }
 
 /**
@@ -129,9 +141,9 @@ export default function Text (props) {
   return <TextBody {...props} />
 }
 
-export function TextBody ({ topLevel, children, className, innerClassName, state, html, imgproxyUrls, rel, name, readerRef }) {
+export function TextBody ({ topLevel, itemId, children, className, innerClassName, state, html, imgproxyUrls, rel, name, readerRef }) {
   const containerRef = useRef(null)
-  const { overflowing, show, Overflow } = useOverflow({ containerRef, truncated: !!children })
+  const { overflowing, show, Overflow } = useOverflow({ containerRef, itemId, topLevel, truncated: !!children })
   const carousel = useCarousel()
 
   const textClassNames = useMemo(() => {

--- a/components/text.js
+++ b/components/text.js
@@ -23,15 +23,23 @@ export function useOverflow ({ containerRef, truncated = false }) {
   const router = useRouter()
   // would the text overflow on the current screen size?
   const [overflowing, setOverflowing] = useState(false)
-  // should we show the full text?
-  const [show, setShow] = useState(false)
-  const showOverflow = useCallback(() => setShow(true), [setShow])
+  // always show the full text if the `full` query param is set
+  const [show, setShow] = useState(!!router.query.full)
+
+  const showOverflow = useCallback(() => {
+    // save the full text state to the query param
+    router.replace({
+      pathname: router.pathname,
+      query: { ...router.query, full: true }
+    }, router.asPath, { shallow: true })
+    setShow(true)
+  }, [router])
 
   // if we are navigating to a hash, show the full text
   useEffect(() => {
-    setShow(router.asPath.includes('#'))
-    const handleRouteChange = (url, { shallow }) => {
-      setShow(url.includes('#'))
+    if (router.asPath.includes('#')) setShow(true)
+    const handleRouteChange = (url) => {
+      if (url.includes('#')) setShow(true)
     }
 
     router.events.on('hashChangeStart', handleRouteChange)

--- a/components/text.js
+++ b/components/text.js
@@ -19,7 +19,7 @@ export function SearchText ({ text }) {
   )
 }
 
-export function useOverflow ({ containerRef, itemId, topLevel, truncated = false }) {
+export function useOverflow ({ containerRef, itemId, truncated = false }) {
   const router = useRouter()
   // would the text overflow on the current screen size?
   const [overflowing, setOverflowing] = useState(false)
@@ -29,17 +29,16 @@ export function useOverflow ({ containerRef, itemId, topLevel, truncated = false
 
   const storageKey = itemId && `showFullText:${itemId}`
 
-  // was the text expanded earlier in this tab session, or are we on a hash anchor?
-  // scroll restoration measures the first render, so we read this during it;
-  // subscribe is a no-op because sessionStorage doesn't emit same-tab events.
-  const subscribe = useCallback(() => () => {}, [])
+  // read-on-mount, not reactive: no same-tab storage event, so subscribe never fires.
+  // getSnapshot runs during render so scroll restoration sees the right height.
+  const subscribeNever = useCallback(() => () => {}, [])
   const storedShow = useSyncExternalStore(
-    subscribe,
+    subscribeNever,
     () => (!!storageKey && window.sessionStorage.getItem(storageKey) === 'true') || window.location.hash !== '',
     () => false
   )
 
-  const show = expanded || storedShow || !!(topLevel && router.query.full)
+  const show = expanded || storedShow
 
   const showOverflow = useCallback(() => {
     // remember the expanded state for the rest of the tab session
@@ -143,7 +142,7 @@ export default function Text (props) {
 
 export function TextBody ({ topLevel, itemId, children, className, innerClassName, state, html, imgproxyUrls, rel, name, readerRef }) {
   const containerRef = useRef(null)
-  const { overflowing, show, Overflow } = useOverflow({ containerRef, itemId, topLevel, truncated: !!children })
+  const { overflowing, show, Overflow } = useOverflow({ containerRef, itemId, truncated: !!children })
   const carousel = useCarousel()
 
   const textClassNames = useMemo(() => {


### PR DESCRIPTION
## Description

Fixes #2818

After clicking `show full text` we now persist the expanded state of an item with `full=true` in the query params.
Coming back to an item with the `full` query param will present the item already expanded. Solves scroll restoration in long posts.

## Screenshots


https://github.com/user-attachments/assets/2e3b0c58-ad9e-4c41-b7b5-6420d8049fac



## Additional Context

The `nprogress` loading bar appears when clicking `show full text` because we're doing a router action.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

8

**Did you use AI for this? If so, how much did it assist you?**

No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk UI state change using shallow routing; may trigger the nprogress bar on expand as noted in the PR.
> 
> **Overview**
> **Expanded post text** now survives navigation and reloads via a `full=true` query parameter instead of living only in component state.
> 
> `useOverflow` initializes `show` from `router.query.full`, and clicking **show full text** performs a shallow `router.replace` that merges `full: true` into the current query while still calling `setShow(true)`. Hash-based expansion is unchanged in behavior but only forces `show` to true (it no longer collapses expanded text when the URL has no hash).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8902b1d30f045ccb42a7e4002bc6d3c1fd9d5766. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->