### PR TITLE
Downgrade over strong row locks

### DIFF
--- a/api/payIn/README.md
+++ b/api/payIn/README.md
@@ -354,7 +354,14 @@ From the [postgres source docs](https://git.postgresql.org/gitweb/?p=postgresql.
 
 # `IMPORTANT: deadlocks`
 
-Deadlocks can occur when two transactions are waiting for each other to release locks. This can happen when two transactions lock rows in different orders whether explicit or implicit.
+Deadlocks can occur when two transactions are waiting for each other to release locks.
+
+This can happen when:
+
+1. two transactions lock the same rows in different orders whether explicit or implicit.
+2. two transactions lock the same row with compatible locks but interleave upgraded incompatible locks on that row.
+
+## Locking the same rows in different orders
 
 If both transactions lock the rows in the same order, the deadlock is avoided.
 
@@ -411,6 +418,51 @@ UPDATE users
     "stackedMsats" = users."stackedMsats" + forwardees.msats
     FROM forwardees
     WHERE users.id = forwardees."userId";
+```
+
+## Locking the same row with compatible locks then taking interleaved incompatible locks
+
+## Incorrect
+
+```sql
+-- transaction 1 (payIn): obtainRowLevelLocks
+BEGIN;
+SELECT 1 FROM users WHERE id = 1 FOR NO KEY UPDATE;   -- holds NO KEY UPDATE
+
+-- transaction 2 (wallet logger): INSERT walletLog FK-locks the user row
+BEGIN;
+INSERT INTO "WalletLog" ("userId", ...) VALUES (1, ...);  -- holds KEY SHARE
+-- ^ does NOT block: KEY SHARE is compatible with NO KEY UPDATE
+
+-- transaction 1: upgrades NO KEY UPDATE -> FOR UPDATE
+SELECT 1 FROM users WHERE id = 1 FOR UPDATE;  -- blocks: FOR UPDATE conflicts with T2's KEY SHARE
+
+-- transaction 2: upgrades KEY SHARE -> NO KEY UPDATE
+UPDATE users SET "walletsUpdatedAt" = now() WHERE id = 1;  -- blocks: NO KEY UPDATE conflicts with T1's NO KEY UPDATE
+-- deadlock: each waits for the other to release
+```
+
+## Correct
+
+```sql
+-- transaction 1 (payIn): obtainRowLevelLocks
+BEGIN;
+SELECT 1 FROM users WHERE id = 1 FOR NO KEY UPDATE;   -- holds NO KEY UPDATE
+
+-- transaction 2 (wallet logger): INSERT walletLog FK-locks the user row
+BEGIN;
+INSERT INTO "WalletLog" ("userId", ...) VALUES (1, ...);  -- holds KEY SHARE
+
+-- transaction 1: stays compatible with T2's KEY SHARE
+UPDATE users SET msats = msats + 1 WHERE id = 1;
+
+-- transaction 2: waits for T1 to commit
+UPDATE users SET "walletsUpdatedAt" = now() WHERE id = 1;
+
+-- transaction 1: commits
+COMMIT;
+-- transaction 2: commits
+COMMIT;
 ```
 
 ## More resources

--- a/api/payIn/lib/payInCustodialTokens.js
+++ b/api/payIn/lib/payInCustodialTokens.js
@@ -26,7 +26,9 @@ export async function getPayInCustodialTokens (tx, mCustodialCost, payIn, { me }
         (${mCustodialCost} - LEAST(mcredits, ${mCreditPayable})) % 1000 as max_mcredits_modulo_1000
       FROM users
       WHERE id = ${me.id}
-      FOR UPDATE
+      -- this only updates non-key balance columns, so FOR NO KEY UPDATE is the
+      -- appropriate lock — and it matches the lock obtainRowLevelLocks already
+      FOR NO KEY UPDATE
     ),
     user_spending AS (
       SELECT

--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -258,7 +258,9 @@ export default {
           SET "foundNotesAt" = now(), "lastSeenAt" = now()
           WHERE "id" = (
             SELECT "id" FROM users WHERE "id" = ${me.id}
-            FOR UPDATE SKIP LOCKED
+            -- non-key best-effort update: NO KEY UPDATE skips only on real writers,
+            -- not on benign KEY SHARE FK-insert locks, and never blocks (SKIP LOCKED)
+            FOR NO KEY UPDATE SKIP LOCKED
           )`.catch(console.error)
       }
 
