### PR TITLE
Sort profile sats by item sats

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -19,7 +19,7 @@ import {
 import { msatsToSats } from '@/lib/format'
 import uu from 'url-unshort'
 import { actSchema, bountySchema, commentSchema, discussionSchema, jobSchema, linkSchema, pollSchema, validateSchema } from '@/lib/validate'
-import { defaultCommentSort, isJob, deleteItemByAuthor } from '@/lib/item'
+import { defaultCommentSort, isJob, deleteItemByAuthor, itemOrderByClause } from '@/lib/item'
 import { datePivot, whenRange } from '@/lib/time'
 import { uploadIdsFromText } from './upload'
 import assertGofacYourself from './ofac'
@@ -57,19 +57,6 @@ export async function getItemsById (ids, { me, models }) {
   })
 
   return items.map(({ rank, ...item }) => item)
-}
-
-const orderByClause = (by, me, models, type, sub) => {
-  switch (by) {
-    case 'comments':
-      return 'ORDER BY "Item".ncomments DESC'
-    case 'sats':
-      return 'ORDER BY "Item".ranktop DESC, "Item".id DESC'
-    case 'downsats':
-      return 'ORDER BY "Item"."downMsats" DESC'
-    default:
-      return `ORDER BY ${type === 'bookmarks' ? '"bookmarkCreatedAt"' : '"Item".created_at'} DESC`
-  }
 }
 
 // this grabs all the stuff we need to display the item list and only
@@ -431,10 +418,10 @@ export default {
                 typeClause(type),
                 by === 'downsats' && '"Item"."downMsats" > 0',
                 whenClause(when || 'forever', table))}
-              ${orderByClause(by, me, models, type)}
+              ${itemOrderByClause({ by, sort, type })}
               OFFSET $4
               LIMIT $5`,
-            orderBy: orderByClause(by, me, models, type)
+            orderBy: itemOrderByClause({ by, sort, type })
           }, ...whenRange(when, from, to || decodedCursor.time), user.id, decodedCursor.offset, limit)
           break
         case 'new':
@@ -479,10 +466,10 @@ export default {
                 by === 'downsats' && '"Item"."downMsats" > 0',
                 await filterClause(type, sub, 'top', ctx, by),
                 muteClause(me))}
-              ${orderByClause(by || 'sats', me, models, type, sub)}
+              ${itemOrderByClause({ by: by || 'sats', sort, type })}
               OFFSET $3
               LIMIT $4`,
-            orderBy: orderByClause(by || 'sats', me, models, type, sub)
+            orderBy: itemOrderByClause({ by: by || 'sats', sort, type })
           }, ...whenRange(when, from, to || decodedCursor.time), decodedCursor.offset, limit, ...subArr)
           break
         default:

--- a/lib/item.js
+++ b/lib/item.js
@@ -1,6 +1,22 @@
 import { COMMENT_DEPTH_LIMIT, COMMENTS_OF_COMMENT_LIMIT, FULL_COMMENTS_THRESHOLD } from './constants'
 import { datePivot } from './time'
 
+export const itemOrderByClause = ({ by, sort, type } = {}) => {
+  switch (by) {
+    case 'comments':
+      return 'ORDER BY "Item".ncomments DESC'
+    case 'sats':
+      if (sort === 'user') {
+        return 'ORDER BY (COALESCE("Item".msats, 0) + ((COALESCE("Item".boost, 0) + COALESCE("Item".cost, 0))::BIGINT * 1000)) DESC, "Item".id DESC'
+      }
+      return 'ORDER BY "Item".ranktop DESC, "Item".id DESC'
+    case 'downsats':
+      return 'ORDER BY "Item"."downMsats" DESC'
+    default:
+      return `ORDER BY ${type === 'bookmarks' ? '"bookmarkCreatedAt"' : '"Item".created_at'} DESC`
+  }
+}
+
 export const defaultCommentSort = (pinned, bio, createdAt) => {
   // pins sort by new
   if (pinned) return 'new'

--- a/lib/item.spec.js
+++ b/lib/item.spec.js
@@ -1,0 +1,38 @@
+/* eslint-env jest */
+
+import { itemOrderByClause } from './item.js'
+
+describe('itemOrderByClause', () => {
+  test('sorts user profile sats by the visible item sats total', () => {
+    const orderBy = itemOrderByClause({ by: 'sats', sort: 'user', type: 'posts' })
+
+    expect(orderBy).toBe('ORDER BY (COALESCE("Item".msats, 0) + ((COALESCE("Item".boost, 0) + COALESCE("Item".cost, 0))::BIGINT * 1000)) DESC, "Item".id DESC')
+    expect(orderBy).not.toContain('ranktop')
+    expect(orderBy).not.toContain('comment')
+  })
+
+  test('keeps global sats sorting on ranktop', () => {
+    expect(itemOrderByClause({ by: 'sats', sort: 'top', type: 'posts' }))
+      .toBe('ORDER BY "Item".ranktop DESC, "Item".id DESC')
+  })
+
+  test('sorts by comments', () => {
+    expect(itemOrderByClause({ by: 'comments', sort: 'user', type: 'posts' }))
+      .toBe('ORDER BY "Item".ncomments DESC')
+  })
+
+  test('sorts by downsats', () => {
+    expect(itemOrderByClause({ by: 'downsats', sort: 'user', type: 'posts' }))
+      .toBe('ORDER BY "Item"."downMsats" DESC')
+  })
+
+  test('defaults posts to newest first', () => {
+    expect(itemOrderByClause({ sort: 'user', type: 'posts' }))
+      .toBe('ORDER BY "Item".created_at DESC')
+  })
+
+  test('defaults bookmarks to bookmark creation time', () => {
+    expect(itemOrderByClause({ sort: 'user', type: 'bookmarks' }))
+      .toBe('ORDER BY "bookmarkCreatedAt" DESC')
+  })
+})


### PR DESCRIPTION
Closes #2903.

## Summary
- use the visible item sats total for profile `by=sats` ordering instead of ranktop
- keep global/top `by=sats` ordering on ranktop
- add focused tests for item order-by clause selection

## Test plan
- `npm test -- --runTestsByPath lib/item.spec.js --runInBand`
- `npx standard lib/item.js lib/item.spec.js api/resolvers/item.js`
- `git diff --check`
- `DATABASE_URL='postgresql://stacker:stacker@127.0.0.1:5432/stacker' OPENSEARCH_URL='http://127.0.0.1:9200' npm run build`