### PR TITLE
Fixups for 3067/3071

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -126,7 +126,7 @@ export function parseEmbedUrl (href) {
     const { hostname, pathname, searchParams } = new URL(href)
 
     // nostr prefixes: [npub1, nevent1, nprofile1, note1]
-    const nostr = href.match(/\/(?<id>(?<type>npub1|nevent1|nprofile1|note1|naddr1)[02-9ac-hj-np-z]+)/)
+    const nostr = pathname.match(/\/(?<id>(?<type>npub1|nevent1|nprofile1|note1|naddr1)[02-9ac-hj-np-z]+)/)
     if (nostr?.groups?.id) {
       let id = nostr.groups.id
       if (nostr.groups.type === 'npub1') {

--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -65,16 +65,24 @@ describe('misleading links', () => {
   )
 })
 
-describe('embed links', () => {
-  test('does not parse nostr ids in hostnames as embeds', () => {
-    const actual = parseEmbedUrl('https://npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk.nsite.lol/')
+const nostrEmbedUrlCases = [
+  ['https://njump.me/nprofile1qqsfy7f8d0lms08wxw2xu4jvxcq2x2zqy6dgypksrh05p3jr9w4qhjc2xjd74', true],
+  ['https://yakihonne.com/note/nevent1qgsfy7f8d0lms08wxw2xu4jvxcq2x2zqy6dgypksrh05p3jr9w4qhjcppemhxue69uhkummn9ekx7mp0qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qpqa56frq6ljgdeh85rntn50yv3c9u5ffkd26nzs698h9xuljtezljs98kq07', true],
+  ['https://npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk.nsite.lol/', false],
+  ['https://njump.me/nevent1qgsfy7f8d0lms08wxw2xu4jvxcq2x2zqy6dgypksrh05p3jr9w4qhjcppemhxue69uhkummn9ekx7mp0qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qpqa56frq6ljgdeh85rntn50yv3c9u5ffkd26nzs698h9xuljtezljs98kq07', true],
+  ['https://primal.net/p/npub1jfujw6llhq7wuvu5detycdsq5v5yqf56sgrdq8wlgrryx2a2p09svwm0gx', true]
+]
 
-    expect(actual).toBeNull()
-  })
-
-  test('parses nostr ids in URL paths as embeds', () => {
-    const actual = parseEmbedUrl('https://njump.me/npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk')
-
-    expect(actual).toMatchObject({ provider: 'nostr' })
-  })
+describe('embed nostr links', () => {
+  test.each(nostrEmbedUrlCases)(
+    'identifies %p as embed: %p',
+    (url, expectedEmbed) => {
+      const actual = parseEmbedUrl(url)
+      if (expectedEmbed) {
+        expect(actual).toMatchObject({ provider: 'nostr' })
+      } else {
+        expect(actual).toBeNull()
+      }
+    }
+  )
 })

--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { parseInternalLinks, isMisleadingLink } from './url.js'
+import { parseEmbedUrl, parseInternalLinks, isMisleadingLink } from './url.js'
 
 const internalLinkCases = [
   ['https://stacker.news/items/123', '#123'],
@@ -63,4 +63,18 @@ describe('misleading links', () => {
       expect(actual).toBe(expected)
     }
   )
+})
+
+describe('embed links', () => {
+  test('does not parse nostr ids in hostnames as embeds', () => {
+    const actual = parseEmbedUrl('https://npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk.nsite.lol/')
+
+    expect(actual).toBeNull()
+  })
+
+  test('parses nostr ids in URL paths as embeds', () => {
+    const actual = parseEmbedUrl('https://njump.me/npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk')
+
+    expect(actual).toMatchObject({ provider: 'nostr' })
+  })
 })

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -295,7 +295,11 @@ export function pollSchema ({ numExistingChoices = 0, ...args }) {
       message: `at least ${MIN_POLL_NUM_CHOICES} choices required`,
       test: arr => arr.length >= MIN_POLL_NUM_CHOICES - numExistingChoices
     }),
-    pollExpiresAt: date().nullable().min(datePivot(new Date(), { days: 1 }), 'Expiration must be at least 1 day in the future'),
+    pollExpiresAt: date().nullable().test({
+      name: 'min',
+      message: 'Expiration must be at least 1 day in the future',
+      test: value => !value || value >= datePivot(new Date(), { days: 1 })
+    }),
     randPollOptions: boolean(),
     ...advPostSchemaMembers(args),
     ...subSelectSchemaMembers('POLL', args)

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+
+import { pollSchema } from './validate'
+
+describe('pollSchema', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test('evaluates poll expiration minimum at validation time', async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
+
+    const schema = pollSchema({})
+    const defaultExpiration = new Date(2026, 5, 15, 0, 0, 0, 0)
+
+    jest.setSystemTime(new Date(2026, 5, 14, 12, 0, 0, 0, 0))
+
+    await expect(schema.validateAt('pollExpiresAt', { pollExpiresAt: defaultExpiration }))
+      .rejects.toThrow('Expiration must be at least 1 day in the future')
+  })
+
+  test('accepts poll expiration at least one day from validation time', async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
+
+    await expect(pollSchema({}).validateAt('pollExpiresAt', {
+      pollExpiresAt: new Date(2026, 5, 14, 0, 0, 0, 0)
+    })).resolves.toEqual(new Date(2026, 5, 14, 0, 0, 0, 0))
+  })
+
+  test('allows poll expiration to be cleared', async () => {
+    await expect(pollSchema({}).validateAt('pollExpiresAt', { pollExpiresAt: null }))
+      .resolves.toBeNull()
+  })
+})

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -7,20 +7,16 @@ describe('pollSchema', () => {
     jest.useRealTimers()
   })
 
