### PR TITLE
Format push notification markdown

### DIFF
--- a/lib/md-plain-text.js
+++ b/lib/md-plain-text.js
@@ -1,0 +1,39 @@
+export function compactPlainText (text) {
+  return text
+    .replace(/\\([,;:!])/g, '$1')
+    .replace(/\s+/g, ' ')
+    .replace(/\s+([,.;:!?])/g, '$1')
+    .trim()
+}
+
+function joinPlainText (values) {
+  return values
+    .map(value => compactPlainText(nodePlainText(value)))
+    .filter(Boolean)
+    .join(' ')
+}
+
+export function nodePlainText (node) {
+  if (!node) return ''
+
+  switch (node.type) {
+    case 'text':
+    case 'inlineCode':
+    case 'code':
+    case 'math':
+    case 'inlineMath':
+      return node.value ?? ''
+    case 'image':
+    case 'imageReference':
+      return node.alt ?? ''
+    case 'html':
+    case 'thematicBreak':
+    case 'definition':
+    case 'footnoteDefinition':
+      return ''
+    case 'break':
+      return ' '
+    default:
+      return joinPlainText(node.children ?? [])
+  }
+}

--- a/lib/md-plain-text.spec.js
+++ b/lib/md-plain-text.spec.js
@@ -1,0 +1,69 @@
+/* eslint-env jest */
+
+import { compactPlainText, nodePlainText } from './md-plain-text'
+
+const text = value => ({ type: 'text', value })
+const paragraph = children => ({ type: 'paragraph', children })
+
+describe('compactPlainText', () => {
+  test('normalizes whitespace and notification-safe escapes', () => {
+    expect(compactPlainText(' ok\\! \n next\\: value  ')).toBe('ok! next: value')
+  })
+})
+
+describe('nodePlainText', () => {
+  test('keeps block and list item text separated', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        paragraph([text('list:')]),
+        {
+          type: 'list',
+          children: [
+            { type: 'listItem', children: [paragraph([text('one')])] },
+            { type: 'listItem', children: [paragraph([text('two')])] },
+            { type: 'listItem', children: [paragraph([text('three')])] }
+          ]
+        }
+      ]
+    }
+
+    expect(compactPlainText(nodePlainText(tree))).toBe('list: one two three')
+  })
+
+  test('keeps table cells separated', () => {
+    const tree = {
+      type: 'table',
+      children: [
+        { type: 'tableRow', children: [{ type: 'tableCell', children: [text('a')] }, { type: 'tableCell', children: [text('b')] }] },
+        { type: 'tableRow', children: [{ type: 'tableCell', children: [text('c')] }, { type: 'tableCell', children: [text('d')] }] }
+      ]
+    }
+
+    expect(compactPlainText(nodePlainText(tree))).toBe('a b c d')
+  })
+
+  test('renders formatted inline content without URLs or markdown syntax', () => {
+    const tree = paragraph([
+      { type: 'strong', children: [text('bold')] },
+      text(' '),
+      { type: 'link', url: 'https://example.com', children: [text('link')] },
+      text(', ok\\!')
+    ])
+
+    expect(compactPlainText(nodePlainText(tree))).toBe('bold link, ok!')
+  })
+
+  test('preserves prices, inline code, code blocks, and image alt text', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        paragraph([text('fees are $1..$5 and '), { type: 'inlineCode', value: 'x = 1' }]),
+        { type: 'code', lang: 'js', value: 'const y = 2' },
+        { type: 'image', url: 'https://example.com/image.png', alt: 'chart' }
+      ]
+    }
+
+    expect(compactPlainText(nodePlainText(tree))).toBe('fees are $1..$5 and x = 1 const y = 2 chart')
+  })
+})

--- a/lib/md.js
+++ b/lib/md.js
@@ -1,11 +1,11 @@
 import { gfmFromMarkdown } from 'mdast-util-gfm'
 import { mathFromMarkdown } from 'mdast-util-math'
-import { toString } from 'mdast-util-to-string'
 import { visit } from 'unist-util-visit'
 import { gfm } from 'micromark-extension-gfm'
 import { math } from 'micromark-extension-math'
 import { fromMarkdown } from 'mdast-util-from-markdown'
 import removeMd from 'remove-markdown'
