### PR TITLE
Reserve special route nyms

### DIFF
--- a/api/ssrApollo.js
+++ b/api/ssrApollo.js
@@ -14,7 +14,7 @@ import { BLOCK_HEIGHT } from '@/fragments/blockHeight'
 import { CHAIN_FEE } from '@/fragments/chainFee'
 import { getServerSession } from 'next-auth/next'
 import { getAuthOptions } from '@/pages/api/auth/[...nextauth]'
-import { NOFOLLOW_LIMIT } from '@/lib/constants'
+import { NOFOLLOW_LIMIT, RESERVED_USER_NAMES } from '@/lib/constants'
 import { satsToMsats } from '@/lib/format'
 import { MULTI_AUTH_ANON, MULTI_AUTH_LIST, MULTI_AUTH_POINTER, multiAuthMiddleware } from '@/lib/auth'
 import { lexicalStateLoader } from '@/lib/lexical/server/loader'
@@ -105,12 +105,7 @@ function oneDayReferral (request, { me }) {
     } else if (referrer.startsWith('profile-')) {
       const name = referrer.slice(8)
       // exclude all pages that are not user profiles
-      if (['api', 'auth', 'day', 'invites', 'invoices', 'referrals', 'rewards',
-        'satistics', 'settings', 'stackers', 'wallet', 'withdrawals', '404', '500',
-        'email', 'live', 'login', 'notifications', 'offline', 'search', 'share',
-        'signup', 'territory', 'new', 'top', 'edit', 'post', 'rss', 'saloon',
-        'faq', 'story', 'privacy', 'copyright', 'tos', 'changes', 'guide', 'daily',
-        'anon', 'ad'].includes(name)) continue
+      if (RESERVED_USER_NAMES.includes(name)) continue
 
       prismaPromise = models.user.findUnique({ where: { name } })
       getData = user => ({

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,6 +5,14 @@ import { ceilBigInt } from './format'
 export const DEFAULT_SUBS = ['bitcoin', 'nostr', 'tech', 'meta', 'jobs']
 export const DEFAULT_SUBS_NO_JOBS = DEFAULT_SUBS.filter(s => s !== 'jobs')
 export const RESERVED_SUB_NAMES = ['all', 'home']
+export const RESERVED_USER_NAMES = [
+  'api', 'auth', 'day', 'invites', 'invoices', 'referrals', 'rewards',
+  'satistics', 'settings', 'stackers', 'wallet', 'withdrawals', '404', '500',
+  'email', 'live', 'login', 'notifications', 'offline', 'search', 'share',
+  'signup', 'territory', 'new', 'top', 'edit', 'post', 'rss', 'saloon',
+  'faq', 'story', 'privacy', 'copyright', 'tos', 'changes', 'guide', 'daily',
+  'anon', 'ad'
+]
 
 export const PAID_ACTION_PAYMENT_METHODS = {
   FEE_CREDIT: 'FEE_CREDIT',

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -3,7 +3,7 @@ import {
   MAX_POLL_CHOICE_LENGTH, MAX_TITLE_LENGTH, MAX_POLL_NUM_CHOICES,
   MIN_POLL_NUM_CHOICES, MAX_FORWARDS, MAX_TERRITORY_DESC_LENGTH, POST_TYPES,
   TERRITORY_BILLING_TYPES, MAX_COMMENT_TEXT_LENGTH, MAX_POST_TEXT_LENGTH, MIN_TITLE_LENGTH, BOUNTY_MIN, BOUNTY_MAX,
-  RESERVED_SUB_NAMES,
+  RESERVED_SUB_NAMES, RESERVED_USER_NAMES,
   BOOST_MAX, MAX_INVOICE_DESCRIPTION_LENGTH, MAX_WALLET_INVOICE_SATS,
   SSR,
   BOOST_MIN,
@@ -401,9 +401,15 @@ export function userSchema (args) {
   return object({
     name: nameValidator
       .test({
+        name: 'reserved',
+        test: name => !RESERVED_USER_NAMES.includes(name),
+        message: 'reserved'
+      })
+      .test({
         name: 'name',
         test: async name => {
           if (!name || !name.length) return false
+          if (RESERVED_USER_NAMES.includes(name)) return true
           return !(await usernameExists(name, args))
         },
         message: 'taken'

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+
+import { userSchema } from './validate'
+
+describe('userSchema', () => {
+  const models = {
+    user: {
+      findUnique: jest.fn()
+    }
+  }
+
+  beforeEach(() => {
+    models.user.findUnique.mockReset()
+  })
+
+  test.each(['404', '500', 'api', 'wallet', 'anon', 'ad'])('rejects reserved nym %s', async name => {
+    await expect(userSchema({ models }).validate({ name })).rejects.toThrow('reserved')
+    expect(models.user.findUnique).not.toHaveBeenCalled()
+  })
+
+  test('allows available non-reserved nym', async () => {
+    models.user.findUnique.mockResolvedValue(null)
+
+    await expect(userSchema({ models }).validate({ name: 'stacker_123' })).resolves.toEqual({ name: 'stacker_123' })
+    expect(models.user.findUnique).toHaveBeenCalledWith({ where: { name: 'stacker_123' } })
+  })
+})


### PR DESCRIPTION
## What changed
- Move the special route/user-name denylist into a shared `RESERVED_USER_NAMES` constant.
- Reuse that constant in referral SSR profile filtering and signup username validation.
- Reject reserved nyms before the database availability lookup, with regression coverage for route-like names such as `api`, `wallet`, `404`, `anon`, and `ad`.

## Why
These names already behave like non-profile routes in referral SSR. Sharing the same denylist with validation keeps signup availability checks aligned with the route/profile behavior and avoids allowing nyms that collide with special application routes.

No linked issue; this is a small correctness-hardening contribution. BTC payout address if this is eligible for a discretionary sats award: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`

## Verification
- `npm test -- lib/validate.spec.js`
- `npx standard api/ssrApollo.js lib/constants.js lib/validate.js lib/validate.spec.js`
- `git diff --check origin/master...HEAD`
