### PR TITLE
Restore trailing underscores in autolinks

### DIFF
--- a/lib/lexical/mdast/transforms/index.js
+++ b/lib/lexical/mdast/transforms/index.js
@@ -1,5 +1,5 @@
 export { mentionTransform } from './mentions.js'
 export { nostrTransform } from './nostr.js'
-export { misleadingLinkTransform, malformedLinkEncodingTransform } from './links.js'
+export { trailingUnderscoreLinkTransform, misleadingLinkTransform, malformedLinkEncodingTransform } from './links.js'
 export { footnoteTransform } from './footnotes.js'
 export { tocTransform } from './toc.js'

--- a/lib/lexical/mdast/transforms/links.js
+++ b/lib/lexical/mdast/transforms/links.js
@@ -2,6 +2,41 @@ import { visit } from 'unist-util-visit'
 import { toString } from 'mdast-util-to-string'
 import { isMisleadingLink } from '@/lib/url'
 
+function isBareAutolink (node, text) {
+  if (!node.position) return false
+  if (!node.url || text !== node.url) return false
+  if (node.position.end.offset === undefined || node.position.start.offset === undefined) return false
+  return node.position.end.offset - node.position.start.offset === node.url.length
+}
+
+/**
+ * GFM excludes trailing underscores from bare autolinks, leaving them as an
+ * adjacent text node. Restore them when the parsed link source is exactly the
+ * URL and the underscore run is followed by text boundary punctuation/space.
+ */
+export function trailingUnderscoreLinkTransform (tree) {
+  visit(tree, 'link', (node, index, parent) => {
+    if (!parent || index === undefined) return
+
+    const text = toString(node)
+    if (!isBareAutolink(node, text)) return
+
+    const next = parent.children[index + 1]
+    if (next?.type !== 'text') return
+
+    const match = next.value.match(/^_+(?=$|[\s.,;:!?)]|["'])/)
+    if (!match) return
+
+    node.url += match[0]
+    node.children = [{ type: 'text', value: node.url }]
+    next.value = next.value.slice(match[0].length)
+
+    if (!next.value) {
+      parent.children.splice(index + 1, 1)
+    }
+  })
+}
+
 /**
  * a link is misleading if the text is not the same as the URL.
  *

--- a/lib/lexical/mdast/transforms/links.spec.js
+++ b/lib/lexical/mdast/transforms/links.spec.js
@@ -1,0 +1,132 @@
+/* eslint-env jest */
+jest.mock('unist-util-visit', () => ({
+  visit: (tree, type, visitor) => {
+    function walk (node, parent) {
+      if (!node?.children) return
+
+      for (let i = 0; i < node.children.length; i++) {
+        const child = node.children[i]
+        if (child.type === type) {
+          const nextIndex = visitor(child, i, node)
+          if (typeof nextIndex === 'number') i = nextIndex
+        }
+        walk(child, node)
+      }
+    }
+
+    walk(tree)
+  }
+}))
+
+jest.mock('mdast-util-to-string', () => ({
+  toString: (node) => {
+    if (!node?.children) return node?.value || ''
+    return node.children.map(child => child.value || '').join('')
+  }
+}))
+
+const { trailingUnderscoreLinkTransform, misleadingLinkTransform } = require('./links.js')
+
+// Mirrors mdast-util-gfm parsing of `https://example.com/path_`:
+// a bare autolink node followed by a text node containing the trailing `_`.
+function parsedBareAutolinkTree (url, suffix = '') {
+  return {
+    type: 'root',
+    children: [{
+      type: 'paragraph',
+      children: [
+        { type: 'text', value: 'see ' },
+        {
+          type: 'link',
+          url,
+          title: null,
+          position: { start: { offset: 4 }, end: { offset: 4 + url.length } },
+          children: [{
+            type: 'text',
+            value: url,
+            position: { start: { offset: 4 }, end: { offset: 4 + url.length } }
+          }]
+        },
+        ...(suffix ? [{ type: 'text', value: suffix }] : [])
+      ]
+    }]
+  }
+}
+
+function explicitMarkdownLinkTree (url, suffix = '') {
+  return {
+    type: 'root',
+    children: [{
+      type: 'paragraph',
+      children: [
+        {
+          type: 'link',
+          url,
+          title: null,
+          position: { start: { offset: 0 }, end: { offset: (url.length * 2) + 4 } },
+          children: [{ type: 'text', value: url }]
+        },
+        ...(suffix ? [{ type: 'text', value: suffix }] : [])
+      ]
+    }]
+  }
+}
+
+function firstParagraphChildren (tree) {
+  return tree.children[0].children
+}
+
+describe('trailingUnderscoreLinkTransform', () => {
+  test('restores one trailing underscore excluded from a bare autolink', () => {
+    const tree = parsedBareAutolinkTree('https://twitter.com/some_user', '_')
+
+    trailingUnderscoreLinkTransform(tree)
+
+    const link = firstParagraphChildren(tree)[1]
+    expect(link.type).toBe('link')
+    expect(link.url).toBe('https://twitter.com/some_user_')
+    expect(link.children).toEqual([{ type: 'text', value: 'https://twitter.com/some_user_' }])
+    expect(firstParagraphChildren(tree)).toHaveLength(2)
+  })
+
+  test('restores multiple trailing underscores before text boundary', () => {
+    const tree = parsedBareAutolinkTree('https://example.com/path', '__ and more')
+
+    trailingUnderscoreLinkTransform(tree)
+
+    const children = firstParagraphChildren(tree)
+    expect(children[1].url).toBe('https://example.com/path__')
+    expect(children[2]).toMatchObject({ type: 'text', value: ' and more' })
+  })
+
+  test('does not merge explicit markdown link suffixes', () => {
+    const tree = explicitMarkdownLinkTree('https://example.com/path', '_')
+
+    trailingUnderscoreLinkTransform(tree)
+
+    const children = firstParagraphChildren(tree)
+    expect(children[0].url).toBe('https://example.com/path')
+    expect(children[1]).toMatchObject({ type: 'text', value: '_' })
+  })
+
+  test('does not steal underscores that begin a word after a URL', () => {
+    const tree = parsedBareAutolinkTree('https://example.com/path', '__bold')
+
+    trailingUnderscoreLinkTransform(tree)
+
+    const children = firstParagraphChildren(tree)
+    expect(children[1].url).toBe('https://example.com/path')
+    expect(children[2]).toMatchObject({ type: 'text', value: '__bold' })
+  })
+
+  test('runs before misleading link normalization without rewriting the restored URL text', () => {
+    const tree = parsedBareAutolinkTree('https://example.com/path', '_')
+
+    trailingUnderscoreLinkTransform(tree)
+    misleadingLinkTransform(tree)
+
+    const link = firstParagraphChildren(tree)[1]
+    expect(link.url).toBe('https://example.com/path_')
+    expect(link.children).toEqual([{ type: 'text', value: 'https://example.com/path_' }])
+  })
+})

--- a/lib/lexical/utils/mdast.js
+++ b/lib/lexical/utils/mdast.js
@@ -16,6 +16,7 @@ import {
 import {
   mentionTransform,
   nostrTransform,
+  trailingUnderscoreLinkTransform,
   misleadingLinkTransform,
   malformedLinkEncodingTransform,
   footnoteTransform,
@@ -51,6 +52,7 @@ export function $markdownToLexical (markdown, { splitInParagraphs = false, appen
     mdastTransforms: [
       mentionTransform,
       nostrTransform,
+      trailingUnderscoreLinkTransform,
       misleadingLinkTransform,
       malformedLinkEncodingTransform,
       footnoteTransform,


### PR DESCRIPTION
Fixes #180.

## Description

GFM parses a bare URL like `https://twitter.com/some_user_` as a link ending at `some_user`, then leaves the trailing `_` as the next text node. This adds a small MDAST transform that runs before misleading-link normalization and merges adjacent trailing underscores back into bare autolinks.

This version is intentionally narrower than my closed #3068 attempt:
- uses the existing `visit(tree, 'link', ...)` traversal, no extra custom production traversal
- only applies when the link source is exactly the URL, so explicit markdown links are left alone
- only consumes underscore runs at a text boundary, avoiding cases like `https://example.com/path__bold`

## Additional Context

Jest in this repo cannot import the ESM GFM parser modules directly, so the committed unit test uses the observed MDAST shape for this parser edge. I also ran a real `mdast-util-from-markdown` + GFM parser smoke through `tsx` against the production transform.

BTC payout address if eligible for a sats award: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. It only changes bare autolinks whose parsed source is exactly the URL and whose next text sibling begins with trailing underscores at a boundary. Explicit markdown links and word-leading underscores are unchanged.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

8/10. Added focused transform coverage, reran URL helper tests, ran a real parser smoke through `tsx`, and completed a production build.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Not a visual frontend change.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes. AI assisted with issue triage, implementation, and validation. I checked the previous closed PR/review, kept the new production change small, and ran the commands below.

Validation:

- `npm test -- --runTestsByPath lib/lexical/mdast/transforms/links.spec.js lib/url.spec.js --runInBand`
- `npx standard lib/lexical/mdast/transforms/links.js lib/lexical/mdast/transforms/links.spec.js lib/lexical/mdast/transforms/index.js lib/lexical/utils/mdast.js`
- real GFM parser smoke with `npx tsx --tsconfig jsconfig.json -`
- `git diff --check`
- `DATABASE_URL='postgresql://stacker:stacker@127.0.0.1:5432/stacker' OPENSEARCH_URL='http://127.0.0.1:9200' npm run build`