### PR TITLE
Payin fail fixes

### DIFF
--- a/api/payIn/index.js
+++ b/api/payIn/index.js
@@ -15,7 +15,7 @@ import { createHmac } from '../resolvers/wallet'
 import createPrisma from '@/lib/create-prisma'
 import { PayInFailureReasonError } from './errors'
 import { payInReplacePayOuts } from './lib/payInFailed'
-import { GqlInputError } from '@/lib/error'
+import { GqlInputError, GqlPayInRetryRaceError } from '@/lib/error'
 const models = createPrisma({ connectionParams: { connection_limit: 2 } })
 
 export default async function pay (payInType, payInArgs, { me, custodialOnly, sendProtocolId } = {}) {
@@ -227,10 +227,11 @@ async function afterBegin (models, { payIn, result, mCostRemaining }, { me, send
     }
   } catch (e) {
     queuePayInFailed(models, payIn.id, e.payInFailureReason).catch(console.error)
-    // if invoice creation or wrapping failed, we want to return the payIn to the client
-    // so that their view is optimistic while we retry
-    // unless it's a payIn that was retried, or it's a pessimistic payIn
-    if (!(e instanceof PayInFailureReasonError) || payIn.pessimisticEnv || payIn.genesisId) {
+    // if invoice creation or wrapping failed, we want to return the (bolt11-less) payIn to the
+    // client so that their view stays optimistic while we retry in the background.
+    // Pessimistic payIns still throw — they have no optimistic view and the user is waiting
+    // on the (now-impossible) invoice.
+    if (!(e instanceof PayInFailureReasonError) || payIn.pessimisticEnv) {
       throw e
     }
   }
@@ -398,7 +399,7 @@ export async function retry (payInId, { me, sendProtocolId }) {
       include: { ...include, beneficiaries: { include } }
     })
     if (!payInFailedInitial) {
-      throw new Error('PayIn with id ' + payInId + ' not found')
+      throw new GqlPayInRetryRaceError('PayIn with id ' + payInId + ' not found')
     }
     if (isWithdrawal(payInFailedInitial)) {
       throw new Error('Withdrawal payIns cannot be retried')
@@ -428,7 +429,7 @@ export async function retry (payInId, { me, sendProtocolId }) {
       // use an optimistic lock on successorId on the payIn
       const rows = await tx.$queryRaw`UPDATE "PayIn" SET "successorId" = ${payIn.id} WHERE "id" = ${payInFailed.id} AND "successorId" IS NULL RETURNING id`
       if (rows.length === 0) {
-        throw new Error('PayIn with id ' + payInFailed.id + ' is already being retried')
+        throw new GqlPayInRetryRaceError('PayIn with id ' + payInFailed.id + ' is already being retried')
       }
 
       // run the onRetry hook for the payIn and its beneficiaries

--- a/api/payIn/lib/payInFailed.js
+++ b/api/payIn/lib/payInFailed.js
@@ -10,7 +10,12 @@ export async function payInReplacePayOuts (models, payInFailedInitial) {
 
   const payInFailed = { ...payInFailedInitial }
   try {
-    payInFailed.payOutBolt11 = await payOutBolt11Replacement(models, payInFailed.genesisId ?? payInFailed.id, payInFailed.payOutBolt11)
+    payInFailed.payOutBolt11 = await payOutBolt11Replacement(
+      models, payInFailed.genesisId ?? payInFailed.id, payInFailed.payOutBolt11, undefined,
+      // P2P-only payments (bounty/proxy) have no custodial fallback, so keep retrying wallets
+      // instead of giving up once each has failed twice.
+      { keepRetryingWallets: isP2POnly(payInFailedInitial) }
+    )
     // it's possible that the replacement payOutBolt11 is less than the original
     // due to msats truncation ... so we need to add the difference to the rewards pool
     if (payInFailed.payOutBolt11.msats !== payInFailedInitial.payOutBolt11.msats) {
@@ -36,7 +41,9 @@ export async function payInReplacePayOuts (models, payInFailedInitial) {
       throw e
     }
     // if we can no longer produce a payOutBolt11, we fallback to custodial tokens
-    payInFailed.payOutCustodialTokens.push(payOutCustodialTokenFromBolt11(payInFailed.payOutBolt11))
+    // use the initial payOutBolt11: the "more msats" throw above happens after payInFailed's
+    // was reassigned to the oversized replacement, which would unbalance the payIn
+    payInFailed.payOutCustodialTokens.push(payOutCustodialTokenFromBolt11(payInFailedInitial.payOutBolt11))
     // convert the routing fee to another rewards pool output
     const routingFee = payInFailed.payOutCustodialTokens.find(t => t.payOutType === 'ROUTING_FEE')
     if (routingFee) {

--- a/api/payIn/lib/payOutBolt11.js
+++ b/api/payIn/lib/payOutBolt11.js
@@ -63,13 +63,18 @@ async function createPayOutBolt11FromWalletProtocols (walletProtocols, bolt11Arg
   throw new NoReceiveWalletError('no wallet to receive available')
 }
 
-export async function payOutBolt11Replacement (models, genesisId, { payOutType, userId, msats }, testBolt11) {
+export async function payOutBolt11Replacement (models, genesisId, { payOutType, userId, msats }, testBolt11, { keepRetryingWallets = false } = {}) {
   const walletProtocols = await getLeastFailedWalletProtocols(models, { genesisId, userId })
-  const leastFailedWalletProtocols = walletProtocols.filter(wp => wp.failedCount < 2)
-  if (leastFailedWalletProtocols.length === 0) {
-    throw new NoReceiveWalletError('least failed wallet has failed at least twice, falling back to custodial tokens')
+  // Credit-payable payments stop using a wallet once it has failed twice and fall back to custodial
+  // tokens. P2P-only payments (bounty/proxy) have no custodial fallback, so rather than give up they
+  // keep retrying all wallets (least-failed first)
+  const candidateWalletProtocols = keepRetryingWallets
+    ? walletProtocols
+    : walletProtocols.filter(wp => wp.failedCount < 2)
+  if (!keepRetryingWallets && candidateWalletProtocols.length === 0) {
+    throw new NoReceiveWalletError('least failed wallet has failed at least twice')
   }
-  return await createPayOutBolt11FromWalletProtocols(leastFailedWalletProtocols, { msats }, { payOutType, userId }, { models }, testBolt11)
+  return await createPayOutBolt11FromWalletProtocols(candidateWalletProtocols, { msats }, { payOutType, userId }, { models }, testBolt11)
 }
 
 export async function payOutBolt11Prospect (models, bolt11Args, { payOutType, userId }, testBolt11) {

--- a/api/payIn/transitions.js
+++ b/api/payIn/transitions.js
@@ -348,8 +348,11 @@ export async function payInForwarding ({ data, models, boss, lnd, ...args }) {
     payInId,
     fromStates: 'PENDING_HELD',
     toState: 'FORWARDING',
-    transitionFunc: async ({ tx, payIn, lndPayInBolt11 }) => {
-      if (!lndPayInBolt11.is_held) {
+    transitionFunc: async ({ tx, payIn }) => {
+      // a racing payInCancel may have canceled the invoice but rolled back,
+      // leaving us with stale invoice reading 'held' but the LND invoice is 'canceled'
+      const fresh = await getInvoice({ id: payIn.payInBolt11.hash, lnd })
+      if (!fresh.is_held) {
         throw new Error('invoice is not held')
       }
 
@@ -357,7 +360,7 @@ export async function payInForwarding ({ data, models, boss, lnd, ...args }) {
         throw new Error('invoice is not associated with a forward')
       }
 
-      const { expiryHeight, acceptHeight } = hodlInvoiceCltvDetails(lndPayInBolt11)
+      const { expiryHeight, acceptHeight } = hodlInvoiceCltvDetails(fresh)
       const invoice = await parsePaymentRequest({ request: payIn.payOutBolt11.bolt11 })
       // maxTimeoutDelta is the number of blocks left for the outgoing payment to settle
       const maxTimeoutDelta = toPositiveNumber(expiryHeight) - toPositiveNumber(acceptHeight) - MIN_SETTLEMENT_CLTV_DELTA
@@ -381,7 +384,7 @@ export async function payInForwarding ({ data, models, boss, lnd, ...args }) {
       return {
         payInBolt11: {
           update: {
-            msatsReceived: BigInt(lndPayInBolt11.received_mtokens),
+            msatsReceived: BigInt(fresh.received_mtokens),
             expiryHeight,
             acceptHeight
           }
@@ -512,7 +515,7 @@ export async function payInFailedForward ({ data, models, lnd, boss, ...args }) 
     fromStates: 'FORWARDING',
     toState: 'FAILED_FORWARD',
     transitionFunc: async ({ tx, payIn, lndPayInBolt11, lndPayOutBolt11 }) => {
-      if (!(lndPayInBolt11.is_held || lndPayInBolt11.is_cancelled)) {
+      if (!(lndPayInBolt11.is_held || lndPayInBolt11.is_canceled)) {
         throw new Error('invoice is not held')
       }
 

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -12,7 +12,7 @@ import { ACT_MUTATION } from '@/fragments/payIn'
 import { actWaitFor, getPayIn } from '@/lib/pay-in'
 import { meAnonSats } from '@/lib/apollo'
 import { useHasSendWallet } from '@/wallets/client/hooks'
-import { toastPayError } from '@/wallets/client/errors'
+import { toastPayError, isTransientNetworkError } from '@/wallets/client/errors'
 import { useAnimation } from '@/components/animation'
 import { useToast } from '@/components/toast'
 import usePayInMutation from '@/components/payIn/hooks/use-pay-in-mutation'
@@ -104,11 +104,17 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
     // instant feedback: bump the item's counters directly in the root cache (assume p2p — the act
     // cache phases add credits later if the response says otherwise)
     const result = { id: item.id, sats: Number(amount), act, path: item.path }
-    const { error } = await withActBump(client.cache, result, me, () =>
-      // don't close modal immediately because we want the QR modal to stack
-      actor({ variables: { id: item.id, sats: Number(amount), act }, ...options }))
-    if (error) throw error
-    addCustomTip(Number(amount))
+    try {
+      const { error } = await withActBump(client.cache, result, me, () =>
+        // don't close modal immediately because we want the QR modal to stack
+        actor({ variables: { id: item.id, sats: Number(amount), act }, ...options }))
+      if (error) throw error
+      addCustomTip(Number(amount))
+    } catch (e) {
+      // a gateway timeout (e.g. the recipient's wallet was slow to invoice) doesn't mean the zap
+      // failed — it's processed server-side and the bump (kept by withActBump) reconciles. don't toast.
+      if (!isTransientNetworkError(e)) throw e
+    }
   }, [me, actor, client, hasReadySendWallet, act, item.id, item.path, onClose, abortSignal, animate, toaster])
 
   return (
@@ -279,7 +285,9 @@ export async function withActBump (cache, result, me, attempt) {
   try {
     return await attempt()
   } catch (e) {
-    revertActBump(cache, result, me)
+    // a gateway timeout means the act is likely still being processed server-side — keep the
+    // optimistic bump
+    if (!isTransientNetworkError(e)) revertActBump(cache, result, me)
     throw e
   }
 }

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -10,7 +10,9 @@ import { ZAP_UNDO_DELAY_MS } from '@/lib/constants'
 import { ACT_MUTATION } from '@/fragments/payIn'
 import { meAnonSats } from '@/lib/apollo'
 import { useHasSendWallet } from '@/wallets/client/hooks'
+import { InvoiceCanceledError } from '@/wallets/client/errors'
 import { useAnimation } from '@/components/animation'
+import { useToast } from '@/components/toast'
 import usePayInMutation from '@/components/payIn/hooks/use-pay-in-mutation'
 import { satsToMsats } from '@/lib/format'
 import { composeCallbacks } from '@/lib/compose-callbacks'
@@ -57,6 +59,7 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
   const inputRef = useRef(null)
   const { me } = useMe()
   const hasReadySendWallet = useHasSendWallet()
+  const toaster = useToast()
   const [oValue, setOValue] = useState()
 
   useEffect(() => {
@@ -84,12 +87,20 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
       if (!me) setItemMeAnonSats({ id: item.id, amount })
     }
 
-    const options = {}
+    // onPayError only fires for failures that won't be auto-retried; e is undefined when it's
+    // invoked purely to revert a retry successor's cache, and a user-canceled QR isn't news
+    const onPayError = (e) => {
+      if (e && !(e instanceof InvoiceCanceledError)) {
+        toaster.danger(e?.message || e?.toString?.())
+      }
+    }
+
+    const options = { cachePhases: { onPayError } }
     if (hasReadySendWallet || me?.privates?.sats > Number(amount)) {
       onPaid()
     } else {
       // we want to close the modal only after paid so the modal can stack
-      options.cachePhases = { onPaid }
+      options.cachePhases.onPaid = onPaid
     }
 
     const { error } = await actor({
@@ -112,7 +123,7 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
     })
     if (error) throw error
     addCustomTip(Number(amount))
-  }, [me, actor, hasReadySendWallet, act, item.id, onClose, abortSignal, animate])
+  }, [me, actor, hasReadySendWallet, act, item.id, onClose, abortSignal, animate, toaster])
 
   return (
     <Form

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -9,9 +9,10 @@ import { amountSchema } from '@/lib/validate'
 import { defaultTipIncludingRandom } from './upvote'
 import { ZAP_UNDO_DELAY_MS } from '@/lib/constants'
 import { ACT_MUTATION } from '@/fragments/payIn'
+import { actWaitFor, getPayIn } from '@/lib/pay-in'
 import { meAnonSats } from '@/lib/apollo'
 import { useHasSendWallet } from '@/wallets/client/hooks'
-import { InvoiceCanceledError } from '@/wallets/client/errors'
+import { toastPayError } from '@/wallets/client/errors'
 import { useAnimation } from '@/components/animation'
 import { useToast } from '@/components/toast'
 import usePayInMutation from '@/components/payIn/hooks/use-pay-in-mutation'
@@ -90,11 +91,7 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
 
     // onPayError only fires for failures that won't be auto-retried; e is undefined when it's
     // invoked purely to revert a retry successor's cache, and a user-canceled QR isn't news
-    const onPayError = (e) => {
-      if (e && !(e instanceof InvoiceCanceledError)) {
-        toaster.danger(e?.message || e?.toString?.())
-      }
-    }
+    const onPayError = (e) => toastPayError(toaster, e)
 
     const options = { cachePhases: { onPayError } }
     if (hasReadySendWallet || me?.privates?.sats > Number(amount)) {
@@ -105,28 +102,11 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
     }
 
     // instant feedback: bump the item's counters directly in the root cache (assume p2p — the act
-    // cache phases add credits later if the response says otherwise). this is the same root bump
-    // the bolt uses; it survives navigation (maxMerge) and is reverted on terminal payment failure
-    // by getActCachePhases.onPayError, or here if the mutation never creates a payIn.
+    // cache phases add credits later if the response says otherwise)
     const result = { id: item.id, sats: Number(amount), act, path: item.path }
-    bumpActCache(client.cache, result, me)
-
-    let error
-    try {
-      ({ error } = await actor({
-        variables: {
-          id: item.id,
-          sats: Number(amount),
-          act
-        },
-        // don't close modal immediately because we want the QR modal to stack
-        ...options
-      }))
-    } catch (mutationError) {
-      // the mutation failed before creating a payIn — no cache phase will revert, so undo the bump
-      revertActBump(client.cache, result, me)
-      throw mutationError
-    }
+    const { error } = await withActBump(client.cache, result, me, () =>
+      // don't close modal immediately because we want the QR modal to stack
+      actor({ variables: { id: item.id, sats: Number(amount), act }, ...options }))
     if (error) throw error
     addCustomTip(Number(amount))
   }, [me, actor, client, hasReadySendWallet, act, item.id, item.path, onClose, abortSignal, animate, toaster])
@@ -290,16 +270,31 @@ export function revertActBump (cache, result, me, payOutBolt11Public = true) {
   modifyActCache(cache, { payerPrivates: { result: { ...result, sats: -result.sats } }, payOutBolt11Public }, me)
 }
 
+// bump an item's counters at click time, run the act attempt, and revert the bump if the attempt
+// throws before a payIn exists (no cache phase reverts then). returns the attempt's result; a
+// returned (non-thrown) error is left for getActCachePhases.onPayError. used by the modal and the
+// notifications retry (the bolt bumps at click and reverts in its deferred fire, so it can't share).
+export async function withActBump (cache, result, me, attempt) {
+  bumpActCache(cache, result, me)
+  try {
+    return await attempt()
+  } catch (e) {
+    revertActBump(cache, result, me)
+    throw e
+  }
+}
+
 // the bump already wrote sats/meSats to the root cache; these phases only reconcile what the bump
 // couldn't know up front: credits (if the act turned out non-p2p), ancestors (on payment), and the
-// reversal (on terminal failure). there is no onMutationResult bump and no onPaidMissingResult —
-// the bump is client-driven at action time, not derived from the mutation response.
+// reversal (on terminal failure).
 export function getActCachePhases (me) {
   return {
     onMutationResult: (cache, { data }) => {
-      const response = Object.values(data)[0]
+      const response = getPayIn(data)
       const result = response?.payerPrivates?.result
-      if (!result || response.payOutBolt11Public) return // no result, or actually p2p — credit skip was correct
+      // only TIP credits the item; boost/downzap are non-p2p but never touch item credits, so gate
+      // on act === 'TIP'
+      if (!result || result.act !== 'TIP' || response.payOutBolt11Public) return
       cache.modify({
         id: `Item:${result.id}`,
         fields: {
@@ -309,12 +304,12 @@ export function getActCachePhases (me) {
       })
     },
     onPayError: (e, cache, { data }) => {
-      const response = Object.values(data)[0]
+      const response = getPayIn(data)
       const result = response?.payerPrivates?.result
       if (result) revertActBump(cache, result, me, response.payOutBolt11Public)
     },
     onPaid: (cache, { data }) => {
-      const response = Object.values(data)[0]
+      const response = getPayIn(data)
       if (!response) return
       updateAncestors(cache, response)
     }
@@ -328,12 +323,7 @@ export function useAct ({ query = ACT_MUTATION, ...options } = {}) {
   const { cachePhases: callerCachePhases = {}, ...restOptions } = options
 
   const [act] = usePayInMutation(query, {
-    waitFor: payIn =>
-      // if we have attached wallets, we might be paying a wrapped invoice in which case we need to make sure
-      // we don't prematurely consider the payment as successful (important for receiver fallbacks)
-      hasSendWallet
-        ? payIn?.payInState === 'PAID'
-        : ['FORWARDING', 'PAID'].includes(payIn?.payInState),
+    waitFor: actWaitFor(hasSendWallet),
     ...restOptions,
     cachePhases: {
       ...callerCachePhases,

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -1,6 +1,7 @@
 import Button from 'react-bootstrap/Button'
 import InputGroup from 'react-bootstrap/InputGroup'
 import React, { useState, useRef, useEffect, useCallback } from 'react'
+import { useApolloClient } from '@apollo/client/react'
 import { Form, Input, SubmitButton } from './form'
 import { useMe } from './me'
 import UpBolt from '@/svgs/bolt.svg'
@@ -14,7 +15,6 @@ import { InvoiceCanceledError } from '@/wallets/client/errors'
 import { useAnimation } from '@/components/animation'
 import { useToast } from '@/components/toast'
 import usePayInMutation from '@/components/payIn/hooks/use-pay-in-mutation'
-import { satsToMsats } from '@/lib/format'
 import { composeCallbacks } from '@/lib/compose-callbacks'
 
 const defaultTips = [100, 1000, 10_000, 100_000]
@@ -60,6 +60,7 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
   const { me } = useMe()
   const hasReadySendWallet = useHasSendWallet()
   const toaster = useToast()
+  const client = useApolloClient()
   const [oValue, setOValue] = useState()
 
   useEffect(() => {
@@ -103,27 +104,32 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
       options.cachePhases.onPaid = onPaid
     }
 
-    const { error } = await actor({
-      variables: {
-        id: item.id,
-        sats: Number(amount),
-        act
-      },
-      optimisticResponse: me
-        ? {
-            payInType: act === 'DONT_LIKE_THIS' ? 'DOWN_ZAP' : act === 'BOOST' ? 'BOOST' : 'ZAP',
-            mcost: satsToMsats(Number(amount)),
-            payerPrivates: {
-              result: { path: item.path, id: item.id, sats: Number(amount), act, __typename: 'ItemAct' }
-            }
-          }
-        : undefined,
-      // don't close modal immediately because we want the QR modal to stack
-      ...options
-    })
+    // instant feedback: bump the item's counters directly in the root cache (assume p2p — the act
+    // cache phases add credits later if the response says otherwise). this is the same root bump
+    // the bolt uses; it survives navigation (maxMerge) and is reverted on terminal payment failure
+    // by getActCachePhases.onPayError, or here if the mutation never creates a payIn.
+    const result = { id: item.id, sats: Number(amount), act, path: item.path }
+    bumpActCache(client.cache, result, me)
+
+    let error
+    try {
+      ({ error } = await actor({
+        variables: {
+          id: item.id,
+          sats: Number(amount),
+          act
+        },
+        // don't close modal immediately because we want the QR modal to stack
+        ...options
+      }))
+    } catch (mutationError) {
+      // the mutation failed before creating a payIn — no cache phase will revert, so undo the bump
+      revertActBump(client.cache, result, me)
+      throw mutationError
+    }
     if (error) throw error
     addCustomTip(Number(amount))
-  }, [me, actor, hasReadySendWallet, act, item.id, onClose, abortSignal, animate, toaster])
+  }, [me, actor, client, hasReadySendWallet, act, item.id, item.path, onClose, abortSignal, animate, toaster])
 
   return (
     <Form
@@ -158,7 +164,7 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
   )
 }
 
-export function modifyActCache (cache, { payerPrivates, payOutBolt11Public }, me, { optimistic = true } = {}) {
+function modifyActCache (cache, { payerPrivates, payOutBolt11Public }, me) {
   const result = payerPrivates?.result
   if (!result) return
   const { id, sats, act } = result
@@ -209,14 +215,13 @@ export function modifyActCache (cache, { payerPrivates, payOutBolt11Public }, me
         }
         return existingBoost
       }
-    },
-    optimistic
+    }
   })
 }
 
 // doing this onPaid fixes issue #1695 because optimistically updating all ancestors
 // conflicts with the writeQuery on navigation from SSR
-export function updateAncestors (cache, { payerPrivates, payOutBolt11Public }, { optimistic = true } = {}) {
+function updateAncestors (cache, { payerPrivates, payOutBolt11Public }) {
   const result = payerPrivates?.result
   if (!result) return
   const { id, sats, act, path } = result
@@ -238,8 +243,7 @@ export function updateAncestors (cache, { payerPrivates, payOutBolt11Public }, {
           commentSats (existingCommentSats = 0) {
             return existingCommentSats + sats
           }
-        },
-        optimistic
+        }
       })
     })
   }
@@ -253,8 +257,7 @@ export function updateAncestors (cache, { payerPrivates, payOutBolt11Public }, {
           commentDownSats (existingCommentDownSats = 0) {
             return existingCommentDownSats + sats
           }
-        },
-        optimistic
+        }
       })
     })
   }
@@ -268,44 +271,52 @@ export function updateAncestors (cache, { payerPrivates, payOutBolt11Public }, {
           commentBoost (existingCommentBoost = 0) {
             return existingCommentBoost + sats
           }
-        },
-        optimistic
+        }
       })
     })
   }
 }
 
