### PR TITLE
Avoid mailto autolinks for Fediverse handles

### DIFF
--- a/lib/lexical/mdast/transforms/index.js
+++ b/lib/lexical/mdast/transforms/index.js
@@ -1,5 +1,5 @@
 export { mentionTransform } from './mentions.js'
 export { nostrTransform } from './nostr.js'
-export { misleadingLinkTransform, malformedLinkEncodingTransform } from './links.js'
+export { fediverseHandleTransform, misleadingLinkTransform, malformedLinkEncodingTransform } from './links.js'
 export { footnoteTransform } from './footnotes.js'
 export { tocTransform } from './toc.js'

--- a/lib/lexical/mdast/transforms/links.js
+++ b/lib/lexical/mdast/transforms/links.js
@@ -2,6 +2,38 @@ import { visit } from 'unist-util-visit'
 import { toString } from 'mdast-util-to-string'
 import { isMisleadingLink } from '@/lib/url'
 
+function isLiteralMailtoAutolink (node) {
+  if (!node.url?.startsWith('mailto:')) return false
+  if (node.children?.length !== 1 || node.children[0].type !== 'text') return false
+  if (node.url !== `mailto:${toString(node)}`) return false
+
+  const child = node.children[0]
+  return child.position?.start?.offset === node.position?.start?.offset &&
+    child.position?.end?.offset === node.position?.end?.offset
+}
+
+function hasAdjacentFediversePrefix (node, index, parent) {
+  const previous = parent?.children?.[index - 1]
+  if (previous?.type !== 'text') return false
+  if (!previous.value.endsWith('@') && !previous.value.endsWith('!')) return false
+
+  return previous.position?.end?.offset === node.position?.start?.offset
+}
+
+export function fediverseHandleTransform (tree) {
+  visit(tree, 'link', (node, index, parent) => {
+    if (index === undefined) return
+    if (!isLiteralMailtoAutolink(node)) return
+    if (!hasAdjacentFediversePrefix(node, index, parent)) return
+
+    parent.children[index] = {
+      type: 'text',
+      value: toString(node),
+      position: node.position
+    }
+  })
+}
+
 /**
  * a link is misleading if the text is not the same as the URL.
  *

--- a/lib/lexical/mdast/transforms/links.spec.js
+++ b/lib/lexical/mdast/transforms/links.spec.js
@@ -1,0 +1,126 @@
+/* eslint-env jest */
+
+jest.mock('unist-util-visit', () => ({
+  visit: (tree, type, visitor) => {
+    function walk (node) {
+      node.children?.forEach((child, index) => {
+        if (child.type === type) visitor(child, index, node)
+        walk(child)
+      })
+    }
+    if (tree.type === type) visitor(tree, undefined, undefined)
+    walk(tree)
+  }
+}))
+
+jest.mock('mdast-util-to-string', () => ({
+  toString: node => {
+    if (node.type === 'text') return node.value
+    return node.children?.map(child => child.value ?? '').join('') ?? ''
+  }
+}))
+
+const { fediverseHandleTransform } = require('./links.js')
+
+function position (start, end) {
+  return {
+    start: { offset: start },
+    end: { offset: end }
+  }
+}
+
+function text (value, start, end) {
+  return {
+    type: 'text',
+    value,
+    position: position(start, end)
+  }
+}
+
+function mailtoLink (value, start, end, { childStart = start, childEnd = end } = {}) {
+  return {
+    type: 'link',
+    title: null,
+    url: `mailto:${value}`,
+    children: [text(value, childStart, childEnd)],
+    position: position(start, end)
+  }
+}
+
+function treeWithParagraph (children) {
+  return {
+    type: 'root',
+    children: [{
+      type: 'paragraph',
+      children
+    }]
+  }
+}
+
+function transform (tree) {
+  fediverseHandleTransform(tree)
+  return tree
+}
+
+function linksIn (tree) {
+  const links = []
+  function walk (node) {
+    if (node.type === 'link') links.push(node.url)
+    node.children?.forEach(walk)
+  }
+  walk(tree)
+  return links
+}
+
+function textIn (tree) {
+  let result = ''
+  function walk (node) {
+    if (node.type === 'text') result += node.value
+    node.children?.forEach(walk)
+  }
+  walk(tree)
+  return result
+}
+
+describe('fediverseHandleTransform', () => {
+  test('keeps fediverse handles as text instead of mailto links', () => {
+    const tree = transform(treeWithParagraph([
+      text('hello @', 0, 7),
+      mailtoLink('Cointastical@BitcoinHackers.org', 7, 38)
+    ]))
+
+    expect(textIn(tree)).toBe('hello @Cointastical@BitcoinHackers.org')
+    expect(linksIn(tree)).toEqual([])
+  })
+
+  test('keeps bang-prefixed handles as text instead of mailto links', () => {
+    const tree = transform(treeWithParagraph([
+      text('follow !', 0, 8),
+      mailtoLink('group@instance.social', 8, 29)
+    ]))
+
+    expect(textIn(tree)).toBe('follow !group@instance.social')
+    expect(linksIn(tree)).toEqual([])
+  })
+
+  test('keeps normal email autolinks', () => {
+    const tree = transform(treeWithParagraph([
+      text('email ', 0, 6),
+      mailtoLink('hello@example.com', 6, 23)
+    ]))
+
+    expect(linksIn(tree)).toEqual(['mailto:hello@example.com'])
+  })
+
+  test('keeps explicit markdown mailto links after an at sign', () => {
+    const tree = transform(treeWithParagraph([
+      text('@', 0, 1),
+      mailtoLink('Cointastical@BitcoinHackers.org', 1, 75, {
+        childStart: 2,
+        childEnd: 33
+      })
+    ]))
+
+    expect(linksIn(tree)).toEqual(['mailto:Cointastical@BitcoinHackers.org'])
+  })
+})

--- a/lib/lexical/utils/mdast.js
+++ b/lib/lexical/utils/mdast.js
@@ -16,6 +16,7 @@ import {
 import {
   mentionTransform,
   nostrTransform,
+  fediverseHandleTransform,
   misleadingLinkTransform,
   malformedLinkEncodingTransform,
   footnoteTransform,
@@ -51,6 +52,7 @@ export function $markdownToLexical (markdown, { splitInParagraphs = false, appen
     mdastTransforms: [
       mentionTransform,
       nostrTransform,
+      fediverseHandleTransform,
       misleadingLinkTransform,
       malformedLinkEncodingTransform,
       footnoteTransform,


### PR DESCRIPTION
Closes #93.

## Summary
- unwrap GFM mailto autolinks when they are immediately preceded by `@` or `!`, preserving Fediverse-style handles as plain text
- keep normal email autolinks and explicit markdown mailto links intact
- run the transform before existing misleading/malformed link transforms in the markdown import pipeline

## Test plan
- `npm test -- --runTestsByPath lib/lexical/mdast/transforms/links.spec.js --runInBand`
- `npx standard lib/lexical/mdast/transforms/links.js lib/lexical/mdast/transforms/index.js lib/lexical/utils/mdast.js lib/lexical/mdast/transforms/links.spec.js`
- real-parser `npx tsx --tsconfig jsconfig.json -` smoke check for `@Cointastical@BitcoinHackers.org` plus `hello@example.com`
- `git diff --check`
- `DATABASE_URL='postgresql://stacker:stacker@127.0.0.1:5432/stacker' OPENSEARCH_URL='http://127.0.0.1:9200' npm run build`