### PR TITLE
[codex] Exclude seen items from pagination

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1,6 +1,6 @@
 import { ensureProtocol, removeTracking, stripTrailingSlash } from '@/lib/url'
 import { snFetch } from '@/lib/fetch'
-import { decodeCursor, nextCursorEncoded } from '@/lib/cursor'
+import { decodeCursor, itemCursorIds, itemCursorOffset, nextItemCursorEncoded } from '@/lib/cursor'
 import { getMetadata, metadataRuleSets } from 'page-metadata-parser'
 import { ruleSet as publicationDateRuleSet } from '@/lib/timedate-scraper'
 import domino from 'domino'
@@ -214,6 +214,9 @@ export const whereClause = (...clauses) => {
   return clause ? ` WHERE ${clause} ` : ''
 }
 
+const seenItemClause = (ids, num) =>
+  ids.length > 0 ? `NOT ("Item".id = ANY($${num}::INTEGER[]))` : ''
+
 function whenClause (when, table) {
   return `"${table}".created_at <= $2 and "${table}".created_at >= $1`
 }
@@ -379,6 +382,9 @@ export default {
     items: async (parent, { sub, sort, type, cursor, name, when, from, to, by, limit }, ctx) => {
       const { me, models, userLoader } = ctx
       const decodedCursor = decodeCursor(cursor)
+      const seenItemIds = itemCursorIds(decodedCursor)
+      const seenItemArgs = seenItemIds.length > 0 ? [seenItemIds] : []
+      const offset = itemCursorOffset(decodedCursor)
       let items, user, pins, table
 
       // special authorization for bookmarks depending on owning users' privacy settings
@@ -430,12 +436,13 @@ export default {
                 activeOrMine(me),
                 typeClause(type),
                 by === 'downsats' && '"Item"."downMsats" > 0',
+                seenItemClause(seenItemIds, 6),
                 whenClause(when || 'forever', table))}
               ${orderByClause(by, me, models, type)}
               OFFSET $4
               LIMIT $5`,
             orderBy: orderByClause(by, me, models, type)
-          }, ...whenRange(when, from, to || decodedCursor.time), user.id, decodedCursor.offset, limit)
+          }, ...whenRange(when, from, to || decodedCursor.time), user.id, offset, limit, ...seenItemArgs)
           break
         case 'new':
           items = await itemQueryWithMeta({
@@ -452,13 +459,14 @@ export default {
                 activeOrMine(me),
                 await filterClause(type, sub, 'new', ctx),
                 typeClause(type),
-                muteClause(me)
+                muteClause(me),
+                seenItemClause(seenItemIds, 4 + subArr.length)
               )}
               ORDER BY "PayIn"."payInStateChangedAt" DESC
               OFFSET $2
               LIMIT $3`,
             orderBy: 'ORDER BY "PayIn"."payInStateChangedAt" DESC'
-          }, decodedCursor.time, decodedCursor.offset, limit, ...subArr)
+          }, decodedCursor.time, offset, limit, ...subArr, ...seenItemArgs)
           break
         case 'top':
           items = await itemQueryWithMeta({
@@ -478,12 +486,13 @@ export default {
                 '"Item".status = \'ACTIVE\'',
                 by === 'downsats' && '"Item"."downMsats" > 0',
                 await filterClause(type, sub, 'top', ctx, by),
-                muteClause(me))}
+                muteClause(me),
+                seenItemClause(seenItemIds, 5 + subArr.length))}
               ${orderByClause(by || 'sats', me, models, type, sub)}
               OFFSET $3
               LIMIT $4`,
             orderBy: orderByClause(by || 'sats', me, models, type, sub)
-          }, ...whenRange(when, from, to || decodedCursor.time), decodedCursor.offset, limit, ...subArr)
+          }, ...whenRange(when, from, to || decodedCursor.time), offset, limit, ...subArr, ...seenItemArgs)
           break
         default:
           if (decodedCursor.offset === 0) {
@@ -530,16 +539,17 @@ export default {
                   '"Item".status = \'ACTIVE\'',
                   await filterClause(type, sub, 'lit', ctx),
                   subClause(sub, 3, 'Item', me, showNsfw),
-                  muteClause(me))}
+                  muteClause(me),
+                  seenItemClause(seenItemIds, 3 + subArr.length))}
                 ORDER BY ranklit DESC, "Item".id DESC
                 OFFSET $1
                 LIMIT $2`,
             orderBy: 'ORDER BY ranklit DESC, "Item".id DESC'
