### PR TITLE
Document @delete bot bio

### DIFF
--- a/prisma/migrations/20260614133000_delete_bot_bio/migration.sql
+++ b/prisma/migrations/20260614133000_delete_bot_bio/migration.sql
@@ -1,0 +1,49 @@
+DO $$
+DECLARE
+  delete_user_id INTEGER;
+  delete_bio_id INTEGER;
+  delete_payin_id INTEGER;
+  delete_bio_text TEXT := E'I delete posts and comments when you ask me to.\n\nUse `@delete in n units` in a post or comment, where `n` is a number and `units` can be seconds, minutes, hours, days, weeks, months, or years.\n\nExamples:\n\n- `@delete in 48 hours`\n- `@delete in 1 week`\n\nOnly the last valid `@delete` command in an item is used. Editing the item updates or removes the scheduled deletion. When the time arrives, the item is deleted by the author and the original content is no longer available from Stacker News.';
+BEGIN
+  SELECT id, "bioId"
+  INTO delete_user_id, delete_bio_id
+  FROM users
+  WHERE name = 'delete';
+
+  IF delete_user_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF delete_bio_id IS NULL THEN
+    INSERT INTO "Item" (title, text, "userId", bio, created_at, updated_at)
+    VALUES ('@delete''s bio', delete_bio_text, delete_user_id, true, now_utc(), now_utc())
+    RETURNING id INTO delete_bio_id;
+
+    UPDATE users
+    SET "bioId" = delete_bio_id
+    WHERE id = delete_user_id;
+  ELSE
+    UPDATE "Item"
+    SET title = '@delete''s bio',
+        text = delete_bio_text,
+        bio = true,
+        updated_at = now_utc()
+    WHERE id = delete_bio_id;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM "ItemPayIn"
+    JOIN "PayIn" ON "PayIn".id = "ItemPayIn"."payInId"
+    WHERE "ItemPayIn"."itemId" = delete_bio_id
+      AND "PayIn"."payInType" = 'ITEM_CREATE'
+      AND "PayIn"."payInState" = 'PAID'
+  ) THEN
+    INSERT INTO "PayIn" (created_at, updated_at, mcost, "payInType", "payInState", "payInStateChangedAt", "userId")
+    VALUES (now_utc(), now_utc(), 0, 'ITEM_CREATE', 'PAID', now_utc(), delete_user_id)
+    RETURNING id INTO delete_payin_id;
+
+    INSERT INTO "ItemPayIn" ("itemId", "payInId")
+    VALUES (delete_bio_id, delete_payin_id);
+  END IF;
+END $$;


### PR DESCRIPTION
Fixes #2994.

## Description

Adds an idempotent migration that creates or updates the `@delete` bot bio so `/delete` explains what the bot does, the supported command format, and examples like `@delete in 48 hours`.

The migration also ensures a newly-created bot bio has a zero-cost paid `ITEM_CREATE` `PayIn` and `ItemPayIn` link, so the profile bio remains visible through the current item query path. Existing bios are updated in place.

## Screenshots

Not applicable; data migration only.

## Additional Context

BTC payout address if eligible for a sats award: `bc1qev5ant33v5y89qqjvcf4mh9hlax5svqf5xd7gc`

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. Existing `@delete` bot behavior is unchanged; this only adds or updates explanatory bio content and repairs the create-pay-in linkage if needed.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

6/10. Verified the Prisma schema with a dummy `DATABASE_URL` and checked the migration diff for whitespace issues. The migration is idempotent and scoped to the `delete` user.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Not a frontend rendering change.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes. AI assisted with issue triage, migration implementation, and validation.

Validation:

- `DATABASE_URL=postgresql://user:pass@localhost:5432/stackernews npx prisma validate`
- `git diff --check`