### PR TITLE
Respect mutes in live comment navigation

### DIFF
--- a/components/comment.js
+++ b/components/comment.js
@@ -29,6 +29,7 @@ import { gql } from '@apollo/client'
 import { useApolloClient } from '@apollo/client/react'
 import classNames from 'classnames'
 import useCallbackRef from './use-callback-ref'
+import { shouldTrackNewComment } from '@/lib/comment-navigation'
 
 function Parent ({ item, rootText }) {
   const root = useRoot()
@@ -166,7 +167,7 @@ export default function Comment ({
 
   useEffect(() => {
     // checking navigator because outlining should happen only on item pages
-    if (!navigator || me?.id === item.user?.id) return
+    if (!shouldTrackNewComment({ hasNavigator: Boolean(navigator), viewerId: me?.id, item })) return
     // bail if we already registered this comment
     if (didTrackRef.current) return
 

--- a/lib/comment-navigation.js
+++ b/lib/comment-navigation.js
@@ -1,0 +1,7 @@
+export function shouldTrackNewComment ({ hasNavigator, viewerId, item }) {
+  return Boolean(
+    hasNavigator &&
+    viewerId !== item.user?.id &&
+    !item.user?.meMute
+  )
+}

--- a/lib/comment-navigation.test.js
+++ b/lib/comment-navigation.test.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+
+import { shouldTrackNewComment } from './comment-navigation'
+
+const item = ({ id = 2, meMute = false } = {}) => ({
+  user: { id, meMute }
+})
+
+describe('shouldTrackNewComment', () => {
+  it('does not track comments from muted users', () => {
+    expect(shouldTrackNewComment({
+      hasNavigator: true,
+      viewerId: 1,
+      item: item({ meMute: true })
+    })).toBe(false)
+  })
+
+  it('tracks comments from other unmuted users', () => {
+    expect(shouldTrackNewComment({
+      hasNavigator: true,
+      viewerId: 1,
+      item: item()
+    })).toBe(true)
+  })
+
+  it('does not track the viewer own comments', () => {
+    expect(shouldTrackNewComment({
+      hasNavigator: true,
+      viewerId: 2,
+      item: item()
+    })).toBe(false)
+  })
+
+  it('does not track comments outside the navigator', () => {
+    expect(shouldTrackNewComment({
+      hasNavigator: false,
+      viewerId: 1,
+      item: item()
+    })).toBe(false)
+  })
+})


### PR DESCRIPTION
Fixes #2842.

## What changed

Muted users’ comments remain collapsed as before, but are no longer highlighted or registered in the new-comment navigator when they arrive through live polling. Comments from unmuted users retain the existing behavior, while own comments and pages without a navigator remain excluded.

The eligibility check is isolated in a pure helper so the mute boundary is regression-tested without coupling the test to browser animation behavior.

## Verification

- `DATABASE_URL=postgresql://postgres:postgres@localhost:5431/stackernews NODE_OPTIONS='--experimental-vm-modules' npx jest lib/comment-navigation.test.js --runInBand` — PASS (1 suite, 4 tests)
- `npx standard components/comment.js lib/comment-navigation.js lib/comment-navigation.test.js` — PASS
- `git diff --check` — PASS

## Compatibility

No API, database, environment variable, or stored preference changes.

## AI use

Implemented and validated with AI assistance.