### PR TITLE
Internationalize pay-in Sankey values

### DIFF
--- a/components/payIn/sankey/data.js
+++ b/components/payIn/sankey/data.js
@@ -1,0 +1,180 @@
+import { msatsToSatsDecimal, numWithUnits } from '@/lib/format'
+import { payTypeShortName } from '@/lib/pay-in'
+
+export function formatSankeyValue (value, locales) {
+  return new Intl.NumberFormat(locales).format(value)
+}
+
+function msatsToSankeyValue (msats) {
+  return Number(msatsToSatsDecimal(msats))
+}
+
+function assetFormatted (msats, type) {
+  if (type === 'CREDITS') {
+    return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
+  }
+  return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
+}
+
+export function getSankeyData (payIn) {
+  const nodes = []
+  const links = []
+
+  // stacker news is always a node
+  nodes.push({
+    id: ''
+  })
+
+  // Create individual nodes for each payInCustodialToken
+  if (payIn.payerPrivates) {
+    payIn.payerPrivates?.payInCustodialTokens?.forEach((token) => {
+      const id = token.custodialTokenType === 'SATS' ? 'sats' : 'CCs'
+      nodes.push({
+        id,
+        mtokens: token.mtokens,
+        custodialTokenType: token.custodialTokenType
+      })
+      links.push({
+        source: id,
+        target: '',
+        mtokens: token.mtokens,
+        custodialTokenType: token.custodialTokenType
+      })
+    })
+  } else if (!payIn.payInBolt11Public?.msats || payIn.mcost - payIn.payInBolt11Public.msats > 0) {
+    const mtokens = payIn.mcost - (payIn.payInBolt11Public?.msats ?? 0)
+    nodes.push({
+      id: 'sats',
+      mtokens,
+      custodialTokenType: 'SATS'
+    })
+    links.push({
+      source: 'sats',
+      target: '',
+      mtokens,
+      custodialTokenType: 'SATS'
+    })
+  }
+
+  // Create node for payInBolt11 if it exists
+  if (payIn.payInBolt11Public) {
+    nodes.push({
+      id: 'lightning',
+      mtokens: payIn.payInBolt11Public.msats,
+      custodialTokenType: 'SATS'
+    })
+
+    let leftOverMsats = payIn.payInBolt11Public.msats
+
+    // this is a p2p zap or payment
+    if (payIn.payOutBolt11Public) {
+      leftOverMsats = payIn.payInBolt11Public.msats - payIn.payOutBolt11Public.msats
+      const id = 'lightning (out)'
+      nodes.push({
+        id,
+        mtokens: payIn.payOutBolt11Public.msats,
+        custodialTokenType: 'SATS'
+      })
+
+      links.push({
+        source: 'lightning',
+        target: id,
+        mtokens: payIn.payOutBolt11Public.msats,
+        custodialTokenType: 'SATS'
+      })
+    }
+
+    if (leftOverMsats > 0) {
+      links.push({
+        source: 'lightning',
+        target: '',
+        mtokens: leftOverMsats,
+        custodialTokenType: 'SATS'
+      })
+    }
+  } else if (payIn.payOutBolt11Public) {
+    // this is a withdrawal
+    nodes.push({
+      id: 'lightning (out)',
+      mtokens: payIn.payOutBolt11Public.msats,
+      custodialTokenType: 'SATS'
+    })
+
+    links.push({
+      source: '',
+      target: 'lightning (out)',
+      mtokens: payIn.payOutBolt11Public.msats,
+      custodialTokenType: 'SATS'
+    })
+  }
+
+  // Create individual nodes for each payOutCustodialToken
+  if (payIn.payOutCustodialTokens && payIn.payOutCustodialTokens.length > 0) {
+    payIn.payOutCustodialTokens.forEach((token) => {
+      let id = payTypeShortName(token.payOutType)
+      if (['TERRITORY_REVENUE', 'DEFUNCT_DELAYED_TERRITORY_REVENUE'].includes(token.payOutType) && token.sub?.name) {
+        id = `~${token.sub.name}`
+      } else if (['ZAP', 'REWARD'].includes(token.payOutType) && token.sometimesPrivates?.user?.name) {
+        // Only label payouts when the resolver exposed viewer-owned identity data.
+        id = `@${token.sometimesPrivates.user.name}`
+      } else if (token.payOutType === 'ROUTING_FEE') {
+        id = 'route'
+      } else if (token.payOutType === 'ROUTING_FEE_REFUND') {
+        id = 'refund'
+      } else if (token.payOutType === 'REWARDS_POOL') {
+        id = 'rewards'
+      }
+
+      nodes.push({
+        id,
+        mtokens: token.mtokens,
+        custodialTokenType: token.custodialTokenType
+      })
+      links.push({
+        source: '',
+        target: id,
+        mtokens: token.mtokens,
+        custodialTokenType: token.custodialTokenType
+      })
+    })
+  }
+
+  return reduceLinksAndNodes({ nodes, links })
+}
+
+// combine duplicate nodes and links, adding the mtokens together
+function reduceLinksAndNodes ({ links, nodes }) {
+  const reducedLinks = []
+  const reducedNodes = []
+
+  nodes.forEach(node => {
+    const existingNode = reducedNodes.find(n => n.id === node.id)
+    if (existingNode) {
+      existingNode.mtokens += node.mtokens
+    } else {
+      reducedNodes.push(node)
+    }
+  })
+
+  reducedNodes.forEach(node => {
+    if (node.mtokens) {
+      node.asset = assetFormatted(node.mtokens, node.custodialTokenType)
+    }
+  })
+
+  links.forEach(link => {
+    const existingLink = reducedLinks.find(l => l.source === link.source && l.target === link.target)
+    if (existingLink) {
+      existingLink.mtokens += link.mtokens
+    } else {
+      reducedLinks.push(link)
+    }
+  })
+
+  reducedLinks.forEach(link => {
+    link.value = msatsToSankeyValue(link.mtokens)
+    link.asset = assetFormatted(link.mtokens, link.custodialTokenType)
+  })
+
+  return { links: reducedLinks, nodes: reducedNodes }
+}

