### PR TITLE
fix: override hard-coded table exportDOM styles

### DIFF
--- a/styles/text.scss
+++ b/styles/text.scss
@@ -935,7 +935,8 @@ span + .sn-link {
   outline: 2px solid rgb(60, 132, 244);
 }
 .sn-table__cell {
-  border: 1px solid var(--theme-borderColor);
+  // override table hard coded border color
+  border: 1px solid var(--theme-borderColor) !important;
   min-width: 75px;
   vertical-align: top;
   text-align: start;
@@ -944,6 +945,12 @@ span + .sn-link {
   outline: none;
   overflow: auto;
   line-height: 1.2;
+}
+
+.sn-table__cell:empty::after {
+  // createDOM places a <br> while exportDOM doesn't
+  // we make sure to have a line box at line-height, like the <br>
+  content: '\00a0';
 }
 
 /*
@@ -964,11 +971,14 @@ span + .sn-link {
   top: 0;
 }
 .sn-table__cell--header {
-  background-color: var(--theme-commentBg);
+  // override table hard coded background color
+  background-color: var(--theme-commentBg) !important;
   text-align: start;
 }
 .sn-table__cell--selected {
   caret-color: transparent;
+  // can't see the highlight in dark mode, so we add a solid border
+  border: 1px solid rgb(60, 132, 244) !important;
 }
 .sn-table__cell--selected::after {
   position: absolute;


### PR DESCRIPTION
## Description

Fixes #2777 
Our SSR HTML placeholder for Lexical uses HTML produced by each node's `exportDOM`.
For compatibility reasons, the Lexical team decided to inject hard coded inline styles to table cells when exporting them. Table cells rendered via `createDOM` (live Lexical instance) don't have inline styles, and instead adhere to our `text.scss` rules.
This results in a very visible discrepancy both in style (border, background color) and in dimensions (empty table cells don't have a `<br>`).

To fix this, instead of overriding `TableCellNode` or using `DOMRenderExtension` to override the node's `exportDOM`, we just prioritize our style via `!important`.
This PR also fixes table cell selection visibility in dark mode by "highlighting" the border other than its background color.

## Screenshots

[before] selected tables

<img width="478" height="182" alt="image" src="https://github.com/user-attachments/assets/7f47e5e1-918b-45b2-982f-5f384a87f5a6" />

<img width="467" height="179" alt="image" src="https://github.com/user-attachments/assets/fa4ff638-53e2-43c0-b4fa-5a698518892d" />


[after] selected tables with colored border

<img width="466" height="178" alt="image" src="https://github.com/user-attachments/assets/c55c1270-f900-45e0-8827-14b1c7940fad" />

<img width="470" height="182" alt="image" src="https://github.com/user-attachments/assets/a89d7c36-6ed6-4d56-a45a-3622634f7fd4" />

---

[before] important styles


https://github.com/user-attachments/assets/41bbfd45-5b42-4c54-8f9a-e69f3357bb18

[after] important styles


https://github.com/user-attachments/assets/35ba13bd-410e-4bc4-b029-7311c9ed9896



## Additional Context

Even though we're not using it here, discovering `DOMRenderExtension` made me think of ways to simplify our `ItemContextExtension`. The extension injects important data such as `imgproxyUrls` and user privacy settings, it influences the state we generate from markdown via carefully orchestrated node transforms. We could probably use `DOMRenderExtension` to inject data without all these extra steps, but needs more exploration.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

8, works great

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Yes, see screenshots

**Did you use AI for this? If so, how much did it assist you?**

No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped presentation changes in table styles only; no logic, auth, or data handling.
> 
> **Overview**
> Aligns SSR/exported table HTML with live editor styling by forcing theme borders and header backgrounds on `.sn-table__cell` / `.sn-table__cell--header` with **`!important`**, so Lexical **`exportDOM`** inline styles no longer win over `text.scss`.
> 
> Adds **`.sn-table__cell:empty::after`** with a non-breaking space so empty cells keep a line box like **`createDOM`**’s `<br>` when export leaves cells truly empty.
> 
> Improves **selected cell** visibility in dark mode by applying a solid blue border on **`.sn-table__cell--selected`** in addition to the existing highlight overlay.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6070a30922dfc19ac8bea92f4e92891f54940fda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->