### PR TITLE
[codex] format sankey values

### DIFF
--- a/components/payIn/sankey/index.js
+++ b/components/payIn/sankey/index.js
@@ -9,6 +9,7 @@ export function PayInSankey ({ payIn }) {
     <div className='position-relative' style={{ width: '100%', maxWidth: '600px', height: '460px' }}>
       <ResponsiveSankey
         data={data}
+        valueFormat={formatSankeyValue}
         margin={{ top: 60, right: 60, bottom: 160, left: 60 }}
         align='justify'
         labelPosition='outside'
@@ -34,6 +35,10 @@ export function PayInSankey ({ payIn }) {
       />
     </div>
   )
+}
+
+function formatSankeyValue (value) {
+  return new Intl.NumberFormat().format(value)
 }
 
 export function PayInSankeySkeleton () {


### PR DESCRIPTION
## Description

Fixes #2942.

The pay-in transaction Sankey now passes a `valueFormat` function to `ResponsiveSankey` so Nivo's generated `formattedValue` strings are localized with `Intl.NumberFormat`.

This keeps the numeric `value` field unchanged for layout calculations while formatting only the displayed value. Existing asset tooltips still use the existing sats/CC formatting path.

## Screenshots

N/A, formatting-only change.

## Additional Context

Root cause: the Sankey data already formats asset strings for custom tooltips, but Nivo's own formatted value path used the raw numeric `value` unless `valueFormat` was provided.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. This only changes display formatting for Sankey values and does not change data shape, GraphQL fields, or persisted data.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

6. Ran `git diff --check` and verified `Intl.NumberFormat` output for integer and decimal values with Node.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

No. This is a formatting-only change and I did not run the full app locally.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes. Codex helped identify the relevant issue and code path; I reviewed the change before submitting.