### PR TITLE
[codex] Resume item threads in installed PWA

### DIFF
--- a/lib/pwa-resume.js
+++ b/lib/pwa-resume.js
@@ -1,0 +1,44 @@
+export const PWA_RESUME_STORAGE_KEY = 'sn:pwa-resume'
+export const PWA_RESUME_MAX_AGE_MS = 24 * 60 * 60 * 1000
+
+export function isStandalonePWA (win = typeof window === 'undefined' ? null : window) {
+  return !!(
+    win?.navigator?.standalone === true ||
+    win?.matchMedia?.('(display-mode: standalone)')?.matches
+  )
+}
+
+export function isPWAStartPath (asPath) {
+  const [pathAndSearch] = String(asPath || '').split('#')
+  const [pathname, search] = pathAndSearch.split('?')
+  if (pathname !== '/') return false
+
+  const params = new URLSearchParams(search)
+  params.delete('nodata')
+  return Array.from(params).length === 0
+}
+
+export function isPWAResumePath (asPath) {
+  const [pathAndSearch] = String(asPath || '').split('#')
+  const [pathname] = pathAndSearch.split('?')
+  return /^\/items\/[^/]+$/.test(pathname)
+}
+
+export function createPWAResumeEntry (asPath, now = Date.now()) {
+  if (!isPWAResumePath(asPath)) return null
+  return JSON.stringify({ asPath, ts: now })
+}
+
+export function getPWAResumePath (entry, now = Date.now(), maxAge = PWA_RESUME_MAX_AGE_MS) {
+  if (!entry) return null
+
+  try {
+    const parsed = JSON.parse(entry)
+    if (!isPWAResumePath(parsed?.asPath)) return null
+    if (typeof parsed?.ts !== 'number') return null
+    if (parsed.ts > now || now - parsed.ts > maxAge) return null
+    return parsed.asPath
+  } catch {
+    return null
+  }
+}

--- a/lib/pwa-resume.spec.js
+++ b/lib/pwa-resume.spec.js
@@ -1,0 +1,55 @@
+/* eslint-env jest */
+
+import {
+  createPWAResumeEntry,
+  getPWAResumePath,
+  isPWAResumePath,
+  isPWAStartPath,
+  isStandalonePWA,
+  PWA_RESUME_MAX_AGE_MS
+} from './pwa-resume'
+
+describe('PWA resume helpers', () => {
+  test('detects standalone display modes', () => {
+    expect(isStandalonePWA({
+      navigator: { standalone: true }
+    })).toBe(true)
+
+    expect(isStandalonePWA({
+      navigator: {},
+      matchMedia: () => ({ matches: true })
+    })).toBe(true)
+
+    expect(isStandalonePWA({
+      navigator: {},
+      matchMedia: () => ({ matches: false })
+    })).toBe(false)
+  })
+
+  test('treats only root paths as PWA start paths', () => {
+    expect(isPWAStartPath('/')).toBe(true)
+    expect(isPWAStartPath('/?nodata=true')).toBe(true)
+    expect(isPWAStartPath('/?disablePrompt=true')).toBe(false)
+    expect(isPWAStartPath('/items/123')).toBe(false)
+  })
+
+  test('stores item threads and ignores other app paths', () => {
+    expect(isPWAResumePath('/items/123')).toBe(true)
+    expect(isPWAResumePath('/items/123?commentId=456#comments')).toBe(true)
+    expect(isPWAResumePath('/wallets/send')).toBe(false)
+    expect(isPWAResumePath('/')).toBe(false)
+  })
+
+  test('round trips a valid resume entry', () => {
+    const entry = createPWAResumeEntry('/items/123?commentId=456#comments', 1000)
+
+    expect(getPWAResumePath(entry, 2000)).toBe('/items/123?commentId=456#comments')
+  })
+
+  test('rejects stale, future, malformed, and non-resumable entries', () => {
+    expect(getPWAResumePath(createPWAResumeEntry('/items/123', 1000), 1000 + PWA_RESUME_MAX_AGE_MS + 1)).toBe(null)
+    expect(getPWAResumePath(createPWAResumeEntry('/items/123', 2000), 1000)).toBe(null)
+    expect(getPWAResumePath('nope', 1000)).toBe(null)
+    expect(getPWAResumePath(JSON.stringify({ asPath: '/wallets/send', ts: 1000 }), 2000)).toBe(null)
+  })
+})

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -26,6 +26,13 @@ import { WalletsProvider } from '@/wallets/client/hooks'
 import FaviconProvider from '@/components/favicon'
 import { CookiesProvider } from '@/components/use-cookie'
 import { patchDOMTranslations } from '@/lib/patch-dom-translate'
+import {
+  createPWAResumeEntry,
+  getPWAResumePath,
+  isPWAStartPath,
+  isStandalonePWA,
+  PWA_RESUME_STORAGE_KEY
+} from '@/lib/pwa-resume'
 
 const PWAPrompt = dynamic(() => import('react-ios-pwa-prompt'), { ssr: false })
 
@@ -98,6 +105,31 @@ export default function MyApp ({ Component, pageProps: { ...props } }) {
       window.localStorage.setItem('iosPwaPrompt', JSON.stringify({ isiOS: false, visits: 0 }))
     }
   }, [router?.query?.disablePrompt])
+
+  useEffect(() => {
+    if (!isStandalonePWA() || !isPWAStartPath(router.asPath)) return
+
+    const resumePath = getPWAResumePath(window.localStorage.getItem(PWA_RESUME_STORAGE_KEY))
+    if (!resumePath) return
+
+    router.replace(resumePath).catch((e) => {
+      if (!e.cancelled) console.log(e)
+    })
+  }, [router])
+
+  useEffect(() => {
+    if (!isStandalonePWA()) return
+
+    const recordResumePath = (asPath) => {
+      const entry = createPWAResumeEntry(asPath)
+      if (entry) window.localStorage.setItem(PWA_RESUME_STORAGE_KEY, entry)
+    }
+
+    recordResumePath(router.asPath)
+    router.events.on('routeChangeComplete', recordResumePath)
+
+    return () => router.events.off('routeChangeComplete', recordResumePath)
+  }, [router.asPath, router.events])
 
   /*
     If we are on the client, we populate the apollo cache with the


### PR DESCRIPTION
## Summary
- remember the most recent item thread path while SN runs as an installed standalone PWA
- when the PWA restarts at `/`, restore that saved item path if it is less than 24 hours old
- keep the resume scope conservative by storing only `/items/<id>` paths, including query params and hashes
- add focused helper coverage for standalone detection, start-path checks, item path filtering, TTL expiry, and malformed storage entries

## Why
On iOS, the installed web app can be killed in the background and reopened from the manifest `start_url`, which is `/`. That drops readers back on the homepage instead of the thread they were reading. This persists the last item thread path locally and restores it only for standalone PWA starts.

Closes #2760.

## Testing
- `npm test -- --runTestsByPath lib/pwa-resume.spec.js --runInBand`
- `npx standard pages/_app.js lib/pwa-resume.js lib/pwa-resume.spec.js`
- `git diff --check`
- `DATABASE_URL=postgresql://stacker:stacker@127.0.0.1:5432/stacker OPENSEARCH_URL=http://127.0.0.1:9200 npm run build`
