### PR TITLE
[codex] Show images in push notifications

### DIFF
--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -1,11 +1,11 @@
 import webPush from 'web-push'
-import removeMd from 'remove-markdown'
 import { COMMENT_DEPTH_LIMIT, FOUND_BLURBS, LOST_BLURBS, DEFAULT_POSTS_SATS_FILTER, DEFAULT_COMMENTS_SATS_FILTER } from './constants'
 import { msatsToSats, numWithUnits } from './format'
 import { nextBillingWithGrace } from '@/lib/territory'
 import models from '@/api/models'
 import { isMuted } from '@/lib/user'
 import { Prisma } from '@prisma/client'
+import { createPayload, firstPushImageUrl } from './webPushPayload'
 
 // Check if an item meets a user's sat filter threshold for push notifications
 async function meetsUserSatFilter (userId, item) {
@@ -60,28 +60,12 @@ function log (...args) {
   console.log('[webPush]', ...args)
 }
 
-function createPayload (notification) {
-  // https://web.dev/push-notifications-display-a-notification/#visual-options
-  // https://webkit.org/blog/16535/meet-declarative-web-push/
-  // DEV: localhost in URLs is not supported by declarative web push
-  let { title, body, ...options } = notification
-  if (body) body = removeMd(body)
-  return JSON.stringify({
-    web_push: 8030, // Declarative Web Push JSON format
-    notification: {
-      title,
-      body,
-      timestamp: Date.now(),
-      icon: process.env.NEXT_PUBLIC_URL + '/icons/icon_x96.png',
-      navigate: process.env.NEXT_PUBLIC_URL + '/notifications', // navigate is required
-      app_badge: 1, // TODO: establish a proper badge count system
-      ...options
-    }
-  })
-}
-
 function userFilterFragment (setting) {
   return setting ? { user: { [setting]: true } } : undefined
+}
+
+function itemImage (item) {
+  return firstPushImageUrl(item?.text, item?.imgproxyUrls)
 }
 
 async function createItemUrl (id) {
@@ -227,6 +211,8 @@ export async function notifyUserSubscribers ({ models, item }) {
         .map(({ followerId, followeeName }) => sendUserNotification(followerId, {
           title: `@${followeeName} ${isPost ? 'created a post' : 'replied to a post'}`,
           body: isPost ? item.title : item.text,
+          image: itemImage(item),
+          imgproxyUrls: item.imgproxyUrls,
           itemId: item.id
         }))
     )
@@ -272,6 +258,8 @@ export async function notifyTerritorySubscribers ({ models, item }) {
           sendUserNotification(userId, {
             title: `@${author.name} created a post in ~${subName}`,
             body: item.title,
+            image: itemImage(item),
+            imgproxyUrls: item.imgproxyUrls,
             itemId: item.id
           }))
     )
@@ -315,6 +303,8 @@ export async function notifyThreadSubscribers ({ models, item }) {
           sendUserNotification(userId, {
             title: `@${author.name} replied to a post`,
             body: item.text,
+            image: itemImage(item),
+            imgproxyUrls: item.imgproxyUrls,
             itemId: item.id
           })
         )
@@ -354,6 +344,8 @@ export async function notifyItemParents ({ models, item }) {
           return sendUserNotification(userId, {
             title: `@${user.name} replied to you`,
             body: item.text,
+            image: itemImage(item),
+            imgproxyUrls: item.imgproxyUrls,
             itemId: item.id,
             setting: isDirect ? undefined : 'noteAllDescendants'
           })
@@ -395,6 +387,8 @@ export async function notifyZapped ({ models, item }) {
     await sendUserNotification(item.userId, {
       title,
       body: item.title ? item.title : item.text,
+      image: itemImage(item),
+      imgproxyUrls: item.imgproxyUrls,
       itemId: item.id,
       setting: 'noteItemSats',
       tag: `TIP-${item.id}`
@@ -405,6 +399,8 @@ export async function notifyZapped ({ models, item }) {
       await Promise.allSettled(mappedForwards.map(forward => sendUserNotification(forward.user.id, {
         title: `you were forwarded ${numWithUnits(Math.round(msatsToSats(item.msats) * forward.pct / 100))}`,
         body: item.title ?? item.text,
+        image: itemImage(item),
+        imgproxyUrls: item.imgproxyUrls,
         itemId: item.id,
         setting: 'noteForwardedSats',
         tag: `FORWARDEDTIP-${item.id}`
@@ -432,6 +428,8 @@ export async function notifyBountyPaid ({ models, item, payIn }) {
     await sendUserNotification(item.userId, {
       title,
       body: item.title ?? item.text,
+      image: itemImage(item),
+      imgproxyUrls: item.imgproxyUrls,
       itemId: item.id,
       setting: 'noteItemSats',
       tag: `BOUNTY-${item.id}`
@@ -452,6 +450,8 @@ export async function notifyMention ({ models, userId, item }) {
     await sendUserNotification(userId, {
       title: `@${item.user.name} mentioned you`,
       body: item.text,
+      image: itemImage(item),
+      imgproxyUrls: item.imgproxyUrls,
       itemId: item.id,
       setting: 'noteMentions'
     })
@@ -476,6 +476,8 @@ export async function notifyItemMention ({ models, referrerItem, refereeItem }) 
     await sendUserNotification(refereeItem.userId, {
       title: `@${referrer.name} mentioned one of your items`,
       body,
+      image: itemImage(referrerItem),
+      imgproxyUrls: referrerItem.imgproxyUrls,
       itemId: referrerItem.id,
       setting: 'noteItemMentions'
     })
@@ -601,6 +603,8 @@ export async function notifyReminder ({ userId, item }) {
   await sendUserNotification(userId, {
     title: 'you requested this reminder',
     body: item.title ?? item.text,
+    image: itemImage(item),
+    imgproxyUrls: item.imgproxyUrls,
     itemId: item.id
   })
 }

--- a/lib/webPushPayload.js
+++ b/lib/webPushPayload.js
@@ -1,0 +1,61 @@
+import removeMd from 'remove-markdown'
+
+const MARKDOWN_IMAGE_URL_REGEXP = /!\[[^\]]*]\(\s*(?:<([^>]+)>|([^\s)]+))(?:\s+["'][^"']*["'])?\s*\)/g
+const URL_REGEXP = /https?:\/\/[^\s<>)]+/g
+const IMAGE_URL_REGEXP = /\.(?:png|jpe?g|gif|webp)(?:[?#].*)?$/i
+
+function normalizedHttpUrl (url) {
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return
+    return parsed.toString()
+  } catch {
+    return undefined
+  }
+}
+
+function isPushImageUrl (url, imgproxyUrls) {
+  const metadata = imgproxyUrls?.[url]
+  if (metadata?.video) return false
+  if (metadata) return true
+
+  return IMAGE_URL_REGEXP.test(new URL(url).pathname)
+}
+
+export function firstPushImageUrl (markdown, imgproxyUrls) {
+  if (typeof markdown !== 'string') return
+
+  for (const match of markdown.matchAll(MARKDOWN_IMAGE_URL_REGEXP)) {
+    const url = normalizedHttpUrl(match[1] || match[2])
+    if (url && isPushImageUrl(url, imgproxyUrls)) return url
+  }
+
+  for (const match of markdown.matchAll(URL_REGEXP)) {
+    const url = normalizedHttpUrl(match[0])
+    if (url && isPushImageUrl(url, imgproxyUrls)) return url
+  }
+}
+
+export function createPayload (notification) {
+  // https://web.dev/push-notifications-display-a-notification/#visual-options
+  // https://webkit.org/blog/16535/meet-declarative-web-push/
+  // DEV: localhost in URLs is not supported by declarative web push
+  let { title, body, imgproxyUrls, ...options } = notification
+  if (body) {
+    options.image ??= firstPushImageUrl(body, imgproxyUrls)
+    body = removeMd(body).trim() || undefined
+  }
+
+  return JSON.stringify({
+    web_push: 8030, // Declarative Web Push JSON format
+    notification: {
+      title,
+      body,
+      timestamp: Date.now(),
+      icon: process.env.NEXT_PUBLIC_URL + '/icons/icon_x96.png',
+      navigate: process.env.NEXT_PUBLIC_URL + '/notifications', // navigate is required
+      app_badge: 1, // TODO: establish a proper badge count system
+      ...options
+    }
+  })
+}

--- a/lib/webPushPayload.spec.js
+++ b/lib/webPushPayload.spec.js
@@ -1,0 +1,80 @@
+/* eslint-env jest */
+
+import { createPayload, firstPushImageUrl } from './webPushPayload.js'
+
+const parsePayload = notification => JSON.parse(createPayload(notification)).notification
+
+describe('web push payload', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_URL = 'https://stacker.news'
+  })
+
+  test('uses the first markdown image as the notification image', () => {
+    const image = 'https://example.com/first.png'
+    const second = 'https://example.com/second.png'
+
+    expect(firstPushImageUrl(`![](${image})\n![](${second})`)).toBe(image)
+  })
+
+  test('uses imgproxy metadata for uploaded image URLs without extensions', () => {
+    const image = 'https://m.stacker.news/12345'
+
+    expect(firstPushImageUrl(`![](${image})`, {
+      [image]: { width: 640, height: 480 }
+    })).toBe(image)
+  })
+
+  test('skips uploaded videos when choosing a push image', () => {
+    const video = 'https://m.stacker.news/12345'
+    const image = 'https://m.stacker.news/67890'
+
+    expect(firstPushImageUrl(`![](${video})\n![](${image})`, {
+      [video]: { video: true },
+      [image]: { width: 640, height: 480 }
+    })).toBe(image)
+  })
+
+  test('finds bare image URLs in notification bodies', () => {
+    const image = 'https://example.com/photo.webp'
+
+    expect(firstPushImageUrl(`look ${image}`)).toBe(image)
+  })
+
+  test('adds image while preserving formatted text as plain body', () => {
+    const image = 'https://example.com/photo.jpg'
+    const notification = parsePayload({
+      title: '@alice replied to you',
+      body: `**hello**\n\n![](${image})`
+    })
+
+    expect(notification.title).toBe('@alice replied to you')
+    expect(notification.body).toBe('hello')
+    expect(notification.image).toBe(image)
+    expect(notification.icon).toBe('https://stacker.news/icons/icon_x96.png')
+    expect(notification.navigate).toBe('https://stacker.news/notifications')
+  })
+
+  test('does not override an explicit notification image', () => {
+    const notification = parsePayload({
+      title: 'title',
+      body: '![](https://example.com/from-body.jpg)',
+      image: 'https://example.com/explicit.jpg'
+    })
+
+    expect(notification.image).toBe('https://example.com/explicit.jpg')
+  })
+
+  test('does not leak imgproxy metadata into the payload', () => {
+    const image = 'https://m.stacker.news/12345'
+    const notification = parsePayload({
+      title: 'title',
+      body: `![](${image})`,
+      imgproxyUrls: {
+        [image]: { width: 640, height: 480 }
+      }
+    })
+
+    expect(notification.image).toBe(image)
+    expect(notification.imgproxyUrls).toBeUndefined()
+  })
+})

--- a/lib/webPushPayload.spec.js
+++ b/lib/webPushPayload.spec.js
@@ -54,6 +54,16 @@ describe('web push payload', () => {
     expect(notification.navigate).toBe('https://stacker.news/notifications')
   })
 
+  test('normalizes formatted markdown replies to a plain notification body', () => {
+    const notification = parsePayload({
+      title: '@alice replied to you',
+      body: '> **hello** [stackers](https://stacker.news)\n\n`ship it`'
+    })
+
+    expect(notification.body).toBe('hello stackers\n\nship it')
+    expect(notification.image).toBeUndefined()
+  })
+
   test('does not override an explicit notification image', () => {
     const notification = parsePayload({
       title: 'title',


### PR DESCRIPTION
## Summary
- extract the first image URL from notification markdown bodies
- attach it with the Web Push notification image option
- support SN uploaded media URLs through existing imgproxy metadata while skipping uploaded videos
- normalize formatted markdown replies into a plain notification body
- avoid leaking imgproxy metadata into the push payload

## Why
Image-only replies/posts can lose their visible body after markdown cleanup. Adding the notification image option lets supported browsers show the first image while preserving the usual plain-text body when text is present.

Formatted replies can also surface raw markdown in Android/PWA push bodies; this keeps push notification text browser-safe and readable by using the same payload normalization path.

Fixes #577.
Fixes #2852.

## Testing
- npm test -- --runTestsByPath lib/webPushPayload.spec.js --runInBand
- npx standard lib/webPush.js lib/webPushPayload.js lib/webPushPayload.spec.js
- npm test -- --runInBand
- git diff --check
- DATABASE_URL='postgresql://stacker:stacker@127.0.0.1:5432/stacker' OPENSEARCH_URL='http://127.0.0.1:9200' npm run build
