### PR TITLE
[codex] Avoid Nostr embeds from URL hostnames

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -126,7 +126,7 @@ export function parseEmbedUrl (href) {
     const { hostname, pathname, searchParams } = new URL(href)
 
     // nostr prefixes: [npub1, nevent1, nprofile1, note1]
-    const nostr = href.match(/\/(?<id>(?<type>npub1|nevent1|nprofile1|note1|naddr1)[02-9ac-hj-np-z]+)/)
+    const nostr = pathname.match(/\/(?<id>(?<type>npub1|nevent1|nprofile1|note1|naddr1)[02-9ac-hj-np-z]+)/)
     if (nostr?.groups?.id) {
       let id = nostr.groups.id
       if (nostr.groups.type === 'npub1') {

--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 
+import { nip19 } from 'nostr-tools'
 import { parseEmbedUrl, parseInternalLinks, isMisleadingLink } from './url.js'
 
 const internalLinkCases = [
@@ -66,15 +67,53 @@ describe('misleading links', () => {
 })
 
 describe('embed links', () => {
+  const nostrPubkey = '0'.repeat(64)
+  const nostrEventId = '1'.repeat(64)
+  const nostrEmbedCases = [
+    {
+      type: 'npub',
+      id: nip19.npubEncode(nostrPubkey),
+      expectedType: 'nprofile',
+      expectedData: { pubkey: nostrPubkey }
+    },
+    {
+      type: 'nprofile',
+      id: nip19.nprofileEncode({ pubkey: nostrPubkey }),
+      expectedType: 'nprofile',
+      expectedData: { pubkey: nostrPubkey }
+    },
+    {
+      type: 'note',
+      id: nip19.noteEncode(nostrEventId),
+      expectedType: 'nevent',
+      expectedData: { id: nostrEventId }
+    },
+    {
+      type: 'nevent',
+      id: nip19.neventEncode({ id: nostrEventId }),
+      expectedType: 'nevent',
+      expectedData: { id: nostrEventId }
+    },
+    {
+      type: 'naddr',
+      id: nip19.naddrEncode({ identifier: 'test-article', pubkey: nostrPubkey, kind: 30023 }),
+      expectedType: 'naddr',
+      expectedData: { identifier: 'test-article', pubkey: nostrPubkey, kind: 30023 }
+    }
+  ]
+
   test('does not parse nostr ids in hostnames as embeds', () => {
     const actual = parseEmbedUrl('https://npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk.nsite.lol/')
 
     expect(actual).toBeNull()
   })
 
-  test('parses nostr ids in URL paths as embeds', () => {
-    const actual = parseEmbedUrl('https://njump.me/npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk')
+  test.each(nostrEmbedCases)('parses $type ids in URL paths as nostr embeds', ({ id, expectedType, expectedData }) => {
+    const actual = parseEmbedUrl(`https://njump.me/${id}`)
 
     expect(actual).toMatchObject({ provider: 'nostr' })
+    const decoded = nip19.decode(actual.id)
+    expect(decoded.type).toBe(expectedType)
+    expect(decoded.data).toMatchObject(expectedData)
   })
 })

--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { parseInternalLinks, isMisleadingLink } from './url.js'
+import { parseEmbedUrl, parseInternalLinks, isMisleadingLink } from './url.js'
 
 const internalLinkCases = [
   ['https://stacker.news/items/123', '#123'],
@@ -63,4 +63,18 @@ describe('misleading links', () => {
       expect(actual).toBe(expected)
     }
   )
+})
+
+describe('embed links', () => {
+  test('does not parse nostr ids in hostnames as embeds', () => {
+    const actual = parseEmbedUrl('https://npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk.nsite.lol/')
+
+    expect(actual).toBeNull()
+  })
+
+  test('parses nostr ids in URL paths as embeds', () => {
+    const actual = parseEmbedUrl('https://njump.me/npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk')
+
+    expect(actual).toMatchObject({ provider: 'nostr' })
+  })
 })


### PR DESCRIPTION
Fixes #2252.

## Summary
- match Nostr IDs for embeds from the parsed URL pathname instead of the whole href
- keep `https://njump.me/npub...` parsing as a Nostr embed
- keep URLs like `https://npub....nsite.lol/` as normal raw links
- add URL parser coverage for both cases

## Why
The old whole-href regex sees the leading `//npub...` in hostnames and treats that hostname as a path Nostr ID. That makes ordinary links with npub-based hostnames behave like Nostr embeds/links instead of staying as the original URL.

## Prior context
PR #2253 was closed after the editor overhaul, but maintainer review there specified the current expected behavior: njump path links should embed, bare npubs should link to njump, and npub hostnames such as nsite links should stay raw. This patch applies the remaining URL-parser part to the current code path.

## Validation
- `npm run lint -- lib/url.js lib/url.spec.js`
- `npm test -- lib/url.spec.js`
- `git diff --check`

BTC payout address: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`