### PR TITLE
prevent multiple in-flight autowithdraws

### DIFF
--- a/api/payIn/types/autoWithdrawal.js
+++ b/api/payIn/types/autoWithdrawal.js
@@ -1,5 +1,5 @@
 import { PAID_ACTION_PAYMENT_METHODS } from '@/lib/constants'
-import { numWithUnits, msatsToSats } from '@/lib/format'
+import { numWithUnits, msatsToSats, msatsSatsFloor, satsToMsats } from '@/lib/format'
 import { payOutBolt11Prospect } from '../lib/payOutBolt11'
 
 export const anonable = false
@@ -8,7 +8,49 @@ export const paymentMethods = [
   PAID_ACTION_PAYMENT_METHODS.REWARD_SATS
 ]
 
-export async function getInitial (models, { msats, maxFeeMsats }, { me }) {
+export class AutoWithdrawIneligibleError extends Error {
+  constructor (message) {
+    super(message)
+    this.name = 'AutoWithdrawIneligibleError'
+  }
+}
+
+// Single source of truth for the autowithdraw amount + eligibility arithmetic. Returns
+// { threshold, excess, maxFeeMsats, msats } or null when the user is not eligible right now.
+export function computeAutoWithdrawAmount (user) {
+  if (
+    user.autoWithdrawThreshold === null ||
+    user.autoWithdrawMaxFeePercent === null ||
+    user.autoWithdrawMaxFeeTotal === null) return null
+
+  const threshold = satsToMsats(user.autoWithdrawThreshold)
+  const excess = Number(user.msats - threshold)
+
+  // excess must be greater than 10% of threshold
+  if (excess < Number(threshold) * 0.1) return null
+
+  // floor fee to nearest sat but still denominated in msats
+  const maxFeeMsats = msatsSatsFloor(Math.max(
+    Math.ceil(excess * (user.autoWithdrawMaxFeePercent / 100.0)),
+    Number(satsToMsats(user.autoWithdrawMaxFeeTotal))
+  ))
+  // msats will be floored by createInvoice if it needs to be
+  const msats = BigInt(excess) - maxFeeMsats
+
+  // must be >= 100000 msats (100 sats)
+  if (msats < 100000n) return null
+
+  return { threshold, excess: BigInt(excess), maxFeeMsats, msats }
+}
+
+export async function getInitial (models, args, { me }) {
+  const user = await models.user.findUnique({ where: { id: me?.id } })
+  const amount = computeAutoWithdrawAmount(user)
+  if (!amount) {
+    throw new AutoWithdrawIneligibleError('autowithdraw no longer eligible')
+  }
+  const { msats, maxFeeMsats } = amount
+
   // TODO: description, expiry?
   const payOutBolt11 = await payOutBolt11Prospect(models, { msats, description: 'SN: auto-withdrawal' }, { userId: me?.id, payOutType: 'WITHDRAWAL' })
   return {
@@ -25,6 +67,41 @@ export async function getInitial (models, { msats, maxFeeMsats }, { me }) {
         custodialTokenType: 'SATS'
       }
     ]
+  }
+}
+
+// Authoritative, transactional eligibility re-check. Runs inside begin()'s transaction with
+// the user row locked FOR NO KEY UPDATE (obtainRowLevelLocks) and before the debit, so two
+// concurrent autowithdraws serialize on the user row
+export async function validateBeforeCreate (tx, payInProspect, args, { me }) {
+  const user = await tx.user.findUnique({ where: { id: me.id } })
+  const amount = computeAutoWithdrawAmount(user)
+  if (!amount) {
+    throw new AutoWithdrawIneligibleError('autowithdraw no longer eligible')
+  }
+
+  // the already-minted amount (+ routing fee) must still fit under the current excess
+  const routingFeeMsats = payInProspect.payOutCustodialTokens
+    .find(t => t.payOutType === 'ROUTING_FEE')?.mtokens ?? 0n
+  const mintedMsats = payInProspect.payOutBolt11.msats + routingFeeMsats
+  if (mintedMsats > amount.excess) {
+    throw new AutoWithdrawIneligibleError('autowithdraw amount exceeds current excess')
+  }
+
+  // once-per-hour pending/failed-withdrawal guard, now read transactionally under the lock.
+  // keyed on the actually-minted payOutBolt11.msats (post truncation), matching what gets persisted.
+  const [pendingOrFailed] = await tx.$queryRaw`
+    SELECT EXISTS(
+      SELECT *
+      FROM "PayOutBolt11"
+      WHERE "userId" = ${me.id}
+      AND status IS DISTINCT FROM 'CONFIRMED'
+      AND "payOutType" = 'WITHDRAWAL'
+      AND created_at > now() - interval '1 hour'
+      AND "msats" >= ${satsToMsats(msatsToSats(payInProspect.payOutBolt11.msats))}
+    )`
+  if (pendingOrFailed.exists) {
+    throw new AutoWithdrawIneligibleError('autowithdraw pending or recently attempted')
   }
 }
 

