### PR TITLE
[codex] Support paginated comment navigator targets

### DIFF
--- a/api/resolvers/comment-tree.js
+++ b/api/resolvers/comment-tree.js
@@ -81,7 +81,7 @@ async function fetchFullCommentRows ({ itemId, me, models, sortClause, decodedCu
   )
 }
 
-async function fetchLimitedCommentRows ({ itemId, me, models, sortClause, decodedCursor, itemQueryWithMeta, payInJoinFilter, select }) {
+async function fetchLimitedCommentRows ({ itemId, commentId, me, models, sortClause, decodedCursor, itemQueryWithMeta, payInJoinFilter, select }) {
   const query = `
     WITH RECURSIVE base AS (
       (
@@ -110,10 +110,32 @@ async function fetchLimitedCommentRows ({ itemId, me, models, sortClause, decode
           AND (base.depth = 1 OR base.rn <= $5)
       )
     ),
+    focus AS (
+      SELECT
+        "Item".id,
+        nlevel("Item"."path") - root.depth AS depth,
+        0::BIGINT AS rn
+      FROM "Item" focus
+      JOIN root ON focus.id = $7
+      JOIN "Item" ON "Item"."path" @> focus."path"
+        AND "Item"."path" <@ root.path
+        AND "Item".id <> $1
+      ${payInJoinFilter(me)}
+      WHERE $7 > 0
+        AND focus.id <> $1
+        AND focus."path" <@ root.path
+    ),
     visible AS (
-      SELECT id, depth, rn
-      FROM base
-      WHERE depth = 1 OR rn <= $5 - depth + 2
+      SELECT DISTINCT ON (id) id, depth, rn
+      FROM (
+        SELECT id, depth, rn
+        FROM base
+        WHERE depth = 1 OR rn <= $5 - depth + 2
+        UNION ALL
+        SELECT id, depth, rn
+        FROM focus
+      ) rows
+      ORDER BY id, depth ASC
     )
     ${select}
     FROM visible
@@ -127,19 +149,20 @@ async function fetchLimitedCommentRows ({ itemId, me, models, sortClause, decode
     COMMENTS_LIMIT,
     decodedCursor.offset,
     COMMENTS_OF_COMMENT_LIMIT,
-    LIMITED_COMMENT_DEPTH
+    LIMITED_COMMENT_DEPTH,
+    decodedCursor.offset === 0 ? Number(commentId || 0) : 0
   )
 }
 
-async function fetchComments ({ item, me, models, sortClause, decodedCursor, itemQueryWithMeta, payInJoinFilter, select }) {
+async function fetchComments ({ item, commentId, me, models, sortClause, decodedCursor, itemQueryWithMeta, payInJoinFilter, select }) {
   const rows = item.ncomments > FULL_COMMENTS_THRESHOLD
-    ? await fetchLimitedCommentRows({ itemId: Number(item.id), me, models, sortClause, decodedCursor, itemQueryWithMeta, payInJoinFilter, select })
+    ? await fetchLimitedCommentRows({ itemId: Number(item.id), commentId, me, models, sortClause, decodedCursor, itemQueryWithMeta, payInJoinFilter, select })
     : await fetchFullCommentRows({ itemId: Number(item.id), me, models, sortClause, decodedCursor, itemQueryWithMeta, payInJoinFilter, select })
 
   return buildCommentTree(rows, { rootId: Number(item.id) })
 }
 
-export async function resolveItemComments (item, sort, cursor, { me, models, userLoader, itemQueryWithMeta, payInJoinFilter, select }) {
+export async function resolveItemComments (item, sort, cursor, commentId, { me, models, userLoader, itemQueryWithMeta, payInJoinFilter, select }) {
   let commentsSatsFilter = DEFAULT_COMMENTS_SATS_FILTER
   if (me) {
     const user = await userLoader.load(me.id)
@@ -156,7 +179,7 @@ export async function resolveItemComments (item, sort, cursor, { me, models, use
   }
 
   const decodedCursor = decodeCursor(cursor)
-  const comments = await fetchComments({ item, me, models, sortClause, decodedCursor, itemQueryWithMeta, payInJoinFilter, select })
+  const comments = await fetchComments({ item, commentId, me, models, sortClause, decodedCursor, itemQueryWithMeta, payInJoinFilter, select })
 
   return {
     comments,

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1166,7 +1166,7 @@ export default {
         }
       })
     },
-    comments: async (item, { sort, cursor }, ctx) => {
+    comments: async (item, { sort, cursor, commentId }, ctx) => {
       const { me } = ctx
       if (typeof item.comments !== 'undefined') {
         if (Array.isArray(item.comments)) {
@@ -1186,7 +1186,7 @@ export default {
         }
       }
 
-      return await resolveItemComments(item, sort || defaultCommentSort(item.pinId, item.bioId, item.createdAt), cursor, { ...ctx, itemQueryWithMeta, payInJoinFilter, select: SELECT })
+      return await resolveItemComments(item, sort || defaultCommentSort(item.pinId, item.bioId, item.createdAt), cursor, commentId, { ...ctx, itemQueryWithMeta, payInJoinFilter, select: SELECT })
     },
     freedFreebie: async (item) => {
       return item.weightedVotes - item.weightedDownVotes > 0

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -131,7 +131,7 @@ export default gql`
     bio: Boolean!
     ncomments: Int!
     nDirectComments: Int!
-    comments(sort: String, cursor: String): Comments!
+    comments(sort: String, cursor: String, commentId: ID): Comments!
     path: String
     position: Int
     prior: Int

--- a/components/use-comments-navigator.js
+++ b/components/use-comments-navigator.js
@@ -1,11 +1,13 @@
-import { useCallback, useEffect, useRef, useState, startTransition, createContext, useContext } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, startTransition, createContext, useContext } from 'react'
 import styles from './comment.module.css'
 import LongPressable from './long-pressable'
 import { useFavicon } from './favicon'
+import { useRouter } from 'next/router'
 
 const CommentsNavigatorContext = createContext({
   navigator: {
     trackNewComment: () => {},
+    trackNewCommentTarget: () => {},
     untrackNewComment: () => {},
     scrollToComment: () => {},
     clearCommentRefs: () => {}
@@ -28,12 +30,12 @@ export function useCommentsNavigatorContext () {
 
 export function useCommentsNavigator () {
   const { setHasNewComments } = useFavicon()
+  const router = useRouter()
   const [commentCount, setCommentCount] = useState(0)
   // refs in ref to not re-render on tracking
   const commentRefs = useRef([])
   // ref to track if the comment count is being updated
   const frameRef = useRef(null)
-  const navigatorRef = useRef(null)
 
   // batch updates to the comment count
   const throttleCountUpdate = useCallback(() => {
@@ -43,7 +45,7 @@ export function useCommentsNavigator () {
     window.requestAnimationFrame(() => {
       // filter out disconnected refs before counting
       commentRefs.current = commentRefs.current.filter(item =>
-        item.ref?.current?.isConnected
+        item.targetId || item.ref?.current?.isConnected
       )
       const next = commentRefs.current.length
       // transition to the new comment count
@@ -57,7 +59,7 @@ export function useCommentsNavigator () {
     commentRefs.current = []
     startTransition?.(() => setCommentCount(0))
     setHasNewComments(false)
-  }, [])
+  }, [setHasNewComments])
 
   // track a new comment, returns true if the ref was actually inserted
   const trackNewComment = useCallback((commentRef, createdAt) => {
@@ -77,6 +79,28 @@ export function useCommentsNavigator () {
       commentRefs.current.push(newItem)
     } else {
       // insert at the correct position to maintain sort order
+      commentRefs.current.splice(insertIndex, 0, newItem)
+    }
+
+    setHasNewComments(true)
+    throttleCountUpdate()
+    return true
+  }, [throttleCountUpdate, setHasNewComments])
+
+  const trackNewCommentTarget = useCallback(({ id, createdAt }) => {
+    if (!id) return false
+
+    const targetId = String(id)
+    const existing = commentRefs.current.some(item => item.targetId === targetId)
+    if (existing) return false
+
+    const createdAtMs = new Date(createdAt).getTime()
+    const insertIndex = commentRefs.current.findIndex(item => item.createdAt > createdAtMs)
+    const newItem = { targetId, createdAt: createdAtMs }
+
+    if (insertIndex === -1) {
+      commentRefs.current.push(newItem)
+    } else {
       commentRefs.current.splice(insertIndex, 0, newItem)
     }
 
@@ -123,7 +147,7 @@ export function useCommentsNavigator () {
       commentRefs.current = commentRefs.current.filter(item => !toRemove.includes(item))
     }
     throttleCountUpdate()
-  }, [throttleCountUpdate])
+  }, [throttleCountUpdate, setHasNewComments])
 
   // scroll to the next new comment
   const scrollToComment = useCallback(() => {
@@ -132,6 +156,19 @@ export function useCommentsNavigator () {
 
     const ref = list[0]?.ref
     const node = ref?.current
+    const targetId = list[0]?.targetId
+    if (!node && targetId) {
+      commentRefs.current.shift()
+      throttleCountUpdate()
+      if (commentRefs.current.length === 0) setHasNewComments(false)
+      const id = router.query.id
+      router.push({
+        pathname: '/items/[id]',
+        query: { ...router.query, id, commentId: targetId }
+      }, `/items/${id}?commentId=${targetId}`, { scroll: false })
+      return
+    }
+
     if (!node) {
       // update the comment count, the ref may be disconnected
       throttleCountUpdate()
@@ -156,19 +193,22 @@ export function useCommentsNavigator () {
 
     // if we reached the end, reset the navigator
     if (list.length === 1) clearCommentRefs()
-  }, [clearCommentRefs, untrackNewComment, throttleCountUpdate])
+  }, [clearCommentRefs, untrackNewComment, throttleCountUpdate, router, setHasNewComments])
 
-  // create the navigator object once
-  if (!navigatorRef.current) {
-    navigatorRef.current = { trackNewComment, untrackNewComment, scrollToComment, clearCommentRefs }
-  }
+  const navigator = useMemo(() => ({
+    trackNewComment,
+    trackNewCommentTarget,
+    untrackNewComment,
+    scrollToComment,
+    clearCommentRefs
+  }), [trackNewComment, trackNewCommentTarget, untrackNewComment, scrollToComment, clearCommentRefs])
 
   // clear the navigator on unmount
   useEffect(() => {
     return () => clearCommentRefs()
   }, [clearCommentRefs])
 
-  return { navigator: navigatorRef.current, commentCount }
+  return { navigator, commentCount }
 }
 
 export function CommentsNavigator ({ navigator, commentCount, className }) {
@@ -190,7 +230,7 @@ export function CommentsNavigator ({ navigator, commentCount, className }) {
     if (!commentCount) return
     document.addEventListener('keydown', onNext)
     return () => document.removeEventListener('keydown', onNext)
-  }, [onNext])
+  }, [commentCount, onNext])
 
   return (
     <LongPressable onShortPress={scrollToComment} onLongPress={clearCommentRefs}>

--- a/components/use-live-comments.js
+++ b/components/use-live-comments.js
@@ -5,6 +5,7 @@ import preserveScroll from './preserve-scroll'
 import { GET_NEW_COMMENTS } from '../fragments/comments'
 import { injectComment } from '../lib/comments'
 import useCommentsView from './use-comments-view'
+import { useCommentsNavigatorContext } from './use-comments-navigator'
 
 // live comments polling interval
 const POLL_INTERVAL = 1000 * 5
@@ -19,13 +20,16 @@ const readStoredLatest = (key, latest) => {
 
 // cache new comments and return the most recent timestamp between current latest and new comment
 // regardless of whether the comments were injected or not
-function cacheNewComments (cache, latest, itemId, newComments, markCommentViewedAt) {
+function cacheNewComments (cache, latest, itemId, newComments, markCommentViewedAt, navigator) {
   let injected = 0
 
   const injectedLatest = newComments.reduce((latestTimestamp, newComment) => {
     const result = injectComment(cache, newComment, { live: true, rootId: itemId, optimistic: false })
     // if any comment was injected, increment injected
     injected = result ? injected + 1 : injected
+    if (result === 'hidden') {
+      navigator?.trackNewCommentTarget(newComment)
+    }
     return new Date(newComment.createdAt) > new Date(latestTimestamp)
       ? newComment.createdAt
       : latestTimestamp
@@ -44,17 +48,19 @@ export default function useLiveComments (itemId, after) {
   const latestKey = `liveCommentsLatest:${itemId}`
   const { cache } = useApolloClient()
   const { markCommentViewedAt } = useCommentsView(itemId)
+  const { navigator } = useCommentsNavigatorContext()
   const [disableLiveComments] = useLiveCommentsToggle()
 
   const [latest, setLatest] = useState(after)
   const [initialized, setInitialized] = useState(false)
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLatest(readStoredLatest(latestKey, after))
     // Apollo might update the cache before the page has fully rendered, causing reads of stale cached data
     // this prevents GET_NEW_COMMENTS from producing results before the page has fully rendered
     setInitialized(true)
-  }, [itemId, after])
+  }, [itemId, after, latestKey])
 
   const { data } = useQuery(GET_NEW_COMMENTS, {
     pollInterval: POLL_INTERVAL,
@@ -70,16 +76,17 @@ export default function useLiveComments (itemId, after) {
 
     // directly inject new comments into the cache, preserving scroll position
     // quirk: scroll is preserved even if we are not injecting new comments due to dedupe
-    const injectedLatest = preserveScroll(() => cacheNewComments(cache, latest, itemId, newComments, markCommentViewedAt))
+    const injectedLatest = preserveScroll(() => cacheNewComments(cache, latest, itemId, newComments, markCommentViewedAt, navigator))
 
     // if we didn't process any newer comments, bail
     if (new Date(injectedLatest).getTime() <= new Date(latest).getTime()) return
 
     // update latest timestamp to the latest comment created at
     // save it to session storage, to persist between client-side navigations
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setLatest(injectedLatest)
     window.sessionStorage.setItem(latestKey, injectedLatest)
-  }, [data, cache, itemId, latest, markCommentViewedAt])
+  }, [data, cache, itemId, latest, latestKey, markCommentViewedAt, navigator])
 }
 
 export function useLiveCommentsToggle () {

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -181,12 +181,12 @@ export const ITEM_FULL = gql`
   ${ITEM_FULL_FIELDS}
   ${POLL_FIELDS}
   ${COMMENTS}
-  query Item($id: ID!, $sort: String, $cursor: String) {
+  query Item($id: ID!, $sort: String, $cursor: String, $commentId: ID) {
     item(id: $id) {
       ...ItemFullFields
       prior
       ...PollFields
-      comments(sort: $sort, cursor: $cursor) {
+      comments(sort: $sort, cursor: $cursor, commentId: $commentId) {
         cursor
         comments {
           ...CommentsRecursive

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -353,7 +353,7 @@ function getClient (uri) {
             commentDownSats: { merge: maxMerge },
             commentBoost: { merge: maxMerge },
             comments: {
-              keyArgs: ['sort'],
+              keyArgs: ['sort', 'commentId'],
               merge (existing, incoming) {
                 // check if we're not on a paginated item: it shouldn't have an incoming or an already existing cursor,
                 // and its incoming comments shouldn't be more than COMMENTS_LIMIT

--- a/lib/comments.js
+++ b/lib/comments.js
@@ -53,7 +53,7 @@ export function injectComment (cache, newComment, { live = false, rootId, optimi
     const ancestors = newComment.path.split('.').slice(0, -1)
     updateAncestorsCommentCount(cache, ancestors, { commentCost: newComment.cost || 0, optimistic })
 
-    return true
+    return updated ? 'rendered' : 'hidden'
   }
 
   return false

--- a/lib/comments.spec.js
+++ b/lib/comments.spec.js
@@ -1,0 +1,67 @@
+/* global describe, expect, jest, test */
+
+import { injectComment } from './comments'
+
+function makeComment (overrides = {}) {
+  return {
+    id: 3,
+    parentId: 1,
+    path: '1.3',
+    cost: 0,
+    ...overrides
+  }
+}
+
+function makeCache ({ hasParentComments = true } = {}) {
+  return {
+    readFragment: jest.fn(() => hasParentComments ? { comments: [] } : null),
+    writeFragment: jest.fn(() => ({ __ref: 'Item:3' })),
+    modify: jest.fn(({ fields }) => {
+      fields.comments?.({ comments: [] }, { readField: jest.fn() })
+      return true
+    })
+  }
+}
+
+describe('injectComment', () => {
+  test('returns rendered when a live comment is written into the cache', () => {
+    const cache = makeCache()
+
+    const result = injectComment(cache, makeComment(), {
+      live: true,
+      rootId: 1,
+      optimistic: false
+    })
+
+    expect(result).toBe('rendered')
+    expect(cache.writeFragment).toHaveBeenCalled()
+    expect(cache.modify).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'Item:1',
+      optimistic: false
+    }))
+  })
+
+  test('returns hidden when a live reply parent is not in the cache', () => {
+    const cache = makeCache({ hasParentComments: false })
+
+    const result = injectComment(cache, makeComment({
+      parentId: 2,
+      path: '1.2.3'
+    }), {
+      live: true,
+      rootId: 1,
+      optimistic: false
+    })
+
+    expect(result).toBe('hidden')
+    expect(cache.writeFragment).not.toHaveBeenCalled()
+    expect(cache.modify).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'Item:2',
+      optimistic: false
+    }))
+    expect(cache.modify).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'Item:1',
+      optimistic: false
+    }))
+  })
+})


### PR DESCRIPTION
## Summary

- thread `commentId` through the item comments query and Apollo cache key
- include a focused comment's ancestor path in the limited comment resolver when loading the first page
- track live comments hidden by pagination as navigator URL targets and route them to `/items/:id?commentId=:commentId`
- add focused tests for `injectComment` returning rendered vs hidden live-comment outcomes

## Why

The new-comments navigator only had DOM refs for comments that were already rendered. In heavily paginated threads, a live reply whose parent was outside the cached page could still update ancestor counts, but it left the navigator with no element to scroll to. Direct `commentId` item loads also continued to request the default limited comment tree, so the target path was not guaranteed to be present.

This lets the navigator preserve a target id for hidden live replies, then reload the item page with `commentId` so the resolver can include that focused path.

## Testing

- `npm test -- --runTestsByPath lib/comments.spec.js --runInBand`
- `npx eslint api/resolvers/comment-tree.js api/resolvers/item.js api/typeDefs/item.js components/use-comments-navigator.js components/use-live-comments.js fragments/items.js lib/apollo.js lib/comments.js lib/comments.spec.js --max-warnings=999` (0 errors; existing `import/no-anonymous-default-export` warning in `api/resolvers/item.js`)
- `git diff --check`

Fixes #2428
