### PR TITLE
Reject URLs in post titles

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -53,7 +53,7 @@ export function truncateToCharLength (value, maxLength) {
   return out
 }
 
-const TITLE_URL_WITH_SCHEME_REGEXP = /\b[a-z][a-z0-9+.-]*:\/\/\S+/i
+const TITLE_URL_WITH_SCHEME_REGEXP = /\b[a-z][a-z0-9+.-]*:(?:\/\/|\S+)/i
 
 const titleValidator = string().required('required').trim().test(
   'no-title-url-with-scheme',

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -53,7 +53,13 @@ export function truncateToCharLength (value, maxLength) {
   return out
 }
 
-const titleValidator = string().required('required').trim().max(
+const TITLE_URL_WITH_SCHEME_REGEXP = /\b[a-z][a-z0-9+.-]*:\/\/\S+/i
+
+const titleValidator = string().required('required').trim().test(
+  'no-title-url-with-scheme',
+  'must not contain URLs with URI schemes',
+  value => !TITLE_URL_WITH_SCHEME_REGEXP.test(value || '')
+).max(
   MAX_TITLE_LENGTH,
   ({ max, value }) => `-${Math.abs(max - value.length)} characters remaining`
 ).min(MIN_TITLE_LENGTH, `must be at least ${MIN_TITLE_LENGTH} characters`)

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -42,17 +42,36 @@ const postSchemaCases = [
   }]
 ]
 
+const titleUriSchemeCases = [
+  ['https URL', 'Read this https://example.com/story'],
+  ['mailto URI', 'Email mailto:jobs@example.com'],
+  ['bitcoin URI', 'Pay bitcoin:bc1qexampleaddress'],
+  ['lightning URI', 'Zap lightning:lnbc1exampleinvoice']
+]
+
+const invalidPostTitleCases = postSchemaCases.flatMap(([schemaName, schema, fields]) =>
+  titleUriSchemeCases.map(([uriName, title]) => [schemaName, uriName, schema, fields, title]))
+
 describe('post title validation', () => {
-  test.each(postSchemaCases)('%s rejects URLs with URI schemes in titles', async (_, schema, fields) => {
+  test.each(invalidPostTitleCases)('%s rejects %s in titles', async (_, __, schema, fields, title) => {
     await expect(schema.validate({
       ...fields,
-      title: 'Read this https://example.com/story'
+      title
     })).rejects.toThrow('must not contain URLs with URI schemes')
   })
 
   test.each(postSchemaCases)('%s allows bare domains in titles', async (_, schema, fields) => {
     await expect(schema.validate(fields)).resolves.toEqual(expect.objectContaining({
       title: 'Crypto.com stadium hosts big game'
+    }))
+  })
+
+  test.each(postSchemaCases)('%s allows titles with colon punctuation', async (_, schema, fields) => {
+    await expect(schema.validate({
+      ...fields,
+      title: 'PSA: site maintenance window'
+    })).resolves.toEqual(expect.objectContaining({
+      title: 'PSA: site maintenance window'
     }))
   })
 })

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -1,0 +1,58 @@
+/* eslint-env jest */
+
+import { bountySchema, discussionSchema, jobSchema, linkSchema, pollSchema } from './validate'
+
+const models = {
+  sub: {
+    findMany: jest.fn(async () => [{
+      name: 'bitcoin',
+      status: 'ACTIVE',
+      postTypes: ['LINK', 'DISCUSSION', 'BOUNTY', 'POLL']
+    }])
+  },
+  user: {
+    findUnique: jest.fn()
+  }
+}
+
+const schemaArgs = { models, me: { name: 'alice' } }
+
+const validPostFields = {
+  title: 'Crypto.com stadium hosts big game',
+  text: '',
+  subNames: ['bitcoin']
+}
+
+const postSchemaCases = [
+  ['discussion', discussionSchema(schemaArgs), validPostFields],
+  ['link', linkSchema(schemaArgs), { ...validPostFields, url: 'https://example.com/story' }],
+  ['bounty', bountySchema(schemaArgs), { ...validPostFields, bounty: 1000 }],
+  ['poll', pollSchema({ ...schemaArgs }), {
+    ...validPostFields,
+    options: ['yes', 'no'],
+    pollExpiresAt: new Date(Date.now() + 48 * 60 * 60 * 1000)
+  }],
+  ['job', jobSchema(schemaArgs), {
+    title: 'Crypto.com stadium hosts big game',
+    company: 'Example Inc',
+    text: 'Build useful things',
+    url: 'jobs@example.com',
+    location: 'New York',
+    remote: false
+  }]
+]
+
+describe('post title validation', () => {
+  test.each(postSchemaCases)('%s rejects URLs with URI schemes in titles', async (_, schema, fields) => {
+    await expect(schema.validate({
+      ...fields,
+      title: 'Read this https://example.com/story'
+    })).rejects.toThrow('must not contain URLs with URI schemes')
+  })
+
+  test.each(postSchemaCases)('%s allows bare domains in titles', async (_, schema, fields) => {
+    await expect(schema.validate(fields)).resolves.toEqual(expect.objectContaining({
+      title: 'Crypto.com stadium hosts big game'
+    }))
+  })
+})


### PR DESCRIPTION
Refs #117.

## Description

Post titles currently accept strings containing full URLs such as `https://...`. Issue #117 notes that URI schemes in titles are not needed for normal title text and can break downstream uses such as automated tweet length calculations.

This adds a shared title validation rule that rejects URL-looking values with an explicit URI scheme (`scheme://...`) while still allowing bare domains like `Crypto.com` in titles. Because discussion, link, bounty, poll, and job submissions all use the shared title validator, the rule applies consistently across those title fields.

## Screenshots

Not applicable; validation behavior only.

## Additional Context

The check is intentionally narrow to avoid rejecting ordinary titles with domains or colon punctuation. It targets URLs with URI schemes rather than every string containing a dot or colon.

BTC payout address if eligible for a sats award: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`

## Checklist

- [x] I have tested this change locally
- [x] I have considered false positives for bare domains in titles
- [x] No new environment variables are required

Validation:

- `npm run lint -- lib/validate.js lib/validate.spec.js`
- `npm test -- lib/validate.spec.js`
- `git diff --check`
