### PR TITLE
[codex] Fix LNURL pay casing

### DIFF
--- a/pages/api/lnurlp/[username]/index.js
+++ b/pages/api/lnurlp/[username]/index.js
@@ -9,10 +9,11 @@ export default async ({ query: { username } }, res) => {
     return res.status(400).json({ status: 'ERROR', reason: `user @${username} does not exist` })
   }
 
+  const canonicalUsername = user.name
   const url = process.env.NODE_ENV === 'development' ? process.env.SELF_URL : process.env.NEXT_PUBLIC_URL
-  const { metadata } = lnurlPayMetadata(username)
+  const { metadata } = lnurlPayMetadata(canonicalUsername)
   return res.status(200).json({
-    callback: lnurlpCallbackUrl(username, url), // The URL from LN SERVICE which will accept the pay request parameters
+    callback: lnurlpCallbackUrl(canonicalUsername, url), // The URL from LN SERVICE which will accept the pay request parameters
     minSendable: Number(PROXY_PAYER_MIN_MSATS), // Min amount LN SERVICE is willing to receive, can not be less than 1 or more than `maxSendable`
     maxSendable: Number(PROXY_PAYER_MAX_MSATS), // Max amount LN SERVICE is willing to receive: the largest payer amount whose post-fee payout the wrap pipeline accepts
     metadata, // Metadata json which must be presented as raw string here, this is required to pass signature verification at a later step

--- a/pages/api/lnurlp/[username]/index.spec.js
+++ b/pages/api/lnurlp/[username]/index.spec.js
@@ -1,0 +1,54 @@
+/* eslint-env jest */
+
+jest.mock('../../../../api/models', () => ({
+  __esModule: true,
+  default: {
+    user: {
+      findUnique: jest.fn()
+    }
+  }
+}))
+
+const handler = require('./index').default
+const models = require('../../../../api/models').default
+
+function mockResponse () {
+  return {
+    status: jest.fn(function (code) {
+      this.statusCode = code
+      return this
+    }),
+    json: jest.fn(function (body) {
+      this.body = body
+      return this
+    })
+  }
+}
+
+describe('lnurlp provider descriptor', () => {
+  const env = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...env, NEXT_PUBLIC_URL: 'https://stacker.news' }
+  })
+
+  afterAll(() => {
+    process.env = env
+  })
+
+  test('normalizes lowercased lightning address lookups to the canonical user name', async () => {
+    models.user.findUnique.mockResolvedValue({ id: 1, name: 'SwapMarket' })
+
+    const res = mockResponse()
+    await handler({ query: { username: 'swapmarket' } }, res)
+
+    expect(models.user.findUnique).toHaveBeenCalledWith({ where: { name: 'swapmarket' } })
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.body.callback).toBe('https://stacker.news/api/lnurlp/SwapMarket/pay')
+    expect(JSON.parse(res.body.metadata)).toEqual([
+      ['text/plain', 'Proxied payment to SwapMarket@stacker.news'],
+      ['text/identifier', 'SwapMarket@stacker.news']
+    ])
+  })
+})

--- a/pages/api/lnurlp/[username]/pay.js
+++ b/pages/api/lnurlp/[username]/pay.js
@@ -15,6 +15,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
     return res.status(400).json({ status: 'ERROR', reason: `user @${username} does not exist` })
   }
 
