### PR TITLE
Fix quote toggle for nested code blocks

### DIFF
--- a/lib/lexical/commands/formatting/blocks.js
+++ b/lib/lexical/commands/formatting/blocks.js
@@ -8,14 +8,15 @@ import {
 } from '@lexical/list'
 import {
   createCommand, $getSelection, $isRangeSelection,
-  COMMAND_PRIORITY_EDITOR, $createParagraphNode
+  COMMAND_PRIORITY_EDITOR, $createParagraphNode, $isLineBreakNode
 } from 'lexical'
 import { $setBlocksType } from '@lexical/selection'
-import { $createQuoteNode } from '@lexical/rich-text'
+import { $createQuoteNode, $isQuoteNode } from '@lexical/rich-text'
 import { $createSNHeadingNode } from '@/lib/lexical/nodes/misc/heading'
 import { USE_TRANSFORMER_BRIDGE } from '@/components/editor/plugins/core/transformer-bridge'
 import { MD_INSERT_BLOCK_COMMAND } from '@/lib/lexical/commands/formatting/markdown'
 import { $splitParagraphsByLineBreaks } from '@/lib/lexical/nodes/utils'
+import { isBlockElement } from '@/lib/lexical/mdast/shared'
 
 /** command to format blocks (headings, lists, quotes, etc.)
  * @param {string} block - block type ('paragraph', 'h1', 'bullet', 'quote', etc.)
@@ -47,8 +48,80 @@ const $formatCheckList = (editor, activeBlock, block, selection) => {
   editor.dispatchCommand(INSERT_CHECK_LIST_COMMAND, undefined)
 }
 
+const $findQuoteNode = (node) => {
+  let current = node
+  while (current) {
+    if ($isQuoteNode(current)) return current
+    current = current.getParent()
+  }
+  return null
+}
+
+const $getSelectedQuoteNodes = (selection) => {
+  if (!selection) return []
+
+  const seen = new Set()
+  const quotes = []
+  const addQuote = (node) => {
+    const quoteNode = $findQuoteNode(node)
+    if (!quoteNode) return
+    const key = quoteNode.getKey()
+    if (seen.has(key)) return
+    seen.add(key)
+    quotes.push(quoteNode)
+  }
+
+  addQuote(selection.anchor.getNode())
+  addQuote(selection.focus.getNode())
+  selection.getNodes().forEach(addQuote)
+
+  return quotes
+}
+
+const $unwrapQuoteNode = (quoteNode) => {
+  const parent = quoteNode.getParent()
+  if (!parent) return
+
+  const replacementNodes = []
+  let paragraph = null
+
+  const appendParagraph = () => {
+    if (!paragraph) {
+      paragraph = $createParagraphNode()
+      replacementNodes.push(paragraph)
+    }
+    return paragraph
+  }
+
+  for (const child of quoteNode.getChildren()) {
+    if ($isLineBreakNode(child)) {
+      paragraph = null
+      continue
+    }
+    if (isBlockElement(child)) {
+      paragraph = null
+      replacementNodes.push(child)
+      continue
+    }
+    appendParagraph().append(child)
+  }
+
+  parent.splice(
+    quoteNode.getIndexWithinParent(),
+    1,
+    replacementNodes.length > 0 ? replacementNodes : [$createParagraphNode()]
+  )
+}
+
 const $formatBlockQuote = (activeBlock, block, selection) => {
-  if (activeBlock === block) return $formatParagraph(selection)
+  const quoteNodes = $getSelectedQuoteNodes(selection)
+  if (activeBlock === block || (activeBlock === 'root' && quoteNodes.length > 0)) {
+    if (quoteNodes.length > 0) {
+      quoteNodes.forEach($unwrapQuoteNode)
+      return
+    }
+    return $formatParagraph(selection)
+  }
   if (!selection) return
   $setBlocksType(selection, () => $createQuoteNode())
 }

--- a/lib/lexical/commands/formatting/blocks.spec.js
+++ b/lib/lexical/commands/formatting/blocks.spec.js
@@ -1,0 +1,109 @@
+/* eslint-env jest */
+jest.mock('../../nodes/misc/heading', () => ({
+  $createSNHeadingNode: jest.fn(() => {
+    throw new Error('unexpected heading formatting in block quote tests')
+  })
+}))
+
+jest.mock('../../../../components/editor/plugins/core/transformer-bridge', () => ({
+  USE_TRANSFORMER_BRIDGE: 'USE_TRANSFORMER_BRIDGE'
+}))
+
+jest.mock('./markdown', () => ({
+  MD_INSERT_BLOCK_COMMAND: 'MD_INSERT_BLOCK_COMMAND'
+}))
+
+const { createHeadlessEditor } = require('@lexical/headless')
+const { $createTextNode, $getRoot, $selectAll } = require('lexical')
+const { CodeHighlightNode, CodeNode, $createCodeNode, $isCodeNode } = require('@lexical/code-core')
+const { QuoteNode, $createQuoteNode } = require('@lexical/rich-text')
+const { $formatBlock } = require('./blocks')
+
+function updateEditor (editor, fn) {
+  editor.update(fn, { discrete: true })
+}
+
+function createEditor () {
+  return createHeadlessEditor({
+    namespace: 'sn-test',
+    nodes: [QuoteNode, CodeNode, CodeHighlightNode],
+    onError: error => { throw error }
+  })
+}
+
+describe('$formatBlock', () => {
+  test('unwraps a quote around a fenced code block without dropping the code block', () => {
+    const editor = createEditor()
+
+    let firstChildType
+    let firstChildText
+    let firstChildIsCode
+
+    updateEditor(editor, () => {
+      const root = $getRoot()
+      const code = $createCodeNode('js').append($createTextNode('console.log(hello)'))
+      root.append($createQuoteNode().append(code))
+      code.selectEnd()
+
+      $formatBlock(editor, 'quote')
+
+      const firstChild = root.getFirstChild()
+      firstChildType = firstChild.getType()
+      firstChildText = firstChild.getTextContent()
+      firstChildIsCode = $isCodeNode(firstChild)
+    })
+
+    expect(firstChildIsCode).toBe(true)
+    expect(firstChildType).toBe('code')
+    expect(firstChildText).toBe('console.log(hello)')
+  })
+
+  test('unwraps a selected quote node when the selection starts at the root', () => {
+    const editor = createEditor()
+
+    let firstChildType
+    let firstChildText
+    let firstChildIsCode
+
+    updateEditor(editor, () => {
+      const root = $getRoot()
+      const code = $createCodeNode('js').append($createTextNode('console.log(hello)'))
+      root.append($createQuoteNode().append(code))
+      $selectAll()
+
+      $formatBlock(editor, 'quote')
+
+      const firstChild = root.getFirstChild()
+      firstChildType = firstChild.getType()
+      firstChildText = firstChild.getTextContent()
+      firstChildIsCode = $isCodeNode(firstChild)
+    })
+
+    expect(firstChildIsCode).toBe(true)
+    expect(firstChildType).toBe('code')
+    expect(firstChildText).toBe('console.log(hello)')
+  })
+
+  test('unwraps inline quote content into a paragraph', () => {
+    const editor = createEditor()
+
+    let firstChildType
+    let firstChildText
+
+    updateEditor(editor, () => {
+      const root = $getRoot()
+      const text = $createTextNode('quoted')
+      root.append($createQuoteNode().append(text))
+      text.select()
+
+      $formatBlock(editor, 'quote')
+
+      const firstChild = root.getFirstChild()
+      firstChildType = firstChild.getType()
+      firstChildText = firstChild.getTextContent()
+    })
+
+    expect(firstChildType).toBe('paragraph')
+    expect(firstChildText).toBe('quoted')
+  })
+})


### PR DESCRIPTION
## Summary
- unwrap selected quote nodes instead of converting nested code blocks to paragraphs when toggling Quote off
- preserve block children like code blocks as top-level blocks while wrapping inline quote content back into paragraphs
- add regression coverage for cursor-in-code, root selection, and inline quote text cases

Fixes #2862

## Test plan
- npm test -- --runTestsByPath lib/lexical/commands/formatting/blocks.spec.js
- npx standard lib/lexical/commands/formatting/blocks.js lib/lexical/commands/formatting/blocks.spec.js