--- a/components/payIn/sankey/index.js
+++ b/components/payIn/sankey/index.js
@@ -1,7 +1,6 @@
-import { msatsToSatsDecimal, numWithUnits } from '@/lib/format'
-import { payTypeShortName } from '@/lib/pay-in'
 import { ResponsiveSankey } from '@nivo/sankey'
 import { RotatingSankeyLabels } from './label'
+import { formatSankeyValue, getSankeyData } from './data'
 
 export function PayInSankey ({ payIn }) {
   const data = getSankeyData(payIn)
@@ -30,6 +29,7 @@ export function PayInSankey ({ payIn }) {
         labelComponent={RotatingSankeyLabels}
         nodeTooltip={Tooltip}
         linkTooltip={Tooltip}
+        valueFormat={formatSankeyValue}
         nodeSpacing={24}
       />
     </div>
@@ -42,180 +42,10 @@ export function PayInSankeySkeleton () {
   )
 }
 
-function assetFormatted (msats, type) {
-  if (type === 'CREDITS') {
-    return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
-  }
-  return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
-}
-
 function Tooltip ({ node, link }) {
   node ??= link
   if (!node.asset) {
     return null
   }
   return <div style={{ whiteSpace: 'nowrap', backgroundColor: 'var(--bs-body-bg)', padding: '4px 8px', borderRadius: '4px', border: '1px solid var(--bs-border-color)' }}>{node.asset}</div>
-}
-
-function getSankeyData (payIn) {
-  const nodes = []
-  const links = []
-
-  // stacker news is always a node
-  nodes.push({
-    id: ''
-  })
-
-  // Create individual nodes for each payInCustodialToken
-  if (payIn.payerPrivates) {
-    payIn.payerPrivates?.payInCustodialTokens?.forEach((token, index) => {
-      const id = token.custodialTokenType === 'SATS' ? 'sats' : 'CCs'
-      nodes.push({
-        id,
-        mtokens: token.mtokens,
-        custodialTokenType: token.custodialTokenType
-      })
-      links.push({
-        source: id,
-        target: '',
-        mtokens: token.mtokens,
-        custodialTokenType: token.custodialTokenType
-      })
-    })
-  } else if (!payIn.payInBolt11Public?.msats || payIn.mcost - payIn.payInBolt11Public.msats > 0) {
-    const mtokens = payIn.mcost - (payIn.payInBolt11Public?.msats ?? 0)
-    nodes.push({
-      id: 'sats',
-      mtokens,
-      custodialTokenType: 'SATS'
-    })
-    links.push({
-      source: 'sats',
-      target: '',
-      mtokens,
-      custodialTokenType: 'SATS'
-    })
-  }
-
-  // Create node for payInBolt11 if it exists
-  if (payIn.payInBolt11Public) {
-    nodes.push({
-      id: 'lightning',
-      mtokens: payIn.payInBolt11Public.msats,
-      custodialTokenType: 'SATS'
-    })
-
-    let leftOverMsats = payIn.payInBolt11Public.msats
-
-    // this is a p2p zap or payment
-    if (payIn.payOutBolt11Public) {
-      leftOverMsats = payIn.payInBolt11Public.msats - payIn.payOutBolt11Public.msats
-      const id = 'lightning (out)'
-      nodes.push({
-        id,
-        mtokens: payIn.payOutBolt11Public.msats,
-        custodialTokenType: 'SATS'
-      })
-
-      links.push({
-        source: 'lightning',
-        target: id,
-        mtokens: payIn.payOutBolt11Public.msats,
-        custodialTokenType: 'SATS'
-      })
-    }
-
-    if (leftOverMsats > 0) {
-      links.push({
-        source: 'lightning',
-        target: '',
-        mtokens: leftOverMsats,
-        custodialTokenType: 'SATS'
-      })
-    }
-  } else if (payIn.payOutBolt11Public) {
-    // this is a withdrawal
-    nodes.push({
-      id: 'lightning (out)',
-      mtokens: payIn.payOutBolt11Public.msats,
-      custodialTokenType: 'SATS'
-    })
-
-    links.push({
-      source: '',
-      target: 'lightning (out)',
-      mtokens: payIn.payOutBolt11Public.msats,
-      custodialTokenType: 'SATS'
-    })
-  }
-
-  // Create individual nodes for each payOutCustodialToken
-  if (payIn.payOutCustodialTokens && payIn.payOutCustodialTokens.length > 0) {
-    payIn.payOutCustodialTokens.forEach((token) => {
-      let id = payTypeShortName(token.payOutType)
-      if (['TERRITORY_REVENUE', 'DEFUNCT_DELAYED_TERRITORY_REVENUE'].includes(token.payOutType) && token.sub?.name) {
-        id = `~${token.sub.name}`
-      } else if (['ZAP', 'REWARD'].includes(token.payOutType) && token.sometimesPrivates?.user?.name) {
-        // Only label payouts when the resolver exposed viewer-owned identity data.
-        id = `@${token.sometimesPrivates.user.name}`
-      } else if (token.payOutType === 'ROUTING_FEE') {
-        id = 'route'
-      } else if (token.payOutType === 'ROUTING_FEE_REFUND') {
-        id = 'refund'
-      } else if (token.payOutType === 'REWARDS_POOL') {
-        id = 'rewards'
-      }
-
-      nodes.push({
-        id,
-        mtokens: token.mtokens,
-        custodialTokenType: token.custodialTokenType
-      })
-      links.push({
-        source: '',
-        target: id,
-        mtokens: token.mtokens,
-        custodialTokenType: token.custodialTokenType
-      })
-    })
-  }
-
-  return reduceLinksAndNodes({ nodes, links })
-}
-
-// combine duplicate nodes and links, adding the mtokens together
-function reduceLinksAndNodes ({ links, nodes }) {
-  const reducedLinks = []
-  const reducedNodes = []
-
-  nodes.forEach(node => {
-    const existingNode = reducedNodes.find(n => n.id === node.id)
-    if (existingNode) {
-      existingNode.mtokens += node.mtokens
-    } else {
-      reducedNodes.push(node)
-    }
-  })
-
-  reducedNodes.forEach(node => {
-    if (node.mtokens) {
-      node.asset = assetFormatted(node.mtokens, node.custodialTokenType)
-    }
-  })
-
-  links.forEach(link => {
-    const existingLink = reducedLinks.find(l => l.source === link.source && l.target === link.target)
-    if (existingLink) {
-      existingLink.mtokens += link.mtokens
-    } else {
-      reducedLinks.push(link)
-    }
-  })
-
-  reducedLinks.forEach(link => {
-    link.value = msatsToSatsDecimal(link.mtokens)
-    link.asset = assetFormatted(link.mtokens, link.custodialTokenType)
-  })
-
-  return { links: reducedLinks, nodes: reducedNodes }
 }

--- a/components/payInSankeyData.spec.js
+++ b/components/payInSankeyData.spec.js
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+import { formatSankeyValue, getSankeyData } from './payIn/sankey/data'
+
+describe('pay-in sankey data', () => {
+  test('formats chart values with the active locale', () => {
+    expect(formatSankeyValue(1234.56, 'en-US')).toBe('1,234.56')
+    expect(formatSankeyValue(1234.56, 'de-DE')).toBe('1.234,56')
+  })
+
+  test('uses numeric link values so nivo can localize them', () => {
+    const data = getSankeyData({
+      mcost: 1234560,
+      payOutCustodialTokens: [{
+        payOutType: 'REWARDS_POOL',
+        mtokens: 1234560,
+        custodialTokenType: 'SATS'
+      }]
+    })
+
+    expect(data.links).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        source: 'sats',
+        target: '',
+        value: 1234.56,
+        asset: expect.stringMatching(/sats$/)
+      }),
+      expect.objectContaining({
+        source: '',
+        target: 'rewards',
+        value: 1234.56,
+        asset: expect.stringMatching(/sats$/)
+      })
+    ]))
+    expect(data.links.every(link => typeof link.value === 'number')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- pass an Intl.NumberFormat-backed valueFormat to the pay-in Sankey chart
- keep Sankey link values numeric so Nivo can format them correctly
- move pay-in Sankey data shaping into a helper module with focused coverage

Closes #2942

## Test plan
- npm test -- --runTestsByPath components/payInSankeyData.spec.js
- npm run lint -- components/payIn/sankey/index.js components/payIn/sankey/data.js components/payInSankeyData.spec.js
- git diff --check