### PR TITLE
Fix sats sorting on user item pages

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -32,6 +32,7 @@ import pay, { retry as retryPayIn } from '../payIn'
 import { BOUNTY_ALREADY_PAID_ERROR, BOUNTY_IN_PROGRESS_ERROR, getBountyPaymentTail } from '../payIn/lib/bountyPayment'
 import { lexicalHTMLGenerator } from '@/lib/lexical/server/html'
 import { resolveItemComments } from './comment-tree'
+import { itemOrderByClause } from './itemOrder'
 
 export async function getItem (parent, { id }, { me, models }) {
   const [item] = await getItemsById([id], { me, models })
@@ -57,19 +58,6 @@ export async function getItemsById (ids, { me, models }) {
   })
 
   return items.map(({ rank, ...item }) => item)
-}
-
-const orderByClause = (by, me, models, type, sub) => {
-  switch (by) {
-    case 'comments':
-      return 'ORDER BY "Item".ncomments DESC'
-    case 'sats':
-      return 'ORDER BY "Item".ranktop DESC, "Item".id DESC'
-    case 'downsats':
-      return 'ORDER BY "Item"."downMsats" DESC'
-    default:
-      return `ORDER BY ${type === 'bookmarks' ? '"bookmarkCreatedAt"' : '"Item".created_at'} DESC`
-  }
 }
 
 // this grabs all the stuff we need to display the item list and only
@@ -431,10 +419,10 @@ export default {
                 typeClause(type),
                 by === 'downsats' && '"Item"."downMsats" > 0',
                 whenClause(when || 'forever', table))}
-              ${orderByClause(by, me, models, type)}
+              ${itemOrderByClause({ by, type, sort })}
               OFFSET $4
               LIMIT $5`,
-            orderBy: orderByClause(by, me, models, type)
+            orderBy: itemOrderByClause({ by, type, sort })
           }, ...whenRange(when, from, to || decodedCursor.time), user.id, decodedCursor.offset, limit)
           break
         case 'new':
@@ -479,10 +467,10 @@ export default {
                 by === 'downsats' && '"Item"."downMsats" > 0',
                 await filterClause(type, sub, 'top', ctx, by),
                 muteClause(me))}
-              ${orderByClause(by || 'sats', me, models, type, sub)}
+              ${itemOrderByClause({ by: by || 'sats', type, sort })}
               OFFSET $3
               LIMIT $4`,
-            orderBy: orderByClause(by || 'sats', me, models, type, sub)
+            orderBy: itemOrderByClause({ by: by || 'sats', type, sort })
           }, ...whenRange(when, from, to || decodedCursor.time), decodedCursor.offset, limit, ...subArr)
           break
         default:

--- a/api/resolvers/itemOrder.js
+++ b/api/resolvers/itemOrder.js
@@ -1,0 +1,14 @@
+export function itemOrderByClause ({ by, type, sort }) {
+  switch (by) {
+    case 'comments':
+      return 'ORDER BY "Item".ncomments DESC'
+    case 'sats':
+      return sort === 'user'
+        ? 'ORDER BY "Item".msats DESC, "Item".id DESC'
+        : 'ORDER BY "Item".ranktop DESC, "Item".id DESC'
+    case 'downsats':
+      return 'ORDER BY "Item"."downMsats" DESC'
+    default:
+      return `ORDER BY ${type === 'bookmarks' ? '"bookmarkCreatedAt"' : '"Item".created_at'} DESC`
+  }
+}

--- a/api/resolvers/itemOrder.test.js
+++ b/api/resolvers/itemOrder.test.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+
+import { itemOrderByClause } from './itemOrder'
+
+describe('itemOrderByClause', () => {
+  it('sorts user items by the sats shown on the item', () => {
+    expect(itemOrderByClause({ by: 'sats', sort: 'user' }))
+      .toBe('ORDER BY "Item".msats DESC, "Item".id DESC')
+  })
+
+  it('keeps ranktop for non-user sats feeds', () => {
+    expect(itemOrderByClause({ by: 'sats', sort: 'top' }))
+      .toBe('ORDER BY "Item".ranktop DESC, "Item".id DESC')
+  })
+
+  it.each([
+    ['comments', undefined, 'ORDER BY "Item".ncomments DESC'],
+    ['downsats', undefined, 'ORDER BY "Item"."downMsats" DESC'],
+    ['new', 'bookmarks', 'ORDER BY "bookmarkCreatedAt" DESC'],
+    ['new', 'posts', 'ORDER BY "Item".created_at DESC']
+  ])('preserves the %s ordering', (by, type, expected) => {
+    expect(itemOrderByClause({ by, type, sort: 'user' })).toBe(expected)
+  })
+})

--- a/prisma/migrations/20260722082000_item_user_msats_index/migration.sql
+++ b/prisma/migrations/20260722082000_item_user_msats_index/migration.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "Item_userId_msats_id_idx" ON "Item"("userId", "msats", "id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -501,6 +501,7 @@ model Item {
   @@index([downMsats])
   @@index([ncomments])
   @@index([userId, createdAt])
+  @@index([userId, msats, id])
   @@index([userId, ranktop])
   @@index([userId, downMsats])
   @@index([userId, ncomments])


### PR DESCRIPTION
Fixes #2903.

## What changed

User item pages now sort `by=sats` using `Item.msats`, which is the value exposed as the item’s sats count to its owner. Other sats-ranked feeds continue using `ranktop`, so their existing comment-inclusive ranking is unchanged.

The ordering logic is moved into a small pure helper with regression coverage. A composite `(userId, msats, id)` index supports the user-filtered descending order and deterministic id tie-break.

## Why

The user page displayed each post’s direct sats but ordered by `ranktop`, which also incorporates comment activity. That could visibly place a lower-sats post above a higher-sats post.

## Verification

- `DATABASE_URL=postgresql://postgres:postgres@localhost:5431/stackernews NODE_OPTIONS='--experimental-vm-modules' npx jest api/resolvers/itemOrder.test.js --runInBand` — PASS (1 suite, 6 tests)
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5431/stackernews npx prisma validate` — PASS
- `npx standard api/resolvers/item.js api/resolvers/itemOrder.js api/resolvers/itemOrder.test.js` — PASS
- `git diff --check` — PASS

## Compatibility

No API shape or environment variable changes. Existing comments, downsats, bookmark, chronological, and non-user sats ordering are covered and preserved.

## AI use

Implemented and validated with AI assistance.