### PR TITLE
[codex] Add item references view

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -366,6 +366,50 @@ function typeClause (type) {
   }
 }
 
+export async function getItemReferences (parent, { id, cursor, limit }, ctx) {
+  const { me, models } = ctx
+  const itemId = Number(id)
+  if (!Number.isInteger(itemId) || itemId <= 0) {
+    return { cursor: null, items: [] }
+  }
+
+  const decodedCursor = decodeCursor(cursor)
+  const [currentUser, itemFilterClause] = await Promise.all([
+    me ? ctx.userLoader.load(me.id) : null,
+    filterClause(null, null, null, ctx)
+  ])
+  const showNsfw = currentUser ? currentUser.nsfwMode : false
+  const items = await itemQueryWithMeta({
+    me,
+    models,
+    query: `
+      ${SELECT}, "ItemMention".created_at AS "sortTime"
+      FROM "ItemMention"
+      JOIN "Item" ON "ItemMention"."referrerId" = "Item".id
+      ${payInJoinFilter(me)}
+      ${whereClause(
+        '"ItemMention"."refereeId" = $1',
+        '"ItemMention".created_at <= $2',
+        '"Item"."deletedAt" IS NULL',
+        '"Item"."parentId" IS NULL',
+        '"Item".bio = false',
+        subClause(null, 5, 'Item', me, showNsfw),
+        activeOrMine(me),
+        itemFilterClause,
+        muteClause(me)
+      )}
+      ORDER BY "ItemMention".created_at DESC, "Item".id DESC
+      OFFSET $3
+      LIMIT $4`,
+    orderBy: 'ORDER BY "sortTime" DESC, "Item".id DESC'
+  }, itemId, decodedCursor.time, decodedCursor.offset, limit)
+
+  return {
+    cursor: items.length === limit ? nextCursorEncoded(decodedCursor, limit) : null,
+    items
+  }
+}
+
 export default {
   Query: {
     itemRepetition: async (parent, { parentId }, { me, models }) => {
@@ -545,6 +589,7 @@ export default {
       }
     },
     item: getItem,
+    references: getItemReferences,
     pageTitleAndUnshorted: async (parent, { url }, { models }) => {
       const res = {}
       try {

--- a/api/resolvers/item.spec.js
+++ b/api/resolvers/item.spec.js
@@ -1,0 +1,64 @@
+/* eslint-env jest */
+
+jest.mock('./wallet', () => ({
+  verifyHmac: jest.fn()
+}))
+
+jest.mock('../payIn', () => ({
+  __esModule: true,
+  default: jest.fn(),
+  retry: jest.fn()
+}))
+
+jest.mock('../../lib/lexical/server/html', () => ({
+  lexicalHTMLGenerator: jest.fn()
+}))
+
+const { getItemReferences } = require('./item')
+
+describe('item references', () => {
+  test('queries item mention referrers for an item', async () => {
+    const models = {
+      $queryRawUnsafe: jest.fn().mockResolvedValue([{ id: 7 }])
+    }
+
+    const result = await getItemReferences(null, { id: '42', limit: 1 }, { me: null, models })
+
+    expect(result.items).toEqual([{ id: 7 }])
+    expect(result.cursor).toEqual(expect.any(String))
+
+    const [query, itemId, time, offset, limit] = models.$queryRawUnsafe.mock.calls[0]
+    expect(query).toContain('FROM "ItemMention"')
+    expect(query).toContain('JOIN "Item" ON "ItemMention"."referrerId" = "Item".id')
+    expect(query).toContain('"ItemMention"."refereeId" = $1')
+    expect(query).toContain('"Item"."parentId" IS NULL')
+    expect(query).toContain('"Item".bio = false')
+    expect(itemId).toBe(42)
+    expect(time).toBeInstanceOf(Date)
+    expect(offset).toBe(0)
+    expect(limit).toBe(1)
+  })
+
+  test('applies viewer territory filters to item mention referrers', async () => {
+    const models = {
+      $queryRawUnsafe: jest.fn().mockResolvedValue([])
+    }
+    const userLoader = {
+      load: jest.fn().mockResolvedValue({
+        commentsSatsFilter: null,
+        postsSatsFilter: null,
+        nsfwMode: false
+      })
+    }
+
+    const result = await getItemReferences(null, { id: '42', limit: 1 }, { me: { id: 9 }, models, userLoader })
+
+    expect(result.items).toEqual([])
+    expect(result.cursor).toBeNull()
+    expect(userLoader.load).toHaveBeenCalledWith(9)
+
+    const [query] = models.$queryRawUnsafe.mock.calls[0]
+    expect(query).toContain('"MuteSub"')
+    expect(query).toContain('"MuteSub"."userId" = 9')
+  })
+})

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -8,6 +8,7 @@ export default gql`
     pageTitleAndUnshorted(url: String!): TitleUnshorted
     dupes(url: String!): [Item!]
     related(cursor: String, title: String, id: ID, minMatch: String, limit: Limit! = ${LIMIT}): Items
+    references(id: ID!, cursor: String, limit: Limit! = ${LIMIT}): Items
     search(q: String, cursor: String, what: String, sort: String, when: String, from: String, to: String): Items
     itemRepetition(parentId: ID): Int!
     newComments(itemId: ID, after: Date): Comments!

--- a/components/item-full.js
+++ b/components/item-full.js
@@ -12,6 +12,7 @@ import Button from 'react-bootstrap/Button'
 import { useEffect } from 'react'
 import Poll from './poll'
 import Related from './related'
+import References from './references'
 import PastBounties from './past-bounties'
 import Check from '@/svgs/check-double-line.svg'
 import Share from './share'
@@ -155,6 +156,7 @@ function TopLevelItem ({ item, noReply, ...props }) {
             <Related title={item.title} itemId={item.id} show={item.ncomments === 0} />
           }
           {item.bounty > 0 && <PastBounties item={item} />}
+          {!item.deletedAt && <References itemId={item.id} />}
         </>}
     </ItemComponent>
   )

--- a/components/references.js
+++ b/components/references.js
@@ -1,0 +1,24 @@
+import { ITEM_REFERENCES } from '@/fragments/items'
+import AccordianItem from './accordian-item'
+import Items from './items'
+import { NavigateFooter } from './more-footer'
+
+const LIMIT = 5
+
+export default function References ({ itemId, ...props }) {
+  const variables = { id: itemId, limit: LIMIT }
+  return (
+    <AccordianItem
+      header={<div className='fw-bold'>referenced by</div>}
+      body={
+        <Items
+          query={ITEM_REFERENCES}
+          variables={variables}
+          destructureData={data => data.references}
+          Footer={props => <NavigateFooter {...props} href={`/items/${itemId}/references`} text='view all references' noMoreText='no references' />}
+        />
+      }
+      {...props}
+    />
+  )
+}

--- a/fragments/items.js
+++ b/fragments/items.js
@@ -222,6 +222,33 @@ export const RELATED_ITEMS_WITH_ITEM = gql`
   }
 `
 
+export const ITEM_REFERENCES = gql`
+  ${ITEM_FIELDS}
+  query ItemReferences($id: ID!, $cursor: String, $limit: Limit) {
+    references(id: $id, cursor: $cursor, limit: $limit) {
+      cursor
+      items {
+        ...ItemFields
+      }
+    }
+  }
+`
+
+export const ITEM_REFERENCES_WITH_ITEM = gql`
+  ${ITEM_FIELDS}
+  query ItemReferences($id: ID!, $cursor: String, $limit: Limit) {
+    item(id: $id) {
+      ...ItemFields
+    }
+    references(id: $id, cursor: $cursor, limit: $limit) {
+      cursor
+      items {
+        ...ItemFields
+      }
+    }
+  }
+`
+
 export const UPDATE_ITEM_USER_VIEW = gql`
   mutation updateCommentsViewAt($id: ID!, $meCommentsViewedAt: Date!) {
     updateCommentsViewAt(id: $id, meCommentsViewedAt: $meCommentsViewedAt)

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -258,6 +258,19 @@ function getClient (uri) {
                 }
               }
             },
+            references: {
+              keyArgs: ['id', 'limit'],
+              merge (existing, incoming, { args }) {
+                if (isFirstPage(incoming.cursor, existing?.items, args.limit)) {
+                  return incoming
+                }
+
+                return {
+                  cursor: incoming.cursor,
+                  items: [...(existing?.items || []), ...incoming.items]
+                }
+              }
+            },
             search: {
               keyArgs: ['q', 'sort', 'what', 'when', 'from', 'to', 'limit'],
               merge (existing, incoming) {

--- a/lib/url.js
+++ b/lib/url.js
@@ -82,7 +82,7 @@ export function parseInternalLinks (href) {
     const parts = pathname.split('/').filter(part => !!part)
     const itemId = parts[1]
     // check for valid item page due to referral links like /items/123456/r/ekzyis
-    const itemPages = ['edit', 'ots', 'related']
+    const itemPages = ['edit', 'ots', 'related', 'references']
     const itemPage = itemPages.includes(parts[2]) ? parts[2] : null
     if (itemPage) {
       // parse   https://stacker.news/items/1/related?commentId=2

--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -5,6 +5,7 @@ import { parseInternalLinks, isMisleadingLink } from './url.js'
 const internalLinkCases = [
   ['https://stacker.news/items/123', '#123'],
   ['https://stacker.news/items/123/related', '#123/related'],
+  ['https://stacker.news/items/123/references', '#123/references'],
   // invalid links should not be parsed so user can spot error
   ['https://stacker.news/items/123foobar', undefined],
   // Invalid origin should not be parsed so no malicious links

--- a/pages/items/[id]/references.js
+++ b/pages/items/[id]/references.js
@@ -1,0 +1,36 @@
+import { ITEM_REFERENCES, ITEM_REFERENCES_WITH_ITEM } from '@/fragments/items'
+import { getGetServerSideProps } from '@/api/ssrApollo'
+import Items from '@/components/items'
+import Layout from '@/components/layout'
+import { useRouter } from 'next/router'
+import Item from '@/components/item'
+import { useQuery } from '@apollo/client/react'
+import PageLoading from '@/components/page-loading'
+
+export const getServerSideProps = getGetServerSideProps({
+  query: ITEM_REFERENCES_WITH_ITEM,
+  notFound: data => !data.item
+})
+
+export default function ReferencesPage ({ ssrData }) {
+  const router = useRouter()
+
+  const { data } = useQuery(ITEM_REFERENCES_WITH_ITEM, { variables: { id: router.query.id } })
+  if (!data && !ssrData) return <PageLoading />
+
+  const { item } = data || ssrData
+
+  return (
+    <Layout>
+      <Item item={item} />
+      <div className='fw-bold mt-2'>referenced by</div>
+      <Items
+        ssrData={ssrData}
+        query={ITEM_REFERENCES}
+        destructureData={data => data.references}
+        variables={{ id: router.query.id }}
+        noMoreText='no more'
+      />
+    </Layout>
+  )
+}


### PR DESCRIPTION
## What

Adds a referenced-by surface for SN item pages.

- adds a `references(id)` GraphQL query backed by existing `ItemMention` rows
- shows a `referenced by` accordion on item pages and a full `/items/[id]/references` page
- keeps reference pagination in Apollo cache policy
- parses `/items/:id/references` as an internal item link

## Why

Fixes #667. SN already records internal item links in `ItemMention`; this exposes the reverse lookup so a post can show other top-level SN posts that mention it.

## Validation

- `npm test -- --runTestsByPath lib/url.spec.js api/resolvers/item.spec.js --runInBand`
- `npx standard api/resolvers/item.js api/typeDefs/item.js fragments/items.js lib/apollo.js lib/url.js lib/url.spec.js api/resolvers/item.spec.js components/references.js 'pages/items/[id]/references.js' components/item-full.js`
- `git diff --check`
- `DATABASE_URL='postgresql://stacker:stacker@127.0.0.1:5432/stacker' OPENSEARCH_URL='http://127.0.0.1:9200' npm run build`