### PR TITLE
Do not use .min() in yup's form validation for dates

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -295,7 +295,11 @@ export function pollSchema ({ numExistingChoices = 0, ...args }) {
       message: `at least ${MIN_POLL_NUM_CHOICES} choices required`,
       test: arr => arr.length >= MIN_POLL_NUM_CHOICES - numExistingChoices
     }),
-    pollExpiresAt: date().nullable().min(datePivot(new Date(), { days: 1 }), 'Expiration must be at least 1 day in the future'),
+    pollExpiresAt: date().nullable().test({
+      name: 'min',
+      message: 'Expiration must be at least 1 day in the future',
+      test: value => !value || value >= datePivot(new Date(), { days: 1 })
+    }),
     randPollOptions: boolean(),
     ...advPostSchemaMembers(args),
     ...subSelectSchemaMembers('POLL', args)

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -7,20 +7,16 @@ describe('pollSchema', () => {
     jest.useRealTimers()
   })
 
-  test('evaluates poll expiration minimum at validation time', async () => {
+  test('rejects poll expiration less than one day in the future', async () => {
     jest.useFakeTimers()
-    jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
+    jest.setSystemTime(new Date(2026, 5, 14, 1, 0, 0, 0, 0))
 
-    const schema = pollSchema({})
-    const defaultExpiration = new Date(2026, 5, 15, 0, 0, 0, 0)
-
-    jest.setSystemTime(new Date(2026, 5, 14, 12, 0, 0, 0, 0))
-
-    await expect(schema.validateAt('pollExpiresAt', { pollExpiresAt: defaultExpiration }))
-      .rejects.toThrow('Expiration must be at least 1 day in the future')
+    await expect(pollSchema({}).validateAt('pollExpiresAt', {
+      pollExpiresAt: new Date(2026, 5, 15, 0, 0, 0, 0)
+    })).rejects.toThrow('Expiration must be at least 1 day in the future')
   })
 
-  test('accepts poll expiration at least one day from validation time', async () => {
+  test('accepts poll expiration exactly one day in the future', async () => {
     jest.useFakeTimers()
     jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
 
@@ -29,8 +25,18 @@ describe('pollSchema', () => {
     })).resolves.toEqual(new Date(2026, 5, 14, 0, 0, 0, 0))
   })
 
+  test('accepts poll expiration more than one day in the future', async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
+
+    await expect(pollSchema({}).validateAt('pollExpiresAt', {
+      pollExpiresAt: new Date(2026, 5, 14, 1, 0, 0, 0)
+    })).resolves.toEqual(new Date(2026, 5, 14, 1, 0, 0, 0))
+  })
+
   test('allows poll expiration to be cleared', async () => {
-    await expect(pollSchema({}).validateAt('pollExpiresAt', { pollExpiresAt: null }))
-      .resolves.toBeNull()
+    await expect(pollSchema({}).validateAt('pollExpiresAt', {
+      pollExpiresAt: null
+    })).resolves.toBeNull()
   })
 })

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+
+import { pollSchema } from './validate'
+
+describe('pollSchema', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  test('evaluates poll expiration minimum at validation time', async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
+
+    const schema = pollSchema({})
+    const defaultExpiration = new Date(2026, 5, 15, 0, 0, 0, 0)
+
+    jest.setSystemTime(new Date(2026, 5, 14, 12, 0, 0, 0, 0))
+
+    await expect(schema.validateAt('pollExpiresAt', { pollExpiresAt: defaultExpiration }))
+      .rejects.toThrow('Expiration must be at least 1 day in the future')
+  })
+
+  test('accepts poll expiration at least one day from validation time', async () => {
+    jest.useFakeTimers()
+    jest.setSystemTime(new Date(2026, 5, 13, 0, 0, 0, 0))
+
+    await expect(pollSchema({}).validateAt('pollExpiresAt', {
+      pollExpiresAt: new Date(2026, 5, 14, 0, 0, 0, 0)
+    })).resolves.toEqual(new Date(2026, 5, 14, 0, 0, 0, 0))
+  })
+
+  test('allows poll expiration to be cleared', async () => {
+    await expect(pollSchema({}).validateAt('pollExpiresAt', { pollExpiresAt: null }))
+      .resolves.toBeNull()
+  })
+})


### PR DESCRIPTION
## Description

Do not use `.min()` in `yup`'s form validation but instead write out the minimum date test. Recalculate the minimum date each call (cheap.)

## Screenshots

## Additional Context

Fixes #907. First commit taken from #3067, my work only adds harmonized, cleaner tests in the `.spec` file. Isolated from #3078 

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

8 - manually tested on dev env

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Tested on AOSP/Vanadium

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

No.