### PR TITLE
Skip placeholder YouTube titles

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -33,6 +33,19 @@ import { BOUNTY_ALREADY_PAID_ERROR, BOUNTY_IN_PROGRESS_ERROR, getBountyPaymentTa
 import { lexicalHTMLGenerator } from '@/lib/lexical/server/html'
 import { resolveItemComments } from './comment-tree'
 
+function isYoutubePlaceholderTitle (url, title) {
+  if (!title) return false
+
+  try {
+    const { hostname } = new URL(ensureProtocol(url))
+    if (!['youtube.com', 'www.youtube.com', 'm.youtube.com', 'youtu.be'].includes(hostname)) return false
+  } catch {
+    return false
+  }
+
+  return /^-?\s*youtube$/i.test(title.trim())
+}
+
 export async function getItem (parent, { id }, { me, models }) {
   const [item] = await getItemsById([id], { me, models })
   return item
@@ -561,8 +574,10 @@ export default {
         const dateHint = ` (${metadata.publicationDate?.getFullYear()})`
         const moreThanOneYearAgo = metadata.publicationDate && metadata.publicationDate < datePivot(new Date(), { years: -1 })
 
-        res.title = metadata?.title
-        if (moreThanOneYearAgo) res.title += dateHint
+        if (metadata?.title && !isYoutubePlaceholderTitle(url, metadata.title)) {
+          res.title = metadata?.title
+          if (moreThanOneYearAgo) res.title += dateHint
+        }
       } catch { }
 
       try {

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -33,15 +33,8 @@ import { BOUNTY_ALREADY_PAID_ERROR, BOUNTY_IN_PROGRESS_ERROR, getBountyPaymentTa
 import { lexicalHTMLGenerator } from '@/lib/lexical/server/html'
 import { resolveItemComments } from './comment-tree'
 
-function isYoutubePlaceholderTitle (url, title) {
+function isPlaceholderPageTitle (title) {
   if (!title) return false
-
-  try {
-    const { hostname } = new URL(ensureProtocol(url))
-    if (!['youtube.com', 'www.youtube.com', 'm.youtube.com', 'youtu.be'].includes(hostname)) return false
-  } catch {
-    return false
-  }
 
   return /^-?\s*youtube$/i.test(title.trim())
 }
@@ -574,7 +567,7 @@ export default {
         const dateHint = ` (${metadata.publicationDate?.getFullYear()})`
         const moreThanOneYearAgo = metadata.publicationDate && metadata.publicationDate < datePivot(new Date(), { years: -1 })
 
-        if (metadata?.title && !isYoutubePlaceholderTitle(url, metadata.title)) {
+        if (metadata?.title && !isPlaceholderPageTitle(metadata.title)) {
           res.title = metadata?.title
           if (moreThanOneYearAgo) res.title += dateHint
         }


### PR DESCRIPTION
Refs #2164.

## Description

Some YouTube watch-page responses only expose the placeholder title `- YouTube` through the current unauthenticated server-side metadata path. `pageTitleAndUnshorted` currently passes that value through, so the link form can auto-fill a misleading title.

This filters YouTube placeholder titles before returning metadata and only returns a title when the parser found a real value. It does not add a new YouTube title source; it just avoids populating known-bad placeholder text.

## Screenshots

Not applicable; server-side metadata behavior.

## Additional Context

This is a narrow improvement, not a complete solution for every YouTube URL. In local smoke checks, two YouTube URLs with real metadata still auto-fill, while the known counterexample no longer returns `- YouTube`.

BTC payout address if eligible for a sats award: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`

## Checklist

- [x] I have tested this change locally
- [x] I have considered regressions and scoped the fix narrowly
- [x] No new environment variables are required

Validation:

- `npm run lint -- api/resolvers/item.js`
- `git diff --check`
