### PR TITLE
[codex] Preserve item mention link formatting

### DIFF
--- a/components/editor/nodes/mentions.js
+++ b/components/editor/nodes/mentions.js
@@ -5,12 +5,14 @@ import Link from 'next/link'
 import { useCallback } from 'react'
 import useDecoratorNodeSelection from '@/components/editor/hooks/use-decorator-selection'
 import { $isItemMentionNode } from '@/lib/lexical/nodes/decorative/mentions/item'
+import { formatToClassName } from '@/lib/lexical/mdast/format'
 import { getLinkAttributes } from '@/lib/url'
 import { $createLinkNode } from '@lexical/link'
 
-export default function MentionsComponent ({ nodeKey, href, text }) {
+export default function MentionsComponent ({ nodeKey, href, text, format = 0 }) {
   const [editor] = useLexicalComposerContext()
   const isEditable = useLexicalEditable()
+  const className = formatToClassName(format) || undefined
 
   const breakMention = useCallback(() => {
     if (!isEditable) return
@@ -24,8 +26,10 @@ export default function MentionsComponent ({ nodeKey, href, text }) {
         const url = node.getURL()
         const displayText = node.getText()
         const { target, rel } = getLinkAttributes(url)
+        const textNode = $createTextNode(displayText || url)
+        textNode.setFormat(node.getFormat())
         newNode = $createLinkNode(url, { target, rel })
-          .append($createTextNode(displayText || url))
+          .append(textNode)
       } else {
         // other mention types become plain text
         // cursor will land on the text node triggering mentions menu
@@ -43,7 +47,7 @@ export default function MentionsComponent ({ nodeKey, href, text }) {
     onDoubleClick: breakMention
   })
 
-  if (!isEditable) return <Link href={href}>{text}</Link>
+  if (!isEditable) return <Link className={className} href={href}>{text}</Link>
 
-  return <span title='double click to edit'>{text}</span>
+  return <span className={className} title='double click to edit'>{text}</span>
 }

--- a/lib/lexical/mdast/format.js
+++ b/lib/lexical/mdast/format.js
@@ -1,0 +1,89 @@
+import {
+  IS_BOLD,
+  IS_CODE,
+  IS_HIGHLIGHT,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_SUBSCRIPT,
+  IS_SUPERSCRIPT,
+  IS_UNDERLINE
+} from './format-constants.js'
+
+const TEXT_FORMAT_CLASS_NAMES = [
+  { flag: IS_BOLD, className: 'sn-text__bold' },
+  { flag: IS_ITALIC, className: 'sn-text__italic' },
+  { flag: IS_HIGHLIGHT, className: 'sn-text__highlight' },
+  { flag: IS_SUPERSCRIPT, className: 'sn-text__superscript' },
+  { flag: IS_SUBSCRIPT, className: 'sn-text__subscript' }
+]
+
+const TEXT_FORMAT_MDAST_WRAPPERS = [
+  { flag: IS_ITALIC, type: 'emphasis' },
+  { flag: IS_BOLD, type: 'strong' },
+  { flag: IS_STRIKETHROUGH, type: 'delete' },
+  { flag: IS_HIGHLIGHT, type: 'highlight' }
+]
+
+const TEXT_FORMAT_HTML_TAGS = [
+  { flag: IS_SUPERSCRIPT, open: '<sup>', close: '</sup>' },
+  { flag: IS_SUBSCRIPT, open: '<sub>', close: '</sub>' },
+  { flag: IS_UNDERLINE, open: '<ins>', close: '</ins>' }
+]
+
+function normalizeFormat (format) {
+  return Number(format) || 0
+}
+
+export function formatToClassName (format) {
+  const normalizedFormat = normalizeFormat(format)
+  const classes = []
+
+  for (const { flag, className } of TEXT_FORMAT_CLASS_NAMES) {
+    if (normalizedFormat & flag) {
+      classes.push(className)
+    }
+  }
+
+  if ((normalizedFormat & IS_UNDERLINE) && (normalizedFormat & IS_STRIKETHROUGH)) {
+    classes.push('sn-text__underline-strikethrough')
+  } else {
+    if (normalizedFormat & IS_UNDERLINE) {
+      classes.push('sn-text__underline')
+    }
+    if (normalizedFormat & IS_STRIKETHROUGH) {
+      classes.push('sn-text__strikethrough')
+    }
+  }
+
+  return classes.join(' ')
+}
+
+export function formatTextAsMdastChildren (text, format) {
+  const normalizedFormat = normalizeFormat(format)
+  const children = []
+  const closingTags = []
+
+  for (const { flag, open, close } of TEXT_FORMAT_HTML_TAGS) {
+    if (normalizedFormat & flag) {
+      children.push({ type: 'html', value: open })
+      closingTags.unshift({ type: 'html', value: close })
+    }
+  }
+
+  let textNode = normalizedFormat & IS_CODE
+    ? { type: 'inlineCode', value: text }
+    : { type: 'text', value: text }
+
+  for (let i = TEXT_FORMAT_MDAST_WRAPPERS.length - 1; i >= 0; i--) {
+    const { flag, type } = TEXT_FORMAT_MDAST_WRAPPERS[i]
+    if (normalizedFormat & flag) {
+      textNode = {
+        type,
+        children: [textNode]
+      }
+    }
+  }
+
+  children.push(textNode, ...closingTags)
+  return children
+}

--- a/lib/lexical/mdast/format.spec.js
+++ b/lib/lexical/mdast/format.spec.js
@@ -1,0 +1,60 @@
+/* eslint-env jest */
+
+import {
+  IS_BOLD,
+  IS_CODE,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_UNDERLINE
+} from './format-constants.js'
+import { formatTextAsMdastChildren, formatToClassName } from './format.js'
+
+describe('formatToClassName', () => {
+  test('returns text format classes', () => {
+    expect(formatToClassName(IS_BOLD | IS_ITALIC)).toBe('sn-text__bold sn-text__italic')
+  })
+
+  test('uses a combined underline strikethrough class', () => {
+    expect(formatToClassName(IS_UNDERLINE | IS_STRIKETHROUGH)).toBe('sn-text__underline-strikethrough')
+  })
+
+  test('returns an empty class name for unstyled text', () => {
+    expect(formatToClassName(0)).toBe('')
+  })
+})
+
+describe('formatTextAsMdastChildren', () => {
+  test('wraps text with mdast formatting nodes', () => {
+    expect(formatTextAsMdastChildren('High Risk', IS_ITALIC | IS_BOLD)).toEqual([
+      {
+        type: 'emphasis',
+        children: [
+          {
+            type: 'strong',
+            children: [{ type: 'text', value: 'High Risk' }]
+          }
+        ]
+      }
+    ])
+  })
+
+  test('preserves html formatting tags inside links', () => {
+    expect(formatTextAsMdastChildren('High Risk', IS_UNDERLINE | IS_ITALIC)).toEqual([
+      { type: 'html', value: '<ins>' },
+      {
+        type: 'emphasis',
+        children: [{ type: 'text', value: 'High Risk' }]
+      },
+      { type: 'html', value: '</ins>' }
+    ])
+  })
+
+  test('preserves inline code as a formatted leaf', () => {
+    expect(formatTextAsMdastChildren('High Risk', IS_CODE | IS_ITALIC)).toEqual([
+      {
+        type: 'emphasis',
+        children: [{ type: 'inlineCode', value: 'High Risk' }]
+      }
+    ])
+  })
+})

--- a/lib/lexical/mdast/mentions.spec.js
+++ b/lib/lexical/mdast/mentions.spec.js
@@ -1,0 +1,92 @@
+/* eslint-env jest */
+
+import { createHeadlessEditor } from '@lexical/headless'
+import { $isItemMentionNode } from '@/lib/lexical/nodes/decorative/mentions/item'
+import { ItemMentionNode, $createItemMentionNode } from '@/lib/lexical/nodes/decorative/mentions'
+import { LexicalItemMentionVisitor, MdastItemMentionLinkVisitor } from './visitors/mentions.js'
+import { IS_ITALIC } from './format-constants.js'
+
+function createEditor () {
+  return createHeadlessEditor({
+    namespace: 'item-mention-format-test',
+    nodes: [ItemMentionNode],
+    onError: (error) => { throw error }
+  })
+}
+
+describe('item mention markdown formatting', () => {
+  test('imports italic formatting from an internal item link label', () => {
+    process.env.NEXT_PUBLIC_URL = 'https://stacker.news'
+    const editor = createEditor()
+    let itemMention
+
+    editor.update(() => {
+      MdastItemMentionLinkVisitor.visitNode({
+        mdastNode: {
+          type: 'link',
+          url: 'https://stacker.news/items/778491',
+          children: [
+            {
+              type: 'emphasis',
+              children: [{ type: 'text', value: 'High Risk, Low Reward' }]
+            }
+          ]
+        },
+        actions: {
+          getParentFormatting: () => 0,
+          addAndStepInto: (node) => {
+            itemMention = {
+              isItemMention: $isItemMentionNode(node),
+              text: node.getText(),
+              format: node.getFormat()
+            }
+          },
+          nextVisitor: () => {}
+        }
+      })
+    }, { discrete: true })
+
+    expect(itemMention.isItemMention).toBe(true)
+    expect(itemMention.text).toBe('High Risk, Low Reward')
+    expect(itemMention.format & IS_ITALIC).toBe(IS_ITALIC)
+  })
+
+  test('exports formatted custom item mention text', () => {
+    const editor = createEditor()
+    let link
+
+    editor.update(() => {
+      const lexicalNode = $createItemMentionNode({
+        id: '778491',
+        text: 'High Risk, Low Reward',
+        url: 'https://stacker.news/items/778491',
+        format: IS_ITALIC
+      })
+      const mdastParent = { type: 'paragraph', children: [] }
+
+      LexicalItemMentionVisitor.visitLexicalNode({
+        lexicalNode,
+        mdastParent,
+        actions: {
+          appendToParent: (parent, node) => {
+            parent.children.push(node)
+            return node
+          }
+        }
+      })
+
+      link = mdastParent.children[0]
+    }, { discrete: true })
+
+    expect(link).toEqual({
+      type: 'link',
+      url: 'https://stacker.news/items/778491',
+      children: [
+        {
+          type: 'emphasis',
+          children: [{ type: 'text', value: 'High Risk, Low Reward' }]
+        }
+      ]
+    })
+  })
+})

--- a/lib/lexical/mdast/visitors/mentions.js
+++ b/lib/lexical/mdast/visitors/mentions.js
@@ -5,6 +5,17 @@ import {
 } from '@/lib/lexical/nodes/decorative/mentions'
 import { parseInternalLinks } from '@/lib/url'
 import { $createItemMentionNode, isCustomText } from '@/lib/lexical/nodes/decorative/mentions/item'
+import { formatTextAsMdastChildren } from '@/lib/lexical/mdast/format'
+import {
+  IS_BOLD,
+  IS_CODE,
+  IS_HIGHLIGHT,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_SUBSCRIPT,
+  IS_SUPERSCRIPT,
+  IS_UNDERLINE
+} from '@/lib/lexical/mdast/format-constants'
 
 // user mentions (@user, @user/path)
 // uses transforms to parse mentions
@@ -66,20 +77,71 @@ export const LexicalTerritoryMentionVisitor = {
   }
 }
 
-// extract text by traversing the mdast node children
-function extractText (children) {
-  if (!children || children.length === 0) return ''
+const MDAST_NODE_FORMATS = {
+  emphasis: IS_ITALIC,
+  strong: IS_BOLD,
+  delete: IS_STRIKETHROUGH,
+  highlight: IS_HIGHLIGHT
+}
 
-  return children.map(child => {
+const MDAST_HTML_FORMATS = {
+  '<sup>': { flag: IS_SUPERSCRIPT, enabled: true },
+  '</sup>': { flag: IS_SUPERSCRIPT, enabled: false },
+  '<sub>': { flag: IS_SUBSCRIPT, enabled: true },
+  '</sub>': { flag: IS_SUBSCRIPT, enabled: false },
+  '<ins>': { flag: IS_UNDERLINE, enabled: true },
+  '</ins>': { flag: IS_UNDERLINE, enabled: false }
+}
+
+// extract text and any format common to all text leaves in the link label
+function extractTextAndFormat (children, baseFormat = 0) {
+  let text = ''
+  let commonFormat = null
+
+  function appendText (value, format) {
+    if (!value) return
+    text += value
+    commonFormat = commonFormat === null ? format : commonFormat & format
+  }
+
+  function visitChildren (children, format) {
+    let activeFormat = format
+    for (const child of children) {
+      const htmlFormat = child.type === 'html' ? MDAST_HTML_FORMATS[child.value] : null
+      if (htmlFormat) {
+        activeFormat = htmlFormat.enabled
+          ? activeFormat | htmlFormat.flag
+          : activeFormat & ~htmlFormat.flag
+        continue
+      }
+
+      visitChild(child, activeFormat)
+    }
+  }
+
+  function visitChild (child, format) {
     if (child.type === 'text') {
-      return child.value
+      appendText(child.value, format)
+      return
     }
 
-    if (child.children) {
-      return extractText(child.children)
+    if (child.type === 'inlineCode') {
+      appendText(child.value, format | IS_CODE)
+      return
     }
-    return ''
-  }).join('')
+
+    const childFormat = MDAST_NODE_FORMATS[child.type] || 0
+    if (child.children) {
+      visitChildren(child.children, format | childFormat)
+    }
+  }
+
+  visitChildren(children || [], baseFormat)
+
+  return {
+    text,
+    format: commonFormat ?? baseFormat
+  }
 }
 
 export const MdastItemMentionLinkVisitor = {
@@ -89,11 +151,12 @@ export const MdastItemMentionLinkVisitor = {
     try {
       const { itemId, commentId, linkText } = parseInternalLinks(mdastNode.url)
       if (itemId || commentId) {
-        const text = extractText(mdastNode.children) || linkText
+        const { text, format } = extractTextAndFormat(mdastNode.children, actions.getParentFormatting())
         const mentionNode = $createItemMentionNode({
           id: commentId || itemId,
-          text,
-          url: mdastNode.url
+          text: text || linkText,
+          url: mdastNode.url,
+          format
         })
         actions.addAndStepInto(mentionNode)
         return
@@ -111,6 +174,7 @@ export const LexicalItemMentionVisitor = {
     const url = lexicalNode.getURL()
     const text = lexicalNode.getText()
     const id = lexicalNode.getItemMentionId()
+    const format = lexicalNode.getFormat()
 
     // check if custom text
     if (isCustomText(text, id)) {
@@ -118,7 +182,7 @@ export const LexicalItemMentionVisitor = {
       actions.appendToParent(mdastParent, {
         type: 'link',
         url,
-        children: [{ type: 'text', value: text }]
+        children: formatTextAsMdastChildren(text, format)
       })
     } else {
       // export as text node

--- a/lib/lexical/nodes/decorative/mentions/item.jsx
+++ b/lib/lexical/nodes/decorative/mentions/item.jsx
@@ -1,12 +1,16 @@
 import { DecoratorNode, $applyNodeReplacement } from 'lexical'
+import { formatToClassName } from '@/lib/lexical/mdast/format'
+
+const ITEM_MENTION_FORMAT_ATTRIBUTE = 'data-lexical-item-mention-format'
 
 function $convertItemMentionElement (domNode) {
   const id = domNode.getAttribute('data-lexical-item-mention-id')
   const text = domNode.getAttribute('data-lexical-item-mention-text') ?? domNode.querySelector('a')?.textContent
   const url = domNode.getAttribute('data-lexical-item-mention-url') ?? domNode.querySelector('a')?.getAttribute('href')
+  const format = Number(domNode.getAttribute(ITEM_MENTION_FORMAT_ATTRIBUTE)) || 0
 
   if (id) {
-    const node = $createItemMentionNode({ id, text, url })
+    const node = $createItemMentionNode({ id, text, url, format })
     return { node }
   }
 
@@ -21,6 +25,7 @@ export class ItemMentionNode extends DecoratorNode {
   __itemMentionId
   __text
   __url
+  __format
 
   static getType () {
     return 'item-mention'
@@ -38,19 +43,29 @@ export class ItemMentionNode extends DecoratorNode {
     return this.__url
   }
 
+  getFormat () {
+    return this.__format
+  }
+
   static clone (node) {
-    return new ItemMentionNode(node.__itemMentionId, node.__text, node.__url, node.__key)
+    return new ItemMentionNode(node.__itemMentionId, node.__text, node.__url, node.__format, node.__key)
   }
 
   static importJSON (serializedNode) {
-    return $createItemMentionNode({ id: serializedNode.itemMentionId, text: serializedNode.text, url: serializedNode.url })
+    return $createItemMentionNode({
+      id: serializedNode.itemMentionId,
+      text: serializedNode.text,
+      url: serializedNode.url,
+      format: serializedNode.format
+    })
   }
 
-  constructor (itemMentionId, text, url, key) {
+  constructor (itemMentionId, text, url, format = 0, key) {
     super(key)
     this.__itemMentionId = itemMentionId
     this.__text = text
     this.__url = url
+    this.__format = format
   }
 
   exportJSON () {
@@ -59,19 +74,21 @@ export class ItemMentionNode extends DecoratorNode {
       version: 1,
       itemMentionId: this.__itemMentionId,
       text: this.__text,
-      url: this.__url
+      url: this.__url,
+      format: this.__format
     }
   }
 
   createDOM (config) {
     const domNode = document.createElement('span')
     const theme = config.theme
-    const className = isCustomText(this.__text, this.__itemMentionId) ? theme.link : theme.itemMention
+    const className = itemMentionClassName(theme, this.__text, this.__itemMentionId)
     if (className !== undefined) {
       domNode.className = className
     }
     domNode.setAttribute('data-lexical-item-mention', true)
     domNode.setAttribute('data-lexical-item-mention-id', this.__itemMentionId)
+    domNode.setAttribute(ITEM_MENTION_FORMAT_ATTRIBUTE, this.__format)
     // text/url aren't derivable from id alone, so serialize them for hydration
     this.__text && domNode.setAttribute('data-lexical-item-mention-text', this.__text)
     this.__url && domNode.setAttribute('data-lexical-item-mention-url', this.__url)
@@ -83,11 +100,12 @@ export class ItemMentionNode extends DecoratorNode {
     const wrapper = document.createElement('span')
     wrapper.setAttribute('data-lexical-item-mention', true)
     const theme = editor._config.theme
-    const className = isCustomText(this.__text, this.__itemMentionId) ? theme.link : theme.itemMention
+    const className = formattedItemMentionClassName(theme, this.__text, this.__itemMentionId, this.__format)
     if (className !== undefined) {
       wrapper.className = className
     }
     wrapper.setAttribute('data-lexical-item-mention-id', this.__itemMentionId)
+    wrapper.setAttribute(ITEM_MENTION_FORMAT_ATTRIBUTE, this.__format)
     const a = document.createElement('a')
     a.setAttribute('href', this.__url)
     a.textContent = this.__text || `#${this.__itemMentionId}`
@@ -124,14 +142,25 @@ export class ItemMentionNode extends DecoratorNode {
     const text = this.__text || `#${this.__itemMentionId}`
     return (
       <ItemPopover id={id}>
-        <MentionsComponent nodeKey={this.getKey()} href={href} text={text} />
+        <MentionsComponent nodeKey={this.getKey()} href={href} text={text} format={this.__format} />
       </ItemPopover>
     )
   }
 }
 
-export function $createItemMentionNode ({ id, text, url }) {
-  return $applyNodeReplacement(new ItemMentionNode(id, text, url))
+function itemMentionClassName (theme, text, id) {
+  return isCustomText(text, id) ? theme.link : theme.itemMention
+}
+
+function formattedItemMentionClassName (theme, text, id, format) {
+  return [
+    itemMentionClassName(theme, text, id),
+    formatToClassName(format)
+  ].filter(Boolean).join(' ')
+}
+
+export function $createItemMentionNode ({ id, text, url, format = 0 }) {
+  return $applyNodeReplacement(new ItemMentionNode(id, text, url, format))
 }
 
 export function $isItemMentionNode (node) {


### PR DESCRIPTION
## Summary
- preserve common mdast text formatting when formatted internal item links become item mention nodes
- serialize item mention formatting and apply it in the decorator rendering path
- keep formatting when an item mention is broken back into a regular link or exported to mdast

Fixes #2767

## Testing
- npm run lint -- components/editor/nodes/mentions.js lib/lexical/mdast/format.js lib/lexical/mdast/format.spec.js lib/lexical/mdast/mentions.spec.js lib/lexical/mdast/visitors/mentions.js lib/lexical/nodes/decorative/mentions/item.jsx
- npm test -- lib/lexical/mdast/format.spec.js lib/lexical/mdast/mentions.spec.js lib/url.spec.js
- git diff --check