-// the inverse of an act response: the same response with the result's sats negated, for
-// reverting whatever modifyActCache applied. null when there's no result to negate.
-export function negateActResponse (response) {
-  const result = response?.payerPrivates?.result
-  if (!result) return null
-  return { ...response, payerPrivates: { ...response.payerPrivates, result: { ...result, sats: -1 * result.sats } } }
+// act bump: write an item's counters to the ROOT cache (survives navigation under
+// maxMerge), assuming p2p so credits are skipped — getActCachePhases.onMutationResult adds them if
+// the response turns out non-p2p. both the modal (item-act) and the bolt (use-zap) use this.
+export function bumpActCache (cache, result, me) {
+  modifyActCache(cache, { payerPrivates: { result }, payOutBolt11Public: true }, me)
 }
 
+// reverse a bump. payOutBolt11Public defaults to the bump's p2p assumption (no credits were added);
+// pass the response's real value when reverting after the credit reconcile below may have run.
+export function revertActBump (cache, result, me, payOutBolt11Public = true) {
+  modifyActCache(cache, { payerPrivates: { result: { ...result, sats: -result.sats } }, payOutBolt11Public }, me)
+}
+
+// the bump already wrote sats/meSats to the root cache; these phases only reconcile what the bump
+// couldn't know up front: credits (if the act turned out non-p2p), ancestors (on payment), and the
+// reversal (on terminal failure). there is no onMutationResult bump and no onPaidMissingResult —
+// the bump is client-driven at action time, not derived from the mutation response.
 export function getActCachePhases (me) {
   return {
-    // runs as Apollo update() callback — optimistic: true (default) is correct
     onMutationResult: (cache, { data }) => {
       const response = Object.values(data)[0]
-      if (!response) return
-      modifyActCache(cache, response, me)
-    },
-    // runs outside update() context — write to root cache
-    onPaidMissingResult: (cache, { data }) => {
-      const response = Object.values(data)[0]
-      if (!response) return
-      modifyActCache(cache, response, me, { optimistic: false })
+      const result = response?.payerPrivates?.result
+      if (!result || response.payOutBolt11Public) return // no result, or actually p2p — credit skip was correct
+      cache.modify({
+        id: `Item:${result.id}`,
+        fields: {
+          credits: (existing = 0) => existing + result.sats,
+          meCredits: (existing = 0) => me ? existing + result.sats : existing
+        }
+      })
     },
     onPayError: (e, cache, { data }) => {
-      const negate = negateActResponse(Object.values(data)[0])
-      if (!negate) return
-      modifyActCache(cache, negate, me, { optimistic: false })
+      const response = Object.values(data)[0]
+      const result = response?.payerPrivates?.result
+      if (result) revertActBump(cache, result, me, response.payOutBolt11Public)
     },
     onPaid: (cache, { data }) => {
       const response = Object.values(data)[0]
       if (!response) return
-      updateAncestors(cache, response, { optimistic: false })
+      updateAncestors(cache, response)
     }
   }
 }
@@ -327,9 +338,6 @@ export function useAct ({ query = ACT_MUTATION, ...options } = {}) {
     cachePhases: {
       ...callerCachePhases,
       onMutationResult: composeCallbacks(phases.onMutationResult, callerCachePhases.onMutationResult),
-      // If the initial mutation response had no result payload, run the direct-item
-      // cache modification now so optimistic and pessimistic paths converge.
-      onPaidMissingResult: composeCallbacks(phases.onPaidMissingResult, callerCachePhases.onPaidMissingResult),
       onPayError: composeCallbacks(phases.onPayError, callerCachePhases.onPayError),
       onPaid: composeCallbacks(phases.onPaid, callerCachePhases.onPaid)
     }

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -275,6 +275,14 @@ export function updateAncestors (cache, { payerPrivates, payOutBolt11Public }, {
   }
 }
 
+// the inverse of an act response: the same response with the result's sats negated, for
+// reverting whatever modifyActCache applied. null when there's no result to negate.
+export function negateActResponse (response) {
+  const result = response?.payerPrivates?.result
+  if (!result) return null
+  return { ...response, payerPrivates: { ...response.payerPrivates, result: { ...result, sats: -1 * result.sats } } }
+}
+
 export function getActCachePhases (me) {
   return {
     // runs as Apollo update() callback — optimistic: true (default) is correct
@@ -290,10 +298,8 @@ export function getActCachePhases (me) {
       modifyActCache(cache, response, me, { optimistic: false })
     },
     onPayError: (e, cache, { data }) => {
-      const response = Object.values(data)[0]
-      if (!response?.payerPrivates?.result) return
-      const { payerPrivates: { result: { sats } } } = response
-      const negate = { ...response, payerPrivates: { ...response.payerPrivates, result: { ...response.payerPrivates.result, sats: -1 * sats } } }
+      const negate = negateActResponse(Object.values(data)[0])
+      if (!negate) return
       modifyActCache(cache, negate, me, { optimistic: false })
     },
     onPaid: (cache, { data }) => {

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -28,7 +28,7 @@ import { useShowModal } from './modal'
 import classNames from 'classnames'
 import SubPopover from './sub-popover'
 import useCanEdit from './use-can-edit'
-import { getRetryPayInFailureUpdate, useRetryPayInByType } from './payIn/hooks/use-retry-pay-in'
+import { getFailedRetryPayIn, isBenignRetryRaceError, useRetryPayInByType } from './payIn/hooks/use-retry-pay-in'
 import { isAutoRetryEligiblePayIn } from './payIn/hooks/use-auto-retry-pay-ins'
 import { gql } from '@apollo/client'
 import { useBranding } from './territory-branding'
@@ -321,11 +321,11 @@ export function PayInInfo ({ item, updatePayIn, disableRetry, setDisableRetry })
   const toaster = useToast()
 
   const revertPayIn = useCallback((error, cache, { data }) => {
-    const retryFailureUpdate = getRetryPayInFailureUpdate(error, data)
-    if (!retryFailureUpdate) return
-    const { retryPayInId, failureData } = retryFailureUpdate
+    const failedRetryPayIn = getFailedRetryPayIn(error, data)
+    if (!failedRetryPayIn) return
     cache.writeFragment({
-      id: `PayIn:${retryPayInId}`,
+      // PayIn normalizes by ['id', 'isSend'] (lib/apollo.js), so a raw `PayIn:${id}` writes to an orphan entity
+      id: cache.identify({ __typename: 'PayIn', id: failedRetryPayIn.id, isSend: true }),
       fragment: gql`
         fragment PayInInfoRevert on PayIn {
           payInState
@@ -335,10 +335,7 @@ export function PayInInfo ({ item, updatePayIn, disableRetry, setDisableRetry })
           }
         }
       `,
-      data: {
-        __typename: 'PayIn',
-        ...failureData
-      }
+      data: failedRetryPayIn
     })
   }, [])
 
@@ -382,7 +379,8 @@ export function PayInInfo ({ item, updatePayIn, disableRetry, setDisableRetry })
           const { error } = await retryPayIn()
           if (error) throw error
         } catch (error) {
-          toaster.danger(error.message)
+          // benign retry race (lineage advanced / concurrent retry) — don't surface it; see notifications.js
+          if (!isBenignRetryRaceError(error)) toaster.danger(error.message)
         } finally {
           setDisableDualRetry(false)
         }

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -28,7 +28,7 @@ import { useShowModal } from './modal'
 import classNames from 'classnames'
 import SubPopover from './sub-popover'
 import useCanEdit from './use-can-edit'
-import { getFailedRetryPayIn, isBenignRetryRaceError, useRetryPayIn } from './payIn/hooks/use-retry-pay-in'
+import { getFailedRetryPayIn, runManualRetry, useRetryPayIn } from './payIn/hooks/use-retry-pay-in'
 import { isAutoRetryEligiblePayIn } from './payIn/hooks/use-auto-retry-pay-ins'
 import { gql } from '@apollo/client'
 import { useBranding } from './territory-branding'
@@ -372,18 +372,9 @@ export function PayInInfo ({ item, updatePayIn, disableRetry, setDisableRetry })
       Component = () => <span className={classNames('text-info')}>pending</span>
     } else if (item.payIn.payInState === 'FAILED') {
       Component = () => <span className={classNames('text-warning', disableDualRetry ? 'pulse' : 'pointer')}>retry payment</span>
-      onClick = async () => {
+      onClick = () => {
         if (disableDualRetry) return
-        setDisableDualRetry(true)
-        try {
-          const { error } = await retryPayIn()
-          if (error) throw error
-        } catch (error) {
-          // benign retry race (lineage advanced / concurrent retry) — don't surface it; see notifications.js
-          if (!isBenignRetryRaceError(error)) toaster.danger(error.message)
-        } finally {
-          setDisableDualRetry(false)
-        }
+        return runManualRetry(retryPayIn, { setDisable: setDisableDualRetry, toaster })
       }
     } else {
       Component = () => (

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -28,7 +28,7 @@ import { useShowModal } from './modal'
 import classNames from 'classnames'
 import SubPopover from './sub-popover'
 import useCanEdit from './use-can-edit'
-import { getFailedRetryPayIn, isBenignRetryRaceError, useRetryPayInByType } from './payIn/hooks/use-retry-pay-in'
+import { getFailedRetryPayIn, isBenignRetryRaceError, useRetryPayIn } from './payIn/hooks/use-retry-pay-in'
 import { isAutoRetryEligiblePayIn } from './payIn/hooks/use-auto-retry-pay-ins'
 import { gql } from '@apollo/client'
 import { useBranding } from './territory-branding'
@@ -339,7 +339,7 @@ export function PayInInfo ({ item, updatePayIn, disableRetry, setDisableRetry })
     })
   }, [])
 
-  const retryPayIn = useRetryPayInByType(item.payIn.id, item.payIn.payInType, {
+  const retryPayIn = useRetryPayIn(item.payIn.id, item.payIn.payInType, {
     onRetry: updatePayIn,
     cachePhases: {
       onMutationResult: updatePayIn,

--- a/components/modal.js
+++ b/components/modal.js
@@ -36,11 +36,16 @@ export default function useModal () {
     return modalStack.current[modalStack.current.length - 1]
   }, [])
 
+  // back steps to the previous modal in the stack. we pop (unmounting the current modal — and, for
+  // a QR, stopping its payment watcher) BEFORE running its onClose, so cancelling the invoice can't
+  // escalate into a full-stack close via the watcher's onPaymentError. net: back returns to the
+  // previous step (e.g. the amount form) and still cancels the invoice so it doesn't dangle.
   const onBack = useCallback(() => {
-    getCurrentContent()?.options?.onClose?.()
+    const current = getCurrentContent()
     modalStack.current.pop()
     forceUpdate()
-  }, [])
+    current?.options?.onClose?.()
+  }, [getCurrentContent])
 
   const setOptions = useCallback(options => {
     const current = getCurrentContent()

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -44,6 +44,7 @@ import { getFailedRetryPayIn, runManualRetry, useRetryPayIn } from './payIn/hook
 import { withActBump } from './item-act'
 import { isAutoRetryEligiblePayIn } from './payIn/hooks/use-auto-retry-pay-ins'
 import { isInvoiceSetupPending, toFailedPayIn } from '@/lib/pay-in'
+import { reconcileNotificationItemCounters } from '@/lib/apollo'
 import MapIcon from '@/svgs/map.svg'
 
 function Notification ({ n, fresh }) {
@@ -834,8 +835,17 @@ const nid = n => n.__typename + n.id + n.sortTime
 
 export default function Notifications ({ ssrData }) {
   const { data, fetchMore } = useQuery(NOTIFICATIONS)
+  const client = useApolloClient()
   const router = useRouter()
   const dat = useData(data, ssrData)
+
+  // a failed pay-in optimistically bumped an item's counters; its PayInification notification
+  // carries the server's truth. reconcile here (not in an ApolloLink) because the feed arrives
+  // via SSR + cache-first, so no client-link request ever fires. covers the SSR first page and
+  // fetchMore pages since dat is the merged, displayed list.
+  useEffect(() => {
+    reconcileNotificationItemCounters(client.cache, dat?.notifications?.notifications)
+  }, [client, dat])
 
   const { notifications, lastChecked, cursor } = useMemo(() => {
     if (!dat?.notifications) return {}

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -40,8 +40,8 @@ import HolsterIcon from '@/svgs/holster.svg'
 import SaddleIcon from '@/svgs/saddle.svg'
 import CCInfo from './info/cc'
 import { useMe } from './me'
-import { getFailedRetryPayIn, isBenignRetryRaceError, useRetryPayIn } from './payIn/hooks/use-retry-pay-in'
-import { bumpActCache, revertActBump } from './item-act'
+import { getFailedRetryPayIn, runManualRetry, useRetryPayIn } from './payIn/hooks/use-retry-pay-in'
+import { withActBump } from './item-act'
 import { isAutoRetryEligiblePayIn } from './payIn/hooks/use-auto-retry-pay-ins'
 import { isInvoiceSetupPending, toFailedPayIn } from '@/lib/pay-in'
 import MapIcon from '@/svgs/map.svg'
@@ -479,8 +479,14 @@ function PayInFailed ({ n }) {
   // acts re-bump the item at click time (like the modal/bolt) rather than via an optimisticResponse,
   // so no act optimisticResponse here; bounty bumps bountyPaidTo optimistically.
   const isAct = PAY_IN_ACT_TYPES.includes(payIn.payInType)
-  const act = payIn.payInType === 'ZAP' ? 'TIP' : payIn.payInType === 'DOWN_ZAP' ? 'DONT_LIKE_THIS' : 'BOOST'
-  const actResult = { id: item.id, sats: msatsToSats(payIn.mcost), act, path: item.path }
+  const actResult = isAct
+    ? {
+        id: item.id,
+        sats: msatsToSats(payIn.mcost),
+        act: payIn.payInType === 'ZAP' ? 'TIP' : payIn.payInType === 'DOWN_ZAP' ? 'DONT_LIKE_THIS' : 'BOOST',
+        path: item.path
+      }
+    : null
   const optimisticResponse = payIn.payInType === 'BOUNTY_PAYMENT'
     ? { payInType: 'BOUNTY_PAYMENT', mcost: payIn.mcost, payerPrivates: { result: { id: item.id, path: item.path, __typename: 'Item' } } }
     : undefined
@@ -542,26 +548,12 @@ function PayInFailed ({ n }) {
             size='sm' variant={classNames('outline-warning ms-2 border-1 rounded py-0', disableRetry && 'pulse')}
             style={{ '--bs-btn-hover-color': '#fff', '--bs-btn-active-color': '#fff' }}
             disabled={disableRetry}
-            onClick={async () => {
+            onClick={() => {
               if (disableRetry) return
-              setDisableRetry(true)
-              // instant feedback: bump the item at click time (same root bump the modal/bolt use,
-              // reverted on terminal payment failure by getActCachePhases.onPayError). assume p2p —
-              // the act phases add credits if the response says otherwise.
-              if (isAct) bumpActCache(client.cache, actResult, me)
-              try {
-                const { error } = await retry()
-                if (error) throw error
-              } catch (error) {
-                // the mutation never advanced the lineage (benign race) or otherwise failed before a
-                // payIn existed, so no cache phase will revert — undo the click-time bump here.
-                if (isAct) revertActBump(client.cache, actResult, me)
-                // a manual retry can race the lineage advancing / a concurrent retry — that's
-                // expected (the auto-retry swallows it too), so don't surface it as a payment error.
-                if (!isBenignRetryRaceError(error)) toaster.danger(error?.message || error?.toString?.())
-              } finally {
-                setDisableRetry(false)
-              }
+              // for acts, bump the item at click time (same root bump the modal/bolt use)
+              return runManualRetry(
+                isAct ? () => withActBump(client.cache, actResult, me, retry) : retry,
+                { setDisable: setDisableRetry, toaster })
             }}
           >
             retry

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { gql } from '@apollo/client'
-import { useQuery } from '@apollo/client/react'
+import { useQuery, useApolloClient } from '@apollo/client/react'
 import Comment, { CommentSkeleton } from './comment'
 import Item from './item'
 import ItemJob from './item-job'
@@ -40,7 +40,8 @@ import HolsterIcon from '@/svgs/holster.svg'
 import SaddleIcon from '@/svgs/saddle.svg'
 import CCInfo from './info/cc'
 import { useMe } from './me'
-import { getFailedRetryPayIn, isBenignRetryRaceError, useRetryPayInByType } from './payIn/hooks/use-retry-pay-in'
+import { getFailedRetryPayIn, isBenignRetryRaceError, useRetryPayIn } from './payIn/hooks/use-retry-pay-in'
+import { bumpActCache, revertActBump } from './item-act'
 import { isAutoRetryEligiblePayIn } from './payIn/hooks/use-auto-retry-pay-ins'
 import { isInvoiceSetupPending, toFailedPayIn } from '@/lib/pay-in'
 import MapIcon from '@/svgs/map.svg'
@@ -419,6 +420,8 @@ function PayInProxyPayment ({ n }) {
 function PayInFailed ({ n }) {
   const [disableRetry, setDisableRetry] = useState(false)
   const toaster = useToast()
+  const { me } = useMe()
+  const client = useApolloClient()
   const { payIn, payInItem: item } = n
   const updatePayIn = useCallback((cache, { data }) => {
     // a wrap-/creation-failed retry returns a bolt11-less successor in a transient
@@ -473,16 +476,15 @@ function PayInFailed ({ n }) {
     })
   }, [n.id])
 
-  // only retry once (protocolLimit = 1) with wallets since we want to show the QR code on failures that end up in the notifications
-  const optimisticPayInTypes = PAY_IN_ACT_TYPES
+  // acts re-bump the item at click time (like the modal/bolt) rather than via an optimisticResponse,
+  // so no act optimisticResponse here; bounty bumps bountyPaidTo optimistically.
+  const isAct = PAY_IN_ACT_TYPES.includes(payIn.payInType)
   const act = payIn.payInType === 'ZAP' ? 'TIP' : payIn.payInType === 'DOWN_ZAP' ? 'DONT_LIKE_THIS' : 'BOOST'
-  const actOptimisticResponse = { payInType: payIn.payInType, mcost: payIn.mcost, payerPrivates: { result: { id: item.id, sats: msatsToSats(payIn.mcost), path: item.path, act, __typename: 'ItemAct', payIn } } }
-  const bountyOptimisticResponse = { payInType: 'BOUNTY_PAYMENT', mcost: payIn.mcost, payerPrivates: { result: { id: item.id, path: item.path, __typename: 'Item' } } }
+  const actResult = { id: item.id, sats: msatsToSats(payIn.mcost), act, path: item.path }
   const optimisticResponse = payIn.payInType === 'BOUNTY_PAYMENT'
-    ? bountyOptimisticResponse
-    : optimisticPayInTypes.includes(payIn.payInType)
-      ? actOptimisticResponse
-      : undefined
+    ? { payInType: 'BOUNTY_PAYMENT', mcost: payIn.mcost, payerPrivates: { result: { id: item.id, path: item.path, __typename: 'Item' } } }
+    : undefined
+  // only retry once (protocolLimit = 1) with wallets since we want to show the QR code on failures that end up in the notifications
   const mutationOptions = {
     onRetry: updatePayIn,
     cachePhases: {
@@ -493,7 +495,7 @@ function PayInFailed ({ n }) {
     protocolLimit: 1,
     ...(optimisticResponse ? { optimisticResponse } : {})
   }
-  const retryPayIn = useRetryPayInByType(payIn.id, payIn.payInType, mutationOptions)
+  const retryPayIn = useRetryPayIn(payIn.id, payIn.payInType, mutationOptions)
 
   const [actionString, colorClass, retry] = useMemo(() => {
     const retry = retryPayIn
@@ -543,10 +545,17 @@ function PayInFailed ({ n }) {
             onClick={async () => {
               if (disableRetry) return
               setDisableRetry(true)
+              // instant feedback: bump the item at click time (same root bump the modal/bolt use,
+              // reverted on terminal payment failure by getActCachePhases.onPayError). assume p2p —
+              // the act phases add credits if the response says otherwise.
+              if (isAct) bumpActCache(client.cache, actResult, me)
               try {
                 const { error } = await retry()
                 if (error) throw error
               } catch (error) {
+                // the mutation never advanced the lineage (benign race) or otherwise failed before a
+                // payIn existed, so no cache phase will revert — undo the click-time bump here.
+                if (isAct) revertActBump(client.cache, actResult, me)
                 // a manual retry can race the lineage advancing / a concurrent retry — that's
                 // expected (the auto-retry swallows it too), so don't surface it as a payment error.
                 if (!isBenignRetryRaceError(error)) toaster.danger(error?.message || error?.toString?.())

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -40,8 +40,9 @@ import HolsterIcon from '@/svgs/holster.svg'
 import SaddleIcon from '@/svgs/saddle.svg'
 import CCInfo from './info/cc'
 import { useMe } from './me'
-import { getRetryPayInFailureUpdate, useRetryPayInByType } from './payIn/hooks/use-retry-pay-in'
+import { getFailedRetryPayIn, isBenignRetryRaceError, useRetryPayInByType } from './payIn/hooks/use-retry-pay-in'
 import { isAutoRetryEligiblePayIn } from './payIn/hooks/use-auto-retry-pay-ins'
+import { isInvoiceSetupPending, toFailedPayIn } from '@/lib/pay-in'
 import MapIcon from '@/svgs/map.svg'
 
 function Notification ({ n, fresh }) {
@@ -420,6 +421,12 @@ function PayInFailed ({ n }) {
   const toaster = useToast()
   const { payIn, payInItem: item } = n
   const updatePayIn = useCallback((cache, { data }) => {
+    // a wrap-/creation-failed retry returns a bolt11-less successor in a transient
+    // PENDING_INVOICE_* state. It's a guaranteed failure (queuePayInFailed is already enqueued
+    // server-side), so show it as FAILED now
+    const retryPayIn = isInvoiceSetupPending(data.retryPayIn)
+      ? toFailedPayIn(data.retryPayIn, 'EXECUTION_FAILED')
+      : data.retryPayIn
     cache.writeFragment({
       id: `PayInification:${n.id}`,
       fragment: gql`
@@ -438,15 +445,14 @@ function PayInFailed ({ n }) {
         }
       `,
       data: {
-        payIn: data.retryPayIn
+        payIn: retryPayIn
       }
     })
   }, [n.id])
 
   const revertPayIn = useCallback((error, cache, { data }) => {
-    const retryFailureUpdate = getRetryPayInFailureUpdate(error, data)
-    if (!retryFailureUpdate) return
-    const { retryPayInId, failureData } = retryFailureUpdate
+    const failedRetryPayIn = getFailedRetryPayIn(error, data)
+    if (!failedRetryPayIn) return
     cache.writeFragment({
       id: `PayInification:${n.id}`,
       fragment: gql`
@@ -462,11 +468,7 @@ function PayInFailed ({ n }) {
         }
       `,
       data: {
-        payIn: {
-          __typename: 'PayIn',
-          id: retryPayInId,
-          ...failureData
-        }
+        payIn: failedRetryPayIn
       }
     })
   }, [n.id])
@@ -545,7 +547,9 @@ function PayInFailed ({ n }) {
                 const { error } = await retry()
                 if (error) throw error
               } catch (error) {
-                toaster.danger(error?.message || error?.toString?.())
+                // a manual retry can race the lineage advancing / a concurrent retry — that's
+                // expected (the auto-retry swallows it too), so don't surface it as a payment error.
+                if (!isBenignRetryRaceError(error)) toaster.danger(error?.message || error?.toString?.())
               } finally {
                 setDisableRetry(false)
               }

--- a/components/pay-bounty.js
+++ b/components/pay-bounty.js
@@ -11,6 +11,7 @@ import { Form, SubmitButton } from './form'
 import { PAY_BOUNTY_MUTATION } from '@/fragments/payIn'
 import usePayInMutation from './payIn/hooks/use-pay-in-mutation'
 import { useHasSendWallet } from '@/wallets/client/hooks'
+import { InvoiceCanceledError } from '@/wallets/client/errors'
 
 const addBountyPaidToCache = (cache, { data }, { optimistic = true } = {}) => {
   const response = Object.values(data)[0]
@@ -82,11 +83,20 @@ export default function PayBounty ({ children, item }) {
       onClose?.()
     }
 
-    const options = {}
+    // bounty payments are always optimistic clientside, so failures never surface through the
+    // returned error/payError — toast them here. e is undefined for cache-revert-only calls,
+    // and a user-canceled QR isn't news
+    const onPayError = (e) => {
+      if (e && !(e instanceof InvoiceCanceledError)) {
+        toaster.danger(e?.message || e?.toString?.())
+      }
+    }
+
+    const options = { cachePhases: { onPayError } }
     if (hasSendWallet) {
       onPaid()
     } else {
-      options.cachePhases = { onPaid }
+      options.cachePhases.onPaid = onPaid
     }
 
     try {

--- a/components/pay-bounty.js
+++ b/components/pay-bounty.js
@@ -29,11 +29,11 @@ const addBountyPaidToCache = (cache, { data }, { optimistic = true } = {}) => {
   })
 }
 
+// bounty payments are never pessimistic (payer is always logged-in and BOUNTY_PAYMENT is
+// optimistic), so the genesis response always carries the result
 export const payBountyCachePhases = {
   // runs as Apollo update() callback — optimistic: true (default) is correct
   onMutationResult: addBountyPaidToCache,
-  // runs outside update() context — write to root cache
-  onPaidMissingResult: (cache, args) => addBountyPaidToCache(cache, args, { optimistic: false }),
   onPayError: (_e, cache, { data }) => {
     const response = Object.values(data)[0]
     if (!response?.payerPrivates.result) return

--- a/components/pay-bounty.js
+++ b/components/pay-bounty.js
@@ -10,11 +10,13 @@ import { useToast } from './toast'
 import { Form, SubmitButton } from './form'
 import { PAY_BOUNTY_MUTATION } from '@/fragments/payIn'
 import usePayInMutation from './payIn/hooks/use-pay-in-mutation'
+import { getPayIn } from '@/lib/pay-in'
 import { useHasSendWallet } from '@/wallets/client/hooks'
-import { InvoiceCanceledError } from '@/wallets/client/errors'
+import { toastPayError } from '@/wallets/client/errors'
 
-const addBountyPaidToCache = (cache, { data }, { optimistic = true } = {}) => {
-  const response = Object.values(data)[0]
+// add (or, on revert, remove) the paid beneficiary to the root item's bountyPaidTo list
+const modifyBountyPaidTo = (cache, { data }, { add, optimistic }) => {
+  const response = getPayIn(data)
   if (!response?.payerPrivates.result) return
   const { id, path } = response.payerPrivates.result
   const root = path.split('.')[0]
@@ -22,7 +24,8 @@ const addBountyPaidToCache = (cache, { data }, { optimistic = true } = {}) => {
     id: `Item:${root}`,
     fields: {
       bountyPaidTo (existingPaidTo = []) {
-        return [...(existingPaidTo || []), Number(id)]
+        const paidTo = existingPaidTo || []
+        return add ? [...paidTo, Number(id)] : paidTo.filter(i => i !== Number(id))
       }
     },
     optimistic
@@ -32,24 +35,11 @@ const addBountyPaidToCache = (cache, { data }, { optimistic = true } = {}) => {
 // bounty payments are never pessimistic (payer is always logged-in and BOUNTY_PAYMENT is
 // optimistic), so the genesis response always carries the result
 export const payBountyCachePhases = {
-  // runs as Apollo update() callback — optimistic: true (default) is correct
-  onMutationResult: addBountyPaidToCache,
-  onPayError: (_e, cache, { data }) => {
-    const response = Object.values(data)[0]
-    if (!response?.payerPrivates.result) return
-    const { id, path } = response.payerPrivates.result
-    const root = path.split('.')[0]
-    // runs outside update() context — write to root cache
-    cache.modify({
-      id: `Item:${root}`,
-      fields: {
-        bountyPaidTo (existingPaidTo = []) {
-          return (existingPaidTo || []).filter(i => i !== Number(id))
-        }
-      },
-      optimistic: false
-    })
-  }
+  // runs in Apollo update() under the bounty optimisticResponse (so twice) — optimistic:true writes
+  // the optimistic layer on the optimistic pass and root on the real pass, netting one append
+  onMutationResult: (cache, args) => modifyBountyPaidTo(cache, args, { add: true, optimistic: true }),
+  // runs outside update() context — write to the root cache
+  onPayError: (_e, cache, args) => modifyBountyPaidTo(cache, args, { add: false, optimistic: false })
 }
 
 export default function PayBounty ({ children, item }) {
@@ -86,11 +76,7 @@ export default function PayBounty ({ children, item }) {
     // bounty payments are always optimistic clientside, so failures never surface through the
     // returned error/payError — toast them here. e is undefined for cache-revert-only calls,
     // and a user-canceled QR isn't news
-    const onPayError = (e) => {
-      if (e && !(e instanceof InvoiceCanceledError)) {
-        toaster.danger(e?.message || e?.toString?.())
-      }
-    }
+    const onPayError = (e) => toastPayError(toaster, e)
 
     const options = { cachePhases: { onPayError } }
     if (hasSendWallet) {
@@ -103,8 +89,7 @@ export default function PayBounty ({ children, item }) {
       const { error } = await payBounty(options)
       if (error) throw error
     } catch (error) {
-      const reason = error?.message || error?.toString?.()
-      toaster.danger(reason)
+      toastPayError(toaster, error)
     }
   }
 

--- a/components/payIn/context.js
+++ b/components/payIn/context.js
@@ -14,6 +14,9 @@ export function PayInContext ({ payIn }) {
     case 'BOOST':
     case 'POLL_VOTE':
     case 'BOUNTY_PAYMENT':
+      if (!payIn.item) {
+        return <small className='text-muted d-flex justify-content-center w-100'>item unavailable</small>
+      }
       return (
         <>
           {(!payIn.item.title && <CommentFlat item={payIn.item} includeParent noReply truncate />) ||
@@ -45,7 +48,7 @@ export function PayInContext ({ payIn }) {
     case 'WITHDRAWAL':
     case 'AUTO_WITHDRAWAL':
       return (
-        <Bolt11Info {...toBolt11InfoProps(payIn.payeePrivates.payOutBolt11)} />
+        <Bolt11Info {...toBolt11InfoProps(payIn.payeePrivates?.payOutBolt11)} />
       )
     case 'DONATE':
       return <small className='text-muted d-flex justify-content-center w-100'>Praise be, you donated to the rewards pool.</small>

--- a/components/payIn/hooks/use-auto-retry-pay-ins.js
+++ b/components/payIn/hooks/use-auto-retry-pay-ins.js
@@ -46,7 +46,7 @@ export function useAutoRetryPayIns () {
         if (error) throw error
         failedPayIns = data.failedPayIns
       } catch (err) {
-        console.error('failed to fetch invoices to retry:', err)
+        console.warn('failed to fetch invoices to retry:', err)
         return
       }
 
@@ -58,7 +58,7 @@ export function useAutoRetryPayIns () {
         } catch (err) {
           // some retries are expected to fail since only one client at a time is allowed to retry
           // these should show up as 'invoice not found' errors
-          console.error('retry failed:', err)
+          console.warn('retry failed:', err)
         }
       }
     }
@@ -70,7 +70,7 @@ export function useAutoRetryPayIns () {
         } catch (err) {
           // every error should already be handled in retryPoll
           // but this catch is a safety net to not trigger an unhandled promise rejection
-          console.error('retry poll failed:', err)
+          console.warn('retry poll failed:', err)
         }
         if (!stopped) queuePoll()
       }, NORMAL_POLL_INTERVAL_MS)
@@ -113,7 +113,7 @@ async function retryFailedPayIn (payIn, {
   const hasBolt11 = !!newPayIn.payerPrivates.payInBolt11
   const releaseAttempt = async () => {
     await payInHelper.cancel(newPayIn).catch(err => {
-      console.error('failed to cancel successor payIn:', err)
+      console.warn('failed to cancel successor payIn:', err)
     })
   }
   if (isStopped()) {

--- a/components/payIn/hooks/use-pay-in-helper.js
+++ b/components/payIn/hooks/use-pay-in-helper.js
@@ -1,6 +1,6 @@
 import { useApolloClient, useMutation } from '@apollo/client/react'
 import { useCallback, useMemo } from 'react'
-import { PAY_IN_RECEIVER_FAILURE_REASONS } from '@/lib/pay-in'
+import { PAY_IN_RECEIVER_FAILURE_REASONS, paidWaitFor } from '@/lib/pay-in'
 import { InvoiceCanceledError, InvoiceExpiredError, WalletReceiverError } from '@/wallets/client/errors'
 import { GET_PAY_IN_RESULT, CANCEL_PAY_IN_BOLT11, RETRY_PAY_IN } from '@/fragments/payIn'
 import { FAST_POLL_INTERVAL_MS } from '@/lib/constants'
@@ -73,7 +73,7 @@ export class WaitCheckControllerAbortedError extends Error {
 function waitCheckPayInController (payInId, check) {
   const controller = new AbortController()
   const signal = controller.signal
-  controller.wait = async (waitFor = payIn => payIn?.payInState === 'PAID', options) => {
+  controller.wait = async (waitFor = paidWaitFor, options) => {
     console.log('waitCheckPayInController: wait', payInId)
     let result
     return await new Promise((resolve, reject) => {

--- a/components/payIn/hooks/use-pay-in-mutation.js
+++ b/components/payIn/hooks/use-pay-in-mutation.js
@@ -9,6 +9,7 @@ import { getOperationAST } from 'graphql'
 import { useMe } from '@/components/me'
 import { USER_ID } from '@/lib/constants'
 import { isAutoRetryEligiblePayIn } from './use-auto-retry-pay-ins'
+import { isInvoiceSetupPending } from '@/lib/pay-in'
 import { composeCallbacks } from '@/lib/compose-callbacks'
 import { usePreferredSendProtocolId } from '@/wallets/client/hooks'
 
@@ -90,7 +91,13 @@ export default function usePayInMutation (mutation, { onCompleted, ...options } 
 
     // if the mutation returns in a pending state, it has an invoice we need to pay
     let payError
-    if (payIn.payInState === 'PENDING' || payIn.payInState === 'PENDING_HELD') {
+    if (isInvoiceSetupPending(payIn)) {
+      // the optimistic action already happened (onBegin ran); invoice creation/wrap failed and is
+      // being auto-retried in the background. Treat as success-with-pending-payment: complete
+      // optimistically and keep the optimistic cache (already written by onMutationResult). There's
+      // no invoice to pay, and nothing to surface
+      ourOnCompleted?.(data)
+    } else if (payIn.payInState === 'PENDING' || payIn.payInState === 'PENDING_HELD') {
       if (isClientPessimisticPayIn(payIn, me, forceWaitForPayment)) {
         // the action is pessimistic
         try {

--- a/components/payIn/hooks/use-pay-in-mutation.js
+++ b/components/payIn/hooks/use-pay-in-mutation.js
@@ -9,7 +9,7 @@ import { getOperationAST } from 'graphql'
 import { useMe } from '@/components/me'
 import { USER_ID } from '@/lib/constants'
 import { isAutoRetryEligiblePayIn } from './use-auto-retry-pay-ins'
-import { isInvoiceSetupPending } from '@/lib/pay-in'
+import { isInvoiceSetupPending, paidWaitFor } from '@/lib/pay-in'
 import { composeCallbacks } from '@/lib/compose-callbacks'
 import { usePreferredSendProtocolId } from '@/wallets/client/hooks'
 
@@ -17,8 +17,7 @@ import { usePreferredSendProtocolId } from '@/wallets/client/hooks'
 this is just like useMutation with a few changes:
 1. pays an invoice returned by the mutation
 2. takes grouped cachePhases callbacks and additional options for payment behavior
-  - namely forceWaitForPayment which will always wait for the invoice to be paid
-  - and persistOnNavigate which will keep the invoice in the cache after navigation
+  - namely persistOnNavigate which will keep the invoice in the cache after navigation
 3. onCompleted behaves a little differently, but analogously to useMutation, ie clientside side effects
   of completion can still rely on it. It's composed like other callbacks (hook-level + call-site both run).
   a. it's called before the invoice is paid for optimistic updates
@@ -70,8 +69,8 @@ export default function usePayInMutation (mutation, { onCompleted, ...options } 
       update: composeCallbacks(mergedOptions.update, onMutationResult)
     })
     const {
-      forceWaitForPayment, persistOnNavigate,
-      waitFor = payIn => payIn?.payInState === 'PAID', protocolLimit
+      persistOnNavigate,
+      waitFor = paidWaitFor, protocolLimit
     } = mergedOptions
 
     const payIn = data[mutationName]
@@ -98,7 +97,7 @@ export default function usePayInMutation (mutation, { onCompleted, ...options } 
       // no invoice to pay, and nothing to surface
       ourOnCompleted?.(data)
     } else if (payIn.payInState === 'PENDING' || payIn.payInState === 'PENDING_HELD') {
-      if (isClientPessimisticPayIn(payIn, me, forceWaitForPayment)) {
+      if (isClientPessimisticPayIn(payIn, me)) {
         // the action is pessimistic
         try {
           // wait for the invoice to be paid
@@ -145,9 +144,8 @@ export default function usePayInMutation (mutation, { onCompleted, ...options } 
   return [innerMutate, innerResult]
 }
 
-function isClientPessimisticPayIn (payIn, me, forceWaitForPayment) {
-  return forceWaitForPayment ||
-    !me ||
+function isClientPessimisticPayIn (payIn, me) {
+  return !me ||
     (payIn.payInState === 'PENDING_HELD' && payIn.payInType !== 'ZAP' && payIn.payInType !== 'BOUNTY_PAYMENT')
 }
 

--- a/components/payIn/hooks/use-pay-in-mutation.js
+++ b/components/payIn/hooks/use-pay-in-mutation.js
@@ -70,7 +70,8 @@ export default function usePayInMutation (mutation, { onCompleted, ...options } 
     })
     const {
       persistOnNavigate,
-      waitFor = paidWaitFor, protocolLimit
+      waitFor = paidWaitFor, protocolLimit,
+      failOnInvoiceSetupPending
     } = mergedOptions
 
     const payIn = data[mutationName]
@@ -91,11 +92,21 @@ export default function usePayInMutation (mutation, { onCompleted, ...options } 
     // if the mutation returns in a pending state, it has an invoice we need to pay
     let payError
     if (isInvoiceSetupPending(payIn)) {
-      // the optimistic action already happened (onBegin ran); invoice creation/wrap failed and is
-      // being auto-retried in the background. Treat as success-with-pending-payment: complete
-      // optimistically and keep the optimistic cache (already written by onMutationResult). There's
-      // no invoice to pay, and nothing to surface
-      ourOnCompleted?.(data)
+      if (failOnInvoiceSetupPending) {
+        // a manual retry whose fresh invoice creation/wrap failed is terminal: the successor is
+        // bolt11-less and the server has already enqueued its failure, so surface it instead of
+        // keeping it optimistic. onPayError reverts the optimistic bump and flips the notification to
+        // FAILED — matching how the retry already renders this successor. onMutationResult reconciled
+        // credits first, so onPayError's response-keyed revert is exact.
+        payError = new Error('invoice setup failed')
+        onPayError?.(payError, client.cache, { data })
+      } else {
+        // genesis: the optimistic action already happened (onBegin ran); invoice creation/wrap failed
+        // and is being auto-retried in the background. Treat as success-with-pending-payment: complete
+        // optimistically and keep the optimistic cache (already written by onMutationResult). There's
+        // no invoice to pay, and nothing to surface
+        ourOnCompleted?.(data)
+      }
     } else if (payIn.payInState === 'PENDING' || payIn.payInState === 'PENDING_HELD') {
       if (isClientPessimisticPayIn(payIn, me)) {
         // the action is pessimistic

--- a/components/payIn/hooks/use-pay-pay-in.js
+++ b/components/payIn/hooks/use-pay-pay-in.js
@@ -19,8 +19,11 @@ export default function usePayPayIn () {
       walletError = null
       if (err instanceof WalletError) {
         walletError = err
-        // get the last invoice that was attempted but failed and was canceled
-        if (err.payIn) payIn = err.payIn
+        // aggregate wallet errors carry the lineage's latest payIn (the last attempted,
+        // possibly retried, payIn) as `invoice` — adopt it so the retry/QR fallback below
+        // works on the lineage tail instead of an already-superseded payIn. The payInState
+        // check excludes errors whose `invoice` is a bolt11 row (sender/receiver errors).
+        if (err.invoice?.payInState) payIn = err.invoice
       }
 
       const invoiceError = err instanceof InvoiceCanceledError || err instanceof InvoiceExpiredError
@@ -40,6 +43,10 @@ export default function usePayPayIn () {
 
     const paymentAttempted = walletError instanceof WalletPaymentError
     if (paymentAttempted) {
+      // the wallet loop may have bailed with a bolt11-less successor (its invoice
+      // creation/wrap failed; it's being driven to FAILED and auto-retried) — it isn't
+      // FAILED yet so it can't be retried, and there's no invoice to show a QR for
+      if (isInvoiceSetupPending(payIn)) throw walletError
       // QR/manual fallback should not keep attributing the successor invoice
       // to the wallet protocol that already failed to pay it.
       payIn = await payInHelper.retry(payIn, { sendProtocolId: null, update: onRetry })

--- a/components/payIn/hooks/use-pay-pay-in.js
+++ b/components/payIn/hooks/use-pay-pay-in.js
@@ -1,6 +1,7 @@
 import { useWalletPayment } from '@/wallets/client/hooks'
 import usePayInHelper from './use-pay-in-helper'
 import useQrPayIn from './use-qr-pay-in'
+import { isInvoiceSetupPending } from '@/lib/pay-in'
 import { useCallback } from 'react'
 import { WalletError, InvoiceCanceledError, InvoiceExpiredError, WalletPaymentError } from '@/wallets/client/errors'
 
@@ -42,6 +43,9 @@ export default function usePayPayIn () {
       // QR/manual fallback should not keep attributing the successor invoice
       // to the wallet protocol that already failed to pay it.
       payIn = await payInHelper.retry(payIn, { sendProtocolId: null, update: onRetry })
+      // if the retried successor has no invoice (its creation/wrap failed too), there's nothing to
+      // show a QR for — surface the original wallet error instead of opening a bolt11-less QR.
+      if (isInvoiceSetupPending(payIn)) throw walletError
     }
     return await qrPayIn(payIn, walletError, { persistOnNavigate, waitFor })
   }, [payInHelper, qrPayIn, walletPayment])

--- a/components/payIn/hooks/use-qr-pay-in.js
+++ b/components/payIn/hooks/use-qr-pay-in.js
@@ -7,6 +7,7 @@ import useWatchPayIn from './use-watch-pay-in'
 import Qr, { QrSkeleton } from '@/components/qr'
 import PayInError from '../error'
 import { msatsToSats, numWithUnits } from '@/lib/format'
+import { paidWaitFor } from '@/lib/pay-in'
 import { PayInStatus } from '../status'
 
 export default function useQrPayIn () {
@@ -18,7 +19,7 @@ export default function useQrPayIn () {
       keepOpen = true,
       cancelOnClose = true,
       persistOnNavigate = false,
-      waitFor = payIn => payIn?.payInState === 'PAID'
+      waitFor = paidWaitFor
     } = {}
   ) => {
     // if anon user and webln is available, try to pay with webln
@@ -76,7 +77,7 @@ export default function useQrPayIn () {
         />,
       { keepOpen, persistOnNavigate, onClose: cancelAndReject })
     })
-  }, [payInHelper])
+  }, [payInHelper, showModal])
 
   return waitForQrPayIn
 }

--- a/components/payIn/hooks/use-qr-pay-in.js
+++ b/components/payIn/hooks/use-qr-pay-in.js
@@ -73,7 +73,9 @@ function QrPayIn ({
     return <div>{error.message}</div>
   }
 
-  if (!payIn) {
+  // a creation-/wrap-failed payIn has no bolt11 to render (see isInvoiceSetupPending),
+  // and item-info's 'pending' link can open this modal with one
+  if (!payIn || !payIn.payerPrivates?.payInBolt11) {
     return <QrSkeleton description />
   }
 

--- a/components/payIn/hooks/use-qr-pay-in.js
+++ b/components/payIn/hooks/use-qr-pay-in.js
@@ -29,8 +29,27 @@ export default function useQrPayIn () {
       let updatedPayIn
       const cancelAndReject = async (onClose) => {
         if (!updatedPayIn && cancelOnClose) {
-          const updatedPayIn = await payInHelper.cancel(payIn, { userCancel: true })
-          reject(new InvoiceCanceledError(updatedPayIn?.payerPrivates.payInBolt11))
+          // always settle the promise, even if the cancel mutation throws (e.g. offline),
+          // else the submitting form awaits forever
+          try {
+            const cancelledPayIn = await payInHelper.cancel(payIn, { userCancel: true })
+            if (cancelledPayIn) {
+              reject(new InvoiceCanceledError(cancelledPayIn.payerPrivates.payInBolt11))
+              return
+            }
+            // cancel no-oped because the payIn already reached a terminal state — it may have
+            // been PAID in the instant before the close, in which case the action committed and
+            // the payer was charged, so reporting a cancel would invite a double pay.
+            const { payIn: latestPayIn, check } = await payInHelper.check(payIn.id, waitFor)
+            if (check) {
+              resolve(latestPayIn)
+              return
+            }
+            reject(new InvoiceCanceledError(latestPayIn?.payerPrivates?.payInBolt11 ?? payIn.payerPrivates.payInBolt11))
+          } catch (err) {
+            reject(err)
+          }
+          return
         }
         resolve(updatedPayIn)
       }

--- a/components/payIn/hooks/use-retry-pay-in.js
+++ b/components/payIn/hooks/use-retry-pay-in.js
@@ -8,7 +8,7 @@ import { InvoiceCanceledError } from '@/wallets/client/errors'
 import { composeCallbacks } from '@/lib/compose-callbacks'
 import { PAY_IN_ACT_TYPES } from '@/lib/constants'
 import { E_PAY_IN_RETRY_RACE } from '@/lib/error'
-import { toFailedPayIn } from '@/lib/pay-in'
+import { actWaitFor, getPayIn, toFailedPayIn } from '@/lib/pay-in'
 
 export function useRetryPayIn (payInId, payInType, mutationOptions = {}) {
   const { me } = useMe()
@@ -21,10 +21,7 @@ export function useRetryPayIn (payInId, payInType, mutationOptions = {}) {
   const options = { ...restOptions, cachePhases }
 
   if (isAct) {
-    options.waitFor = payIn =>
-      hasSendWallet
-        ? payIn?.payInState === 'PAID'
-        : ['FORWARDING', 'PAID'].includes(payIn?.payInState)
+    options.waitFor = actWaitFor(hasSendWallet)
   }
 
   const [retryPayIn] = usePayInMutation(RETRY_PAY_IN, { ...options, variables: { payInId } })
@@ -33,7 +30,7 @@ export function useRetryPayIn (payInId, payInType, mutationOptions = {}) {
 
 // the FAILED view of a retry mutation's successor for cache writes when paying it failed
 export function getFailedRetryPayIn (error, data) {
-  const retryResult = Object.values(data ?? {})[0]
+  const retryResult = getPayIn(data)
   if (!retryResult?.id) return null
 
   return toFailedPayIn(retryResult, error instanceof InvoiceCanceledError ? 'USER_CANCELLED' : 'EXECUTION_FAILED')
@@ -45,6 +42,21 @@ export function getFailedRetryPayIn (error, data) {
 // background auto-retry too — so a manual retry shouldn't surface them as an error.
 export function isBenignRetryRaceError (error) {
   return [error, ...(error?.errors ?? [])].some(e => e?.extensions?.code === E_PAY_IN_RETRY_RACE)
+}
+
+// the shared manual-retry click handler for the notifications and item-info retry buttons: disable
+// the button, run the retry, surface non-benign errors, re-enable. `retry` returns { error } or
+// throws; a benign retry race (lineage advanced / concurrent retry) is expected and not surfaced.
+export async function runManualRetry (retry, { setDisable, toaster }) {
+  setDisable(true)
+  try {
+    const { error } = await retry()
+    if (error) throw error
+  } catch (error) {
+    if (!isBenignRetryRaceError(error)) toaster.danger(error?.message || error?.toString?.())
+  } finally {
+    setDisable(false)
+  }
 }
 
 // the per-type cache phases for a retry, composed on top of the caller's phases (e.g. the
@@ -66,6 +78,8 @@ function retryBaseCachePhases (payInType, me) {
 }
 
 function composeRetryCachePhases (baseCachePhases, userCachePhases) {
+  // compose all four phases uniformly so a caller's onPaidMissingResult isn't silently dropped
+  // (act/bounty retries don't currently supply one, but a future ITEM_CREATE retry might)
   return {
     onMutationResult: composeCallbacks(baseCachePhases.onMutationResult, userCachePhases.onMutationResult),
     onPaidMissingResult: composeCallbacks(baseCachePhases.onPaidMissingResult, userCachePhases.onPaidMissingResult),

--- a/components/payIn/hooks/use-retry-pay-in.js
+++ b/components/payIn/hooks/use-retry-pay-in.js
@@ -4,7 +4,7 @@ import { getActCachePhases } from '@/components/item-act'
 import { payBountyCachePhases } from '@/components/pay-bounty'
 import { useMe } from '@/components/me'
 import { useHasSendWallet } from '@/wallets/client/hooks'
-import { InvoiceCanceledError } from '@/wallets/client/errors'
+import { InvoiceCanceledError, isTransientNetworkError } from '@/wallets/client/errors'
 import { composeCallbacks } from '@/lib/compose-callbacks'
 import { PAY_IN_ACT_TYPES } from '@/lib/constants'
 import { E_PAY_IN_RETRY_RACE } from '@/lib/error'
@@ -53,7 +53,10 @@ export async function runManualRetry (retry, { setDisable, toaster }) {
     const { error } = await retry()
     if (error) throw error
   } catch (error) {
-    if (!isBenignRetryRaceError(error)) toaster.danger(error?.message || error?.toString?.())
+    // benign retry races and gateway timeouts (the retry is still being processed) aren't surfaced
+    if (!isBenignRetryRaceError(error) && !isTransientNetworkError(error)) {
+      toaster.danger(error?.message || error?.toString?.())
+    }
   } finally {
     setDisable(false)
   }

--- a/components/payIn/hooks/use-retry-pay-in.js
+++ b/components/payIn/hooks/use-retry-pay-in.js
@@ -72,15 +72,18 @@ function withBountyCachePhases (userCachePhases) {
   })
 }
 
-// the act phases add unconditionally: act retries only happen from the notifications page,
-// whose responses reconcile item counters to server truth (reconcileNotificationsLink in
-// lib/apollo.js), and the retry button only renders once the server stopped counting the
-// failed lineage in the payer's item sats — so the cache never holds the sats this re-adds
+// the genesis act already bumped the item counters optimistically and that bump persists through
+// the lineage, so a retry must NOT re-apply it (there's no reconcile to undo a double-add). it
+// keeps only the act's onPayError (reverse the bump on terminal failure — usePayInMutation gates
+// this to non-retryable failures) and onPaid (bump ancestors on success); the caller's own phases
+// (e.g. the notification's payIn-state writes) compose as usual.
 function withActCachePhases (actCachePhases, userCachePhases) {
-  return withComposedCachePhases(actCachePhases, userCachePhases, {
-    // runs outside update() context — use the dedicated onPaidMissingResult (optimistic:false)
-    onPaidMissingResult: actCachePhases.onPaidMissingResult
-  })
+  return {
+    onMutationResult: userCachePhases.onMutationResult,
+    onPaidMissingResult: userCachePhases.onPaidMissingResult,
+    onPaid: composeCallbacks(actCachePhases.onPaid, userCachePhases.onPaid),
+    onPayError: composeCallbacks(actCachePhases.onPayError, userCachePhases.onPayError)
+  }
 }
 
 function withComposedCachePhases (baseCachePhases, userCachePhases, { onPaidMissingResult } = {}) {

--- a/components/payIn/hooks/use-retry-pay-in.js
+++ b/components/payIn/hooks/use-retry-pay-in.js
@@ -7,6 +7,8 @@ import { useHasSendWallet } from '@/wallets/client/hooks'
 import { InvoiceCanceledError } from '@/wallets/client/errors'
 import { composeCallbacks } from '@/lib/compose-callbacks'
 import { PAY_IN_ACT_TYPES } from '@/lib/constants'
+import { E_PAY_IN_RETRY_RACE } from '@/lib/error'
+import { toFailedPayIn } from '@/lib/pay-in'
 
 export function useRetryPayIn (payInId, mutationOptions = {}) {
   const { restOptions, cachePhases } = splitMutationOptions(mutationOptions)
@@ -40,21 +42,20 @@ export function useRetryPayInByType (payInId, payInType, mutationOptions = {}) {
   return retryPayIn
 }
 
-export function getRetryPayInFailureUpdate (error, data) {
+// the FAILED view of a retry mutation's successor for cache writes when paying it failed
+export function getFailedRetryPayIn (error, data) {
   const retryResult = Object.values(data ?? {})[0]
   if (!retryResult?.id) return null
 
-  return {
-    retryPayInId: retryResult.id,
-    failureData: {
-      payInState: 'FAILED',
-      payInStateChangedAt: new Date().toISOString(),
-      payerPrivates: {
-        __typename: 'PayerPrivates',
-        payInFailureReason: error instanceof InvoiceCanceledError ? 'USER_CANCELLED' : 'EXECUTION_FAILED'
-      }
-    }
-  }
+  return toFailedPayIn(retryResult, error instanceof InvoiceCanceledError ? 'USER_CANCELLED' : 'EXECUTION_FAILED')
+}
+
+// retry() (api/payIn/index.js) rejects with an E_PAY_IN_RETRY_RACE-coded error when the lineage
+// already advanced, the successor isn't FAILED yet, or a concurrent retry won the successorId
+// lock. These races are expected under rapid clicks / multiple tabs and are swallowed by the
+// background auto-retry too — so a manual retry shouldn't surface them as an error.
+export function isBenignRetryRaceError (error) {
+  return [error, ...(error?.errors ?? [])].some(e => e?.extensions?.code === E_PAY_IN_RETRY_RACE)
 }
 
 function splitMutationOptions (mutationOptions = {}) {

--- a/components/payIn/hooks/use-retry-pay-in.js
+++ b/components/payIn/hooks/use-retry-pay-in.js
@@ -10,24 +10,13 @@ import { PAY_IN_ACT_TYPES } from '@/lib/constants'
 import { E_PAY_IN_RETRY_RACE } from '@/lib/error'
 import { toFailedPayIn } from '@/lib/pay-in'
 
-export function useRetryPayIn (payInId, mutationOptions = {}) {
-  const { restOptions, cachePhases } = splitMutationOptions(mutationOptions)
-  const [retryPayIn] = usePayInMutation(RETRY_PAY_IN, { ...restOptions, cachePhases, variables: { payInId } })
-  return retryPayIn
-}
-
-export function useRetryPayInByType (payInId, payInType, mutationOptions = {}) {
+export function useRetryPayIn (payInId, payInType, mutationOptions = {}) {
   const { me } = useMe()
   const hasSendWallet = useHasSendWallet()
-  const { restOptions, cachePhases: userCachePhases } = splitMutationOptions(mutationOptions)
+  const { cachePhases: userCachePhases = {}, ...restOptions } = mutationOptions
 
   const isAct = PAY_IN_ACT_TYPES.includes(payInType)
-  const isBounty = payInType === 'BOUNTY_PAYMENT'
-  const cachePhases = isBounty
-    ? withBountyCachePhases(userCachePhases)
-    : isAct
-      ? withActCachePhases(getActCachePhases(me), userCachePhases)
-      : userCachePhases
+  const cachePhases = composeRetryCachePhases(retryBaseCachePhases(payInType, me), userCachePhases)
 
   const options = { ...restOptions, cachePhases }
 
@@ -58,36 +47,28 @@ export function isBenignRetryRaceError (error) {
   return [error, ...(error?.errors ?? [])].some(e => e?.extensions?.code === E_PAY_IN_RETRY_RACE)
 }
 
-function splitMutationOptions (mutationOptions = {}) {
-  const { cachePhases = {}, ...restOptions } = mutationOptions
-  return {
-    restOptions,
-    cachePhases
+// the per-type cache phases for a retry, composed on top of the caller's phases (e.g. the
+// notification's payIn-state writes).
+// - acts: identical to the genesis act phases. the retry button bumps the item at click time
+//   (notifications.js, same as the modal/bolt), so these only reconcile credits (onMutationResult),
+//   reverse on terminal failure (onPayError, gated by usePayInMutation to non-retryable failures),
+//   and bump ancestors on success (onPaid). the notifications reconcile link had already removed
+//   the failed lineage's bump, so the click-time re-bump is exact.
+// - bounty: re-running the full phases is harmless — onMutationResult appends to a set, onPayError
+//   filters it.
+// - everything else contributes no base phases.
+function retryBaseCachePhases (payInType, me) {
+  if (PAY_IN_ACT_TYPES.includes(payInType)) {
+    return getActCachePhases(me)
   }
+  if (payInType === 'BOUNTY_PAYMENT') return payBountyCachePhases
+  return {}
 }
 
-function withBountyCachePhases (userCachePhases) {
-  return withComposedCachePhases(payBountyCachePhases, userCachePhases)
-}
-
-// the genesis act already bumped the item counters optimistically and that bump persists through
-// the lineage, so a retry must NOT re-apply it (there's no reconcile to undo a double-add). it
-// keeps only the act's onPayError (reverse the bump on terminal failure — usePayInMutation gates
-// this to non-retryable failures) and onPaid (bump ancestors on success); the caller's own phases
-// (e.g. the notification's payIn-state writes) compose as usual.
-function withActCachePhases (actCachePhases, userCachePhases) {
-  return {
-    onMutationResult: userCachePhases.onMutationResult,
-    onPaidMissingResult: userCachePhases.onPaidMissingResult,
-    onPaid: composeCallbacks(actCachePhases.onPaid, userCachePhases.onPaid),
-    onPayError: composeCallbacks(actCachePhases.onPayError, userCachePhases.onPayError)
-  }
-}
-
-function withComposedCachePhases (baseCachePhases, userCachePhases, { onPaidMissingResult } = {}) {
+function composeRetryCachePhases (baseCachePhases, userCachePhases) {
   return {
     onMutationResult: composeCallbacks(baseCachePhases.onMutationResult, userCachePhases.onMutationResult),
-    onPaidMissingResult: composeCallbacks(onPaidMissingResult, userCachePhases.onPaidMissingResult),
+    onPaidMissingResult: composeCallbacks(baseCachePhases.onPaidMissingResult, userCachePhases.onPaidMissingResult),
     onPaid: composeCallbacks(baseCachePhases.onPaid, userCachePhases.onPaid),
     onPayError: composeCallbacks(baseCachePhases.onPayError, userCachePhases.onPayError)
   }

--- a/components/payIn/hooks/use-retry-pay-in.js
+++ b/components/payIn/hooks/use-retry-pay-in.js
@@ -72,6 +72,10 @@ function withBountyCachePhases (userCachePhases) {
   })
 }
 
+// the act phases add unconditionally: act retries only happen from the notifications page,
+// whose responses reconcile item counters to server truth (reconcileNotificationsLink in
+// lib/apollo.js), and the retry button only renders once the server stopped counting the
+// failed lineage in the payer's item sats — so the cache never holds the sats this re-adds
 function withActCachePhases (actCachePhases, userCachePhases) {
   return withComposedCachePhases(actCachePhases, userCachePhases, {
     // runs outside update() context — use the dedicated onPaidMissingResult (optimistic:false)

--- a/components/payIn/hooks/use-retry-pay-in.js
+++ b/components/payIn/hooks/use-retry-pay-in.js
@@ -18,7 +18,9 @@ export function useRetryPayIn (payInId, payInType, mutationOptions = {}) {
   const isAct = PAY_IN_ACT_TYPES.includes(payInType)
   const cachePhases = composeRetryCachePhases(retryBaseCachePhases(payInType, me), userCachePhases)
 
-  const options = { ...restOptions, cachePhases }
+  // a manual retry's fresh invoice creation/wrap failure is terminal — debump and show FAILED. (a
+  // genesis failure instead keeps its optimistic bump and auto-retries in the background.)
+  const options = { ...restOptions, cachePhases, failOnInvoiceSetupPending: true }
 
   if (isAct) {
     options.waitFor = actWaitFor(hasSendWallet)

--- a/components/payIn/hooks/use-retry-pay-in.js
+++ b/components/payIn/hooks/use-retry-pay-in.js
@@ -67,9 +67,7 @@ function splitMutationOptions (mutationOptions = {}) {
 }
 
 function withBountyCachePhases (userCachePhases) {
-  return withComposedCachePhases(payBountyCachePhases, userCachePhases, {
-    onPaidMissingResult: payBountyCachePhases.onPaidMissingResult
-  })
+  return withComposedCachePhases(payBountyCachePhases, userCachePhases)
 }
 
 // the genesis act already bumped the item counters optimistically and that bump persists through

--- a/components/payIn/status.js
+++ b/components/payIn/status.js
@@ -17,8 +17,8 @@ export function PayInStatus ({ payIn }) {
     <div className='d-flex align-items-center'>
       {(payIn.payInState === 'PAID' && <><Check width={statusIconSize} height={statusIconSize} className='fill-success' /><StatusText color='success'>{payIn.mcost > 0 ? 'paid' : 'free'}</StatusText></>) ||
         (FAILED_PAY_IN_STATES.includes(payIn.payInState) && <><ThumbDown width={statusIconSize} height={statusIconSize} className='fill-danger' /><StatusText color='danger'>failed</StatusText></>) ||
-        ((payIn.payInState === 'FORWARDING' || payIn.payInState === 'FORWARDED' || !payIn.payerPrivates.payInBolt11) && <><Moon width={statusIconSize} height={statusIconSize} className='spin fill-grey' /><StatusText color='muted'>settling</StatusText></>) ||
-        (<CompactLongCountdown className='text-muted' date={payIn.payerPrivates.payInBolt11.expiresAt} />)}
+        ((payIn.payInState === 'FORWARDING' || payIn.payInState === 'FORWARDED' || !payIn.payerPrivates?.payInBolt11) && <><Moon width={statusIconSize} height={statusIconSize} className='spin fill-grey' /><StatusText color='muted'>settling</StatusText></>) ||
+        (<CompactLongCountdown className='text-muted' date={payIn.payerPrivates?.payInBolt11?.expiresAt} />)}
     </div>
   )
 }

--- a/components/poll.js
+++ b/components/poll.js
@@ -7,6 +7,7 @@ import { signIn } from 'next-auth/react'
 import ActionTooltip from './action-tooltip'
 import { useToast } from './toast'
 import usePayInMutation from '@/components/payIn/hooks/use-pay-in-mutation'
+import { throwUnlessUserCancel } from '@/wallets/client/errors'
 import { POLL_VOTE } from '@/fragments/payIn'
 import { useState } from 'react'
 import classNames from 'classnames'
@@ -27,10 +28,13 @@ const PollButton = ({ v, item }) => {
             setIsSubmitting(true)
             const variables = { id: v.id }
             try {
-              const { error } = await pollVote({
+              const { error, payError } = await pollVote({
                 variables
               })
               if (error) throw error
+              // poll votes are pessimistic, so a terminal payment failure (expired/canceled
+              // invoice) comes back in payError, never error — but a user-canceled QR isn't news
+              throwUnlessUserCancel(payError)
             } catch (error) {
               const reason = error?.message || error?.toString?.()
               toaster.danger(reason)

--- a/components/territory-payment-due.js
+++ b/components/territory-payment-due.js
@@ -9,6 +9,7 @@ import { useCallback } from 'react'
 import { useApolloClient } from '@apollo/client/react'
 import { nextBillingWithGrace } from '@/lib/territory'
 import usePayInMutation from '@/components/payIn/hooks/use-pay-in-mutation'
+import { throwUnlessUserCancel } from '@/wallets/client/errors'
 import { SUB_PAY } from '@/fragments/payIn'
 
 export default function TerritoryPaymentDue ({ sub }) {
@@ -17,11 +18,14 @@ export default function TerritoryPaymentDue ({ sub }) {
   const [paySub] = usePayInMutation(SUB_PAY)
 
   const onSubmit = useCallback(async ({ ...variables }) => {
-    const { error } = await paySub({
+    const { error, payError } = await paySub({
       variables
     })
 
     if (error) throw error
+    // territory billing is pessimistic, so a terminal payment failure comes back in payError —
+    // but a user-canceled QR isn't news
+    throwUnlessUserCancel(payError)
   }, [client, paySub])
 
   if (!sub || sub.userId !== Number(me?.id) || sub.status === 'ACTIVE') return null

--- a/components/use-item-submit.js
+++ b/components/use-item-submit.js
@@ -119,7 +119,6 @@ export default function useItemSubmit (mutation,
 }
 
 function saveItemInvoiceHmac (mutationData) {
-  console.log('saveItemInvoiceHmac', mutationData)
   const response = Object.values(mutationData)[0]
 
   if (!response?.payerPrivates?.payInBolt11) return

--- a/components/use-item-submit.js
+++ b/components/use-item-submit.js
@@ -6,6 +6,7 @@ import { useCallback } from 'react'
 import { normalizeForwards, toastUpsertSuccessMessages } from '@/lib/form'
 import { USER_ID } from '@/lib/constants'
 import { composeCallbacks } from '@/lib/compose-callbacks'
+import { getPayIn } from '@/lib/pay-in'
 import { useMe } from './me'
 import { useBranding } from './territory-branding'
 
@@ -50,20 +51,13 @@ export default function useItemSubmit (mutation,
       } = payInMutationOptions
       const mergedCachePhases = {
         ...payInCachePhases,
-        // If the initial mutation response had no result payload, rerun mutation-phase
-        // cache work in paid-phase so the UI still updates. We wrap the cache to force
-        // optimistic:false since onPaidMissingResult runs outside Apollo's update() context.
+        // a pessimistic item create/update has no genesis result, so the mutation-phase cache work
+        // (comment injection, ncomments...) must be deferred to the paid phase. re-run it then, but
+        // against the root cache — onPaidMissingResult runs outside Apollo's update() context.
         onPaidMissingResult: composeCallbacks(
           payInCachePhases.onPaidMissingResult,
           payInCachePhases.onMutationResult
-            ? (cache, ...args) => {
-                const nonOptimisticCache = Object.create(cache, {
-                  modify: {
-                    value: (options) => cache.modify({ ...options, optimistic: false })
-                  }
-                })
-                payInCachePhases.onMutationResult(nonOptimisticCache, ...args)
-              }
+            ? (cache, ...args) => payInCachePhases.onMutationResult(nonOptimisticCache(cache), ...args)
             : undefined
         )
       }
@@ -95,7 +89,7 @@ export default function useItemSubmit (mutation,
       if (payError) return
 
       // we don't know the mutation name, so we have to extract the result
-      const response = Object.values(data)[0]
+      const response = getPayIn(data)
       const postId = response?.payerPrivates.result?.id
 
       if (crosspost && postId) {
@@ -118,8 +112,16 @@ export default function useItemSubmit (mutation,
   )
 }
 
+// a cache whose .modify forces optimistic:false, so a mutation-phase cache write can be re-run in
+// a paid phase (outside Apollo's update() context) without leaking into an optimistic layer
+function nonOptimisticCache (cache) {
+  return Object.create(cache, {
+    modify: { value: (options) => cache.modify({ ...options, optimistic: false }) }
+  })
+}
+
 function saveItemInvoiceHmac (mutationData) {
-  const response = Object.values(mutationData)[0]
+  const response = getPayIn(mutationData)
 
   if (!response?.payerPrivates?.payInBolt11) return
 

--- a/components/use-zap.js
+++ b/components/use-zap.js
@@ -6,6 +6,7 @@ import usePayInMutation from '@/components/payIn/hooks/use-pay-in-mutation'
 import { ACT_MUTATION } from '@/fragments/payIn'
 import { ZAP_DEBOUNCE_MS } from '@/lib/constants'
 import { useHasSendWallet } from '@/wallets/client/hooks'
+import { isTransientNetworkError } from '@/wallets/client/errors'
 import { ActCanceledError, bumpActCache, getActCachePhases, revertActBump, zapUndo, zapUndoTrigger } from './item-act'
 import { actWaitFor } from '@/lib/pay-in'
 
@@ -48,9 +49,15 @@ export function useZap ({ nextTip }) {
       // a returned error has a payIn (getActCachePhases.onPayError reverted it); just log
       if (error) console.error('debounced zap error:', error)
     } catch (error) {
-      // mutation threw before creating a payIn — no phase reverts, so undo the bump here
-      console.error('debounced zap failed:', error)
-      revertActBump(client.cache, result, entryMe)
+      if (isTransientNetworkError(error)) {
+        // a gateway timeout means the zap is likely still being processed (it falls back to credits
+        // or persists and auto-retries) — keep the optimistic bump instead of reverting it
+        console.warn('debounced zap timed out (still processing):', error)
+      } else {
+        // mutation threw before creating a payIn — no phase reverts, so undo the bump here
+        console.error('debounced zap failed:', error)
+        revertActBump(client.cache, result, entryMe)
+      }
     }
   }
   const fireZap = useCallback((entry) => fireZapRef.current(entry), [])

--- a/components/use-zap.js
+++ b/components/use-zap.js
@@ -6,7 +6,7 @@ import usePayInMutation from '@/components/payIn/hooks/use-pay-in-mutation'
 import { ACT_MUTATION } from '@/fragments/payIn'
 import { ZAP_DEBOUNCE_MS } from '@/lib/constants'
 import { useHasSendWallet } from '@/wallets/client/hooks'
-import { ActCanceledError, modifyActCache, updateAncestors, zapUndo, zapUndoTrigger } from './item-act'
+import { ActCanceledError, bumpActCache, getActCachePhases, revertActBump, zapUndo, zapUndoTrigger } from './item-act'
 
 const ZAP_ME_SATS_FRAGMENT = gql`
   fragment ZapMeSats on Item { meSats }
@@ -33,6 +33,10 @@ export function useZap ({ nextTip }) {
   // fire the accumulated zap mutation for a buffer entry
   fireZapRef.current = async (entry) => {
     const { totalSats, item, me: entryMe } = entry
+    // the per-click bumps already wrote sats to the root cache; the act phases reconcile credits,
+    // ancestors, and the reversal off the response (its result.sats equals totalSats). entryMe is
+    // the click-time identity. no optimisticResponse — the bump is the optimistic write.
+    const result = { id: item.id, sats: totalSats, act: 'TIP', path: item.path }
     try {
       const { error } = await sendZap({
         variables: { id: item.id, sats: totalSats, act: 'TIP' },
@@ -41,66 +45,14 @@ export function useZap ({ nextTip }) {
           hasSendWallet
             ? payIn?.payInState === 'PAID'
             : ['FORWARDING', 'PAID'].includes(payIn?.payInState),
-        // no optimisticResponse — cache is already updated via modifyActCache
-        cachePhases: {
-          // sats/meSats already correct from per-click modifyActCache.
-          // Pre-mutation write assumed P2P (skipped credits). If actually non-P2P, add credits now.
-          onMutationResult: (cache, { data }) => {
-            const response = data && Object.values(data)[0]
-            if (!response) return
-            if (response.payOutBolt11Public) return // actually P2P — credits correctly skipped
-            // non-P2P — add the credit increment
-            cache.modify({
-              id: `Item:${item.id}`,
-              fields: {
-                credits: (existing = 0) => existing + totalSats,
-                meCredits: (existing = 0) => existing + totalSats
-              },
-              optimistic: true // inside update() context
-            })
-          },
-          onPaid: (cache, { data }) => {
-            const response = Object.values(data)[0]
-            if (!response) return
-            // build a synthetic response with our accumulated sats for ancestor updates
-            updateAncestors(cache, {
-              ...response,
-              payerPrivates: {
-                ...response.payerPrivates,
-                result: { id: item.id, sats: totalSats, act: 'TIP', path: item.path, __typename: 'ItemAct' }
-              }
-            }, { optimistic: false })
-          },
-          onPayError: (e, cache, { data }) => {
-            // revert using real payOutBolt11Public so credit rollback is symmetric:
-            // if non-P2P, onMutationResult added credits → need to subtract them
-            // if P2P, credits were never added → skip credit subtraction
-            const response = data && Object.values(data)[0]
-            const payOutBolt11Public = response ? response.payOutBolt11Public : true
-            modifyActCache(cache, {
-              payerPrivates: { result: { id: item.id, sats: -totalSats, act: 'TIP' } },
-              payOutBolt11Public
-            }, entryMe, { optimistic: false })
-          }
-        }
+        cachePhases: getActCachePhases(entryMe)
       })
-      if (error) {
-        // mutation returned an error (GraphQL-level) — revert cache
-        // mirror initial P2P assumption (credits were never added)
-        console.error('debounced zap error:', error)
-        modifyActCache(client.cache, {
-          payerPrivates: { result: { id: item.id, sats: -totalSats, act: 'TIP', path: item.path } },
-          payOutBolt11Public: true
-        }, entryMe, { optimistic: false })
-      }
+      // a returned error has a payIn (getActCachePhases.onPayError reverted it); just log
+      if (error) console.error('debounced zap error:', error)
     } catch (error) {
-      // mutation threw (network error, etc.) — revert cache
-      // mirror initial P2P assumption (credits were never added)
+      // mutation threw before creating a payIn — no phase reverts, so undo the bump here
       console.error('debounced zap failed:', error)
-      modifyActCache(client.cache, {
-        payerPrivates: { result: { id: item.id, sats: -totalSats, act: 'TIP', path: item.path } },
-        payOutBolt11Public: true
-      }, entryMe, { optimistic: false })
+      revertActBump(client.cache, result, entryMe)
     }
   }
   const fireZap = useCallback((entry) => fireZapRef.current(entry), [])
@@ -136,12 +88,9 @@ export function useZap ({ nextTip }) {
     const meSats = cached?.meSats ?? item?.meSats ?? 0
     const sats = nextTip(meSats, { ...meProp?.privates })
 
-    // instant visual feedback — write directly to root cache (not an optimistic layer)
-    // pass payOutBolt11Public truthy to assume P2P (skip credits) — reconciled in onMutationResult
-    modifyActCache(client.cache, {
-      payerPrivates: { result: { id: item.id, sats, act: 'TIP', path: item.path } },
-      payOutBolt11Public: true
-    }, meProp, { optimistic: false })
+    // instant visual feedback — bump the root cache (survives navigation; credits reconciled by
+    // the act phases on the mutation response)
+    bumpActCache(client.cache, { id: item.id, sats, act: 'TIP', path: item.path }, meProp)
 
     animate()
 
@@ -171,12 +120,8 @@ export function useZap ({ nextTip }) {
           await zapUndo(controller.signal, totalSats)
         } catch (error) {
           if (error instanceof ActCanceledError) {
-            // user canceled — revert all accumulated cache changes
-            // mirror initial P2P assumption (credits were never added)
-            modifyActCache(client.cache, {
-              payerPrivates: { result: { id: savedItem.id, sats: -totalSats, act: 'TIP', path: savedItem.path } },
-              payOutBolt11Public: true
-            }, meProp, { optimistic: false })
+            // user canceled before the mutation fired — undo the accumulated bump
+            revertActBump(client.cache, { id: savedItem.id, sats: totalSats, act: 'TIP', path: savedItem.path }, meProp)
             if (mountedRef.current) setUndoPending(0)
             undoControllerRef.current = null
             return
@@ -200,14 +145,10 @@ export function useZap ({ nextTip }) {
       undoControllerRef.current = null
     }
 
-    // clear all debounce timers and revert cache — use entry.me (click-time identity)
-    // mirror initial P2P assumption (credits were never added)
+    // clear all debounce timers and undo each pending bump — use entry.me (click-time identity)
     for (const [, entry] of bufferRef.current) {
       clearTimeout(entry.timer)
-      modifyActCache(client.cache, {
-        payerPrivates: { result: { id: entry.item.id, sats: -entry.totalSats, act: 'TIP', path: entry.item.path } },
-        payOutBolt11Public: true
-      }, entry.me, { optimistic: false })
+      revertActBump(client.cache, { id: entry.item.id, sats: entry.totalSats, act: 'TIP', path: entry.item.path }, entry.me)
     }
     bufferRef.current.clear()
 

--- a/components/use-zap.js
+++ b/components/use-zap.js
@@ -7,6 +7,7 @@ import { ACT_MUTATION } from '@/fragments/payIn'
 import { ZAP_DEBOUNCE_MS } from '@/lib/constants'
 import { useHasSendWallet } from '@/wallets/client/hooks'
 import { ActCanceledError, bumpActCache, getActCachePhases, revertActBump, zapUndo, zapUndoTrigger } from './item-act'
+import { actWaitFor } from '@/lib/pay-in'
 
 const ZAP_ME_SATS_FRAGMENT = gql`
   fragment ZapMeSats on Item { meSats }
@@ -40,11 +41,8 @@ export function useZap ({ nextTip }) {
     try {
       const { error } = await sendZap({
         variables: { id: item.id, sats: totalSats, act: 'TIP' },
-        // pass waitFor per-call so debounce timer always uses latest send-wallet availability
-        waitFor: payIn =>
-          hasSendWallet
-            ? payIn?.payInState === 'PAID'
-            : ['FORWARDING', 'PAID'].includes(payIn?.payInState),
+        // waitFor passed per-call so the debounce timer uses the latest send-wallet availability
+        waitFor: actWaitFor(hasSendWallet),
         cachePhases: getActCachePhases(entryMe)
       })
       // a returned error has a payIn (getActCachePhases.onPayError reverted it); just log

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -40,6 +40,13 @@ const maxMerge = (existing, incoming) => {
   return Math.max(existing, incoming)
 }
 
+// the Item counters protected by maxMerge; the notifications reconcile link writes these
+// same fields as server truth (see reconcileItemCounters) so the two lists can't drift
+const ITEM_COUNTER_FIELDS = [
+  'sats', 'credits', 'meSats', 'meCredits', 'meDontLikeSats', 'downSats', 'boost',
+  'commentSats', 'commentCredits', 'commentDownSats', 'commentBoost'
+]
+
 const retryLink = new RetryLink({
   delay: {
     initial: 300,
@@ -55,8 +62,42 @@ const retryLink = new RetryLink({
   }
 })
 
+// notifications is the surface every manual payIn retry starts from, so its responses are
+// written as truth: walk the raw (pre-merge) response and write each item's counters via
+// cache.modify, which bypasses merge functions the same way local bumps do; apollo's own
+// result write then merges max(server, server) and converges. This is the one path where
+// counters can move DOWN to match the server (e.g. a lineage canceled in another tab) —
+// the correction maxMerge otherwise blocks forever. modify defaults to the root cache, so
+// an in-flight zap's optimistic layer is never clobbered by a racing notifications response.
+function reconcileItemCounters (cache, data) {
+  if (!data || typeof data !== 'object') return
+  if (data.__typename === 'Item' && data.id != null) {
+    const fields = {}
+    for (const field of ITEM_COUNTER_FIELDS) {
+      if (typeof data[field] === 'number') {
+        fields[field] = () => data[field]
+      }
+    }
+    if (Object.keys(fields).length > 0) {
+      cache.modify({ id: `Item:${data.id}`, fields })
+    }
+  }
+  for (const value of Object.values(data)) {
+    reconcileItemCounters(cache, value)
+  }
+}
+
+const reconcileNotificationsLink = new ApolloLink((operation, forward) =>
+  forward(operation).map(response => {
+    if (operation.operationName === 'Notifications' && response.data) {
+      reconcileItemCounters(operation.client.cache, response.data)
+    }
+    return response
+  }))
+
 function getClient (uri) {
   const link = ApolloLink.from([
+    reconcileNotificationsLink,
     retryLink,
     new HttpLink({ uri })
   ])
@@ -341,17 +382,7 @@ function getClient (uri) {
         },
         Item: {
           fields: {
-            sats: { merge: maxMerge },
-            credits: { merge: maxMerge },
-            meSats: { merge: maxMerge },
-            meCredits: { merge: maxMerge },
-            meDontLikeSats: { merge: maxMerge },
-            downSats: { merge: maxMerge },
-            boost: { merge: maxMerge },
-            commentSats: { merge: maxMerge },
-            commentCredits: { merge: maxMerge },
-            commentDownSats: { merge: maxMerge },
-            commentBoost: { merge: maxMerge },
+            ...Object.fromEntries(ITEM_COUNTER_FIELDS.map(field => [field, { merge: maxMerge }])),
             comments: {
               keyArgs: ['sort'],
               merge (existing, incoming) {

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -4,7 +4,6 @@ import { decodeCursor, LIMIT } from './cursor'
 import { COMMENTS_LIMIT, SSR } from './constants'
 import { RetryLink } from '@apollo/client/link/retry'
 import { isMutationOperation, isQueryOperation } from '@apollo/client/utilities'
-import { map } from 'rxjs'
 
 function isFirstPage (cursor, existingThings, limit = LIMIT) {
   if (cursor) {
@@ -87,21 +86,21 @@ function reconcileItemCounters (cache, data) {
   }
 }
 
-const reconcileNotificationsLink = new ApolloLink((operation, forward) =>
-  forward(operation).pipe(map(response => {
-    if (operation.operationName === 'Notifications') {
-      for (const n of response.data?.notifications?.notifications ?? []) {
-        if (n.__typename === 'PayInification' && n.payInItem) {
-          reconcileItemCounters(operation.client.cache, n.payInItem)
-        }
-      }
+// reconcile item counters for the notifications feed at the data-consumption layer.
+// the feed is delivered via SSR (writeQuery, subject to maxMerge which can't lower a stale
+// optimistic bump) and read cache-first (so no client-link request fires), so this can't live
+// in an ApolloLink — it must run wherever the rendered notifications data is available.
+// callers pass the displayed list so both the SSR first page and fetchMore pages are covered.
+export function reconcileNotificationItemCounters (cache, notifications) {
+  for (const n of notifications ?? []) {
+    if (n.__typename === 'PayInification' && n.payInItem) {
+      reconcileItemCounters(cache, n.payInItem)
     }
-    return response
-  })))
+  }
+}
 
 function getClient (uri) {
   const link = ApolloLink.from([
-    reconcileNotificationsLink,
     retryLink,
     new HttpLink({ uri })
   ])

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -4,6 +4,7 @@ import { decodeCursor, LIMIT } from './cursor'
 import { COMMENTS_LIMIT, SSR } from './constants'
 import { RetryLink } from '@apollo/client/link/retry'
 import { isMutationOperation, isQueryOperation } from '@apollo/client/utilities'
+import { map } from 'rxjs'
 
 function isFirstPage (cursor, existingThings, limit = LIMIT) {
   if (cursor) {
@@ -40,8 +41,9 @@ const maxMerge = (existing, incoming) => {
   return Math.max(existing, incoming)
 }
 
-// the Item counters protected by maxMerge; the notifications reconcile link writes these
-// same fields as server truth (see reconcileItemCounters) so the two lists can't drift
+// the Item counters protected by maxMerge: optimistic act bumps (cache.modify, which bypasses
+// merge) write through cleanly, and stale SSR/query writes can only raise them, never clobber a
+// pending zap. the notifications reconcile link below writes these same fields as server truth.
 const ITEM_COUNTER_FIELDS = [
   'sats', 'credits', 'meSats', 'meCredits', 'meDontLikeSats', 'downSats', 'boost',
   'commentSats', 'commentCredits', 'commentDownSats', 'commentBoost'
@@ -62,13 +64,11 @@ const retryLink = new RetryLink({
   }
 })
 
-// notifications is the surface every manual payIn retry starts from, so its responses are
-// written as truth: walk the raw (pre-merge) response and write each item's counters via
-// cache.modify, which bypasses merge functions the same way local bumps do; apollo's own
-// result write then merges max(server, server) and converges. This is the one path where
-// counters can move DOWN to match the server (e.g. a lineage canceled in another tab) —
-// the correction maxMerge otherwise blocks forever. modify defaults to the root cache, so
-// an in-flight zap's optimistic layer is never clobbered by a racing notifications response.
+// a failed payment is seen and retried on the notifications feed. for each PayInification
+// (failed-payment) notification, write the server's item counters as truth via cache.modify,
+// bypassing maxMerge — correcting an optimistic bump currently in the cache.
+// Scoping to the payInItem (not every item in the feed) is exact: a failed act only
+// ever bumped the acted-on item, so only it can be stale; other notifications' items are untouched.
 function reconcileItemCounters (cache, data) {
   if (!data || typeof data !== 'object') return
   if (data.__typename === 'Item' && data.id != null) {
@@ -88,12 +88,16 @@ function reconcileItemCounters (cache, data) {
 }
 
 const reconcileNotificationsLink = new ApolloLink((operation, forward) =>
-  forward(operation).map(response => {
-    if (operation.operationName === 'Notifications' && response.data) {
-      reconcileItemCounters(operation.client.cache, response.data)
+  forward(operation).pipe(map(response => {
+    if (operation.operationName === 'Notifications') {
+      for (const n of response.data?.notifications?.notifications ?? []) {
+        if (n.__typename === 'PayInification' && n.payInItem) {
+          reconcileItemCounters(operation.client.cache, n.payInItem)
+        }
+      }
     }
     return response
-  }))
+  })))
 
 function getClient (uri) {
   const link = ApolloLink.from([

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -42,7 +42,6 @@ export const PAY_IN_ACT_TYPES = ['ZAP', 'DOWN_ZAP', 'BOOST']
 export const PAY_IN_NOTIFICATION_TYPES = ['ITEM_CREATE', ...PAY_IN_ACT_TYPES, 'BOUNTY_PAYMENT']
 export const PAY_IN_AUTO_RETRY_TYPES = [...PAY_IN_NOTIFICATION_TYPES]
 export const BOUNTY_MIN = 1000
-export const BOUNTY_MAX = 10000000
 export const POST_TYPES = ['LINK', 'DISCUSSION', 'BOUNTY', 'POLL']
 export const TERRITORY_BILLING_TYPES = ['MONTHLY', 'YEARLY', 'ONCE']
 export const TERRITORY_GRACE_DAYS = 5
@@ -117,6 +116,16 @@ export const MAX_OUTGOING_MSATS = 700_000_000n
 // max: largest whole-sat amount whose payout still fits under MAX_OUTGOING_MSATS
 export const PROXY_PAYER_MIN_MSATS = ceilBigInt(ceilBigInt(MIN_RECEIVE_MSATS * 100n, 100n - PROXY_RECEIVE_FEE_PERCENT), 1000n) * 1000n
 export const PROXY_PAYER_MAX_MSATS = MAX_OUTGOING_MSATS * 100n / (100n - PROXY_RECEIVE_FEE_PERCENT) / 1000n * 1000n
+
+// largest whole-sat zap whose 70% single-recipient P2P share (api/payIn/types/zap.js) still fits
+// under MAX_OUTGOING_MSATS. Larger zaps can't be wrapped/delivered P2P to a single recipient, so we
+// reject them at input time instead of silently degrading that recipient to credits.
+export const MAX_ZAP_SATS = Number(MAX_OUTGOING_MSATS * 100n / 70n / 1000n)
+
+// a bounty is paid to the winner as a single 100%-of-amount P2P invoice, so it can't exceed the
+// wrap cap (MAX_OUTGOING_MSATS); a larger bounty could be set but never delivered — and now churns
+// indefinitely since bounties have no custodial fallback — so reject it at input time.
+export const MAX_BOUNTY_SATS = Number(MAX_OUTGOING_MSATS / 1000n)
 
 export const SANCTIONED_COUNTRY_CODES = process.env.SANCTIONED_COUNTRY_CODES?.split(',') || []
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -257,7 +257,9 @@ export const ZAP_DEBOUNCE_MS = 1_000
 
 export const WALLET_SEND_PAYMENT_TIMEOUT_MS = 60_000
 export const WALLET_SHELL_SEND_PAYMENT_TIMEOUT_MS = 30_000
-export const WALLET_CREATE_INVOICE_TIMEOUT_MS = 30_000
+// keep under the load balancer's request timeout so a slow receive wallet fails over (e.g. a zap's
+// P2P wrap falls back to credits) before the LB 504s the in-flight act mutation
+export const WALLET_CREATE_INVOICE_TIMEOUT_MS = 20_000
 
 // interval between which failed invoices are returned to a client for automated retries.
 // retry-after must be high enough such that intermediate failed invoices that will already

--- a/lib/error.js
+++ b/lib/error.js
@@ -8,6 +8,7 @@ export const E_FORBIDDEN = 'E_FORBIDDEN'
 export const E_UNAUTHENTICATED = 'E_UNAUTHENTICATED'
 export const E_BAD_INPUT = 'E_BAD_INPUT'
 export const E_VAULT_KEY_EXISTS = 'E_VAULT_KEY_EXISTS'
+export const E_PAY_IN_RETRY_RACE = 'E_PAY_IN_RETRY_RACE'
 
 export class GqlAuthorizationError extends GraphQLError {
   constructor (message) {
@@ -24,5 +25,13 @@ export class GqlAuthenticationError extends GraphQLError {
 export class GqlInputError extends GraphQLError {
   constructor (message, code) {
     super(message, { extensions: { code: code || E_BAD_INPUT } })
+  }
+}
+
+// a payIn retry lost a benign race (lineage already advanced, successor not FAILED yet,
+// or a concurrent retry won the successorId lock) — clients key on the code to suppress it
+export class GqlPayInRetryRaceError extends GraphQLError {
+  constructor (message) {
+    super(message, { extensions: { code: E_PAY_IN_RETRY_RACE } })
   }
 }

--- a/lib/pay-in.js
+++ b/lib/pay-in.js
@@ -58,6 +58,17 @@ export function payTypeShortName (type) {
 
 export const FAILED_PAY_IN_STATES = ['FAILED', 'CANCELLED', 'FAILED_FORWARD']
 
+// the default "payment settled" predicate
+export const paidWaitFor = payIn => payIn?.payInState === 'PAID'
+
+// an act with a send wallet may be paying a wrapped (p2p-forwarded) invoice, so it waits for full
+// PAID (important for receiver fallbacks); without one, a forwarded invoice settles at FORWARDING
+export const actWaitFor = hasSendWallet => payIn =>
+  hasSendWallet ? paidWaitFor(payIn) : ['FORWARDING', 'PAID'].includes(payIn?.payInState)
+
+// the unique mutation result in a payIn mutation response (every doc returns a single root field)
+export const getPayIn = data => (data ? Object.values(data)[0] : null)
+
 export const INVOICE_SETUP_PENDING_STATES = ['PENDING_INVOICE_CREATION', 'PENDING_INVOICE_WRAP']
 
 // A bolt11-less payIn in an invoice-setup state means its invoice creation/wrap failed: it isn't

--- a/lib/pay-in.js
+++ b/lib/pay-in.js
@@ -2,7 +2,9 @@ export function describePayInType (payIn, me) {
   function type () {
     switch (payIn.payInType) {
       case 'ITEM_CREATE':
-        if (payIn.item.isJob) {
+        if (!payIn.item) {
+          return 'item'
+        } else if (payIn.item.isJob) {
           return 'job'
         } else if (payIn.item.title) {
           return 'post'
@@ -12,7 +14,9 @@ export function describePayInType (payIn, me) {
           return 'item'
         }
       case 'ITEM_UPDATE':
-        if (payIn.item.isJob) {
+        if (!payIn.item) {
+          return 'item edit'
+        } else if (payIn.item.isJob) {
           return 'job edit'
         } else if (payIn.item.title) {
           return 'post edit'

--- a/lib/pay-in.js
+++ b/lib/pay-in.js
@@ -54,6 +54,33 @@ export function payTypeShortName (type) {
 
 export const FAILED_PAY_IN_STATES = ['FAILED', 'CANCELLED', 'FAILED_FORWARD']
 
+export const INVOICE_SETUP_PENDING_STATES = ['PENDING_INVOICE_CREATION', 'PENDING_INVOICE_WRAP']
+
+// A bolt11-less payIn in an invoice-setup state means its invoice creation/wrap failed: it isn't
+// payable right now and is being driven to FAILED + background auto-retry. It is neither an error
+// to surface nor a state to pay — the optimistic view persists while we retry. Keys on state AND
+// the missing bolt11 so a (hypothetical) genuinely-created invoice in these transient states is
+// never misclassified.
+export function isInvoiceSetupPending (payIn) {
+  return INVOICE_SETUP_PENDING_STATES.includes(payIn?.payInState) && !payIn?.payerPrivates?.payInBolt11
+}
+
+// force a payIn into the FAILED shape cache writes expect, preserving any failure reason
+// the server already set and falling back to the given reason
+export function toFailedPayIn (payIn, payInFailureReason) {
+  return {
+    __typename: 'PayIn',
+    ...payIn,
+    payInState: 'FAILED',
+    payInStateChangedAt: new Date().toISOString(),
+    payerPrivates: {
+      __typename: 'PayerPrivates',
+      ...(payIn?.payerPrivates ?? {}),
+      payInFailureReason: payIn?.payerPrivates?.payInFailureReason ?? payInFailureReason
+    }
+  }
+}
+
 export const PAY_IN_RECEIVER_FAILURE_REASONS = [
   'INVOICE_WRAPPING_FAILED_HIGH_PREDICTED_FEE',
   'INVOICE_WRAPPING_FAILED_HIGH_PREDICTED_EXPIRY',

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -2,9 +2,9 @@ import { string, ValidationError, number, object, array, boolean, date, mixed } 
 import {
   MAX_POLL_CHOICE_LENGTH, MAX_TITLE_LENGTH, MAX_POLL_NUM_CHOICES,
   MIN_POLL_NUM_CHOICES, MAX_FORWARDS, MAX_TERRITORY_DESC_LENGTH, POST_TYPES,
-  TERRITORY_BILLING_TYPES, MAX_COMMENT_TEXT_LENGTH, MAX_POST_TEXT_LENGTH, MIN_TITLE_LENGTH, BOUNTY_MIN, BOUNTY_MAX,
+  TERRITORY_BILLING_TYPES, MAX_COMMENT_TEXT_LENGTH, MAX_POST_TEXT_LENGTH, MIN_TITLE_LENGTH, BOUNTY_MIN,
   RESERVED_SUB_NAMES,
-  BOOST_MAX, MAX_INVOICE_DESCRIPTION_LENGTH, MAX_WALLET_INVOICE_SATS,
+  BOOST_MAX, MAX_INVOICE_DESCRIPTION_LENGTH, MAX_WALLET_INVOICE_SATS, MAX_ZAP_SATS, MAX_BOUNTY_SATS,
   SSR,
   BOOST_MIN,
   MAX_SEO_TITLE_LENGTH,
@@ -253,7 +253,7 @@ export function bountySchema (args) {
     text: textValidator(MAX_POST_TEXT_LENGTH),
     bounty: intValidator
       .min(BOUNTY_MIN, `must be at least ${numWithUnits(BOUNTY_MIN)}`)
-      .max(BOUNTY_MAX, `must be at most ${numWithUnits(BOUNTY_MAX)}`),
+      .max(MAX_BOUNTY_SATS, `must be at most ${numWithUnits(MAX_BOUNTY_SATS, { abbreviate: false })}`),
     ...advPostSchemaMembers(args),
     ...subSelectSchemaMembers('BOUNTY', args)
   })
@@ -477,6 +477,11 @@ export const actSchema = object({
     .when(['act'], ([act], schema) => {
       if (act === 'BOOST') {
         return boostValidator
+      }
+      if (act === 'TIP') {
+        // a zap's 70% single-recipient P2P share can't exceed MAX_OUTGOING_MSATS or it can't be
+        // wrapped/delivered to the recipient (it would silently degrade to credits) — see MAX_ZAP_SATS
+        return schema.max(MAX_ZAP_SATS, `must be at most ${numWithUnits(MAX_ZAP_SATS, { abbreviate: false })}`)
       }
       return schema
     }),

--- a/pages/rewards/index.js
+++ b/pages/rewards/index.js
@@ -21,6 +21,7 @@ import { useMemo } from 'react'
 import { CompactLongCountdown } from '@/components/countdown'
 import { DONATE } from '@/fragments/payIn'
 import usePayInMutation from '@/components/payIn/hooks/use-pay-in-mutation'
+import { throwUnlessUserCancel } from '@/wallets/client/errors'
 import { payTypeShortName } from '@/lib/pay-in'
 
 const GrowthPieChart = dynamic(() => import('@/components/charts').then(mod => mod.GrowthPieChart), {
@@ -122,7 +123,7 @@ export function DonateButton () {
             }}
             schema={amountSchema}
             onSubmit={async ({ amount }) => {
-              const { error } = await donateToRewards({
+              const { error, payError } = await donateToRewards({
                 variables: {
                   sats: Number(amount)
                 },
@@ -133,6 +134,9 @@ export function DonateButton () {
               })
               onClose()
               if (error) throw error
+              // donations are pessimistic, so a terminal payment failure comes back in payError —
+              // but a user-canceled QR isn't news
+              throwUnlessUserCancel(payError)
             }}
           >
             <Input

--- a/wallets/client/components/home/actions.js
+++ b/wallets/client/components/home/actions.js
@@ -5,6 +5,7 @@ import { Form, Input, SubmitButton } from '@/components/form'
 import { useShowModal } from '@/components/modal'
 import { useAnimation } from '@/components/animation'
 import usePayInMutation from '@/components/payIn/hooks/use-pay-in-mutation'
+import { throwUnlessUserCancel } from '@/wallets/client/errors'
 import PyramidButton from '@/components/pyramid-button'
 import { amountSchema } from '@/lib/validate'
 import { BUY_CREDITS } from '@/fragments/payIn'
@@ -96,7 +97,7 @@ function BuyCreditsAction () {
           initial={{ amount: 10000 }}
           schema={amountSchema}
           onSubmit={async ({ amount }) => {
-            const { error } = await buyCredits({
+            const { error, payError } = await buyCredits({
               variables: {
                 credits: Number(amount)
               },
@@ -106,6 +107,9 @@ function BuyCreditsAction () {
             })
             onClose()
             if (error) throw error
+            // credit purchases are pessimistic, so a terminal payment failure comes back in payError —
+            // but a user-canceled QR isn't news
+            throwUnlessUserCancel(payError)
           }}
         >
           <Input

--- a/wallets/client/errors.js
+++ b/wallets/client/errors.js
@@ -125,9 +125,16 @@ export class WalletStaleConfigError extends WalletConfigurationError {
 // failure to surface, so callers suppress it.
 export const isUserCancelError = (e) => e instanceof InvoiceCanceledError
 
-// toast a payIn error unless it's absent or a user cancel (used by the act/bounty onPayError phases)
+// a gateway/timeout response (502/503/504 — e.g. the zap recipient's wallet was slow to invoice, so
+// the request blew past the load balancer's timeout) didn't return a normal GraphQL result. the
+// action's outcome is unknown, but optimistic acts are still processed server-side (the zap falls
+// back to credits or persists and auto-retries), so callers shouldn't surface it as a failure.
+export const isTransientNetworkError = (e) => e?.statusCode >= 502 && e?.statusCode <= 504
+
+// toast a payIn error unless it's absent, a user cancel, or a transient gateway timeout (used by
+// the act/bounty onPayError phases)
 export const toastPayError = (toaster, e) => {
-  if (e && !isUserCancelError(e)) toaster.danger(e?.message || e?.toString?.())
+  if (e && !isUserCancelError(e) && !isTransientNetworkError(e)) toaster.danger(e?.message || e?.toString?.())
 }
 
 // rethrow a pessimistic flow's payError unless it's absent or a user cancel

--- a/wallets/client/errors.js
+++ b/wallets/client/errors.js
@@ -120,3 +120,17 @@ export class WalletStaleConfigError extends WalletConfigurationError {
     this.name = 'WalletStaleConfigError'
   }
 }
+
+// payError helpers: a user-canceled QR (closing the invoice modal) is an intentional abort, not a
+// failure to surface, so callers suppress it.
+export const isUserCancelError = (e) => e instanceof InvoiceCanceledError
+
+// toast a payIn error unless it's absent or a user cancel (used by the act/bounty onPayError phases)
+export const toastPayError = (toaster, e) => {
+  if (e && !isUserCancelError(e)) toaster.danger(e?.message || e?.toString?.())
+}
+
+// rethrow a pessimistic flow's payError unless it's absent or a user cancel
+export const throwUnlessUserCancel = (payError) => {
+  if (payError && !isUserCancelError(payError)) throw payError
+}

--- a/wallets/client/hooks/payment.js
+++ b/wallets/client/hooks/payment.js
@@ -7,6 +7,7 @@ import {
   WalletPaymentRejectedError, WalletValidationError, WalletConfigurationError
 } from '@/wallets/client/errors'
 import { timeoutSignal } from '@/lib/time'
+import { isInvoiceSetupPending } from '@/lib/pay-in'
 import { useMe } from '@/components/me'
 import { formatSats, msatsToSats } from '@/lib/format'
 import usePayInHelper from '@/components/payIn/hooks/use-pay-in-helper'
@@ -105,6 +106,12 @@ export function useWalletPayment () {
         }
 
         aggregateError = new WalletAggregateError([aggregateError, paymentError], latestPayIn)
+
+        // if the successor's invoice creation/wrap failed, it has no bolt11 for the next
+        // attempt to pay — bail like the loop exhausting instead of passing null to a wallet
+        if (isInvoiceSetupPending(latestPayIn)) {
+          throw new WalletPaymentAggregateError([aggregateError], latestPayIn)
+        }
 
         continue
       } finally {


### PR DESCRIPTION
QA/review is solid. I may be motivated to reduce some of the indirection and layering if it doesn't require a big refactor.

----------

This mostly addresses the largely unconsidered failure paths wrt to payin clients. At root we have failure paths that vary with failure type, payin type, retry/initial, and pessimistic/optimistic which control fallbacks, client cache, retries, and error presentation. The failure paths branch wildly as `usePayInMutation` fails to contain the complexity. Absent refactoring that (it's probably going to be ugly regardless cuz cache reconciling), we have these fixes.

Much of the turnover here is removing dead code and reuse. Of the code that isn't that:

## `maxMerge`ing cache counts solves one problem but creates another problem on the failure path

`maxMerge` deals with fast zap/boost-then-navigate behavior where the server has not yet registered the zap before navigation renders the page. Without it, a act-then-navigate would show +100, then +0 on first nav, then +100 again on next nav. This, meaning the optimistic outcome display, is exactly what we want until/unless the act eventually fails automatic retries.

When the act fails automatic retries, we surface it in `/notifications` for manual retry. At this point, the server's count reflects the failure but the client's cache does not. We need to avoid `maxMerge` in `/notifications` so that the client sees the true value now. This PR introduces ~~an Apollo link (I couldn't find a better way to do this)~~ a `useEffect` that voids `maxMerge` in `/notifications`.

## return payin on failure to create/wrap invoices

For a noncustodial payment, the state machine records the payment intent before creating/wrapping invoices. Creating and wrapping can fail, which the client needs to suppress in optimistic flows (will be autoretried), avoid dispatching payments because we don't have a bolt11, and treat like a failure on manual retry or pessimistic flows, yet still use the returned payin/intent to update the client cache.

Without this, manual retries would lose track of the id of the last payin attempt (if it failed due to invoice creation/wrapping).

## others
- fix terminal payment failures, ones that can't be autoretried like during pessimistic flows, being swallowed
- fix cache race when paying via qr: if the modal is closed before the client sees the that payment is settled, it would undo the cache counts, making it look like it failed, encouraging stackers to pay a second time
- fix cache behavior inconsistencies across zap/boost/acting via modal and zapping via the bolt
- fix a potentially stale read in payin state machine
- input validate p2p stuff (zaps/boosts) according to wrap maxes so they don't fail later
- when action lacks CC fallback (bounty), allow continued attempts to pay noncustodially
- fix #1440 by suppressing network errors for optimistic payins (also reduce wallet timeout to below load balancer's timeout)
- fix back button inside modal for QR payments causing modal to close

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches payment state machines, Lightning forwarding, and Apollo cache reconciliation for money-moving flows; incorrect failure or cache behavior could mislead users about payment status or encourage double payment.
> 
> **Overview**
> This PR tightens **pay-in failure handling** end-to-end so optimistic flows, manual retries, and pessimistic payments behave consistently when invoices fail to create/wrap, when forwards race with cancel, or when retries collide.
> 
> **Server:** Optimistic genesis pay-ins now **return a bolt11-less payIn** after invoice create/wrap failure (background auto-retry) instead of throwing unless the flow is pessimistic; retries use **`GqlPayInRetryRaceError`** for benign races. **P2P-only** payouts (`keepRetryingWallets`) keep cycling receive wallets on retry; custodial fallback uses the **original** `payOutBolt11` msats. **`payInForwarding`** re-reads LND invoice state before forwarding; **`is_canceled`** spelling is fixed.
> 
> **Client cache & UX:** Zaps/boosts share **`bumpActCache` / `withActBump` / `getActCachePhases`** (modal, bolt debounce, notification retries). **`reconcileNotificationItemCounters`** overwrites stale optimistic item counts when failed payments appear in notifications (complementing **`maxMerge`**). **`usePayInMutation`** treats bolt11-less **`PENDING_INVOICE_*`** as pending success on genesis but **`failOnInvoiceSetupPending`** on manual retry; wallet/QR paths bail when there is no invoice. QR close checks for **paid-before-cancel**; modal **back** pops before `onClose` to avoid stack-wide closes. **502–504** and user-cancel errors are suppressed where appropriate; **`toastPayError`** / **`throwUnlessUserCancel`** unify pessimistic **`payError`** handling.
> 
> **Validation & limits:** **`MAX_ZAP_SATS`** / **`MAX_BOUNTY_SATS`** align inputs with wrap caps; receive invoice timeout is lowered below the LB timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68dfd89c9c4cb5ef270f4ad15dec97443875d370. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->