-  test('evaluates poll expiration minimum at validation time', async () => {
+  test('rejects poll expiration less than one day in the future', async () => {
     jest.useFakeTimers()
-    jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
+    jest.setSystemTime(new Date(2026, 5, 14, 1, 0, 0, 0))
 
-    const schema = pollSchema({})
-    const defaultExpiration = new Date(2026, 5, 15, 0, 0, 0, 0)
-
-    jest.setSystemTime(new Date(2026, 5, 14, 12, 0, 0, 0, 0))
-
-    await expect(schema.validateAt('pollExpiresAt', { pollExpiresAt: defaultExpiration }))
-      .rejects.toThrow('Expiration must be at least 1 day in the future')
+    await expect(pollSchema({}).validateAt('pollExpiresAt', {
+      pollExpiresAt: new Date(2026, 5, 15, 0, 0, 0, 0)
+    })).rejects.toThrow('Expiration must be at least 1 day in the future')
   })
 
-  test('accepts poll expiration at least one day from validation time', async () => {
+  test('accepts poll expiration exactly one day in the future', async () => {
     jest.useFakeTimers()
     jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
 
@@ -29,8 +25,18 @@ describe('pollSchema', () => {
     })).resolves.toEqual(new Date(2026, 5, 14, 0, 0, 0, 0))
   })
 
+  test('accepts poll expiration more than one day in the future', async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
+
+    await expect(pollSchema({}).validateAt('pollExpiresAt', {
+      pollExpiresAt: new Date(2026, 5, 14, 1, 0, 0, 0)
+    })).resolves.toEqual(new Date(2026, 5, 14, 1, 0, 0, 0))
+  })
+
   test('allows poll expiration to be cleared', async () => {
-    await expect(pollSchema({}).validateAt('pollExpiresAt', { pollExpiresAt: null }))
-      .resolves.toBeNull()
+    await expect(pollSchema({}).validateAt('pollExpiresAt', {
+      pollExpiresAt: null
+    })).resolves.toBeNull()
   })
 })


### PR DESCRIPTION
## Description

Fixes up #3067 and #3071 nits in tests - preserves original commits to show what was changed.

1. Remove an extra attr from `Date()` constructor in `lib/validate.spec.js`
2. Wire the tests concisely and uniformely in `lib/validate.spec.js`
3. Rewire the test in `lib/url.spec.js` to use `test.each()` and to test realistic cases with multiple real nostr urls 

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

8 - manually tested on dev env

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Edits were fully meathooked