### PR TITLE
Parse user mentions from markdown before notifying

### DIFF
--- a/api/payIn/lib/item.js
+++ b/api/payIn/lib/item.js
@@ -1,5 +1,6 @@
 import { USER_ID } from '@/lib/constants'
 import { deleteReminders, getDeleteAt, getRemindAt } from '@/lib/item'
+import { extractUserMentions } from '@/lib/md'
 import { parseInternalLinks } from '@/lib/url'
 
 export async function getSubs (models, { subNames, parentId }) {
@@ -30,8 +31,7 @@ export async function getItemResult (tx, { id }) {
 }
 
 export async function getMentions (tx, { text, userId }) {
-  const mentionPattern = /\B@[\w_]+/gi
-  const names = text.match(mentionPattern)?.map(m => m.slice(1))
+  const names = extractUserMentions(text)
   if (names?.length > 0) {
     const users = await tx.user.findMany({
       where: {

--- a/lib/md.js
+++ b/lib/md.js
@@ -2,14 +2,19 @@ import { gfmFromMarkdown } from 'mdast-util-gfm'
 import { visit } from 'unist-util-visit'
 import { gfm } from 'micromark-extension-gfm'
 import { fromMarkdown } from 'mdast-util-from-markdown'
+import { mentionTransform } from './lexical/mdast/transforms/mentions.js'
 
-export function mdHas (md, test) {
+function parseMarkdown (md) {
   if (!md) return []
-  const tree = fromMarkdown(md, {
+  return fromMarkdown(md, {
     extensions: [gfm()],
     mdastExtensions: [gfmFromMarkdown()]
   })
+}
 
+export function mdHas (md, test) {
+  if (!md) return []
+  const tree = parseMarkdown(md)
   let found = false
   visit(tree, test, () => {
     found = true
@@ -21,10 +26,7 @@ export function mdHas (md, test) {
 
 export function extractUrls (md) {
   if (!md) return []
-  const tree = fromMarkdown(md, {
-    extensions: [gfm()],
-    mdastExtensions: [gfmFromMarkdown()]
-  })
+  const tree = parseMarkdown(md)
 
   const urls = new Set()
   visit(tree, ({ type }) => {
@@ -34,6 +36,18 @@ export function extractUrls (md) {
   })
 
   return Array.from(urls)
+}
+
+export function extractUserMentions (md) {
+  if (!md) return []
+  const tree = parseMarkdown(md)
+  mentionTransform(tree)
+
+  const names = new Set()
+  visit(tree, 'userMention', ({ value }) => {
+    if (value?.name) names.add(value.name)
+  })
+  return Array.from(names)
 }
 
 export const quote = (orig) =>

--- a/lib/md.spec.js
+++ b/lib/md.spec.js
@@ -1,0 +1,26 @@
+/* eslint-env jest */
+
+import { execFileSync } from 'node:child_process'
+
+describe('markdown helpers', () => {
+  test('extracts user mentions using the markdown parser', () => {
+    const script = `
+      import assert from 'node:assert/strict'
+      import { extractUserMentions } from './lib/md.js'
+
+      const tick = String.fromCharCode(96)
+      const fence = tick.repeat(3)
+      const fencedCode = [fence + 'java', '@Entity', 'class Zap {}', fence, 'hello @alice'].join('\\n')
+
+      assert.deepEqual(extractUserMentions('hello @alice and @bob'), ['alice', 'bob'])
+      assert.deepEqual(extractUserMentions(fencedCode), ['alice'])
+      assert.deepEqual(extractUserMentions('do not notify ' + tick + '@Entity' + tick + ' but notify @alice'), ['alice'])
+      assert.deepEqual(extractUserMentions('[@alice](https://example.com) and @bob'), ['bob'])
+      assert.deepEqual(extractUserMentions('@alice @alice @bob/thread'), ['alice', 'bob'])
+    `
+
+    expect(() => execFileSync('npx', ['tsx', '-e', script], {
+      cwd: process.cwd()
+    })).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- route server-side user mention detection through the existing MDAST mention transform instead of scanning raw markdown with a regex
- ignore mentions in fenced code, inline code, and links, matching the editor mention transform behavior
- reuse a shared markdown parse helper in `lib/md` and add focused parser coverage

Closes #2589

Context: #2726 has been open for a while with a regex-based approach. This takes the maintainer feedback there into account by using the markdown/editor parsing path instead of stripping code blocks with another regex.

## Test plan
- `npm test -- --runTestsByPath lib/md.spec.js --runInBand`
- `npx standard api/payIn/lib/item.js lib/md.js lib/md.spec.js`
- `git diff --check`
- `DATABASE_URL='postgresql://stacker:stacker@127.0.0.1:5432/stacker' OPENSEARCH_URL='http://127.0.0.1:9200' npm run build`

Build note: the production build logged local LND GRPC connection errors during page-data collection, but the command exited successfully.