### PR TITLE
Check receive wallet invoice network

### DIFF
--- a/wallets/server/bolt11-network.js
+++ b/wallets/server/bolt11-network.js
@@ -1,0 +1,21 @@
+import { parsePaymentRequest } from 'ln-service'
+import { WalletValidationError } from '@/wallets/client/errors'
+
+export function bolt11Network (request, label = 'wallet') {
+  try {
+    const { network } = parsePaymentRequest({ request })
+    if (!network) throw new Error('missing network')
+    return network
+  } catch {
+    throw new WalletValidationError(`${label} returned invalid invoice`)
+  }
+}
+
+export function assertSameBolt11Network ({ actual, expected }) {
+  const actualNetwork = bolt11Network(actual, 'wallet')
+  const expectedNetwork = bolt11Network(expected, 'local wallet')
+
+  if (actualNetwork !== expectedNetwork) {
+    throw new WalletValidationError(`wallet invoice network mismatch: expected ${expectedNetwork}, got ${actualNetwork}`)
+  }
+}

--- a/wallets/server/bolt11-network.spec.js
+++ b/wallets/server/bolt11-network.spec.js
@@ -1,0 +1,37 @@
+/* eslint-env jest */
+
+import { assertSameBolt11Network, bolt11Network } from './bolt11-network'
+
+const mainnetInvoice = 'lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w'
+const testnetInvoice = 'lntb1500n1pdn4czkpp5ugdqer05qrrxuchrzkcue94th9w2xzasp9qm7d0yxcgp4uh4kn4qdpa2fjkzep6yprkcmmzv9kzqsmj09c8gmmrw4e8yetwvdujq5n9va6kcct5d9hkucqzysdlghdpua7uvjjkcfj49psxtlqzkp5pdncffdfk2cp3mp76thrl29qhqgzufm503pjj96586n5w6edgw3n66j4rxxs707y4zdjuhyt6qqe5weu4'
+const regtestInvoice = 'lnbcrt1u1p0fmafmpp5ptazmjuehcr3dk5wxdqd9uxz4e857w0xwz5h9rnem98wx86dhk0qdqqcqzpgxq92fjuqsp5ulvng3vsa6spedynlxeaufjy76njua2ykvhdnjztshcg92lfd2kq9qy9qsqsf9ct3nsfmfjz9fz9jkh376txuse520jjyg9vmm4tchnd9rh7umzwwxz7em5wmfx0y2eudcjj98kmgryz9r9evrcp7e4c9rwkemnswsqgptmd9'
+
+describe('bolt11Network', () => {
+  test.each([
+    [mainnetInvoice, 'bitcoin'],
+    [testnetInvoice, 'testnet'],
+    [regtestInvoice, 'regtest']
+  ])('parses invoice network %p', (invoice, expected) => {
+    expect(bolt11Network(invoice)).toBe(expected)
+  })
+
+  test('throws a wallet validation error for invalid invoices', () => {
+    expect(() => bolt11Network('lnbcnotvalid')).toThrow('wallet returned invalid invoice')
+  })
+})
+
+describe('assertSameBolt11Network', () => {
+  test('accepts invoices from the same network', () => {
+    expect(() => assertSameBolt11Network({
+      actual: regtestInvoice,
+      expected: regtestInvoice
+    })).not.toThrow()
+  })
+
+  test('rejects invoices from different networks', () => {
+    expect(() => assertSameBolt11Network({
+      actual: mainnetInvoice,
+      expected: regtestInvoice
+    })).toThrow('wallet invoice network mismatch: expected regtest, got bitcoin')
+  })
+})

--- a/wallets/server/resolvers/protocol.js
+++ b/wallets/server/resolvers/protocol.js
@@ -1,8 +1,10 @@
 import { GqlAuthenticationError, GqlInputError } from '@/lib/error'
 import { utf8ByteLength } from '@/lib/validate'
+import lnd from '@/api/lnd'
 import { protocolRelationName } from '@/wallets/lib/util'
 import { mapWalletResolveTypes, parseWalletId } from '@/wallets/server/resolvers/util'
 import { protocolTestCreateInvoice } from '@/wallets/server/protocols'
+import { assertSameBolt11Network } from '@/wallets/server/bolt11-network'
 import { commitWithBadgeNotifications, updateWalletBadges } from '@/wallets/server/badges'
 import {
   applyRemoves,
@@ -14,11 +16,12 @@ import {
   upsertProtocolInTransaction,
   validateProtocolConfig
 } from '@/wallets/server/persist'
-import { timeoutSignal } from '@/lib/time'
+import { datePivot, raceAbort, timeoutSignal } from '@/lib/time'
 import { WALLET_CREATE_INVOICE_TIMEOUT_MS } from '@/lib/constants'
 import { decodeCursor, LIMIT, nextCursorEncoded } from '@/lib/cursor'
 import { writeWalletLog } from '@/wallets/server/logger'
 import { WalletValidationError } from '@/wallets/client/errors'
+import { createInvoice as lndCreateInvoice } from 'ln-service'
 
 const MAX_WALLET_LOG_MESSAGE_BYTES = 4096
 
@@ -66,11 +69,35 @@ export async function testWalletRecvProtocol (parent, { config: wrapper }, { me 
     throw new GqlInputError('failed to create invoice: ' + e.message)
   }
 
-  if (!invoice || !invoice.startsWith('lnbc')) {
-    throw new GqlInputError('wallet returned invalid invoice')
+  let localInvoice
+  try {
+    localInvoice = await localTestCreateInvoice({ signal: timeoutSignal(WALLET_CREATE_INVOICE_TIMEOUT_MS) })
+  } catch (e) {
+    throw new GqlInputError('failed to create local invoice: ' + e.message)
+  }
+
+  try {
+    assertSameBolt11Network({ actual: invoice, expected: localInvoice })
+  } catch (e) {
+    if (e instanceof WalletValidationError) {
+      throw new GqlInputError(e.message)
+    }
+    throw e
   }
 
   return true
+}
+
+async function localTestCreateInvoice ({ signal } = {}) {
+  const { request } = await raceAbort(
+    lndCreateInvoice({
+      lnd,
+      mtokens: '1000',
+      expires_at: datePivot(new Date(), { seconds: 1 })
+    }),
+    signal
+  )
+  return request
 }
 
 // Atomic configure-save: validate every upsert, then apply upserts + removes


### PR DESCRIPTION
## Summary
- compare tested receive-wallet invoices against an invoice minted by the local SN LND node
- reject receive wallet tests when the parsed BOLT11 networks differ, instead of accepting any `lnbc` invoice
- add focused BOLT11 network parsing and mismatch tests

Closes #1028

## Testing
- npm test -- --runTestsByPath wallets/server/bolt11-network.spec.js --runInBand
- npx standard wallets/server/bolt11-network.js wallets/server/bolt11-network.spec.js wallets/server/resolvers/protocol.js
- git diff --check
- DATABASE_URL=postgresql://stacker:stacker@127.0.0.1:5432/stacker OPENSEARCH_URL=http://127.0.0.1:9200 npm run build