### PR TITLE
fix: disallow URLs in item titles

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -53,10 +53,15 @@ export function truncateToCharLength (value, maxLength) {
   return out
 }
 
+export function hasUrlProtocol (value) {
+  return /\b[a-z][a-z0-9+.-]*:\/\//i.test(value || '')
+}
+
 const titleValidator = string().required('required').trim().max(
   MAX_TITLE_LENGTH,
   ({ max, value }) => `-${Math.abs(max - value.length)} characters remaining`
 ).min(MIN_TITLE_LENGTH, `must be at least ${MIN_TITLE_LENGTH} characters`)
+  .test('no-url-protocol', 'title cannot contain URLs', value => !hasUrlProtocol(value))
 
 const textValidator = (max) => string().trim().max(
   max,

--- a/lib/validate.test.js
+++ b/lib/validate.test.js
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+
+import { bountySchema, discussionSchema, hasUrlProtocol, jobSchema, linkSchema, pollSchema } from './validate'
+
+const mockArgs = (postTypes = ['DISCUSSION', 'LINK', 'POLL', 'BOUNTY']) => ({
+  models: {
+    sub: {
+      findMany: jest.fn(async ({ where: { name: { in: subNames } } }) =>
+        subNames.map(name => ({ name, status: 'ACTIVE', postTypes })))
+    }
+  }
+})
+
+describe('title validation', () => {
+  test('detects URL protocols without rejecting bare domains or non-URL URI schemes', () => {
+    expect(hasUrlProtocol('https://stacker.news')).toBe(true)
+    expect(hasUrlProtocol('See ftp://example.com')).toBe(true)
+    expect(hasUrlProtocol('Crypto.com stadium hosts big game')).toBe(false)
+    expect(hasUrlProtocol('example.com/path')).toBe(false)
+    expect(hasUrlProtocol('mailto:jobs@example.com')).toBe(false)
+  })
+
+  test.each([
+    ['discussion', discussionSchema(mockArgs()), { subNames: ['bitcoin'], title: 'https://example.com', text: '' }],
+    ['link', linkSchema(mockArgs()), { subNames: ['bitcoin'], title: 'Read https://example.com', url: 'https://stacker.news', text: '' }],
+    ['poll', pollSchema({ ...mockArgs(), numExistingChoices: 0 }), { subNames: ['bitcoin'], title: 'ftp://example.com', options: ['yes', 'no'] }],
+    ['bounty', bountySchema(mockArgs()), { subNames: ['bitcoin'], title: 'bitcoin://invoice', text: '', bounty: 1000 }],
+    ['job', jobSchema(mockArgs()), { title: 'Apply at https://example.com', company: 'SN', text: 'job', url: 'jobs@example.com', remote: true }]
+  ])('rejects URL protocols in %s titles', async (_name, schema, value) => {
+    await expect(schema.validate(value)).rejects.toThrow('title cannot contain URLs')
+  })
+
+  test('allows bare domains in titles', async () => {
+    await expect(discussionSchema(mockArgs()).validate({
+      subNames: ['bitcoin'],
+      title: 'Crypto.com stadium hosts big game',
+      text: ''
+    })).resolves.toMatchObject({ title: 'Crypto.com stadium hosts big game' })
+  })
+})


### PR DESCRIPTION
## Description

Fixes #117.

Post titles now reject URL protocol strings like `https://example.com` or `ftp://example.com` through the shared `titleValidator`. Bare domains such as `Crypto.com stadium hosts big game` remain allowed, matching the issue's example.

The shared validator covers discussion, link, poll, bounty, and job titles.

## QA

- `npm test -- --runTestsByPath lib/validate.test.js --runInBand`
- `npx standard lib/validate.js lib/validate.test.js`
- `git diff --check`

## Notes

I intentionally limited detection to protocol URLs containing `://` so ordinary title text and non-URL URI-like strings such as email/lightning address text are not rejected by accident.