### PR TITLE
[codex] Normalize Lexical table HTML styles

### DIFF
--- a/lib/lexical/server/html.js
+++ b/lib/lexical/server/html.js
@@ -2,11 +2,13 @@ import { $generateHtmlFromNodes } from '@lexical/html'
 import { sanitizeHTML } from '@/lib/dompurify'
 import { withDOM } from '@/lib/lexical/server/dom'
 import { createSNHeadlessEditor } from '@/lib/lexical/headless'
+import { normalizeLexicalHTML } from '@/lib/lexical/server/normalize-html'
 
 export function generateHTML (editor, selection = null, sanitize = true, window = global.window) {
   let html = ''
   try {
     html = editor.read(() => $generateHtmlFromNodes(editor, selection))
+    html = normalizeLexicalHTML(html, window)
     if (sanitize) {
       html = sanitizeHTML(html, window)
     }

--- a/lib/lexical/server/normalize-html.js
+++ b/lib/lexical/server/normalize-html.js
@@ -1,0 +1,38 @@
+const LEXICAL_DEFAULT_TABLE_CELL_WIDTH = '75px'
+
+function createFallbackDocument () {
+  if (typeof window !== 'undefined') {
+    return window.document
+  }
+
+  const { parseHTML } = require('linkedom')
+  return parseHTML('<!doctype html><body></body>').document
+}
+
+function normalizeStyleAttribute (element) {
+  const style = element.getAttribute('style')
+  if (!style || style.trim() === '') {
+    element.removeAttribute('style')
+  }
+}
+
+export function normalizeLexicalHTML (html, domWindow = globalThis.window) {
+  const doc = domWindow?.document ?? globalThis.document ?? createFallbackDocument()
+  const wrapper = doc.createElement('div')
+  wrapper.innerHTML = html
+
+  wrapper.querySelectorAll('.sn-table__cell').forEach((cell) => {
+    cell.style.removeProperty('border')
+    cell.style.removeProperty('vertical-align')
+    cell.style.removeProperty('text-align')
+    cell.style.removeProperty('background-color')
+
+    if (cell.style.width === LEXICAL_DEFAULT_TABLE_CELL_WIDTH) {
+      cell.style.removeProperty('width')
+    }
+
+    normalizeStyleAttribute(cell)
+  })
+
+  return wrapper.innerHTML
+}

--- a/lib/lexical/server/normalize-html.spec.js
+++ b/lib/lexical/server/normalize-html.spec.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+
+import { normalizeLexicalHTML } from './normalize-html.js'
+
+describe('normalizeLexicalHTML', () => {
+  test('removes Lexical default table cell styles from SSR HTML', () => {
+    const html = [
+      '<table class="sn-table">',
+      '<tr>',
+      '<th class="sn-table__cell sn-table__cell--header" style="border: 1px solid black; width: 75px; vertical-align: top; text-align: start; background-color: rgb(242, 243, 245);">heading</th>',
+      '<td class="sn-table__cell" style="border: 1px solid black; width: 75px; vertical-align: top; text-align: start;">cell</td>',
+      '</tr>',
+      '</table>'
+    ].join('')
+
+    expect(normalizeLexicalHTML(html)).toBe([
+      '<table class="sn-table">',
+      '<tr>',
+      '<th class="sn-table__cell sn-table__cell--header">heading</th>',
+      '<td class="sn-table__cell">cell</td>',
+      '</tr>',
+      '</table>'
+    ].join(''))
+  })
+
+  test('keeps explicit non-default cell widths', () => {
+    const html = '<td class="sn-table__cell" style="border: 1px solid black; width: 180px; vertical-align: top; text-align: start;">cell</td>'
+
+    expect(normalizeLexicalHTML(html)).toBe('<td class="sn-table__cell" style="width:180px">cell</td>')
+  })
+
+  test('does not alter non-Lexical table cells', () => {
+    const html = '<td style="border: 1px solid black; width: 75px;">cell</td>'
+
+    expect(normalizeLexicalHTML(html)).toBe(html)
+  })
+})


### PR DESCRIPTION
## Summary
- normalize generated Lexical HTML before sanitizing it
- remove Lexical's default inline table-cell visual styles from `sn-table__cell` elements so SSR tables use SN table CSS immediately
- preserve explicit non-default cell widths and leave non-Lexical table cells untouched

Fixes #2777

## Testing
- npm run lint -- lib/lexical/server/html.js lib/lexical/server/normalize-html.js lib/lexical/server/normalize-html.spec.js
- npm test -- lib/lexical/server/normalize-html.spec.js lib/url.spec.js
- git diff --check
