### PR TITLE
Restore trailing underscores in autolinks

### DIFF
--- a/lib/lexical/mdast/transforms/index.js
+++ b/lib/lexical/mdast/transforms/index.js
@@ -1,5 +1,5 @@
 export { mentionTransform } from './mentions.js'
 export { nostrTransform } from './nostr.js'
-export { misleadingLinkTransform, malformedLinkEncodingTransform } from './links.js'
+export { misleadingLinkTransform, malformedLinkEncodingTransform, trailingUnderscoreAutolinkTransform } from './links.js'
 export { footnoteTransform } from './footnotes.js'
 export { tocTransform } from './toc.js'

--- a/lib/lexical/mdast/transforms/links.js
+++ b/lib/lexical/mdast/transforms/links.js
@@ -1,25 +1,6 @@
+import { visit } from 'unist-util-visit'
+import { toString } from 'mdast-util-to-string'
 import { isMisleadingLink } from '@/lib/url'
-
-function visitLinks (node, visitor) {
-  if (!node?.children) return
-
-  for (let index = 0; index < node.children.length; index++) {
-    const child = node.children[index]
-    if (child.type === 'link') {
-      visitor(child, index, node)
-    }
-
-    visitLinks(node.children[index], visitor)
-  }
-}
-
-function nodeToString (node) {
-  if (typeof node?.value === 'string') return node.value
-  if (typeof node?.alt === 'string') return node.alt
-  if (!node?.children) return ''
-
-  return node.children.map(nodeToString).join('')
-}
 
 /**
  * a link is misleading if the text is not the same as the URL.
@@ -28,15 +9,15 @@ function nodeToString (node) {
  * if the link wraps only an image, the link is removed but the image is kept.
  */
 export function misleadingLinkTransform (tree) {
-  visitLinks(tree, (node, index, parent) => {
+  visit(tree, 'link', (node, index, parent) => {
     // if the link has only an image child, unwrap it (remove the link but keep the image)
     const hasOnlyImage = node.children?.length === 1 && node.children[0].type === 'image'
     if (hasOnlyImage && parent && index !== undefined) {
       parent.children[index] = node.children[0]
-      return
+      return index
     }
 
-    const text = nodeToString(node)
+    const text = toString(node)
     if (!text) return
     if (!node.url) return
 
@@ -47,10 +28,10 @@ export function misleadingLinkTransform (tree) {
 }
 
 export function trailingUnderscoreAutolinkTransform (tree) {
-  visitLinks(tree, (node, index, parent) => {
+  visit(tree, 'link', (node, index, parent) => {
     if (!parent || index === undefined) return
     if (!node.url) return
-    if (nodeToString(node) !== node.url) return
+    if (toString(node) !== node.url) return
 
     const next = parent.children[index + 1]
     if (next?.type !== 'text') return
@@ -76,7 +57,7 @@ export function trailingUnderscoreAutolinkTransform (tree) {
 /** LinkeDOM patch: decodeURI(url) fails on malformed URLs,
  * so we replace the link node with a text node */
 export function malformedLinkEncodingTransform (tree) {
-  visitLinks(tree, (node, index, parent) => {
+  visit(tree, 'link', (node, index, parent) => {
     if (!node.url) return
 
     try {

--- a/lib/lexical/mdast/transforms/links.js
+++ b/lib/lexical/mdast/transforms/links.js
@@ -1,6 +1,25 @@
-import { visit } from 'unist-util-visit'
-import { toString } from 'mdast-util-to-string'
 import { isMisleadingLink } from '@/lib/url'
+
+function visitLinks (node, visitor) {
+  if (!node?.children) return
+
+  for (let index = 0; index < node.children.length; index++) {
+    const child = node.children[index]
+    if (child.type === 'link') {
+      visitor(child, index, node)
+    }
+
+    visitLinks(node.children[index], visitor)
+  }
+}
+
+function nodeToString (node) {
+  if (typeof node?.value === 'string') return node.value
+  if (typeof node?.alt === 'string') return node.alt
+  if (!node?.children) return ''
+
+  return node.children.map(nodeToString).join('')
+}
 
 /**
  * a link is misleading if the text is not the same as the URL.
@@ -9,15 +28,15 @@ import { isMisleadingLink } from '@/lib/url'
  * if the link wraps only an image, the link is removed but the image is kept.
  */
 export function misleadingLinkTransform (tree) {
-  visit(tree, 'link', (node, index, parent) => {
+  visitLinks(tree, (node, index, parent) => {
     // if the link has only an image child, unwrap it (remove the link but keep the image)
     const hasOnlyImage = node.children?.length === 1 && node.children[0].type === 'image'
     if (hasOnlyImage && parent && index !== undefined) {
       parent.children[index] = node.children[0]
-      return index
+      return
     }
 
-    const text = toString(node)
+    const text = nodeToString(node)
     if (!text) return
     if (!node.url) return
 
@@ -27,10 +46,37 @@ export function misleadingLinkTransform (tree) {
   })
 }
 
+export function trailingUnderscoreAutolinkTransform (tree) {
+  visitLinks(tree, (node, index, parent) => {
+    if (!parent || index === undefined) return
+    if (!node.url) return
+    if (nodeToString(node) !== node.url) return
+
+    const next = parent.children[index + 1]
+    if (next?.type !== 'text') return
+
+    const trailingUnderscores = next.value.match(/^_+/)?.[0]
+    if (!trailingUnderscores) return
+
+    node.url += trailingUnderscores
+    if (node.children.length === 1 && node.children[0].type === 'text') {
+      node.children[0].value += trailingUnderscores
+    } else {
+      node.children = [{ type: 'text', value: node.url }]
+    }
+
+    if (next.value === trailingUnderscores) {
+      parent.children.splice(index + 1, 1)
+    } else {
+      next.value = next.value.slice(trailingUnderscores.length)
+    }
+  })
+}
+
 /** LinkeDOM patch: decodeURI(url) fails on malformed URLs,
  * so we replace the link node with a text node */
 export function malformedLinkEncodingTransform (tree) {
-  visit(tree, 'link', (node, index, parent) => {
+  visitLinks(tree, (node, index, parent) => {
     if (!node.url) return
 
     try {

--- a/lib/lexical/mdast/transforms/links.spec.js
+++ b/lib/lexical/mdast/transforms/links.spec.js
@@ -1,6 +1,34 @@
 /* eslint-env jest */
 
-import { trailingUnderscoreAutolinkTransform } from './links'
+jest.mock('unist-util-visit', () => ({
+  visit: (node, type, visitor) => {
+    function walk (current, parent) {
+      if (!current?.children) return
+      for (let index = 0; index < current.children.length; index++) {
+        const child = current.children[index]
+        if (child.type === type) {
+          const nextIndex = visitor(child, index, current)
+          if (typeof nextIndex === 'number') {
+            index = nextIndex
+          }
+        }
+        walk(current.children[index], current)
+      }
+    }
+
+    walk(node, null)
+  }
+}))
+
+jest.mock('mdast-util-to-string', () => ({
+  toString: (node) => {
+    if (typeof node?.value === 'string') return node.value
+    if (typeof node?.alt === 'string') return node.alt
+    return node?.children?.map(child => child.value ?? child.alt ?? '').join('') ?? ''
+  }
+}))
+
+const { trailingUnderscoreAutolinkTransform } = require('./links')
 
 function transformChildren (children) {
   const tree = {
@@ -14,7 +42,7 @@ function transformChildren (children) {
   return tree.children[0].children
 }
 
-function autolink (url) {
+function gfmBareAutolink (url) {
   return {
     type: 'link',
     url,
@@ -23,9 +51,9 @@ function autolink (url) {
 }
 
 describe('trailingUnderscoreAutolinkTransform', () => {
-  test('restores a trailing underscore to a bare autolink', () => {
+  test('restores a trailing underscore from the text node GFM parses after a bare autolink', () => {
     const [link] = transformChildren([
-      autolink('https://twitter.com/some_user'),
+      gfmBareAutolink('https://twitter.com/some_user'),
       { type: 'text', value: '_' }
     ])
 
@@ -36,9 +64,9 @@ describe('trailingUnderscoreAutolinkTransform', () => {
     })
   })
 
-  test('restores multiple trailing underscores to a bare autolink', () => {
+  test('restores multiple trailing underscores from the text node GFM parses after a bare autolink', () => {
     const [link] = transformChildren([
-      autolink('https://example.com/path'),
+      gfmBareAutolink('https://example.com/path'),
       { type: 'text', value: '__' }
     ])
 
@@ -48,7 +76,7 @@ describe('trailingUnderscoreAutolinkTransform', () => {
 
   test('preserves text after trailing autolink underscores', () => {
     const [link, text] = transformChildren([
-      autolink('https://example.com/path'),
+      gfmBareAutolink('https://example.com/path'),
       { type: 'text', value: '__ suffix' }
     ])
 

--- a/lib/lexical/mdast/transforms/links.spec.js
+++ b/lib/lexical/mdast/transforms/links.spec.js
@@ -1,0 +1,74 @@
+/* eslint-env jest */
+
+import { trailingUnderscoreAutolinkTransform } from './links'
+
+function transformChildren (children) {
+  const tree = {
+    type: 'root',
+    children: [{
+      type: 'paragraph',
+      children
+    }]
+  }
+  trailingUnderscoreAutolinkTransform(tree)
+  return tree.children[0].children
+}
+
+function autolink (url) {
+  return {
+    type: 'link',
+    url,
+    children: [{ type: 'text', value: url }]
+  }
+}
+
+describe('trailingUnderscoreAutolinkTransform', () => {
+  test('restores a trailing underscore to a bare autolink', () => {
+    const [link] = transformChildren([
+      autolink('https://twitter.com/some_user'),
+      { type: 'text', value: '_' }
+    ])
+
+    expect(link).toMatchObject({
+      type: 'link',
+      url: 'https://twitter.com/some_user_',
+      children: [{ type: 'text', value: 'https://twitter.com/some_user_' }]
+    })
+  })
+
+  test('restores multiple trailing underscores to a bare autolink', () => {
+    const [link] = transformChildren([
+      autolink('https://example.com/path'),
+      { type: 'text', value: '__' }
+    ])
+
+    expect(link.url).toBe('https://example.com/path__')
+    expect(link.children[0].value).toBe('https://example.com/path__')
+  })
+
+  test('preserves text after trailing autolink underscores', () => {
+    const [link, text] = transformChildren([
+      autolink('https://example.com/path'),
+      { type: 'text', value: '__ suffix' }
+    ])
+
+    expect(link.url).toBe('https://example.com/path__')
+    expect(text).toMatchObject({ type: 'text', value: ' suffix' })
+  })
+
+  test('does not change explicit markdown links', () => {
+    const [link] = transformChildren([
+      {
+        type: 'link',
+        url: 'https://example.com/path_',
+        children: [{ type: 'text', value: 'example' }]
+      }
+    ])
+
+    expect(link).toMatchObject({
+      type: 'link',
+      url: 'https://example.com/path_',
+      children: [{ type: 'text', value: 'example' }]
+    })
+  })
+})

--- a/lib/lexical/utils/mdast.js
+++ b/lib/lexical/utils/mdast.js
@@ -16,6 +16,7 @@ import {
 import {
   mentionTransform,
   nostrTransform,
+  trailingUnderscoreAutolinkTransform,
   misleadingLinkTransform,
   malformedLinkEncodingTransform,
   footnoteTransform,
@@ -51,6 +52,7 @@ export function $markdownToLexical (markdown, { splitInParagraphs = false, appen
     mdastTransforms: [
       mentionTransform,
       nostrTransform,
+      trailingUnderscoreAutolinkTransform,
       misleadingLinkTransform,
       malformedLinkEncodingTransform,
       footnoteTransform,


### PR DESCRIPTION
Fixes #180.

## Description

Bare GFM autolinks drop trailing underscores from the link node and leave them as adjacent text. For example, `https://twitter.com/some_user_` is parsed as a link to `https://twitter.com/some_user` followed by a plain `_`, so the final underscore is not clickable.

This adds a small MDAST transform that runs before misleading-link normalization. When a bare autolink's rendered text exactly matches its URL and the following sibling text starts with one or more underscores, the transform merges those underscores back into the link URL/text and trims them from the sibling text.

The transform does not change explicit markdown links like `[example](https://example.com/path_)`, because those already preserve the intended URL.

## Screenshots

Not applicable; markdown parsing/rendering behavior.

## Additional Context

A previous PR for this issue (#2797) was closed by its author for insufficient local testing. This version includes focused transform coverage and keeps existing misleading-link tests passing.

BTC payout address if eligible for a sats award: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. Only bare autolinks followed by text that starts with underscores are changed. Explicit markdown links and non-underscore trailing punctuation keep their existing behavior.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7/10. Reproduced the current GFM parse shape, added focused unit tests for one/multiple trailing underscores, sibling text preservation, and explicit markdown links, and reran existing URL/misleading-link tests.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Not a visual frontend change.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes. AI assisted with issue triage, implementation, and validation. I checked duplicate PR history, reproduced the parser behavior, and ran the commands below.

Validation:

- `npm run lint -- lib/lexical/mdast/transforms/links.js lib/lexical/mdast/transforms/index.js lib/lexical/utils/mdast.js lib/lexical/mdast/transforms/links.spec.js`
- `npm test -- lib/lexical/mdast/transforms/links.spec.js lib/url.spec.js`
- `git diff --check`