@@ -591,7 +593,9 @@ export default {
         SET "checkedNotesAt" = now(), "lastSeenAt" = now()
         WHERE "id" = (
           SELECT "id" FROM users WHERE "id" = ${me.id}
-          FOR UPDATE SKIP LOCKED
+          -- non-key best-effort update: NO KEY UPDATE skips only on real writers,
+          -- not on benign KEY SHARE FK-insert locks, and never blocks (SKIP LOCKED)
+          FOR NO KEY UPDATE SKIP LOCKED
         )`.catch(console.error)
 
       return false

--- a/wallets/server/badges.js
+++ b/wallets/server/badges.js
@@ -27,9 +27,12 @@ export async function updateWalletBadges ({ userId, tx }) {
   // Lock the user row before reading the old badge state so concurrent saves for
   // the same user serialize here. Otherwise both read the pre-transition value and
   // each start a duplicate, never-reaped HORSE/GUN streak (no open-streak unique
-  // constraint exists). Mirrors assertVaultKeyUnchanged's FOR UPDATE on users.
+  // constraint exists). Mirrors assertVaultKeyUnchanged's FOR NO KEY UPDATE on users.
+  // FOR NO KEY UPDATE (not FOR UPDATE): only non-key columns are read/updated, so this
+  // still serializes concurrent saves without upgrading the user-row lock and
+  // deadlocking (e.g. with the wallet logger's status write via wallet_updated_at).
   const [{ hasRecvWallet: oldHasRecvWallet, hasSendWallet: oldHasSendWallet }] = await tx.$queryRaw`
-    SELECT "hasRecvWallet", "hasSendWallet" FROM users WHERE id = ${userId} FOR UPDATE`
+    SELECT "hasRecvWallet", "hasSendWallet" FROM users WHERE id = ${userId} FOR NO KEY UPDATE`
 
   const wallets = await tx.wallet.findMany({
     where: {

--- a/wallets/server/persist.js
+++ b/wallets/server/persist.js
@@ -214,7 +214,11 @@ export async function deleteWalletIfEmpty (tx, walletId) {
 // conditional key *write* via updateVaultMetadata — since they rotate the key.)
 export async function assertVaultKeyUnchanged (tx, userId, expectedHash) {
   const [current] = await tx.$queryRaw`
-    SELECT "vaultKeyHash" FROM users WHERE id = ${userId} FOR UPDATE`
+    -- FOR NO KEY UPDATE (not FOR UPDATE): this is a non-key read/guard, so it still
+    -- serializes against the passphrase rotation (a non-key vaultKeyHash write) but
+    -- doesn't upgrade the user-row lock this tx already holds — which would deadlock
+    -- with another tx escalating its own lock on the same row.
+    SELECT "vaultKeyHash" FROM users WHERE id = ${userId} FOR NO KEY UPDATE`
   if (current?.vaultKeyHash !== expectedHash) {
     throw new GqlInputError('passphrase changed, please retry')
   }


### PR DESCRIPTION
While testing #3110 I experienced deadlocks caused by the `FOR UPDATE` locks (debiting for payins) contending with `walletLog`. Example in the updated README, but tldr:

1. all payins take `FOR NO KEY UPDATE` on `users` to serialize balance updates
2. `payInCustodialTokens` took `FOR UPDATE` locks on `users` as defense-in-depth when debiting CCs/sats (and before I knew I could/should take weaker locks)
3. `walletLog` takes an implicit `FOR KEY SHARE` on `users` when updating an fk relation
4. then `walletLog`'s status update trigger takes an implicit `FOR NO KEY UPDATE` on `users` to update `walletUpdatedAt`

When performed in the right order (e.g. 1,3,2,4), deadlock occurs.

-----------

I also took the liberty to downgrade other over-strong locks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency and locking on `users` during pay-ins, wallet saves, and notification polling; behavior should be safer but any lock-semantics mistake could affect balance serialization or OCC guards.
> 
> **Overview**
> Fixes deadlocks between pay-ins and wallet logging by **downgrading** `users` row locks from `FOR UPDATE` to **`FOR NO KEY UPDATE`** wherever only non-key columns (balances, badges, vault hash, note timestamps) are read or updated.
> 
> **`payInCustodialTokens`** now locks the payer with `FOR NO KEY UPDATE`, aligned with `obtainRowLevelLocks`, so custodial debits no longer escalate to `FOR UPDATE` and fight `WalletLog`’s implicit `KEY SHARE` plus `walletsUpdatedAt`’s `NO KEY UPDATE`.
> 
> The same weaker lock is used in **`assertVaultKeyUnchanged`**, **`updateWalletBadges`**, and best-effort **`hasNewNotes`** updates (`FOR NO KEY UPDATE SKIP LOCKED` instead of `FOR UPDATE SKIP LOCKED`) so benign FK locks do not cause skips or circular waits.
> 
> **`api/payIn/README.md`** documents the second deadlock pattern: compatible locks on one row followed by interleaved incompatible upgrades, with payIn vs wallet logger examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cfa3b8c78e7f66554240e42e957e81ced173fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->