-          }, decodedCursor.offset, limit, ...subArr)
+          }, offset, limit, ...subArr, ...seenItemArgs)
           break
       }
       return {
-        cursor: items.length === limit ? nextCursorEncoded(decodedCursor, limit) : null,
+        cursor: items.length === limit ? nextItemCursorEncoded(decodedCursor, items, limit) : null,
         items,
         pins
       }

--- a/lib/cursor.js
+++ b/lib/cursor.js
@@ -17,6 +17,33 @@ export function nextCursorEncoded (cursor, limit = LIMIT) {
   return Buffer.from(JSON.stringify(nextCursor)).toString('base64')
 }
 
+export function itemCursorIds (cursor) {
+  if (!Array.isArray(cursor?.ids)) {
+    return []
+  }
+
+  return [...new Set(cursor.ids
+    .map(id => Number(id))
+    .filter(id => Number.isInteger(id) && id > 0))]
+}
+
+export function itemCursorOffset (cursor) {
+  return itemCursorIds(cursor).length > 0 ? 0 : cursor.offset
+}
+
+export function nextItemCursorEncoded (cursor, items = [], limit = LIMIT) {
+  const ids = itemCursorIds({
+    ids: [
+      ...itemCursorIds(cursor),
+      ...items.map(item => item?.id)
+    ]
+  })
+
+  const nextCursor = { ...cursor, ids }
+  nextCursor.offset += limit
+  return Buffer.from(JSON.stringify(nextCursor)).toString('base64')
+}
+
 export function nextNoteCursorEncoded (cursor, notifications = [], limit = LIMIT) {
   const nextCursor = { ...cursor }
   // what we are looking for this oldest sort time for every table we are looking at

--- a/lib/cursor.spec.js
+++ b/lib/cursor.spec.js
@@ -1,0 +1,62 @@
+/* eslint-env jest */
+
+import {
+  decodeCursor,
+  itemCursorIds,
+  itemCursorOffset,
+  nextCursorEncoded,
+  nextItemCursorEncoded
+} from './cursor.js'
+
+const baseCursor = () => ({
+  offset: 0,
+  time: new Date('2026-06-14T00:00:00.000Z')
+})
+
+describe('cursor', () => {
+  test('nextCursorEncoded keeps generic cursors offset-only', () => {
+    const decoded = decodeCursor(nextCursorEncoded(baseCursor()))
+
+    expect(decoded.offset).toBe(21)
+    expect(decoded.ids).toBeUndefined()
+    expect(decoded.time).toEqual(baseCursor().time)
+  })
+
+  test('nextItemCursorEncoded records rendered item ids', () => {
+    const decoded = decodeCursor(nextItemCursorEncoded(baseCursor(), [
+      { id: '1' },
+      { id: 2 },
+      { id: 'not-a-number' },
+      { id: 0 },
+      null
+    ]))
+
+    expect(decoded.offset).toBe(21)
+    expect(decoded.ids).toEqual([1, 2])
+    expect(itemCursorOffset(decoded)).toBe(0)
+  })
+
+  test('nextItemCursorEncoded appends ids without duplicating them', () => {
+    const firstPage = decodeCursor(nextItemCursorEncoded(baseCursor(), [
+      { id: 1 },
+      { id: 2 }
+    ]))
+    const secondPage = decodeCursor(nextItemCursorEncoded(firstPage, [
+      { id: 2 },
+      { id: 3 }
+    ]))
+
+    expect(secondPage.offset).toBe(42)
+    expect(secondPage.ids).toEqual([1, 2, 3])
+  })
+
+  test('itemCursorOffset preserves old offset-only cursors', () => {
+    expect(itemCursorOffset({ offset: 42 })).toBe(42)
+  })
+
+  test('itemCursorIds normalizes cursor ids', () => {
+    expect(itemCursorIds({
+      ids: [1, '2', 1, -3, 1.1, null, undefined, 'nope']
+    })).toEqual([1, 2])
+  })
+})


### PR DESCRIPTION
## Summary
- add item-specific cursor payloads that carry already-rendered item IDs
- exclude those seen IDs from subsequent item list pages
- keep old offset-only cursors compatible while using offset 0 once seen IDs are available

## Why
Ranked lit/top feeds can reorder between the initial page and the More request, so an offset-only cursor can return an item the user already saw. Carrying seen item IDs in the cursor lets the next page explicitly filter them out.

Fixes #147.

## Testing
- npm test -- --runTestsByPath lib/cursor.spec.js --runInBand
- npx standard api/resolvers/item.js lib/cursor.js lib/cursor.spec.js
- npm test -- --runInBand
- git diff --check
- DATABASE_URL='postgresql://stacker:stacker@127.0.0.1:5432/stacker' OPENSEARCH_URL='http://127.0.0.1:9200' npm run build