### PR TITLE
fix: don't parse domain npubs, parse pathname instead

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -126,7 +126,7 @@ export function parseEmbedUrl (href) {
     const { hostname, pathname, searchParams } = new URL(href)
 
     // nostr prefixes: [npub1, nevent1, nprofile1, note1]
-    const nostr = href.match(/\/(?<id>(?<type>npub1|nevent1|nprofile1|note1|naddr1)[02-9ac-hj-np-z]+)/)
+    const nostr = pathname.match(/\/(?<id>(?<type>npub1|nevent1|nprofile1|note1|naddr1)[02-9ac-hj-np-z]+)/)
     if (nostr?.groups?.id) {
       let id = nostr.groups.id
       if (nostr.groups.type === 'npub1') {

--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { parseInternalLinks, isMisleadingLink } from './url.js'
+import { parseInternalLinks, isMisleadingLink, parseEmbedUrl } from './url.js'
 
 const internalLinkCases = [
   ['https://stacker.news/items/123', '#123'],
@@ -61,6 +61,28 @@ describe('misleading links', () => {
     (text, href, expected) => {
       const actual = isMisleadingLink(text, href)
       expect(actual).toBe(expected)
+    }
+  )
+})
+
+const nostrEmbedUrlCases = [
+  ['https://njump.me/nprofile1qqsfy7f8d0lms08wxw2xu4jvxcq2x2zqy6dgypksrh05p3jr9w4qhjc2xjd74', true],
+  ['https://yakihonne.com/note/nevent1qgsfy7f8d0lms08wxw2xu4jvxcq2x2zqy6dgypksrh05p3jr9w4qhjcppemhxue69uhkummn9ekx7mp0qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qpqa56frq6ljgdeh85rntn50yv3c9u5ffkd26nzs698h9xuljtezljs98kq07', true],
+  ['https://npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk.nsite.lol/', false],
+  ['https://njump.me/nevent1qgsfy7f8d0lms08wxw2xu4jvxcq2x2zqy6dgypksrh05p3jr9w4qhjcppemhxue69uhkummn9ekx7mp0qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qpqa56frq6ljgdeh85rntn50yv3c9u5ffkd26nzs698h9xuljtezljs98kq07', true],
+  ['https://primal.net/p/npub1jfujw6llhq7wuvu5detycdsq5v5yqf56sgrdq8wlgrryx2a2p09svwm0gx', true]
+]
+
+describe('embed nostr links', () => {
+  test.each(nostrEmbedUrlCases)(
+    'identifies %p as embed: %p',
+    (url, expectedEmbed) => {
+      const actual = parseEmbedUrl(url)
+      if (expectedEmbed) {
+        expect(actual).toMatchObject({ provider: 'nostr' })
+      } else {
+        expect(actual).toBeNull()
+      }
     }
   )
 })


### PR DESCRIPTION
## Description

Fixes #2252, confirms #2253

The original issue talked about npubs being erroneously parsed from links, causing a double link. Now that we differentiate between an autolink and a link, the story is a bit different.
An autolink can be a plain text URL or a markdown `[url](url)`, npubs present in full links `[](url)`/`[text](url)` are not subjected to autolink detection anymore.

This issue now only applies to autolinks, and the result is not a double link anymore. It's an embed!
This PR fixes this by confirming #2253's resolution, which is to parse npubs from pathnames instead of whole URLs.

Of course, if someone creates an autolink like this: `https://google.com/npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk`, it will get converted into a nostr embed. To opt-out of nostr embeds, users need to create a link rather than an autolink.

## Screenshots

text example:

```
should be an embed
https://njump.me/npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk

should be a nostr link
npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk

should be a normal link
https://npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk.nsite.lol
```

Before:

<img width="721" height="562" alt="image" src="https://github.com/user-attachments/assets/22127979-4e71-4f22-a0ef-7e44ecf06266" />


After:

<img width="708" height="349" alt="image" src="https://github.com/user-attachments/assets/4987abf1-a488-4ba8-a411-6a0fe43cc1c3" />

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7, works great and nostr embed detection happens only on pathnames of autolinks.

**Did you use AI for this? If so, how much did it assist you?**

No


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to autolink embed heuristics with regression tests; no auth or data handling impact.
> 
> **Overview**
> **Nostr embed detection** in `parseEmbedUrl` now runs the bech32 regex against the URL **pathname** instead of the full href string.
> 
> That stops hostnames like `npub1….nsite.lol` from being misread as nostr embeds while still embedding njump, primal, yakihonne, and similar links whose path contains `npub1` / `nevent1` / etc.
> 
> **Tests** add `parseEmbedUrl` cases for path-based nostr URLs (expect embed) vs npub-in-domain URLs (expect no embed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b569624c9719eae3f9f7951a2dc803b50bce345e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->