### PR TITLE
[codex] Highlight hidden new replies

### DIFF
--- a/components/comment.js
+++ b/components/comment.js
@@ -29,6 +29,7 @@ import { gql } from '@apollo/client'
 import { useApolloClient } from '@apollo/client/react'
 import classNames from 'classnames'
 import useCallbackRef from './use-callback-ref'
+import { newHiddenComments } from '@/lib/new-comments'
 
 function Parent ({ item, rootText }) {
   const root = useRoot()
@@ -343,7 +344,15 @@ export default function Comment ({
 
 export function ViewMoreReplies ({ item, threadContext = false }) {
   const root = useRoot()
+  const { me } = useMe()
+  const router = useRouter()
   const id = threadContext ? commentSubTreeRootId(item, root) : item.id
+  const hasNewComments = newHiddenComments({
+    item,
+    root,
+    meId: me?.id,
+    commentsViewedAt: router.query.commentsViewedAt
+  })
 
   // if threadContext is true, we travel to some comments before the current comment, focusing on the comment itself
   // otherwise, we directly navigate to the comment
@@ -357,9 +366,13 @@ export function ViewMoreReplies ({ item, threadContext = false }) {
     <Link
       href={href}
       as={`/items/${id}`}
-      className='fw-bold d-flex align-items-center gap-2 text-muted'
+      className={classNames(
+        'fw-bold d-flex align-items-center gap-2',
+        hasNewComments ? 'text-info' : 'text-muted'
+      )}
     >
       {text}
+      {hasNewComments && <span className={styles.newCommentDot} />}
     </Link>
   )
 }

--- a/fragments/comments.js
+++ b/fragments/comments.js
@@ -62,6 +62,7 @@ export const COMMENT_FIELDS = gql`
     otsHash
     ncomments
     nDirectComments
+    lastCommentAt
     live @client
     imgproxyUrls
     rel
@@ -119,6 +120,7 @@ export const COMMENT_FIELDS_NO_CHILD_COMMENTS = gql`
     commentBoost
     mine
     otsHash
+    lastCommentAt
     live @client
     imgproxyUrls
     rel

--- a/lib/new-comments.js
+++ b/lib/new-comments.js
@@ -40,3 +40,14 @@ export function newComments (item) {
 
   return false
 }
+
+export function newHiddenComments ({ item, root, meId, commentsViewedAt }) {
+  if (!item?.lastCommentAt) return false
+
+  const hiddenLastCommentAt = new Date(item.lastCommentAt).getTime()
+  const viewedAt = meId
+    ? new Date(root?.meCommentsViewedAt).getTime()
+    : Number(commentsViewedAt)
+
+  return Boolean(viewedAt && hiddenLastCommentAt > viewedAt)
+}

--- a/lib/new-comments.spec.js
+++ b/lib/new-comments.spec.js
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+
+import { newHiddenComments } from './new-comments.js'
+
+describe('newHiddenComments', () => {
+  test('detects hidden replies newer than a logged-in viewer timestamp', () => {
+    expect(newHiddenComments({
+      item: { lastCommentAt: '2026-06-13T10:00:00.000Z' },
+      root: { meCommentsViewedAt: '2026-06-13T09:00:00.000Z' },
+      meId: 1
+    })).toBe(true)
+  })
+
+  test('detects hidden replies newer than an anon viewer timestamp', () => {
+    expect(newHiddenComments({
+      item: { lastCommentAt: '2026-06-13T10:00:00.000Z' },
+      commentsViewedAt: new Date('2026-06-13T09:00:00.000Z').getTime()
+    })).toBe(true)
+  })
+
+  test('ignores hidden replies already seen by the viewer', () => {
+    expect(newHiddenComments({
+      item: { lastCommentAt: '2026-06-13T09:00:00.000Z' },
+      root: { meCommentsViewedAt: '2026-06-13T10:00:00.000Z' },
+      meId: 1
+    })).toBe(false)
+  })
+
+  test('ignores comments without subtree activity data', () => {
+    expect(newHiddenComments({
+      item: {},
+      root: { meCommentsViewedAt: '2026-06-13T09:00:00.000Z' },
+      meId: 1
+    })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add `lastCommentAt` to comment fragments so hidden reply subtrees can expose their latest activity
- highlight the `view all N replies` link when hidden replies are newer than the viewer's last comment view
- share the timestamp comparison through a tested `newHiddenComments` helper for logged-in and anon viewers

Fixes #2127

## Testing
- npm run lint -- components/comment.js fragments/comments.js lib/new-comments.js lib/new-comments.spec.js
- npm test -- lib/new-comments.spec.js lib/url.spec.js
- git diff --check
