### PR TITLE
Fix analytics tooltip stacking

### DIFF
--- a/components/charts.js
+++ b/components/charts.js
@@ -107,7 +107,7 @@ export function WhenAreaChart ({ data }) {
           tick={{ fill: 'var(--theme-grey)' }}
         />
         <YAxis tickFormatter={abbrNum} tick={{ fill: 'var(--theme-grey)' }} />
-        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)', opacity: 1, zIndex: -1 }} />
+        <Tooltip labelFormatter={labelFormatter(when, from, to)} wrapperStyle={{ zIndex: 1 }} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)', opacity: 1 }} />
         <Legend />
         {Object.keys(data[0]).filter(v => v !== 'time' && v !== '__typename').map((v, i) =>
           <Area key={v} type='monotone' dataKey={v} name={v} stackId='1' stroke={getColor(i)} fill={getColor(i)} />)}
@@ -144,7 +144,7 @@ export function WhenLineChart ({ data }) {
           tick={{ fill: 'var(--theme-grey)' }}
         />
         <YAxis tickFormatter={abbrNum} tick={{ fill: 'var(--theme-grey)' }} />
-        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)' }} />
+        <Tooltip labelFormatter={labelFormatter(when, from, to)} wrapperStyle={{ zIndex: 1 }} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)' }} />
         <Legend />
         {Object.keys(data[0]).filter(v => v !== 'time' && v !== '__typename').map((v, i) =>
           <Line key={v} type='monotone' dataKey={v} name={v} stroke={getColor(i)} fill={getColor(i)} />)}
@@ -187,7 +187,7 @@ export function WhenComposedChart ({
         />
         <YAxis yAxisId='left' orientation='left' allowDecimals={false} stroke='var(--theme-grey)' tickFormatter={abbrNum} tick={{ fill: 'var(--theme-grey)' }} />
         <YAxis yAxisId='right' orientation='right' allowDecimals={false} stroke='var(--theme-grey)' tickFormatter={abbrNum} tick={{ fill: 'var(--theme-grey)' }} />
-        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)' }} />
+        <Tooltip labelFormatter={labelFormatter(when, from, to)} wrapperStyle={{ zIndex: 1 }} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)' }} />
         <Legend />
         {barNames?.map((v, i) =>
           <Bar yAxisId={barAxis} key={v} stackId={barStackId} type='monotone' dataKey={v} name={v} stroke={getColor(i)} fill={getColor(i)} />)}


### PR DESCRIPTION
## Description

Fixes #3122.

Analytics chart tooltips can render behind neighboring chart elements because the area chart tooltip content used a negative z-index. This removes that negative stacking value and gives Recharts' tooltip wrapper a small positive z-index across the analytics chart components so hovered tooltips stay above adjacent chart content.

## Screenshots

Not attached. I verified the affected analytics chart tooltip locally in the browser.

## Additional Context

The change is intentionally limited to Recharts tooltip stacking styles in `components/charts.js`.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. This is a display-only style change for chart tooltips and does not alter data shape, GraphQL fields, or persisted data.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

8. Ran `npm run lint`, `npm test`, and `git diff --check`. Also checked the issue scope, affected chart usages, and Recharts tooltip `wrapperStyle` behavior. Ran the local Stacker News dev app with `COMPOSE_PROFILES=minimal` and verified `/stackers/all/day` in Chrome DevTools: the `unique spenders` tooltip renders above adjacent chart/legend content.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Yes. Checked desktop light mode, desktop dark mode, and a mobile-width layout. The tooltip renders above chart content in the tested states.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes. Codex helped identify the relevant issue and code path, made the small local change, and ran lint/test/diff/browser checks. The change was reviewed before opening this draft PR.
