### PR TITLE
Validate poll expiry at submit time

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -295,7 +295,11 @@ export function pollSchema ({ numExistingChoices = 0, ...args }) {
       message: `at least ${MIN_POLL_NUM_CHOICES} choices required`,
       test: arr => arr.length >= MIN_POLL_NUM_CHOICES - numExistingChoices
     }),
-    pollExpiresAt: date().nullable().min(datePivot(new Date(), { days: 1 }), 'Expiration must be at least 1 day in the future'),
+    pollExpiresAt: date().nullable().test({
+      name: 'min',
+      message: 'Expiration must be at least 1 day in the future',
+      test: value => !value || value >= datePivot(new Date(), { days: 1 })
+    }),
     randPollOptions: boolean(),
     ...advPostSchemaMembers(args),
     ...subSelectSchemaMembers('POLL', args)

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -2,35 +2,50 @@
 
 import { pollSchema } from './validate'
 
+const POLL_EXPIRATION_ERROR = 'Expiration must be at least 1 day in the future'
+
+function validatePollExpiresAt (pollExpiresAt, schema = pollSchema({})) {
+  return schema.validateAt('pollExpiresAt', { pollExpiresAt })
+}
+
 describe('pollSchema', () => {
   afterEach(() => {
     jest.useRealTimers()
   })
 
-  test('evaluates poll expiration minimum at validation time', async () => {
-    jest.useFakeTimers()
-    jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
+  describe('pollExpiresAt', () => {
+    test('evaluates minimum at validation time instead of schema creation time', async () => {
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
 
-    const schema = pollSchema({})
-    const defaultExpiration = new Date(2026, 5, 15, 0, 0, 0, 0)
+      const schema = pollSchema({})
+      const defaultExpiration = new Date(2026, 5, 15, 0, 0, 0, 0)
 
-    jest.setSystemTime(new Date(2026, 5, 14, 12, 0, 0, 0, 0))
+      jest.setSystemTime(new Date(2026, 5, 14, 12, 0, 0, 0, 0))
 
-    await expect(schema.validateAt('pollExpiresAt', { pollExpiresAt: defaultExpiration }))
-      .rejects.toThrow('Expiration must be at least 1 day in the future')
-  })
+      await expect(validatePollExpiresAt(defaultExpiration, schema))
+        .rejects.toThrow(POLL_EXPIRATION_ERROR)
+    })
 
-  test('accepts poll expiration at least one day from validation time', async () => {
-    jest.useFakeTimers()
-    jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
+    test('rejects expiration less than one day from validation time', async () => {
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
 
-    await expect(pollSchema({}).validateAt('pollExpiresAt', {
-      pollExpiresAt: new Date(2026, 5, 14, 0, 0, 0, 0)
-    })).resolves.toEqual(new Date(2026, 5, 14, 0, 0, 0, 0))
-  })
+      await expect(validatePollExpiresAt(new Date(2026, 5, 13, 23, 59, 59, 999)))
+        .rejects.toThrow(POLL_EXPIRATION_ERROR)
+    })
 
-  test('allows poll expiration to be cleared', async () => {
-    await expect(pollSchema({}).validateAt('pollExpiresAt', { pollExpiresAt: null }))
-      .resolves.toBeNull()
+    test('accepts expiration at least one day from validation time', async () => {
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
+
+      const expiration = new Date(2026, 5, 14, 0, 0, 0, 0)
+
+      await expect(validatePollExpiresAt(expiration)).resolves.toEqual(expiration)
+    })
+
+    test('allows expiration to be cleared', async () => {
+      await expect(validatePollExpiresAt(null)).resolves.toBeNull()
+    })
   })
 })

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+
+import { pollSchema } from './validate'
+
+describe('pollSchema', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test('evaluates poll expiration minimum at validation time', async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
+
+    const schema = pollSchema({})
+    const defaultExpiration = new Date(2026, 5, 15, 0, 0, 0, 0)
+
+    jest.setSystemTime(new Date(2026, 5, 14, 12, 0, 0, 0, 0))
+
+    await expect(schema.validateAt('pollExpiresAt', { pollExpiresAt: defaultExpiration }))
+      .rejects.toThrow('Expiration must be at least 1 day in the future')
+  })
+
+  test('accepts poll expiration at least one day from validation time', async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
+
+    await expect(pollSchema({}).validateAt('pollExpiresAt', {
+      pollExpiresAt: new Date(2026, 5, 14, 0, 0, 0, 0)
+    })).resolves.toEqual(new Date(2026, 5, 14, 0, 0, 0, 0))
+  })
+
+  test('allows poll expiration to be cleared', async () => {
+    await expect(pollSchema({}).validateAt('pollExpiresAt', { pollExpiresAt: null }))
+      .resolves.toBeNull()
+  })
+})


### PR DESCRIPTION
Fixes #907.

## Description

`pollSchema` currently computes the minimum poll expiration date when the schema is created:

```js
.min(datePivot(new Date(), { days: 1 }), ...)
```

That makes the minimum stale for any form/session that lives across time before validation. A default expiration that was valid when the poll form mounted can later be validated against an outdated minimum instead of the actual submit-time minimum.

This changes `pollExpiresAt` to a custom Yup test that evaluates `datePivot(new Date(), { days: 1 })` during validation. Clearing the expiration remains valid because the field is still nullable.

## Screenshots

Not applicable; validation behavior only.

## Additional Context

A previous PR for this issue (#2781) was closed by its author because it was submitted without proper local testing. This version includes focused Jest coverage for the stale-schema case.

BTC payout address if eligible for a sats award: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. Poll expirations at least one day in the future still pass, and cleared expirations still pass. Expirations less than one day from validation time still fail with the existing message.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7/10. Added focused Jest coverage for the stale-schema validation case, valid one-day future expiration, and nullable expiration. Ran lint and whitespace checks.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Not a frontend rendering change.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes. AI assisted with issue triage, implementation, and validation. I checked for duplicate/current PR coverage and ran the commands below.

Validation:

- `npm run lint -- lib/validate.js lib/validate.spec.js`
- `npm test -- lib/validate.spec.js`
- `git diff --check`
