### PR TITLE
Improve YouTube title fallback

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -32,6 +32,7 @@ import pay, { retry as retryPayIn } from '../payIn'
 import { BOUNTY_ALREADY_PAID_ERROR, BOUNTY_IN_PROGRESS_ERROR, getBountyPaymentTail } from '../payIn/lib/bountyPayment'
 import { lexicalHTMLGenerator } from '@/lib/lexical/server/html'
 import { resolveItemComments } from './comment-tree'
+import { cleanPageTitle, fetchYouTubeOEmbedTitle } from '@/lib/page-title'
 
 export async function getItem (parent, { id }, { me, models }) {
   const [item] = await getItemsById([id], { me, models })
@@ -561,8 +562,8 @@ export default {
         const dateHint = ` (${metadata.publicationDate?.getFullYear()})`
         const moreThanOneYearAgo = metadata.publicationDate && metadata.publicationDate < datePivot(new Date(), { years: -1 })
 
-        res.title = metadata?.title
-        if (moreThanOneYearAgo) res.title += dateHint
+        res.title = cleanPageTitle(metadata?.title, url) || await fetchYouTubeOEmbedTitle(url, snFetch)
+        if (res.title && moreThanOneYearAgo) res.title += dateHint
       } catch { }
 
       try {

--- a/lib/page-title.js
+++ b/lib/page-title.js
@@ -1,0 +1,54 @@
+import { ensureProtocol } from './url'
+
+const YOUTUBE_HOSTS = new Set(['www.youtube.com', 'youtube.com', 'm.youtube.com', 'youtu.be'])
+const YOUTUBE_OEMBED_URL = 'https://www.youtube.com/oembed'
+const TITLE_FALLBACK_TIMEOUT_MS = 3000
+const TITLE_FALLBACK_SIZE = 64 * 1024
+
+export function isYouTubeUrl (value) {
+  try {
+    const { hostname } = new URL(ensureProtocol(value))
+    return YOUTUBE_HOSTS.has(hostname.toLowerCase())
+  } catch {
+    return false
+  }
+}
+
+export function cleanPageTitle (title, url) {
+  const normalized = title?.replace(/\s+/g, ' ').trim()
+  if (!normalized) return
+
+  if (isYouTubeUrl(url)) {
+    if (/^-?\s*youtube$/i.test(normalized)) return
+
+    const withoutSuffix = normalized.replace(/\s+-\s*youtube$/i, '').trim()
+    if (withoutSuffix !== normalized) return withoutSuffix || undefined
+  }
+
+  return normalized
+}
+
+export function youTubeOEmbedUrl (url) {
+  if (!isYouTubeUrl(url)) return
+
+  const oembedUrl = new URL(YOUTUBE_OEMBED_URL)
+  oembedUrl.searchParams.set('url', ensureProtocol(url))
+  oembedUrl.searchParams.set('format', 'json')
+  return oembedUrl.toString()
+}
+
+export async function fetchYouTubeOEmbedTitle (url, fetcher) {
+  const oembedUrl = youTubeOEmbedUrl(url)
+  if (!oembedUrl) return
+
+  try {
+    const response = await fetcher(oembedUrl, {
+      timeout: TITLE_FALLBACK_TIMEOUT_MS,
+      size: TITLE_FALLBACK_SIZE
+    })
+    if (!response.ok) return
+
+    const data = await response.json()
+    return cleanPageTitle(data?.title, url)
+  } catch {}
+}

--- a/lib/page-title.spec.js
+++ b/lib/page-title.spec.js
@@ -1,0 +1,67 @@
+/* eslint-env jest */
+
+import { cleanPageTitle, fetchYouTubeOEmbedTitle, isYouTubeUrl, youTubeOEmbedUrl } from './page-title'
+
+describe('page title helpers', () => {
+  test.each([
+    'https://www.youtube.com/watch?v=AHRtMxVrP78',
+    'https://youtube.com/watch?v=AHRtMxVrP78',
+    'https://m.youtube.com/watch?v=AHRtMxVrP78',
+    'https://youtu.be/AHRtMxVrP78'
+  ])('identifies YouTube urls: %p', (url) => {
+    expect(isYouTubeUrl(url)).toBe(true)
+  })
+
+  test('does not treat non-YouTube urls as YouTube', () => {
+    expect(isYouTubeUrl('https://example.com/watch?v=AHRtMxVrP78')).toBe(false)
+  })
+
+  test.each([
+    '- YouTube',
+    ' -   YouTube ',
+    'YouTube'
+  ])('drops the known bad YouTube title fallback: %p', (title) => {
+    expect(cleanPageTitle(title, 'https://www.youtube.com/watch?v=mvuWLob3CFU')).toBeUndefined()
+  })
+
+  test('preserves the same title for non-YouTube urls', () => {
+    expect(cleanPageTitle('- YouTube', 'https://example.com')).toBe('- YouTube')
+  })
+
+  test('normalizes meaningful titles', () => {
+    expect(cleanPageTitle(' Happy   4th of July Stackers! | SNL #179 ', 'https://youtu.be/AHRtMxVrP78'))
+      .toBe('Happy 4th of July Stackers! | SNL #179')
+  })
+
+  test('drops the YouTube browser-title suffix from meaningful titles', () => {
+    expect(cleanPageTitle('Happy 4th of July Stackers! | SNL #179 - YouTube', 'https://www.youtube.com/watch?v=AHRtMxVrP78'))
+      .toBe('Happy 4th of July Stackers! | SNL #179')
+  })
+
+  test('builds a YouTube oEmbed URL', () => {
+    const url = youTubeOEmbedUrl('https://www.youtube.com/watch?v=AHRtMxVrP78&t=10s')
+
+    expect(url).toBe('https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DAHRtMxVrP78%26t%3D10s&format=json')
+  })
+
+  test('fetches a title from YouTube oEmbed', async () => {
+    const fetcher = jest.fn(async () => ({
+      ok: true,
+      json: async () => ({ title: 'Happy 4th of July Stackers! | SNL #179' })
+    }))
+
+    await expect(fetchYouTubeOEmbedTitle('https://www.youtube.com/watch?v=AHRtMxVrP78', fetcher))
+      .resolves.toBe('Happy 4th of July Stackers! | SNL #179')
+    expect(fetcher).toHaveBeenCalledWith(
+      'https://www.youtube.com/oembed?url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DAHRtMxVrP78&format=json',
+      { timeout: 3000, size: 64 * 1024 }
+    )
+  })
+
+  test('ignores unavailable oEmbed responses', async () => {
+    const fetcher = jest.fn(async () => ({ ok: false }))
+
+    await expect(fetchYouTubeOEmbedTitle('https://www.youtube.com/watch?v=mvuWLob3CFU', fetcher))
+      .resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- normalize fetched page titles before returning them to the link form
- drop YouTube known-bad fallback titles like `- YouTube` instead of auto-filling them
- strip the browser-title `- YouTube` suffix and use YouTube oEmbed as a best-effort fallback when page metadata is missing or unusable
- add focused helper coverage for YouTube URL detection, fallback filtering, suffix cleanup, and oEmbed handling

Closes #2164

## Test plan
- `npm test -- --runTestsByPath lib/page-title.spec.js --runInBand`
- `npx standard api/resolvers/item.js lib/page-title.js lib/page-title.spec.js`
- `git diff --check`
- `DATABASE_URL='postgresql://stacker:stacker@127.0.0.1:5432/stacker' OPENSEARCH_URL='http://127.0.0.1:9200' npm run build`

Build note: the production build logged local LND GRPC connection errors during page-data collection, but the command exited successfully.