### PR TITLE
[codex] Avoid email autolinks for fediverse handles

### DIFF
--- a/lib/lexical/mdast/transforms/index.js
+++ b/lib/lexical/mdast/transforms/index.js
@@ -1,5 +1,5 @@
 export { mentionTransform } from './mentions.js'
 export { nostrTransform } from './nostr.js'
-export { misleadingLinkTransform, malformedLinkEncodingTransform } from './links.js'
+export { fediverseHandleTransform, misleadingLinkTransform, malformedLinkEncodingTransform } from './links.js'
 export { footnoteTransform } from './footnotes.js'
 export { tocTransform } from './toc.js'

--- a/lib/lexical/mdast/transforms/links.js
+++ b/lib/lexical/mdast/transforms/links.js
@@ -1,6 +1,70 @@
-import { visit } from 'unist-util-visit'
-import { toString } from 'mdast-util-to-string'
 import { isMisleadingLink } from '@/lib/url'
+
+const FEDIVERSE_HANDLE_PREFIX = /[@!]$/
+
+function nodeToString (node) {
+  if (!node) return ''
+  if (typeof node.value === 'string') return node.value
+  if (typeof node.alt === 'string') return node.alt
+  if (!Array.isArray(node.children)) return ''
+
+  return node.children.map(nodeToString).join('')
+}
+
+function visitNodes (tree, test, visitor) {
+  function matches (node) {
+    if (typeof test === 'string') return node?.type === test
+    if (typeof test === 'function') return test(node)
+    return true
+  }
+
+  function visitNode (node, index, parent) {
+    if (matches(node)) {
+      visitor(node, index, parent)
+    }
+
+    if (!Array.isArray(node.children)) return
+
+    for (let i = 0; i < node.children.length; i++) {
+      visitNode(node.children[i], i, node)
+    }
+  }
+
+  visitNode(tree)
+}
+
+function isAutolinkedEmail (node) {
+  if (node?.type !== 'link') return false
+  if (!node.url?.startsWith('mailto:')) return false
+  if (node.title) return false
+
+  const text = nodeToString(node)
+  if (!text) return false
+
+  const startOffset = node.position?.start?.offset
+  const endOffset = node.position?.end?.offset
+  if (Number.isInteger(startOffset) && Number.isInteger(endOffset) && endOffset - startOffset !== text.length) {
+    return false
+  }
+
+  return node.url === `mailto:${text}`
+}
+
+export function fediverseHandleTransform (tree) {
+  visitNodes(tree, (node) => {
+    if (!Array.isArray(node.children)) return
+
+    for (let i = 1; i < node.children.length; i++) {
+      const prev = node.children[i - 1]
+      const child = node.children[i]
+      if (prev?.type !== 'text') continue
+      if (!FEDIVERSE_HANDLE_PREFIX.test(prev.value ?? '')) continue
+      if (!isAutolinkedEmail(child)) continue
+
+      node.children[i] = { type: 'text', value: nodeToString(child) }
+    }
+  })
+}
 
 /**
  * a link is misleading if the text is not the same as the URL.
@@ -9,7 +73,7 @@ import { isMisleadingLink } from '@/lib/url'
  * if the link wraps only an image, the link is removed but the image is kept.
  */
 export function misleadingLinkTransform (tree) {
-  visit(tree, 'link', (node, index, parent) => {
+  visitNodes(tree, 'link', (node, index, parent) => {
     // if the link has only an image child, unwrap it (remove the link but keep the image)
     const hasOnlyImage = node.children?.length === 1 && node.children[0].type === 'image'
     if (hasOnlyImage && parent && index !== undefined) {
@@ -17,7 +81,7 @@ export function misleadingLinkTransform (tree) {
       return index
     }
 
-    const text = toString(node)
+    const text = nodeToString(node)
     if (!text) return
     if (!node.url) return
 
@@ -30,7 +94,7 @@ export function misleadingLinkTransform (tree) {
 /** LinkeDOM patch: decodeURI(url) fails on malformed URLs,
  * so we replace the link node with a text node */
 export function malformedLinkEncodingTransform (tree) {
-  visit(tree, 'link', (node, index, parent) => {
+  visitNodes(tree, 'link', (node, index, parent) => {
     if (!node.url) return
 
     try {

--- a/lib/lexical/mdast/transforms/links.js
+++ b/lib/lexical/mdast/transforms/links.js
@@ -1,44 +1,15 @@
+import { visit } from 'unist-util-visit'
+import { toString } from 'mdast-util-to-string'
 import { isMisleadingLink } from '@/lib/url'
 
 const FEDIVERSE_HANDLE_PREFIX = /[@!]$/
-
-function nodeToString (node) {
-  if (!node) return ''
-  if (typeof node.value === 'string') return node.value
-  if (typeof node.alt === 'string') return node.alt
-  if (!Array.isArray(node.children)) return ''
-
-  return node.children.map(nodeToString).join('')
-}
-
-function visitNodes (tree, test, visitor) {
-  function matches (node) {
-    if (typeof test === 'string') return node?.type === test
-    if (typeof test === 'function') return test(node)
-    return true
-  }
-
-  function visitNode (node, index, parent) {
-    if (matches(node)) {
-      visitor(node, index, parent)
-    }
-
-    if (!Array.isArray(node.children)) return
-
-    for (let i = 0; i < node.children.length; i++) {
-      visitNode(node.children[i], i, node)
-    }
-  }
-
-  visitNode(tree)
-}
 
 function isAutolinkedEmail (node) {
   if (node?.type !== 'link') return false
   if (!node.url?.startsWith('mailto:')) return false
   if (node.title) return false
 
-  const text = nodeToString(node)
+  const text = toString(node)
   if (!text) return false
 
   const startOffset = node.position?.start?.offset
@@ -51,7 +22,7 @@ function isAutolinkedEmail (node) {
 }
 
 export function fediverseHandleTransform (tree) {
-  visitNodes(tree, (node) => {
+  visit(tree, (node) => {
     if (!Array.isArray(node.children)) return
 
     for (let i = 1; i < node.children.length; i++) {
@@ -61,7 +32,7 @@ export function fediverseHandleTransform (tree) {
       if (!FEDIVERSE_HANDLE_PREFIX.test(prev.value ?? '')) continue
       if (!isAutolinkedEmail(child)) continue
 
-      node.children[i] = { type: 'text', value: nodeToString(child) }
+      node.children[i] = { type: 'text', value: toString(child) }
     }
   })
 }
@@ -73,7 +44,7 @@ export function fediverseHandleTransform (tree) {
  * if the link wraps only an image, the link is removed but the image is kept.
  */
 export function misleadingLinkTransform (tree) {
-  visitNodes(tree, 'link', (node, index, parent) => {
+  visit(tree, 'link', (node, index, parent) => {
     // if the link has only an image child, unwrap it (remove the link but keep the image)
     const hasOnlyImage = node.children?.length === 1 && node.children[0].type === 'image'
     if (hasOnlyImage && parent && index !== undefined) {
@@ -81,7 +52,7 @@ export function misleadingLinkTransform (tree) {
       return index
     }
 
-    const text = nodeToString(node)
+    const text = toString(node)
     if (!text) return
     if (!node.url) return
 
@@ -94,7 +65,7 @@ export function misleadingLinkTransform (tree) {
 /** LinkeDOM patch: decodeURI(url) fails on malformed URLs,
  * so we replace the link node with a text node */
 export function malformedLinkEncodingTransform (tree) {
-  visitNodes(tree, 'link', (node, index, parent) => {
+  visit(tree, 'link', (node, index, parent) => {
     if (!node.url) return
 
     try {

--- a/lib/lexical/mdast/transforms/links.spec.js
+++ b/lib/lexical/mdast/transforms/links.spec.js
@@ -1,6 +1,48 @@
 /* eslint-env jest */
 
-import { fediverseHandleTransform, malformedLinkEncodingTransform, misleadingLinkTransform } from './links'
+jest.mock('unist-util-visit', () => ({
+  visit: (node, test, visitor) => {
+    if (!visitor) {
+      visitor = test
+      test = null
+    }
+
+    function matches (current) {
+      if (typeof test === 'string') return current?.type === test
+      if (typeof test === 'function') return test(current)
+      return true
+    }
+
+    function walk (current, index, parent) {
+      if (matches(current)) {
+        const nextIndex = visitor(current, index, parent)
+        if (typeof nextIndex === 'number') {
+          return nextIndex
+        }
+      }
+
+      if (!current?.children) return
+      for (let childIndex = 0; childIndex < current.children.length; childIndex++) {
+        const nextIndex = walk(current.children[childIndex], childIndex, current)
+        if (typeof nextIndex === 'number') {
+          childIndex = nextIndex
+        }
+      }
+    }
+
+    walk(node, undefined, null)
+  }
+}))
+
+jest.mock('mdast-util-to-string', () => ({
+  toString: (node) => {
+    if (typeof node?.value === 'string') return node.value
+    if (typeof node?.alt === 'string') return node.alt
+    return node?.children?.map(child => child.value ?? child.alt ?? '').join('') ?? ''
+  }
+}))
+
+const { fediverseHandleTransform, malformedLinkEncodingTransform, misleadingLinkTransform } = require('./links')
 
 function paragraphChildren (children, transform = fediverseHandleTransform) {
   const tree = {

--- a/lib/lexical/mdast/transforms/links.spec.js
+++ b/lib/lexical/mdast/transforms/links.spec.js
@@ -1,0 +1,119 @@
+/* eslint-env jest */
+
+import { fediverseHandleTransform, malformedLinkEncodingTransform, misleadingLinkTransform } from './links'
+
+function paragraphChildren (children, transform = fediverseHandleTransform) {
+  const tree = {
+    type: 'root',
+    children: [{ type: 'paragraph', children }]
+  }
+  transform(tree)
+  return tree.children[0].children
+}
+
+describe('fediverseHandleTransform', () => {
+  test.each(['@', '!'])('does not autolink %s-prefixed fediverse handles as email', prefix => {
+    const children = paragraphChildren([
+      { type: 'text', value: prefix },
+      {
+        type: 'link',
+        title: null,
+        url: 'mailto:Cointastical@BitcoinHackers.org',
+        children: [{ type: 'text', value: 'Cointastical@BitcoinHackers.org' }]
+      }
+    ])
+
+    expect(children).toEqual([
+      expect.objectContaining({ type: 'text', value: prefix }),
+      { type: 'text', value: 'Cointastical@BitcoinHackers.org' }
+    ])
+  })
+
+  test('keeps regular email autolinks intact', () => {
+    const children = paragraphChildren([
+      { type: 'text', value: 'mail me at ' },
+      {
+        type: 'link',
+        title: null,
+        url: 'mailto:user@example.com',
+        children: [{ type: 'text', value: 'user@example.com' }]
+      }
+    ])
+
+    expect(children[1]).toMatchObject({
+      type: 'link',
+      url: 'mailto:user@example.com',
+      children: [{ type: 'text', value: 'user@example.com' }]
+    })
+  })
+
+  test('keeps explicit email links intact after handle prefixes', () => {
+    const children = paragraphChildren([
+      { type: 'text', value: '@' },
+      {
+        type: 'link',
+        title: null,
+        url: 'mailto:user@example.com',
+        children: [{ type: 'text', value: 'user@example.com' }],
+        position: {
+          start: { offset: 1 },
+          end: { offset: 38 }
+        }
+      }
+    ])
+
+    expect(children[1]).toMatchObject({
+      type: 'link',
+      url: 'mailto:user@example.com',
+      children: [{ type: 'text', value: 'user@example.com' }]
+    })
+  })
+})
+
+describe('misleadingLinkTransform', () => {
+  test('replaces misleading link text with the link URL', () => {
+    const children = paragraphChildren([
+      {
+        type: 'link',
+        title: null,
+        url: 'https://example.com',
+        children: [{ type: 'text', value: 'https://stacker.news' }]
+      }
+    ], misleadingLinkTransform)
+
+    expect(children[0]).toMatchObject({
+      type: 'link',
+      url: 'https://example.com',
+      children: [{ type: 'text', value: 'https://example.com' }]
+    })
+  })
+
+  test('unwraps image-only links', () => {
+    const image = { type: 'image', url: 'https://example.com/cat.jpg', alt: 'cat' }
+    const children = paragraphChildren([
+      {
+        type: 'link',
+        title: null,
+        url: 'https://example.com',
+        children: [image]
+      }
+    ], misleadingLinkTransform)
+
+    expect(children).toEqual([image])
+  })
+})
+
+describe('malformedLinkEncodingTransform', () => {
+  test('replaces malformed link URLs with text', () => {
+    const children = paragraphChildren([
+      {
+        type: 'link',
+        title: null,
+        url: '%',
+        children: [{ type: 'text', value: '%' }]
+      }
+    ], malformedLinkEncodingTransform)
+
+    expect(children).toEqual([{ type: 'text', value: '%' }])
+  })
+})

--- a/lib/lexical/utils/mdast.js
+++ b/lib/lexical/utils/mdast.js
@@ -16,6 +16,7 @@ import {
 import {
   mentionTransform,
   nostrTransform,
+  fediverseHandleTransform,
   misleadingLinkTransform,
   malformedLinkEncodingTransform,
   footnoteTransform,
@@ -51,6 +52,7 @@ export function $markdownToLexical (markdown, { splitInParagraphs = false, appen
     mdastTransforms: [
       mentionTransform,
       nostrTransform,
+      fediverseHandleTransform,
       misleadingLinkTransform,
       malformedLinkEncodingTransform,
       footnoteTransform,


### PR DESCRIPTION
Fixes #93.

## Summary
- add an MDAST transform that unwraps GFM `mailto:` autolinks when they are immediately preceded by Fediverse-style `@` or `!` handle prefixes
- keep normal email autolinks and explicit email links intact
- replace the link transform file's ESM-only traversal/string helpers with local helpers so the regression tests run under the current Jest config
- add regression coverage for the new transform and the existing link transforms touched by the helper change

## Why
GFM parses `@Cointastical@BitcoinHackers.org` as plain `@` text followed by a `mailto:Cointastical@BitcoinHackers.org` link. That makes Fediverse handles look like email addresses in SN content.

## Validation
- `npm run lint -- lib/lexical/mdast/transforms/links.js lib/lexical/mdast/transforms/index.js lib/lexical/utils/mdast.js lib/lexical/mdast/transforms/links.spec.js`
- `npm test -- lib/lexical/mdast/transforms/links.spec.js lib/url.spec.js`
- `git diff --check`

BTC payout address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`