--- a/prisma/migrations/20260616120000_autowithdraw_block_inflight_jobs/migration.sql
+++ b/prisma/migrations/20260616120000_autowithdraw_block_inflight_jobs/migration.sql
@@ -1,0 +1,34 @@
+-- Block enqueuing a new autoWithdraw job while one is already in-flight
+-- (created/active/retry), not just 'created'. pg-boss moves a job to 'active'
+-- as soon as a worker picks it up, so the old 'created'-only guard let every
+-- subsequent balance update queue a duplicate while a job was running.
+CREATE OR REPLACE FUNCTION user_auto_withdraw() RETURNS TRIGGER AS $$
+DECLARE
+BEGIN
+    INSERT INTO pgboss.job (name, data)
+    SELECT 'autoWithdraw', jsonb_build_object('id', NEW.id)
+    -- only if there isn't already a pending job for this user
+    WHERE NOT EXISTS (
+        SELECT *
+        FROM pgboss.job
+        WHERE name = 'autoWithdraw'
+        AND data->>'id' = NEW.id::TEXT
+        AND (
+            -- in-flight: queued, running, or awaiting retry
+            state IN ('created', 'active', 'retry')
+            OR
+            -- recently failed: brief backoff before re-enqueuing
+            (state = 'failed' AND startedon > now() - interval '1 minutes')
+        )
+    )
+    AND EXISTS (
+        SELECT *
+        FROM "Wallet" w
+        JOIN "WalletProtocol" wp ON w.id = wp."walletId"
+        WHERE w."userId" = NEW.id
+        AND wp."enabled" = true
+        AND wp.send = false
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/worker/autowithdraw.js
+++ b/worker/autowithdraw.js
@@ -1,45 +1,18 @@
-import { msatsSatsFloor, msatsToSats, satsToMsats } from '@/lib/format'
 import pay from '@/api/payIn'
+import { AutoWithdrawIneligibleError, computeAutoWithdrawAmount } from '@/api/payIn/types/autoWithdrawal'
 
-export async function autoWithdraw ({ data: { id }, models, lnd }) {
+export async function autoWithdraw ({ data: { id }, models }) {
+  // cheap best-effort pre-check so we don't mint a wasted invoice in the common
+  // ineligible case.
   const user = await models.user.findUnique({ where: { id } })
-  if (
-    user.autoWithdrawThreshold === null ||
-    user.autoWithdrawMaxFeePercent === null ||
-    user.autoWithdrawMaxFeeTotal === null) return
+  if (!computeAutoWithdrawAmount(user)) return
 
-  const threshold = satsToMsats(user.autoWithdrawThreshold)
-  const excess = Number(user.msats - threshold)
-
-  // excess must be greater than 10% of threshold
-  if (excess < Number(threshold) * 0.1) return
-
-  // floor fee to nearest sat but still denominated in msats
-  const maxFeeMsats = msatsSatsFloor(Math.max(
-    Math.ceil(excess * (user.autoWithdrawMaxFeePercent / 100.0)),
-    Number(satsToMsats(user.autoWithdrawMaxFeeTotal))
-  ))
-  // msats will be floored by createInvoice if it needs to be
-  const msats = BigInt(excess) - maxFeeMsats
-
-  // must be >= 100000 msats (100 sats)
-  if (msats < 100000n) return
-
-  // check that
-  // 1. the user doesn't have an autowithdraw pending
-  // 2. we have not already attempted to autowithdraw this fee recently
-  const [pendingOrFailed] = await models.$queryRaw`
-    SELECT EXISTS(
-      SELECT *
-      FROM "PayOutBolt11"
-      WHERE "userId" = ${id}
-      AND status IS DISTINCT FROM 'CONFIRMED'
-      AND "payOutType" = 'WITHDRAWAL'
-      AND created_at > now() - interval '1 hour'
-      AND "msats" >= ${satsToMsats(msatsToSats(msats))}
-    )`
-
-  if (pendingOrFailed.exists) return
-
-  await pay('AUTO_WITHDRAWAL', { msats, maxFeeMsats }, { models, me: { id: user.id } })
+  try {
+    await pay('AUTO_WITHDRAWAL', {}, { models, me: { id } })
+  } catch (e) {
+    // a concurrent autowithdraw or a balance drop can make us ineligible by the time we
+    // hold the user-row lock; that's a benign no-op.
+    if (e instanceof AutoWithdrawIneligibleError) return
+    throw e
+  }
 }


### PR DESCRIPTION
This fix #1154 by 

1. preventing additional auto-withdrawals being queued when another one is inflight (or recently failed).
2. making auto-withdrawal eligibility transactional, ie sats eligible for autowithdraw can only be used in one in-flight autowithdraw


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes withdrawal eligibility, job enqueue rules, and transactional locking around custodial debits—incorrect logic could block legitimate withdrawals or allow duplicate payouts under race conditions.
> 
> **Overview**
> Stops duplicate auto-withdraw jobs from piling up while one is already queued, running, retrying, or recently failed, and tightens eligibility so concurrent attempts serialize safely on the user balance.
> 
> The **`user_auto_withdraw`** trigger now treats pg-boss jobs in **`created`**, **`active`**, or **`retry`** (plus **`failed`** within the last minute) as blocking another enqueue for the same user—fixing the case where only **`created`** was checked while a worker had already moved the job to **`active`**.
> 
> Auto-withdraw **amount and fee math** live in shared **`computeAutoWithdrawAmount`**; **`getInitial`** derives **`msats`** / **`maxFeeMsats`** from the current user instead of trusting worker args, and **`validateBeforeCreate`** re-checks eligibility inside **`begin()`**’s transaction (after row locks, before debit), including minted amount vs excess and the hourly pending/failed withdrawal guard. Failures surface as **`AutoWithdrawIneligibleError`**, which the worker treats as a benign no-op.
> 
> The **worker** only does a cheap pre-check, calls **`pay('AUTO_WITHDRAWAL', {})`**, and no longer passes amounts or runs the pending-withdrawal query itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ce36afdc3a74da738256c7c38e17c7e6abfca34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->