### PR TITLE
refactor: extract user and item mention nodes via MDAST

### DIFF
--- a/api/payIn/lib/item.js
+++ b/api/payIn/lib/item.js
@@ -1,6 +1,5 @@
 import { USER_ID } from '@/lib/constants'
 import { deleteReminders, getDeleteAt, getRemindAt } from '@/lib/item'
-import { parseInternalLinks } from '@/lib/url'
 
 export async function getSubs (models, { subNames, parentId }) {
   if (!subNames && !parentId) {
@@ -29,47 +28,28 @@ export async function getItemResult (tx, { id }) {
   )[0]
 }
 
-export async function getMentions (tx, { text, userId }) {
-  const mentionPattern = /\B@[\w_]+/gi
-  const names = text.match(mentionPattern)?.map(m => m.slice(1))
-  if (names?.length > 0) {
-    const users = await tx.user.findMany({
-      where: {
-        name: {
-          in: names
-        },
-        id: {
-          not: userId || USER_ID.anon
-        }
-      }
-    })
-    return users.map(user => ({ userId: user.id }))
-  }
-  return []
+export async function getMentions (tx, { names, userId }) {
+  if (!names?.length) return []
+
+  const users = await tx.user.findMany({
+    where: {
+      name: { in: names },
+      id: { not: userId || USER_ID.anon }
+    }
+  })
+  return users.map(user => ({ userId: user.id }))
 }
 
-export const getItemMentions = async (tx, { text, userId }) => {
-  const linkPattern = new RegExp(`${process.env.NEXT_PUBLIC_URL}/items/\\d+[a-zA-Z0-9/?=]*`, 'gi')
-  const refs = text.match(linkPattern)?.map(m => {
-    try {
-      const { itemId, commentId } = parseInternalLinks(m)
-      return Number(commentId || itemId)
-    } catch (err) {
-      return null
+export const getItemMentions = async (tx, { itemIds, userId }) => {
+  if (!itemIds?.length) return []
+
+  const referee = await tx.item.findMany({
+    where: {
+      id: { in: itemIds },
+      userId: { not: userId || USER_ID.anon }
     }
-  }).filter(r => !!r)
-
-  if (refs?.length > 0) {
-    const referee = await tx.item.findMany({
-      where: {
-        id: { in: refs },
-        userId: { not: userId || USER_ID.anon }
-      }
-    })
-    return referee.map(r => ({ refereeId: r.id }))
-  }
-
-  return []
+  })
+  return referee.map(r => ({ refereeId: r.id }))
 }
 
 export async function performBotBehavior (tx, { text, id, userId = USER_ID.anon }) {

--- a/api/payIn/types/itemCreate.js
+++ b/api/payIn/types/itemCreate.js
@@ -1,6 +1,7 @@
 import { ANON_FEE_MULTIPLIER, ANON_ITEM_SPAM_INTERVAL, ITEM_SPAM_INTERVAL, PAID_ACTION_PAYMENT_METHODS, USER_ID } from '@/lib/constants'
 import { notifyItemMention, notifyItemParents, notifyMention, notifyTerritorySubscribers, notifyUserSubscribers, notifyThreadSubscribers } from '@/lib/webPush'
 import { getItemMentions, getMentions, performBotBehavior, getSubs } from '../lib/item'
+import { extractMentions } from '@/lib/lexical/server/mentions'
 import { msatsToSats, satsToMsats } from '@/lib/format'
 import { GqlInputError } from '@/lib/error'
 import { getRedistributedPayOutCustodialTokens } from '../lib/payOutCustodialTokens'
@@ -124,8 +125,9 @@ export async function onBegin (tx, payInId, args) {
   const { parentId, uploadIds = [], forwardUsers = [], options: pollOptions = [], subNames = [], ...data } = args
   const payIn = await tx.payIn.findUnique({ where: { id: payInId } })
 
-  const mentions = await getMentions(tx, { ...args, userId: payIn.userId })
-  const itemMentions = await getItemMentions(tx, { ...args, userId: payIn.userId })
+  const { userNames, itemIds } = extractMentions(args.text)
+  const mentions = await getMentions(tx, { names: userNames, userId: payIn.userId })
+  const itemMentions = await getItemMentions(tx, { itemIds, userId: payIn.userId })
 
   // start with median vote
   if (payIn.userId !== USER_ID.anon) {

--- a/api/payIn/types/itemUpdate.js
+++ b/api/payIn/types/itemUpdate.js
@@ -1,6 +1,7 @@
 import { PAID_ACTION_PAYMENT_METHODS } from '@/lib/constants'
 import { uploadFees } from '../../resolvers/upload'
 import { getItemMentions, getMentions, getSubs, performBotBehavior } from '../lib/item'
+import { extractMentions } from '@/lib/lexical/server/mentions'
 import { notifyItemMention, notifyMention } from '@/lib/webPush'
 import { getRedistributedPayOutCustodialTokens } from '../lib/payOutCustodialTokens'
 import { satsToMsats, msatsToSats } from '@/lib/format'
@@ -109,8 +110,9 @@ export async function onBegin (tx, payInId, args) {
   const intersectionMerge = (a = [], b = [], key) => a.filter(x => b.find(y => y.userId === x.userId))
     .map(x => ({ [key]: x[key], ...b.find(y => y.userId === x.userId) }))
 
-  const mentions = await getMentions(tx, args)
-  const itemMentions = await getItemMentions(tx, args)
+  const { userNames, itemIds } = extractMentions(args.text)
+  const mentions = await getMentions(tx, { names: userNames, userId: args.userId })
+  const itemMentions = await getItemMentions(tx, { itemIds, userId: args.userId })
   const itemUploads = uploadIds.map(id => ({ uploadId: id }))
 
   const newUploadIds = difference(itemUploads, old.itemUploads, 'uploadId').map(({ uploadId }) => uploadId)

--- a/lib/lexical/mdast/shared.js
+++ b/lib/lexical/mdast/shared.js
@@ -1,5 +1,3 @@
-import { $isDecoratorNode, $isElementNode } from 'lexical'
-
 /**
  * checks if a node is a parent node
  * @param {Object} node - mdast node
@@ -10,10 +8,10 @@ export function isParent (node) {
 }
 
 /**
- * checks if a node is a block element
- * @param {Object} node - lexical node
- * @returns {boolean} true if node is a block element
+ * checks if a node is a link whose sole child is an image
+ * @param {Object} node - mdast node
+ * @returns {boolean} true if node is a link wrapping only an image
  */
-export function isBlockElement (node) {
-  return ($isElementNode(node) || $isDecoratorNode(node)) && !node.isInline()
+export function isImageOnlyLink (node) {
+  return node?.type === 'link' && node.children?.length === 1 && node.children[0].type === 'image'
 }

--- a/lib/lexical/mdast/transforms/index.js
+++ b/lib/lexical/mdast/transforms/index.js
@@ -1,4 +1,4 @@
-export { mentionTransform } from './mentions.js'
+export { mentionTransform, itemMentionTransform } from './mentions.js'
 export { nostrTransform } from './nostr.js'
 export { misleadingLinkTransform, malformedLinkEncodingTransform } from './links.js'
 export { footnoteTransform } from './footnotes.js'

--- a/lib/lexical/mdast/transforms/links.js
+++ b/lib/lexical/mdast/transforms/links.js
@@ -1,6 +1,7 @@
 import { visit } from 'unist-util-visit'
 import { toString } from 'mdast-util-to-string'
 import { isMisleadingLink } from '@/lib/url'
+import { isImageOnlyLink } from '@/lib/lexical/mdast/shared'
 
 /**
  * a link is misleading if the text is not the same as the URL.
@@ -11,8 +12,7 @@ import { isMisleadingLink } from '@/lib/url'
 export function misleadingLinkTransform (tree) {
   visit(tree, 'link', (node, index, parent) => {
     // if the link has only an image child, unwrap it (remove the link but keep the image)
-    const hasOnlyImage = node.children?.length === 1 && node.children[0].type === 'image'
-    if (hasOnlyImage && parent && index !== undefined) {
+    if (isImageOnlyLink(node) && parent && index !== undefined) {
       parent.children[index] = node.children[0]
       return index
     }

--- a/lib/lexical/mdast/transforms/mentions.js
+++ b/lib/lexical/mdast/transforms/mentions.js
@@ -2,6 +2,7 @@ import { findAndReplace } from 'mdast-util-find-and-replace'
 import { visit } from 'unist-util-visit'
 import { toString } from 'mdast-util-to-string'
 import { parseInternalLinks } from '@/lib/url'
+import { isImageOnlyLink } from '@/lib/lexical/mdast/shared'
 
 // regexes from rehype-sn.js
 const userGroup = '[\\w_]+'
@@ -47,6 +48,10 @@ export function mentionTransform (tree) {
 export function itemMentionTransform (tree) {
   visit(tree, 'link', (node, index, parent) => {
     if (!node.url || !parent || index === undefined) return
+
+    // skip if link wraps only an image
+    if (isImageOnlyLink(node)) return
+
     try {
       const { itemId, commentId } = parseInternalLinks(node.url)
       if (itemId || commentId) {

--- a/lib/lexical/mdast/transforms/mentions.js
+++ b/lib/lexical/mdast/transforms/mentions.js
@@ -1,4 +1,7 @@
 import { findAndReplace } from 'mdast-util-find-and-replace'
+import { visit } from 'unist-util-visit'
+import { toString } from 'mdast-util-to-string'
+import { parseInternalLinks } from '@/lib/url'
 
 // regexes from rehype-sn.js
 const userGroup = '[\\w_]+'
@@ -35,4 +38,33 @@ export function mentionTransform (tree) {
     ],
     { ignore: IGNORE_TYPES }
   )
+}
+
+/** walk link nodes and replace internal item links with an itemMention node.
+*
+* must run before misleadingLinkTransform so we don't lose custom link text.
+*/
+export function itemMentionTransform (tree) {
+  visit(tree, 'link', (node, index, parent) => {
+    if (!node.url || !parent || index === undefined) return
+    try {
+      const { itemId, commentId } = parseInternalLinks(node.url)
+      if (itemId || commentId) {
+        // bare links (text === url) carry no custom text: leave text undefined
+        // non-bare links keep their custom text and round-trip as [text](url).
+        const linkContent = toString(node)
+        const text = linkContent && linkContent !== node.url ? linkContent : undefined
+        parent.children[index] = {
+          type: 'itemMention',
+          value: {
+            id: commentId || itemId,
+            text,
+            url: node.url
+          }
+        }
+      }
+    } catch {
+      // parseInternalLinks throws on malformed URLs; leave the link untouched
+    }
+  })
 }

--- a/lib/lexical/mdast/visitors/index.js
+++ b/lib/lexical/mdast/visitors/index.js
@@ -54,7 +54,7 @@ import {
   MdastTerritoryMentionVisitor,
   LexicalUserMentionVisitor,
   LexicalTerritoryMentionVisitor,
-  MdastItemMentionLinkVisitor,
+  MdastItemMentionVisitor,
   LexicalItemMentionVisitor
 } from './mentions.js'
 
@@ -100,7 +100,6 @@ export const importVisitors = [
   MdastHeadingVisitor,
   MdastTOCVisitor,
   MdastAutolinkVisitor,
-  MdastItemMentionLinkVisitor,
   MdastLinkVisitor,
   MdastImageVisitor,
   MdastQuoteVisitor,
@@ -110,6 +109,7 @@ export const importVisitors = [
   MdastHorizontalRuleVisitor,
   MdastUserMentionVisitor,
   MdastTerritoryMentionVisitor,
+  MdastItemMentionVisitor,
   MdastNostrIdVisitor,
   MdastTableVisitor,
   MdastTableRowVisitor,

--- a/lib/lexical/mdast/visitors/list.js
+++ b/lib/lexical/mdast/visitors/list.js
@@ -1,5 +1,5 @@
 import { $createListNode, $createListItemNode, $isListNode, $isListItemNode } from '@lexical/list'
-import { isBlockElement } from '@/lib/lexical/mdast/shared'
+import { $isBlockElement } from '@/lib/lexical/nodes/utils'
 
 // mdast -> lexical: list
 export const MdastListVisitor = {
@@ -54,7 +54,7 @@ const isParentCheckList = (lexicalNode) => {
 
 const createListItemNode = ({ lexicalNode, children }) => ({
   type: 'listItem',
-  spread: children.some(isBlockElement),
+  spread: children.some($isBlockElement),
   checked: isParentCheckList(lexicalNode) ? Boolean(lexicalNode.getChecked()) : null,
   children: []
 })
@@ -62,7 +62,7 @@ const createListItemNode = ({ lexicalNode, children }) => ({
 const wrapInlineContent = ({ children, listItem, actions }) => {
   let paragraph = null
   children.forEach((child) => {
-    if (isBlockElement(child)) {
+    if ($isBlockElement(child)) {
       paragraph = null
       actions.visit(child, listItem)
       return

--- a/lib/lexical/mdast/visitors/mentions.js
+++ b/lib/lexical/mdast/visitors/mentions.js
@@ -3,7 +3,6 @@ import {
   $createTerritoryMentionNode, $isTerritoryMentionNode,
   $isItemMentionNode
 } from '@/lib/lexical/nodes/decorative/mentions'
-import { parseInternalLinks } from '@/lib/url'
 import { $createItemMentionNode, isCustomText } from '@/lib/lexical/nodes/decorative/mentions/item'
 
 // user mentions (@user, @user/path)
@@ -66,44 +65,18 @@ export const LexicalTerritoryMentionVisitor = {
   }
 }
 
-// extract text by traversing the mdast node children
-function extractText (children) {
-  if (!children || children.length === 0) return ''
-
-  return children.map(child => {
-    if (child.type === 'text') {
-      return child.value
-    }
-
-    if (child.children) {
-      return extractText(child.children)
-    }
-    return ''
-  }).join('')
-}
-
-export const MdastItemMentionLinkVisitor = {
-  testNode: 'link',
-  priority: 20,
+export const MdastItemMentionVisitor = {
+  testNode: 'itemMention',
   visitNode ({ mdastNode, actions }) {
-    try {
-      const { itemId, commentId, linkText } = parseInternalLinks(mdastNode.url)
-      if (itemId || commentId) {
-        const text = extractText(mdastNode.children) || linkText
-        const mentionNode = $createItemMentionNode({
-          id: commentId || itemId,
-          text,
-          url: mdastNode.url
-        })
-        actions.addAndStepInto(mentionNode)
-        return
-      }
-    } catch {}
-    actions.nextVisitor()
+    const node = $createItemMentionNode({
+      id: mdastNode.value.id,
+      text: mdastNode.value.text,
+      url: mdastNode.value.url
+    })
+    actions.addAndStepInto(node)
   }
 }
 
-// item mentions are created from bare links (see link.js)
 // lexical -> mdast: outputs as link if custom text, otherwise plain text URL
 export const LexicalItemMentionVisitor = {
   testLexicalNode: $isItemMentionNode,

--- a/lib/lexical/mdast/visitors/quote.js
+++ b/lib/lexical/mdast/visitors/quote.js
@@ -1,6 +1,6 @@
 import { $createQuoteNode, $isQuoteNode } from '@lexical/rich-text'
 import { $isLineBreakNode } from 'lexical'
-import { isBlockElement } from '@/lib/lexical/mdast/shared'
+import { $isBlockElement } from '@/lib/lexical/nodes/utils'
 
 // mdast -> lexical
 export const MdastQuoteVisitor = {
@@ -38,7 +38,7 @@ export const LexicalQuoteVisitor = {
         continue
       }
       // block-level elements (nested quotes, lists, code blocks, etc.) are direct children of the blockquote
-      if (isBlockElement(child)) {
+      if ($isBlockElement(child)) {
         dropTrailingEmptyParagraph()
         actions.visit(child, blockquote)
         paragraph = newParagraph()

--- a/lib/lexical/nodes/decorative/mentions/item.jsx
+++ b/lib/lexical/nodes/decorative/mentions/item.jsx
@@ -1,4 +1,5 @@
 import { DecoratorNode, $applyNodeReplacement } from 'lexical'
+import { parseItemUrl } from '@/lib/url'
 
 function $convertItemMentionElement (domNode) {
   const id = domNode.getAttribute('data-lexical-item-mention-id')
@@ -36,6 +37,16 @@ export class ItemMentionNode extends DecoratorNode {
 
   getURL () {
     return this.__url
+  }
+
+  getDisplayText () {
+    if (this.__text) return this.__text
+    try {
+      // derive the label straight from the url's path
+      const { linkText } = parseItemUrl(new URL(this.__url))
+      if (linkText) return linkText
+    } catch {}
+    return `#${this.__itemMentionId}`
   }
 
   static clone (node) {
@@ -90,7 +101,7 @@ export class ItemMentionNode extends DecoratorNode {
     wrapper.setAttribute('data-lexical-item-mention-id', this.__itemMentionId)
     const a = document.createElement('a')
     a.setAttribute('href', this.__url)
-    a.textContent = this.__text || `#${this.__itemMentionId}`
+    a.textContent = this.getDisplayText()
     wrapper.appendChild(a)
     return { element: wrapper }
   }
@@ -113,7 +124,7 @@ export class ItemMentionNode extends DecoratorNode {
   }
 
   getTextContent () {
-    return this.__text || `#${this.__itemMentionId}`
+    return this.getDisplayText()
   }
 
   decorate () {
@@ -121,7 +132,7 @@ export class ItemMentionNode extends DecoratorNode {
     const MentionsComponent = require('@/components/editor/nodes/mentions').default
     const id = this.__itemMentionId
     const href = this.__url
-    const text = this.__text || `#${this.__itemMentionId}`
+    const text = this.getDisplayText()
     return (
       <ItemPopover id={id}>
         <MentionsComponent nodeKey={this.getKey()} href={href} text={text} />

--- a/lib/lexical/nodes/utils.js
+++ b/lib/lexical/nodes/utils.js
@@ -26,6 +26,15 @@ export function $replaceNodeWithLink (node, url) {
   }
 }
 
+/**
+ * checks if a Lexical node is a block element
+ * @param {Object} node - lexical node
+ * @returns {boolean} true if node is a block element
+ */
+export function $isBlockElement (node) {
+  return ($isElementNode(node) || $isDecoratorNode(node)) && !node.isInline()
+}
+
 export function $isUnwritable (node) {
   if ($isDecoratorNode(node) && !node.isInline()) return true
   if ($isElementNode(node)) {

--- a/lib/lexical/server/mentions.js
+++ b/lib/lexical/server/mentions.js
@@ -1,0 +1,43 @@
+import { fromMarkdown } from 'mdast-util-from-markdown'
+import { gfmFromMarkdown } from 'mdast-util-gfm'
+import { mathFromMarkdown } from 'mdast-util-math'
+import { gfm } from 'micromark-extension-gfm'
+import { math } from 'micromark-extension-math'
+import { visit } from 'unist-util-visit'
+import { mentionTransform, itemMentionTransform } from '@/lib/lexical/mdast/transforms/mentions'
+
+// extract user and item mentions from an item's markdown
+export function extractMentions (text) {
+  // no text, or no clear signs of mentions, so nothing to extract
+  if (!text?.trim() || (!text.includes('@') && !text.includes('/items/'))) {
+    return { userNames: [], itemIds: [] }
+  }
+
+  let tree
+  try {
+    tree = fromMarkdown(text, {
+      extensions: [gfm(), math({ singleDollarTextMath: false })],
+      mdastExtensions: [gfmFromMarkdown(), mathFromMarkdown()]
+    })
+  } catch {
+    // never let malformed markdown block item creation/notifications
+    return { userNames: [], itemIds: [] }
+  }
+
+  mentionTransform(tree)
+  itemMentionTransform(tree)
+
+  const userNames = new Set()
+  const itemIds = new Set()
+
+  visit(tree, ['userMention', 'itemMention'], (node) => {
+    if (node.type === 'userMention') {
+      userNames.add(node.value.name)
+    } else {
+      const id = Number(node.value.id)
+      if (!Number.isNaN(id)) itemIds.add(id)
+    }
+  })
+
+  return { userNames: [...userNames], itemIds: [...itemIds] }
+}

--- a/lib/lexical/utils/mdast.js
+++ b/lib/lexical/utils/mdast.js
@@ -15,6 +15,7 @@ import {
 } from '@/lib/lexical/mdast'
 import {
   mentionTransform,
+  itemMentionTransform,
   nostrTransform,
   misleadingLinkTransform,
   malformedLinkEncodingTransform,
@@ -50,6 +51,7 @@ export function $markdownToLexical (markdown, { splitInParagraphs = false, appen
     ],
     mdastTransforms: [
       mentionTransform,
+      itemMentionTransform,
       nostrTransform,
       misleadingLinkTransform,
       malformedLinkEncodingTransform,

--- a/lib/url.js
+++ b/lib/url.js
@@ -69,35 +69,36 @@ export function isItemPath (pathname) {
   return page === 'items' && /^[0-9]+$/.test(id)
 }
 
+export function parseItemUrl (url) {
+  const { pathname, searchParams } = url
+  if (!isItemPath(pathname)) return {}
+
+  // ignore empty parts which exist due to pathname starting with '/'
+  const parts = pathname.split('/').filter(part => !!part)
+  const itemId = parts[1]
+  // check for valid item page due to referral links like /items/123456/r/ekzyis
+  const itemPages = ['edit', 'ots', 'related']
+  const itemPage = itemPages.includes(parts[2]) ? parts[2] : null
+  if (itemPage) {
+    // parse   https://stacker.news/items/1/related?commentId=2
+    // as      #1/related
+    // and not #2
+    // since commentId will be ignored anyway
+    return { itemId, linkText: `#${itemId}/${itemPage}` }
+  }
+  const commentId = searchParams.get('commentId')
+  return { itemId, commentId, linkText: `#${commentId || itemId}` }
+}
+
 export function parseInternalLinks (href) {
   const url = new URL(href)
   const internalURL = process.env.NEXT_PUBLIC_URL
-  const { pathname, searchParams } = url
 
   const isInternal = url.origin === internalURL ||
     (typeof window !== 'undefined' && url.origin === window.location.origin)
 
-  // ignore empty parts which exist due to pathname starting with '/'
-  if (isItemPath(pathname) && isInternal) {
-    const parts = pathname.split('/').filter(part => !!part)
-    const itemId = parts[1]
-    // check for valid item page due to referral links like /items/123456/r/ekzyis
-    const itemPages = ['edit', 'ots', 'related']
-    const itemPage = itemPages.includes(parts[2]) ? parts[2] : null
-    if (itemPage) {
-      // parse   https://stacker.news/items/1/related?commentId=2
-      // as      #1/related
-      // and not #2
-      // since commentId will be ignored anyway
-      const linkText = `#${itemId}/${itemPage}`
-      return { itemId, linkText }
-    }
-    const commentId = searchParams.get('commentId')
-    const linkText = `#${commentId || itemId}`
-    return { itemId, commentId, linkText }
-  }
-
-  return {}
+  if (!isInternal) return {}
+  return parseItemUrl(url)
 }
 
 export function parseYoutubeStart (t) {


### PR DESCRIPTION
## Description

Fixes #2589 by extracting user and (also!) item mention nodes via MDAST.
`extractMentions` first parses the item's markdown into an MDAST tree with `itemMention` and `userMention` nodes support (via transforms), then walks the tree collecting them.

Also fixes path omissions e.g. `https://stacker.news/items/1/related -> #1` instead of `#1/related`.

bits:
- fix: `getDisplayText`, computes the display text for an item mention node. It returns custom text if available, otherwise parses the default label, with path, from the node's URL. If both fail, defaults to the item id.
  - extracted `parseItemUrl` from `parseInternalLinks` to avoid unnecessary checks for an already confirmed `ItemMentionNode`
- enhancement: item mentions are true MDAST nodes via `itemMentionTransform`, this made the MDAST walk trivial when extracting mentions
- cleanup: moved lexical utility from mdast shared utils

## Additional Context

It didn't make sense to use Lexical for this. The item create/update route doesn't have a Lexical state, it carries the `text` markdown ... so we would've needed MDAST conversion anyway.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7, mention roundtrips, detection and notifications work correctly. also tested edge cases such as item mentions with image as `linkText`.

**Did you use AI for this? If so, how much did it assist you?**

Yes, review and e2e tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how @users and internal item links are detected for DB mentions and push notifications; behavior should align with markdown structure (code blocks, custom link text) but differs from the old plain-text regex approach.
> 
> **Overview**
> **Mention detection for item create/update** no longer scans raw text with regexes. A new server helper `extractMentions` parses markdown to MDAST, runs the same mention transforms as the editor, and collects `userMention` / `itemMention` nodes. `getMentions` and `getItemMentions` now take pre-extracted `names` and `itemIds` and only resolve them in the database.
> 
> **Item links in markdown** are promoted to first-class MDAST `itemMention` nodes via `itemMentionTransform` (before misleading-link rewriting), with a dedicated import visitor instead of inferring mentions from generic `link` nodes. Editor import/export and server extraction share this pipeline.
> 
> **Display labels** for item mentions use `getDisplayText()` / `parseItemUrl`, so URLs like `/items/1/related` show `#1/related` instead of dropping the path segment.
> 
> Small cleanups: `isImageOnlyLink` in mdast shared utils, `$isBlockElement` moved to Lexical node utils for list/quote export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9470521cd8732a8c2dbc3bb341e11783700994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->