+  const canonicalUsername = user.name
   const amountMsats = Number(amount)
   if (!Number.isFinite(amountMsats) || amountMsats < Number(PROXY_PAYER_MIN_MSATS)) {
     return res.status(400).json({ status: 'ERROR', reason: `amount must be >= ${PROXY_PAYER_MIN_MSATS} msats` })
@@ -33,7 +34,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
   try {
     await assertGofacYourself({ models, headers })
     // if nostr, decode, validate sig, check tags, set description hash
-    let { description, descriptionHash } = lnurlPayMetadata(username)
+    let { description, descriptionHash } = lnurlPayMetadata(canonicalUsername)
     let noteStr
     let lud18Data
     if (nostr) {
@@ -71,7 +72,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
         return res.status(400).json({ status: 'ERROR', reason: err.toString() })
       }
 
-      descriptionHash = createHash('sha256').update(lnurlPayMetadata(username).metadata + payerData).digest('hex')
+      descriptionHash = createHash('sha256').update(lnurlPayMetadata(canonicalUsername).metadata + payerData).digest('hex')
     }
 
     if (comment && characterLength(comment) > LNURLP_COMMENT_MAX_LENGTH) {
@@ -96,7 +97,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
     return res.status(200).json({
       pr: payInBolt11.bolt11,
       routes: [],
-      verify: lnurlpVerifyUrl(username, payInBolt11.hash)
+      verify: lnurlpVerifyUrl(canonicalUsername, payInBolt11.hash)
     })
   } catch (error) {
     console.log(error)

--- a/pages/api/lnurlp/[username]/pay.spec.js
+++ b/pages/api/lnurlp/[username]/pay.spec.js
@@ -1,0 +1,97 @@
+/* eslint-env jest */
+
+jest.mock('../../../../api/models', () => ({
+  __esModule: true,
+  default: {
+    user: {
+      findUnique: jest.fn()
+    }
+  }
+}))
+
+jest.mock('../../../../api/payIn', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+jest.mock('../../../../api/resolvers/ofac', () => ({
+  __esModule: true,
+  default: jest.fn()
+}))
+
+const logger = {
+  info: jest.fn(() => Promise.resolve()),
+  error: jest.fn(() => Promise.resolve())
+}
+
+jest.mock('../../../../wallets/server', () => ({
+  walletLogger: jest.fn(() => logger)
+}))
+
+const handler = require('./pay').default
+const models = require('../../../../api/models').default
+const pay = require('../../../../api/payIn').default
+const assertGofacYourself = require('../../../../api/resolvers/ofac').default
+const { lnurlPayMetadata } = require('../../../../lib/lnurl')
+const { createHash } = require('crypto')
+
+function mockResponse () {
+  return {
+    status: jest.fn(function (code) {
+      this.statusCode = code
+      return this
+    }),
+    json: jest.fn(function (body) {
+      this.body = body
+      return this
+    })
+  }
+}
+
+describe('lnurlp pay callback', () => {
+  const env = process.env
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    process.env = { ...env, NEXT_PUBLIC_URL: 'https://stacker.news' }
+    models.user.findUnique.mockResolvedValue({ id: 1, name: 'SwapMarket' })
+    assertGofacYourself.mockResolvedValue()
+    pay.mockResolvedValue({
+      payInBolt11: {
+        bolt11: 'lnbc210n1example',
+        hash: 'payment-hash'
+      }
+    })
+  })
+
+  afterAll(() => {
+    process.env = env
+  })
+
+  test('uses the canonical user name when a wallet lowercases the callback path', async () => {
+    const res = mockResponse()
+    await handler({ query: { username: 'swapmarket', amount: '21000' }, headers: {} }, res)
+
+    const { description, descriptionHash } = lnurlPayMetadata('SwapMarket')
+    expect(pay).toHaveBeenCalledWith('PROXY_PAYMENT', expect.objectContaining({
+      msats: 21000n,
+      description,
+      descriptionHash
+    }), { models, me: { id: 1, name: 'SwapMarket' } })
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.body.verify).toBe('https://stacker.news/api/lnurlp/SwapMarket/verify/payment-hash')
+  })
+
+  test('hashes payer data against canonical metadata for lowercased callback paths', async () => {
+    const payerdata = JSON.stringify({ name: 'Alice' })
+    const res = mockResponse()
+    await handler({ query: { username: 'swapmarket', amount: '21000', payerdata }, headers: {} }, res)
+
+    const { metadata } = lnurlPayMetadata('SwapMarket')
+    expect(pay).toHaveBeenCalledWith('PROXY_PAYMENT', expect.objectContaining({
+      descriptionHash: createHash('sha256').update(metadata + payerdata).digest('hex'),
+      lud18Data: { name: 'Alice' }
+    }), { models, me: { id: 1, name: 'SwapMarket' } })
+    expect(res.status).toHaveBeenCalledWith(200)
+  })
+})


### PR DESCRIPTION
## Summary

- normalize LNURL provider metadata, callback, and verify URLs to the canonical stored user name after case-insensitive lookup
- use canonical metadata when building proxy payment invoice descriptions and LUD-18 payer-data description hashes
- add focused route tests for lowercased wallet callback paths

Closes #3058.

## Validation

- npm test -- --runTestsByPath pages/api/lnurlp/[username]/index.spec.js pages/api/lnurlp/[username]/pay.spec.js --runInBand
- npx standard pages/api/lnurlp/[username]/index.js pages/api/lnurlp/[username]/pay.js pages/api/lnurlp/[username]/index.spec.js pages/api/lnurlp/[username]/pay.spec.js
- git diff --check origin/master...HEAD