### PR TITLE
[codex] Include poll options in related search

### DIFF
--- a/api/resolvers/search.js
+++ b/api/resolvers/search.js
@@ -5,7 +5,7 @@ import { parse } from 'tldts'
 import { searchSchema, validateSchema } from '@/lib/validate'
 import { DEFAULT_POSTS_SATS_FILTER, DEFAULT_COMMENTS_SATS_FILTER, HOMEPAGE_POSTS_SATS_FILTER } from '@/lib/constants'
 import { resolveOpensearchModelId } from '../search/model-id'
-import removeMd from 'remove-markdown'
+import { buildRelatedSource } from '@/lib/search-text'
 
 const DOUBLE_QUOTE_VARIANTS = [
   '\u201C', // left double quotation mark
@@ -367,28 +367,6 @@ function exactTextLeg (query) {
       ],
       minimum_should_match: 1
     }
-  }
-}
-
-function normalizeSearchText (text = '') {
-  return typeof text === 'string' ? removeMd(text).trim() : ''
-}
-
-function joinTitleAndText (title = '', text = '') {
-  const normalizedTitle = title.trim()
-  const normalizedText = text.trim()
-  if (normalizedTitle && normalizedText) return `${normalizedTitle}\n\n${normalizedText}`
-  return normalizedTitle || normalizedText
-}
-
-function buildRelatedSource ({ title, text }) {
-  const normalizedTitle = title?.trim() || ''
-  const normalizedText = normalizeSearchText(text)
-
-  return {
-    title: normalizedTitle,
-    hasBody: normalizedText.length > 0,
-    textQuery: joinTitleAndText(normalizedTitle, normalizedText)
   }
 }
 
