### PR TITLE
[codex] Fix sticky header horizontal shift

### DIFF
--- a/components/header.module.css
+++ b/components/header.module.css
@@ -119,7 +119,8 @@
 .sticky {
     position: fixed;
     border-bottom: 1px solid var(--theme-toolbarActive);
-    width: 100vw;
+    left: 0;
+    right: 0;
     top: -1px;
     padding-top: 1px;
     background-color: var(--bs-body-bg);


### PR DESCRIPTION
## Summary
- replace the sticky header's `width: 100vw` with `left: 0` and `right: 0`
- avoid counting the vertical scrollbar in the fixed header width, matching the normal topbar width

Fixes #2346

## Testing
- npm run lint -- components/nav/sticky-bar.js
- git diff --check
