### PR TITLE
[codex] Check receive wallet network

### DIFF
--- a/lib/bolt11.js
+++ b/lib/bolt11.js
@@ -3,6 +3,32 @@ import { decode as decodeBolt11 } from 'light-bolt11-decoder'
 // Client-side BOLT11 parsing is for UX only. Server payment validation remains
 // authoritative and continues to use ln-service in the payment path.
 
+const BOLT11_BITCOIN_NETWORKS = [
+  {
+    name: 'bitcoin regtest',
+    prefixes: ['lnbcrt'],
+    chainIds: ['0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206']
+  },
+  {
+    name: 'bitcoin signet',
+    prefixes: ['lntbs'],
+    chainIds: ['00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6']
+  },
+  {
+    name: 'bitcoin testnet',
+    prefixes: ['lntb'],
+    chainIds: [
+      '000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943',
+      '00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043'
+    ]
+  },
+  {
+    name: 'bitcoin mainnet',
+    prefixes: ['lnbc'],
+    chainIds: ['000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f']
+  }
+]
+
 class Bolt11Error extends Error {
   constructor (message) {
     super(message)
@@ -41,6 +67,38 @@ export function bolt11Section (decoded, name) {
 
 export function isBolt11PaymentRequest (value) {
   return Boolean(safeDecodeBolt11(value))
+}
+
+export function bolt11Network (bolt11) {
+  const normalized = normalizeBolt11PaymentRequest(bolt11).toLowerCase()
+  if (!normalized) return null
+
+  return BOLT11_BITCOIN_NETWORKS.find(({ prefixes }) => (
+    prefixes.some(prefix => normalized.startsWith(prefix))
+  )) ?? null
+}
+
+export function bolt11NetworkForChains (chains = []) {
+  const chainSet = new Set(chains)
+  return BOLT11_BITCOIN_NETWORKS.find(({ chainIds }) => (
+    chainIds.some(chainId => chainSet.has(chainId))
+  )) ?? null
+}
+
+export function assertBolt11MatchesChains (bolt11, chains) {
+  const invoiceNetwork = bolt11Network(bolt11)
+  if (!invoiceNetwork) {
+    throw new InvalidBolt11Error()
+  }
+
+  const localNetwork = bolt11NetworkForChains(chains)
+  if (!localNetwork) {
+    throw new Bolt11Error('unable to determine local bitcoin network')
+  }
+
+  if (invoiceNetwork !== localNetwork) {
+    throw new Bolt11Error(`wallet invoice is for ${invoiceNetwork.name}, but SN node is on ${localNetwork.name}`)
+  }
 }
 
 export function bolt11Msats (bolt11) {

--- a/lib/bolt11.spec.js
+++ b/lib/bolt11.spec.js
@@ -1,0 +1,54 @@
+/* eslint-env jest */
+
+import {
+  assertBolt11MatchesChains,
+  bolt11Network,
+  bolt11NetworkForChains
+} from './bolt11'
+
+const CHAINS = {
+  mainnet: '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f',
+  testnet: '000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943',
+  testnet4: '00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043',
+  signet: '00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6',
+  regtest: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206'
+}
+
+describe('bolt11 networks', () => {
+  it('detects bitcoin networks from BOLT11 prefixes', () => {
+    expect(bolt11Network('lnbc1pvalidish')?.name).toBe('bitcoin mainnet')
+    expect(bolt11Network('lntb1pvalidish')?.name).toBe('bitcoin testnet')
+    expect(bolt11Network('lntbs1pvalidish')?.name).toBe('bitcoin signet')
+    expect(bolt11Network('lnbcrt1pvalidish')?.name).toBe('bitcoin regtest')
+  })
+
+  it('unwraps lightning-prefixed invoices before detecting the network', () => {
+    expect(bolt11Network('lightning:lnbcrt1pvalidish')?.name).toBe('bitcoin regtest')
+    expect(bolt11Network('bitcoin:bcrt1qexample?lightning=lnbcrt1pvalidish')?.name).toBe('bitcoin regtest')
+  })
+
+  it('maps ln-service wallet chains to BOLT11 networks', () => {
+    expect(bolt11NetworkForChains([CHAINS.mainnet])?.name).toBe('bitcoin mainnet')
+    expect(bolt11NetworkForChains([CHAINS.testnet])?.name).toBe('bitcoin testnet')
+    expect(bolt11NetworkForChains([CHAINS.testnet4])?.name).toBe('bitcoin testnet')
+    expect(bolt11NetworkForChains([CHAINS.signet])?.name).toBe('bitcoin signet')
+    expect(bolt11NetworkForChains([CHAINS.regtest])?.name).toBe('bitcoin regtest')
+  })
+
+  it('accepts invoices for the local wallet chain', () => {
+    expect(() => assertBolt11MatchesChains('lnbc1pvalidish', [CHAINS.mainnet])).not.toThrow()
+    expect(() => assertBolt11MatchesChains('lnbcrt1pvalidish', [CHAINS.regtest])).not.toThrow()
+  })
+
+  it('rejects invoices for a different bitcoin network', () => {
+    expect(() => assertBolt11MatchesChains('lnbc1pvalidish', [CHAINS.regtest]))
+      .toThrow('wallet invoice is for bitcoin mainnet, but SN node is on bitcoin regtest')
+  })
+
+  it('rejects unknown invoice and chain networks', () => {
+    expect(() => assertBolt11MatchesChains('not-an-invoice', [CHAINS.regtest]))
+      .toThrow('invalid bolt11 invoice')
+    expect(() => assertBolt11MatchesChains('lnbc1pvalidish', ['unknown-chain']))
+      .toThrow('unable to determine local bitcoin network')
+  })
+})

--- a/wallets/server/resolvers/protocol.js
+++ b/wallets/server/resolvers/protocol.js
@@ -19,6 +19,8 @@ import { WALLET_CREATE_INVOICE_TIMEOUT_MS } from '@/lib/constants'
 import { decodeCursor, LIMIT, nextCursorEncoded } from '@/lib/cursor'
 import { writeWalletLog } from '@/wallets/server/logger'
 import { WalletValidationError } from '@/wallets/client/errors'
+import { getWalletInfo } from 'ln-service'
+import { assertBolt11MatchesChains } from '@/lib/bolt11'
 
 const MAX_WALLET_LOG_MESSAGE_BYTES = 4096
 
@@ -43,7 +45,7 @@ export const resolvers = {
 // `WalletRecvProtocolTestInput` guarantees exactly one branch is set and only
 // lists recv branches, so we decode the relation name and forward the plaintext
 // config to the provider probe.
-export async function testWalletRecvProtocol (parent, { config: wrapper }, { me }) {
+export async function testWalletRecvProtocol (parent, { config: wrapper }, { me, lnd }) {
   if (!me) throw new GqlAuthenticationError()
 
   const { protocol, config } = decodeProtocolConfig(wrapper)
@@ -66,8 +68,11 @@ export async function testWalletRecvProtocol (parent, { config: wrapper }, { me 
     throw new GqlInputError('failed to create invoice: ' + e.message)
   }
 
-  if (!invoice || !invoice.startsWith('lnbc')) {
-    throw new GqlInputError('wallet returned invalid invoice')
+  try {
+    const { chains } = await getWalletInfo({ lnd })
+    assertBolt11MatchesChains(invoice, chains)
+  } catch (e) {
+    throw new GqlInputError(e.message || 'wallet returned invalid invoice')
   }
 
   return true


### PR DESCRIPTION
Closes #1028

## Summary
- map BOLT11 Bitcoin invoice prefixes to the chain IDs returned by `ln-service` wallet info
- validate receive-wallet probe invoices against the local SN LND chain before accepting a capability test
- add focused coverage for mainnet, testnet/testnet4, signet, regtest, and mismatch errors

## Why
Receive wallet tests previously accepted invoices by prefix only. That let a wallet on a different Bitcoin network pass the probe instead of failing before it could be saved for auto-withdrawals.

## Validation
- `npm test -- --runTestsByPath lib/bolt11.spec.js --runInBand`
- `npx standard lib/bolt11.js lib/bolt11.spec.js wallets/server/resolvers/protocol.js`
- `git diff --check`