@@ -811,7 +789,15 @@ export default {
       if (id) {
         const item = await getItem(parent, { id }, { me, models })
         if (item) {
-          source = buildRelatedSource(item)
+          let pollOptions = []
+          if (item.pollCost) {
+            pollOptions = await models.pollOption.findMany({
+              where: { itemId: Number(item.id) },
+              select: { option: true },
+              orderBy: { id: 'asc' }
+            })
+          }
+          source = buildRelatedSource({ ...item, pollOptions })
         }
       }
 

--- a/lib/search-text.js
+++ b/lib/search-text.js
@@ -1,0 +1,40 @@
+import removeMd from 'remove-markdown'
+
+export function pollOptionsText (pollOptions = []) {
+  return pollOptions
+    .map(option => typeof option === 'string' ? option : option?.option)
+    .filter(Boolean)
+    .join('\n')
+}
+
+export function searchableText (text, pollOptions = []) {
+  return [
+    text ? removeMd(text) : '',
+    pollOptionsText(pollOptions)
+  ].filter(Boolean).join('\n\n')
+}
+
+function normalizeRelatedText (text = '') {
+  return typeof text === 'string' ? removeMd(text).trim() : ''
+}
+
+function joinTitleAndText (title = '', text = '') {
+  const normalizedTitle = title.trim()
+  const normalizedText = text.trim()
+  if (normalizedTitle && normalizedText) return `${normalizedTitle}\n\n${normalizedText}`
+  return normalizedTitle || normalizedText
+}
+
+export function buildRelatedSource ({ title, text, pollOptions }) {
+  const normalizedTitle = title?.trim() || ''
+  const normalizedText = [
+    normalizeRelatedText(text),
+    normalizeRelatedText(pollOptionsText(pollOptions))
+  ].filter(Boolean).join('\n\n')
+
+  return {
+    title: normalizedTitle,
+    hasBody: normalizedText.length > 0,
+    textQuery: joinTitleAndText(normalizedTitle, normalizedText)
+  }
+}

--- a/lib/search-text.spec.js
+++ b/lib/search-text.spec.js
@@ -1,0 +1,31 @@
+/* eslint-env jest */
+
+import { buildRelatedSource, pollOptionsText, searchableText } from './search-text'
+
+describe('search text helpers', () => {
+  test('joins poll options from strings and poll option records', () => {
+    expect(pollOptionsText([
+      'yes',
+      { option: 'no' },
+      { option: '' },
+      null
+    ])).toBe('yes\nno')
+  })
+
+  test('adds poll options to indexed searchable text', () => {
+    expect(searchableText('**body** text', [{ option: 'choice one' }, { option: 'choice two' }]))
+      .toBe('body text\n\nchoice one\nchoice two')
+  })
+
+  test('adds poll options to related-search source text', () => {
+    expect(buildRelatedSource({
+      title: 'Favorite wallet?',
+      text: 'Which one do you use?',
+      pollOptions: [{ option: 'LND' }, { option: 'CLN' }]
+    })).toEqual({
+      title: 'Favorite wallet?',
+      hasBody: true,
+      textQuery: 'Favorite wallet?\n\nWhich one do you use?\n\nLND\nCLN'
+    })
+  })
+})

--- a/worker/search.js
+++ b/worker/search.js
@@ -1,7 +1,7 @@
 import { gql } from 'graphql-tag'
 import search from '@/api/search/index'
-import removeMd from 'remove-markdown'
 import { msatsToSats } from '@/lib/format'
+import { searchableText } from '@/lib/search-text'
 
 const ITEM_SEARCH_FIELDS = gql`
   fragment ItemSearchFields on Item {
@@ -13,6 +13,7 @@ const ITEM_SEARCH_FIELDS = gql`
     text
     url
     userId
+    pollCost
     subNames
     user {
       name
@@ -52,8 +53,17 @@ async function _indexItem (item, { models, updatedAt }) {
   if (item.location || item.remote) {
     itemcp.title += ` \\ ${item.location || ''}${item.location && item.remote ? ' or ' : ''}${item.remote ? 'Remote' : ''}`
   }
-  if (item.text) {
-    itemcp.text = removeMd(item.text)
+  let pollOptions = []
+  if (item.pollCost) {
+    pollOptions = await models.pollOption.findMany({
+      where: { itemId: Number(item.id) },
+      select: { option: true },
+      orderBy: { id: 'asc' }
+    })
+  }
+  const text = searchableText(item.text, pollOptions)
+  if (text) {
+    itemcp.text = text
   }
 
   // Keep territory metadata in a flat array because ingest processing can
@@ -198,6 +208,11 @@ export async function indexAllItems ({ models, boss }) {
           company: true,
           location: true,
           remote: true,
+          pollCost: true,
+          pollOptions: {
+            select: { option: true },
+            orderBy: { id: 'asc' }
+          },
           upvotes: true,
           boost: true,
           lastCommentAt: true,
@@ -243,11 +258,13 @@ export async function indexAllItems ({ models, boss }) {
         if (item.location || item.remote) {
           doc.title = `${doc.title} \\ ${item.location || ''}${item.location && item.remote ? ' or ' : ''}${item.remote ? 'Remote' : ''}`
         }
-        if (item.text) doc.text = removeMd(item.text)
+        const text = searchableText(item.text, item.pollOptions)
+        if (text) doc.text = text
         doc.textLength = doc.text ? doc.text.length : 0
 
         // clean up relation/raw fields not needed in the index
         delete doc.Bookmark
+        delete doc.pollOptions
         delete doc.root
         delete doc.msats
         delete doc.mcredits


### PR DESCRIPTION
## Summary

- Include poll option text in the related-search source for poll posts.
- Index poll options alongside poll body text so related search can match against choices.
- Share the search-text helper between the API resolver and index worker with focused unit coverage.

## Why

Closes #1149. This replaces the closed, unreopenable #3054 with a rebased branch and focused helper tests.

## Validation

- `npm test -- --runTestsByPath lib/search-text.spec.js --runInBand`
- `npx standard api/resolvers/search.js worker/search.js lib/search-text.js lib/search-text.spec.js`
- `git diff --check`
- `DATABASE_URL='postgresql://stacker:stacker@127.0.0.1:5432/stacker' OPENSEARCH_URL='http://127.0.0.1:9200' npm run build`