### PR TITLE
fix: resolve LNURL-pay usernames case-insensitively (#3058)

### DIFF
--- a/pages/api/lnurlp/[username]/index.js
+++ b/pages/api/lnurlp/[username]/index.js
@@ -4,7 +4,9 @@ import { lnurlPayMetadata, lnurlpCallbackUrl } from '@/lib/lnurl'
 import { LNURLP_COMMENT_MAX_LENGTH, PROXY_PAYER_MIN_MSATS, PROXY_PAYER_MAX_MSATS } from '@/lib/constants'
 
 export default async ({ query: { username } }, res) => {
-  const user = await models.user.findUnique({ where: { name: username } })
+  // LNURL-pay usernames are case-insensitive (the `name` column is Citext);
+  // look up case-insensitively so e.g. SwapMarket@ resolves to swapmarket. (#3058)
+  const user = await models.user.findFirst({ where: { name: { equals: username, mode: 'insensitive' } } })
   if (!user) {
     return res.status(400).json({ status: 'ERROR', reason: `user @${username} does not exist` })
   }

--- a/pages/api/lnurlp/[username]/pay.js
+++ b/pages/api/lnurlp/[username]/pay.js
@@ -10,7 +10,9 @@ import { walletLogger } from '@/wallets/server'
 import pay from '@/api/payIn'
 
 export default async ({ query: { username, amount, nostr, comment, payerdata: payerData }, headers }, res) => {
-  const user = await models.user.findUnique({ where: { name: username } })
+  // Case-insensitive username lookup (the `name` column is Citext) so that
+  // mixed-case LNURL-pay addresses like SwapMarket@ resolve correctly. (#3058)
+  const user = await models.user.findFirst({ where: { name: { equals: username, mode: 'insensitive' } } })
   if (!user) {
     return res.status(400).json({ status: 'ERROR', reason: `user @${username} does not exist` })
   }


### PR DESCRIPTION
## Description

Fixes #3058. Paying a mixed-case Lightning address such as `SwapMarket@stacker.news` returned "user `@SwapMarket` does not exist", while the lowercase form worked.

Both LNURL-pay endpoints resolved the recipient with:

```js
models.user.findUnique({ where: { name: username } })
```

The `users.name` column is `Citext`, so equality in Postgres is case-insensitive — but Prisma's `findUnique` on the unique key does not reliably fold case for the bound parameter here, so a mixed-case `username` from the URL missed the row. The codebase already compensates for this elsewhere by comparing names with `.toUpperCase()` (see `api/resolvers/user.js`).

This PR makes the two LNURL-pay lookups explicitly case-insensitive:

```js
models.user.findFirst({ where: { name: { equals: username, mode: 'insensitive' } } })
```

in `pages/api/lnurlp/[username]/index.js` (the LNURL-pay metadata response) and `pages/api/lnurlp/[username]/pay.js` (the invoice/callback). Any casing of an existing username now resolves to the same account.

## Screenshots

N/A — server-side payment-resolution fix, no UI change.

## Additional Context

`name` is both `@unique` and `Citext`, so a case-insensitive match returns at most one row; `findFirst` is therefore equivalent to `findUnique` for valid data while tolerating casing. This cannot create users or change who an address maps to — it only lets an already-existing recipient be found regardless of the sender's casing.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. Lowercase addresses behave exactly as before; only previously-failing mixed-case lookups now succeed. No schema, GraphQL, or API-shape changes.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7/10. Verified the root cause by reading the schema (`name … @db.Citext`, line 19 of `prisma/schema.prisma`) and confirming both LNURL-pay routes used the case-sensitive `findUnique`. Confirmed `mode: 'insensitive'` is supported on the project's Prisma 5.20 `findFirst`. Both changed files pass `node --check`. I did not spin up the full stack to send a live mixed-case LNURL payment, so an end-to-end test against a running node would be the remaining QA step.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

N/A — no frontend changes.
