### PR TITLE
fix: unescape brackets in link text

### DIFF
--- a/lib/lexical/utils/mdast.js
+++ b/lib/lexical/utils/mdast.js
@@ -87,6 +87,26 @@ function escapeConfig (node, _parent, state, info) {
   return state.safe(node.value, info).replace(/&#x20;/g, ' ')
 }
 
+/** unescape `[` and `]` in link text if brackets are balanced
+ *
+ * brackets are balanced when the number of opening brackets is equal to the number of closing brackets
+ */
+function unescapeBalancedBrackets (text) {
+  if (text.includes('`')) return text
+
+  // drop the backslash before each escaped bracket: `\[` -> `[`, `\]` -> `]`
+  const unescaped = text.replace(/\\([[\]])/g, '$1')
+
+  // check if the brackets are balanced
+  let open = 0
+  for (const char of unescaped) {
+    if (char === '[') open++
+    else if (char === ']') open--
+    if (open < 0) return text // a closing bracket with nothing open
+  }
+  return open === 0 ? unescaped : text
+}
+
 export function $lexicalToMarkdown (transformerBridge = false) {
   const markdown = exportMarkdownFromLexical({
     root: $getRoot(),
@@ -128,7 +148,8 @@ export function $lexicalToMarkdown (transformerBridge = false) {
         // prevent autolink syntax (<url>), always use [text](url)
         link: (node, _parent, state) => {
           const text = state.containerPhrasing(node, { before: '[', after: ']' })
-          return `[${text}](${node.url || ''}${node.title ? ` "${node.title}"` : ''})`
+          const linkText = unescapeBalancedBrackets(text)
+          return `[${linkText}](${node.url || ''}${node.title ? ` "${node.title}"` : ''})`
         }
       }
     }

--- a/lib/lexical/utils/mdast.js
+++ b/lib/lexical/utils/mdast.js
@@ -91,26 +91,6 @@ function escapeConfig (node, _parent, state, info) {
   return state.safe(node.value, info).replace(/&#x20;/g, ' ')
 }
 
-/** unescape `[` and `]` in link text if brackets are balanced
- *
- * brackets are balanced when the number of opening brackets is equal to the number of closing brackets
- */
-function unescapeBalancedBrackets (text) {
-  if (text.includes('`')) return text
-
-  // drop the backslash before each escaped bracket: `\[` -> `[`, `\]` -> `]`
-  const unescaped = text.replace(/\\([[\]])/g, '$1')
-
-  // check if the brackets are balanced
-  let open = 0
-  for (const char of unescaped) {
-    if (char === '[') open++
-    else if (char === ']') open--
-    if (open < 0) return text // a closing bracket with nothing open
-  }
-  return open === 0 ? unescaped : text
-}
-
 export function $lexicalToMarkdown (transformerBridge = false) {
   const markdown = exportMarkdownFromLexical({
     root: $getRoot(),
@@ -149,11 +129,15 @@ export function $lexicalToMarkdown (transformerBridge = false) {
           const title = node.title ? ` "${node.title}"` : ''
           return `![${alt}](${node.url || ''}${title})`
         },
-        // prevent autolink syntax (<url>), always use [text](url)
-        link: (node, _parent, state) => {
-          const text = state.containerPhrasing(node, { before: '[', after: ']' })
-          const linkText = unescapeBalancedBrackets(text)
-          return `[${linkText}](${node.url || ''}${node.title ? ` "${node.title}"` : ''})`
+        // prevent autolink syntax (<url>), always use [text](url).
+        // enter the 'label' construct so mdast escapes [ and ] symmetrically;
+        // without it a lone ] ends the label early and the link silently
+        // degrades to plain text (e.g. text `a]b` -> broken `[a]b](url)`).
+        link: (node, _parent, state, info) => {
+          const exit = state.enter('label')
+          const text = state.containerPhrasing(node, { ...info, before: '[', after: '](' })
+          exit()
+          return `[${text}](${node.url || ''}${node.title ? ` "${node.title}"` : ''})`
         }
       }
     }


### PR DESCRIPTION
## Description

Fixes #2879 by unescaping opening brackets that have a closing bracket in link nodes.

## Screenshots


https://github.com/user-attachments/assets/9d9eb778-c2c4-4af0-a5b5-a607c6b81dce


## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

6:

- `[text [here](url)` textnode and link
- `[[text] here](url)` whole link
- `[text] here](url)` textnode

**Did you use AI for this? If so, how much did it assist you?**

yes review and tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path change to the Lexical→markdown link handler; improves escaping for edge-case link labels with no auth or data implications.
> 
> **Overview**
> Fixes Lexical→markdown export for links whose label text contains `[` or `]`, which could produce invalid markdown (e.g. `a]b` becoming a broken `[a]b](url)` instead of a proper link).
> 
> The custom **`link`** handler in `$lexicalToMarkdown` now enters mdast’s **`label`** construct while serializing link phrasing, so brackets are escaped symmetrically like standard link labels. **`containerPhrasing`** is called with `after: ']('` (instead of `']'`) and the handler’s **`info`** is passed through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08bffdb928cbf03072cfdb7b83e6b0e85f8a0874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->