+import { compactPlainText, nodePlainText } from '@/lib/md-plain-text'
 
 function markdownTree (md) {
   return fromMarkdown(md, {
@@ -50,14 +50,9 @@ export function mdToPlainText (md) {
   if (!md) return ''
 
   try {
-    return toString(markdownTree(md))
-      .replace(/\\([,;:!])/g, '$1')
-      .replace(/\s+/g, ' ')
-      .trim()
+    return compactPlainText(nodePlainText(markdownTree(md)))
   } catch {
-    return removeMd(md)
-      .replace(/\s+/g, ' ')
-      .trim()
+    return compactPlainText(removeMd(md))
   }
 }
 

--- a/lib/md.js
+++ b/lib/md.js
@@ -1,14 +1,22 @@
 import { gfmFromMarkdown } from 'mdast-util-gfm'
+import { mathFromMarkdown } from 'mdast-util-math'
+import { toString } from 'mdast-util-to-string'
 import { visit } from 'unist-util-visit'
 import { gfm } from 'micromark-extension-gfm'
+import { math } from 'micromark-extension-math'
 import { fromMarkdown } from 'mdast-util-from-markdown'
+import removeMd from 'remove-markdown'
+
+function markdownTree (md) {
+  return fromMarkdown(md, {
+    extensions: [gfm(), math({ singleDollarTextMath: false })],
+    mdastExtensions: [gfmFromMarkdown(), mathFromMarkdown()]
+  })
+}
 
 export function mdHas (md, test) {
   if (!md) return []
-  const tree = fromMarkdown(md, {
-    extensions: [gfm()],
-    mdastExtensions: [gfmFromMarkdown()]
-  })
+  const tree = markdownTree(md)
 
   let found = false
   visit(tree, test, () => {
@@ -21,10 +29,7 @@ export function mdHas (md, test) {
 
 export function extractUrls (md) {
   if (!md) return []
-  const tree = fromMarkdown(md, {
-    extensions: [gfm()],
-    mdastExtensions: [gfmFromMarkdown()]
-  })
+  const tree = markdownTree(md)
 
   const urls = new Set()
   visit(tree, ({ type }) => {
@@ -40,6 +45,21 @@ export const quote = (orig) =>
   orig.split('\n')
     .map(line => `> ${line}`)
     .join('\n') + '\n'
+
+export function mdToPlainText (md) {
+  if (!md) return ''
+
+  try {
+    return toString(markdownTree(md))
+      .replace(/\\([,;:!])/g, '$1')
+      .replace(/\s+/g, ' ')
+      .trim()
+  } catch {
+    return removeMd(md)
+      .replace(/\s+/g, ' ')
+      .trim()
+  }
+}
 
 /** checks if the markdown string is a markdown link */
 export function hasMarkdownLink (markdown) {

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -1,11 +1,11 @@
 import webPush from 'web-push'
-import removeMd from 'remove-markdown'
 import { COMMENT_DEPTH_LIMIT, FOUND_BLURBS, LOST_BLURBS, DEFAULT_POSTS_SATS_FILTER, DEFAULT_COMMENTS_SATS_FILTER } from './constants'
 import { msatsToSats, numWithUnits } from './format'
 import { nextBillingWithGrace } from '@/lib/territory'
 import models from '@/api/models'
 import { isMuted } from '@/lib/user'
 import { Prisma } from '@prisma/client'
+import { mdToPlainText } from '@/lib/md'
 
 // Check if an item meets a user's sat filter threshold for push notifications
 async function meetsUserSatFilter (userId, item) {
@@ -65,7 +65,7 @@ function createPayload (notification) {
   // https://webkit.org/blog/16535/meet-declarative-web-push/
   // DEV: localhost in URLs is not supported by declarative web push
   let { title, body, ...options } = notification
-  if (body) body = removeMd(body)
+  if (body) body = mdToPlainText(body)
   return JSON.stringify({
     web_push: 8030, // Declarative Web Push JSON format
     notification: {


### PR DESCRIPTION
Fixes #2852.

## Description

Push notification bodies currently use `remove-markdown`, which leaves some Stacker News markdown/math formatting visible in Android notifications. This switches notification body formatting to a shared markdown-to-plain-text helper based on the existing mdast parser stack, with a `remove-markdown` fallback if parsing fails.

The helper preserves readable text for links, emphasis, code, and normal dollar amounts while stripping markdown syntax before the declarative web push payload is serialized.

## Screenshots

Not applicable; this changes server-side push payload text formatting.

## Additional Context

A prior attempt at this issue was closed because it used a regex that could remove ordinary dollar amounts. This implementation parses markdown with GFM plus math support and explicitly disables single-dollar text math, so strings like `If you send me $1 I will send you $2 back` are preserved.

BTC payout address if this is eligible for a sats award: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. This only changes push notification body text formatting before payload serialization. It does not change schema, APIs, settings, or notification routing.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

6/10. Ran `npm run lint -- lib/md.js lib/webPush.js`, `git diff --check`, and a Node smoke check for `mdToPlainText` covering links/formatting, dollar amounts, and display math text.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Not a frontend change.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes. AI assisted with implementation and verification. I inspected the relevant issue/previous PR feedback, made the code changes, and ran the checks above.
