### PR TITLE
Disallow URL schemes in post titles

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -57,6 +57,11 @@ const titleValidator = string().required('required').trim().max(
   MAX_TITLE_LENGTH,
   ({ max, value }) => `-${Math.abs(max - value.length)} characters remaining`
 ).min(MIN_TITLE_LENGTH, `must be at least ${MIN_TITLE_LENGTH} characters`)
+  .test(
+    'no-url-scheme',
+    'remove the URL scheme from title',
+    value => !/\b[a-z][a-z0-9+.-]*:\/\//i.test(value || '')
+  )
 
 const textValidator = (max) => string().trim().max(
   max,

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -1,0 +1,23 @@
+/* eslint-env jest */
+
+import { bountySchema, discussionSchema, jobSchema, linkSchema, pollSchema } from './validate.js'
+
+const titleSchemas = [
+  ['bounty', bountySchema({})],
+  ['discussion', discussionSchema({})],
+  ['job', jobSchema({})],
+  ['link', linkSchema({})],
+  ['poll', pollSchema({})]
+]
+
+describe('title validation', () => {
+  test.each(titleSchemas)('rejects URL schemes in %s titles', async (_, schema) => {
+    await expect(schema.validateAt('title', { title: 'Read https://example.com now' }))
+      .rejects.toThrow('remove the URL scheme from title')
+  })
+
+  test.each(titleSchemas)('allows bare domains in %s titles', async (_, schema) => {
+    await expect(schema.validateAt('title', { title: 'Crypto.com stadium hosts big game' }))
+      .resolves.toBe('Crypto.com stadium hosts big game')
+  })
+})


### PR DESCRIPTION
Closes #117.

## Summary
- reject `://` URL schemes in the shared post title validator
- keep bare domains such as `Crypto.com` allowed in titles
- cover discussion, link, bounty, poll, and job title schemas

## Test plan
- `npm test -- --runTestsByPath lib/validate.spec.js --runInBand`
- `npx standard lib/validate.js lib/validate.spec.js`
- `git diff --check`
- `DATABASE_URL='postgresql://stacker:stacker@127.0.0.1:5432/stacker' OPENSEARCH_URL='http://127.0.0.1:9200' npm run build`