### PR TITLE
fix: roundtrip empty Lexical nodes on mode switch

### DIFF
--- a/components/editor/plugins/core/formik.js
+++ b/components/editor/plugins/core/formik.js
@@ -33,9 +33,9 @@ export default function FormikBridgePlugin ({ name = 'text' }) {
     })
   }, 500, [editor, textHelpers, disableSubmit])
 
-  const syncFormik = useCallback((flush = false) => {
+  const syncFormik = useCallback(({ switchMode = false, flush = false } = {}) => {
     editor.getEditorState().read(() => {
-      if ($isTextEmpty()) {
+      if ($isTextEmpty() && !switchMode) {
         textHelpers.setValue('')
         disableSubmit(false) // always enable submit if text is empty
         return
@@ -69,7 +69,7 @@ export default function FormikBridgePlugin ({ name = 'text' }) {
     return editor.registerCommand(
       BLUR_COMMAND,
       () => {
-        syncFormik(true)
+        syncFormik({ flush: true })
         return false
       },
       COMMAND_PRIORITY_HIGH
@@ -79,8 +79,8 @@ export default function FormikBridgePlugin ({ name = 'text' }) {
   useEffect(() => {
     return editor.registerCommand(
       SYNC_FORMIK_COMMAND,
-      (flush = true) => {
-        syncFormik(flush)
+      ({ switchMode = false, flush = true }) => {
+        syncFormik({ switchMode, flush })
         return true
       },
       COMMAND_PRIORITY_HIGH

--- a/components/editor/plugins/toolbar/switch.js
+++ b/components/editor/plugins/toolbar/switch.js
@@ -37,7 +37,7 @@ export default function ModeSwitchPlugin ({ name }) {
 
         if (newMode === (isMarkdownMode(editor) ? MARKDOWN_MODE : RICH_MODE)) return false
 
-        editor.dispatchCommand(SYNC_FORMIK_COMMAND)
+        editor.dispatchCommand(SYNC_FORMIK_COMMAND, { switchMode: true })
 
         // toggle mode
         if (newMode) {

--- a/lib/lexical/mdast/visitors/code.js
+++ b/lib/lexical/mdast/visitors/code.js
@@ -20,7 +20,7 @@ export const LexicalCodeBlockVisitor = {
 
     actions.appendToParent(mdastParent, {
       type: 'code',
-      lang: language === 'text' || language === null ? null : language,
+      lang: language,
       value: lexicalNode.getTextContent()
     })
   }


### PR DESCRIPTION
## Description

Fixes #3109 by not detecting empty nodes when switching editor modes.

Mode switches are based on the current Formik value. Triggered on each mode switch and submit, `syncFormik` checks if the Lexical editor state contains nodes but no text content. If so, it resets the `text` field, helping Formik validation catch empty item creation.

This should happen only on submission, not on mode switches. This PR makes mode switches call `syncFormik` with the flag `switchMode: true`, avoiding cleanup.



## Screenshots


https://github.com/user-attachments/assets/e92399f4-a09d-4165-94f2-a7fdcde1c68e



## Additional Context

This issue exacerbated another, bigger, issue: empty items can be created via `markdown` mode!
`markdown` mode always contains text content, `syncFormik` and `$isTextEmpty()` can't catch empty markdown nodes.
I'll open a separate issue for this.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7, empty content roundtrips on mode switches, submission from `compose` still doesn't allow empty nodes

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**
n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**
n/a

**Did you use AI for this? If so, how much did it assist you?**
No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized editor/Formik sync and markdown export behavior; submit-time empty validation is unchanged when `switchMode` is false.
> 
> **Overview**
> Fixes mode-switch roundtripping where **compose** content with empty structural nodes (e.g. blank paragraphs) was wiped because `syncFormik` treated “no text” like submit-time validation and cleared Formik’s `text`.
> 
> `syncFormik` and `SYNC_FORMIK_COMMAND` now take an options object (`switchMode`, `flush`). The empty-text → `''` shortcut is **skipped** when `switchMode` is true. The toolbar dispatches sync with `{ switchMode: true }` before toggling modes.
> 
> **Code blocks:** Lexical → mdast export no longer forces `lang: null` for `text` or missing language—it writes the Lexical language value through for better roundtrip fidelity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fdc431efdb5258511973b5b51eb2bb2c31870fd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->