### PR TITLE
Only count recent items toward unpaid item limit

### DIFF
--- a/api/payIn/types/itemCreate.js
+++ b/api/payIn/types/itemCreate.js
@@ -1,4 +1,5 @@
-import { ANON_FEE_MULTIPLIER, ANON_ITEM_SPAM_INTERVAL, ITEM_SPAM_INTERVAL, PAID_ACTION_PAYMENT_METHODS, USER_ID } from '@/lib/constants'
+import { ANON_FEE_MULTIPLIER, ANON_ITEM_SPAM_INTERVAL, ITEM_SPAM_INTERVAL, PAID_ACTION_PAYMENT_METHODS, UNPAID_ITEM_SPAM_WINDOW_HOURS, USER_ID } from '@/lib/constants'
+import { datePivot } from '@/lib/time'
 import { notifyItemMention, notifyItemParents, notifyMention, notifyTerritorySubscribers, notifyUserSubscribers, notifyThreadSubscribers } from '@/lib/webPush'
 import { getItemMentions, getMentions, performBotBehavior, getSubs } from '../lib/item'
 import { extractMentions } from '@/lib/lexical/server/mentions'
@@ -98,7 +99,10 @@ export async function validateBeforeCreate (tx, payInProspect, payInArgs, { me }
   }
 
   const recentItems = await tx.item.findMany({
-    where: { userId: me.id },
+    where: {
+      userId: me.id,
+      createdAt: { gt: datePivot(new Date(), { hours: -UNPAID_ITEM_SPAM_WINDOW_HOURS }) }
+    },
     orderBy: { createdAt: 'desc' },
     take: 3,
     select: {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -58,6 +58,7 @@ export const MAX_POLL_CHOICE_LENGTH = 40
 export const ITEM_EDIT_SECONDS = 600
 export const ITEM_SPAM_INTERVAL = '10m'
 export const ANON_ITEM_SPAM_INTERVAL = '0'
+export const UNPAID_ITEM_SPAM_WINDOW_HOURS = 24 // only recent unpaid items count toward the limit
 export const FREE_COMMENTS_PER_MONTH = 5
 // Default sat filter values for users (also used for logged-out users)
 export const DEFAULT_POSTS_SATS_FILTER = 10


### PR DESCRIPTION
## Description

The user with id 25176 has many unpaid items (accumulating a lot of bad karma 😅) from a long time ago. The user is currently unable to post unless they have paid for one of their last three items. However, this requires a payment of at least 1m sats. Since the unpaid items are over six months old, I'm not sure whether this is the intended behavior of the "too many unpaid items" filter. So I suggest adding a time window.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

`1`. I ran `sndev start` and looked at the code, with special consideration for time-related bugs, that's it

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

n/a

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

Yes and yes