### PR TITLE
enhancement: open link editor in edit mode by default on new links

### DIFF
--- a/components/editor/plugins/link/editor.js
+++ b/components/editor/plugins/link/editor.js
@@ -75,7 +75,7 @@ export default function LinkEditor ({ nodeKey, anchorElem, onDismiss }) {
     const newUrl = linkNode.getURL()
     setLinkUrl(newUrl)
 
-    if (!isLinkEditMode && (newUrl.trim() === '')) {
+    if (!isLinkEditMode && (newUrl.trim() === 'https://')) {
       setEditedLinkUrl('')
       setIsLinkEditMode(true)
     }

--- a/components/editor/plugins/link/editor.js
+++ b/components/editor/plugins/link/editor.js
@@ -75,7 +75,7 @@ export default function LinkEditor ({ nodeKey, anchorElem, onDismiss }) {
     const newUrl = linkNode.getURL()
     setLinkUrl(newUrl)
 
-    if (!isLinkEditMode && (newUrl.trim() === 'https://')) {
+    if (!isLinkEditMode && (newUrl.trim() === '' || newUrl.trim() === DEFAULT_URL)) {
       setEditedLinkUrl('')
       setIsLinkEditMode(true)
     }


### PR DESCRIPTION
## Description

Automatically opens the link editor in edit mode when creating a new link (`url: 'https://'`)

## Screenshots


https://github.com/user-attachments/assets/c85f3823-a6b3-4bec-bf36-d9a2f93fed34


## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7 - empty links; links with default url from markdown; new link from url; new link from text

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional in the Lexical link floater UI; behavior aligns with existing cancel/unlink handling for `DEFAULT_URL`.
> 
> **Overview**
> When the floating link editor opens on a link whose URL is still the **default placeholder** (`DEFAULT_URL`, e.g. `https://` for new links), it now **enters edit mode automatically**, same as for an empty URL.
> 
> The `$updateLink` condition was extended from `newUrl.trim() === ''` to also treat `newUrl.trim() === DEFAULT_URL`, so users can type a real URL immediately instead of seeing view mode with the placeholder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f3fe6d5b12fe84d17a5a8b52b941261edb73c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->