### PR TITLE
[codex] Preserve full text expansion in route

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router'
 import classNames from 'classnames'
 import { CarouselProvider, useCarousel } from './carousel'
 import { SNReader } from './editor'
+import { fullTextAsPath, shouldShowFullTextForPath } from '@/lib/full-text'
 
 export function SearchText ({ text }) {
   return (
@@ -19,27 +20,38 @@ export function SearchText ({ text }) {
   )
 }
 
-export function useOverflow ({ containerRef, truncated = false }) {
+export function useOverflow ({ containerRef, truncated = false, itemId }) {
   const router = useRouter()
   // would the text overflow on the current screen size?
   const [overflowing, setOverflowing] = useState(false)
   // should we show the full text?
   const [show, setShow] = useState(false)
-  const showOverflow = useCallback(() => setShow(true), [setShow])
+  const showOverflow = useCallback(() => {
+    setShow(true)
 
-  // if we are navigating to a hash, show the full text
+    if (!itemId) return
+
+    const nextAsPath = fullTextAsPath(router.asPath, itemId)
+    if (nextAsPath !== router.asPath) {
+      router.replace(nextAsPath, undefined, { shallow: true, scroll: false })
+    }
+  }, [itemId, router])
+
+  // if the route targets hidden text, show the full text
   useEffect(() => {
-    setShow(router.asPath.includes('#'))
-    const handleRouteChange = (url, { shallow }) => {
-      setShow(url.includes('#'))
+    setShow(shouldShowFullTextForPath(router.asPath, itemId))
+    const handleRouteChange = (url) => {
+      setShow(shouldShowFullTextForPath(url, itemId))
     }
 
     router.events.on('hashChangeStart', handleRouteChange)
+    router.events.on('routeChangeComplete', handleRouteChange)
 
     return () => {
       router.events.off('hashChangeStart', handleRouteChange)
+      router.events.off('routeChangeComplete', handleRouteChange)
     }
-  }, [router.asPath, router.events])
+  }, [itemId, router.asPath, router.events])
 
   // clip item and give it a`show full text` button if we are overflowing
   useEffect(() => {
@@ -121,9 +133,9 @@ export default function Text (props) {
   return <TextBody {...props} />
 }
 
-export function TextBody ({ topLevel, children, className, innerClassName, state, html, imgproxyUrls, rel, name, readerRef }) {
+export function TextBody ({ itemId, topLevel, children, className, innerClassName, state, html, imgproxyUrls, rel, name, readerRef }) {
   const containerRef = useRef(null)
-  const { overflowing, show, Overflow } = useOverflow({ containerRef, truncated: !!children })
+  const { overflowing, show, Overflow } = useOverflow({ containerRef, truncated: !!children, itemId })
   const carousel = useCarousel()
 
   const textClassNames = useMemo(() => {

--- a/lib/full-text.js
+++ b/lib/full-text.js
@@ -1,0 +1,27 @@
+export const FULL_TEXT_QUERY_PARAM = 'fullText'
+
+export function fullTextAsPath (asPath, itemId) {
+  if (!itemId) return asPath
+
+  const [pathAndSearch, hash] = asPath.split('#')
+  const [pathname, search] = pathAndSearch.split('?')
+  const params = new URLSearchParams(search)
+  params.set(FULL_TEXT_QUERY_PARAM, String(itemId))
+
+  const query = params.toString()
+  return `${pathname}${query ? `?${query}` : ''}${hash ? `#${hash}` : ''}`
+}
+
+export function isFullTextItemPath (asPath, itemId) {
+  if (!itemId) return false
+
+  const [pathAndSearch] = asPath.split('#')
+  const [, search] = pathAndSearch.split('?')
+  const params = new URLSearchParams(search)
+
+  return params.get(FULL_TEXT_QUERY_PARAM) === String(itemId)
+}
+
+export function shouldShowFullTextForPath (asPath, itemId) {
+  return asPath.includes('#') || isFullTextItemPath(asPath, itemId)
+}

--- a/lib/full-text.spec.js
+++ b/lib/full-text.spec.js
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+
+import { fullTextAsPath, shouldShowFullTextForPath } from './full-text'
+
+describe('full text route state', () => {
+  test('adds the matching item id to a clean item path', () => {
+    expect(fullTextAsPath('/items/123', 123)).toBe('/items/123?fullText=123')
+  })
+
+  test('preserves existing query params and hash fragments', () => {
+    expect(fullTextAsPath('/items/123?sort=recent#comments', 123))
+      .toBe('/items/123?sort=recent&fullText=123#comments')
+  })
+
+  test('replaces stale full text ids', () => {
+    expect(fullTextAsPath('/items/123?fullText=456&sort=recent', 123))
+      .toBe('/items/123?fullText=123&sort=recent')
+  })
+
+  test('expands hash links and matching item ids only', () => {
+    expect(shouldShowFullTextForPath('/items/123#section', 456)).toBe(true)
+    expect(shouldShowFullTextForPath('/items/123?fullText=123', 123)).toBe(true)
+    expect(shouldShowFullTextForPath('/items/123?fullText=456', 123)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- store expanded item text state in a `fullText=<itemId>` route query param when a truncated post/comment is opened
- restore expanded text from that route state after back/forward navigation
- keep existing hash-link behavior so hash targets still reveal hidden text
- add focused coverage for full-text route helpers

## Why
Long posts collapse again after clicking an internal link and using browser back, which also breaks scroll restoration. Persisting the expanded item id in the route lets the item render fully when the browser returns to the previous entry.

Closes #2818.

## Testing
- `npm test -- --runTestsByPath lib/full-text.spec.js --runInBand`
- `npx standard components/text.js lib/full-text.js lib/full-text.spec.js`
- `DATABASE_URL=postgresql://stacker:stacker@127.0.0.1:5432/stacker OPENSEARCH_URL=http://127.0.0.1:9200 npm run build`
