### PR TITLE
Preserve formatting on internal item links

### DIFF
--- a/components/editor/nodes/mention-format.jsx
+++ b/components/editor/nodes/mention-format.jsx
@@ -1,0 +1,25 @@
+import {
+  IS_BOLD,
+  IS_CODE,
+  IS_HIGHLIGHT,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_SUBSCRIPT,
+  IS_SUPERSCRIPT,
+  IS_UNDERLINE
+} from '@/lib/lexical/mdast/format-constants'
+
+export default function MentionFormat ({ children, format = 0 }) {
+  let content = children
+
+  if (format & IS_CODE) content = <code>{content}</code>
+  if (format & IS_HIGHLIGHT) content = <mark>{content}</mark>
+  if (format & IS_STRIKETHROUGH) content = <s>{content}</s>
+  if (format & IS_BOLD) content = <strong>{content}</strong>
+  if (format & IS_ITALIC) content = <em>{content}</em>
+  if (format & IS_UNDERLINE) content = <u>{content}</u>
+  if (format & IS_SUBSCRIPT) content = <sub>{content}</sub>
+  if (format & IS_SUPERSCRIPT) content = <sup>{content}</sup>
+
+  return content
+}

--- a/components/editor/nodes/mention-format.test.jsx
+++ b/components/editor/nodes/mention-format.test.jsx
@@ -1,0 +1,25 @@
+/* eslint-env jest */
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import MentionFormat from './mention-format'
+import { IS_BOLD, IS_ITALIC, IS_UNDERLINE } from '@/lib/lexical/mdast/format-constants'
+
+describe('MentionFormat', () => {
+  it('renders an italic internal-link label as emphasis', () => {
+    expect(renderToStaticMarkup(
+      <MentionFormat format={IS_ITALIC}>High Risk, Low Reward</MentionFormat>
+    )).toBe('<em>High Risk, Low Reward</em>')
+  })
+
+  it('composes multiple text formats', () => {
+    expect(renderToStaticMarkup(
+      <MentionFormat format={IS_BOLD | IS_ITALIC | IS_UNDERLINE}>formatted</MentionFormat>
+    )).toBe('<u><em><strong>formatted</strong></em></u>')
+  })
+
+  it('leaves an unformatted label unchanged', () => {
+    expect(renderToStaticMarkup(
+      <MentionFormat>plain</MentionFormat>
+    )).toBe('plain')
+  })
+})

--- a/components/editor/nodes/mentions.js
+++ b/components/editor/nodes/mentions.js
@@ -25,7 +25,7 @@ export default function MentionsComponent ({ nodeKey, href, text }) {
         const displayText = node.getText()
         const { target, rel } = getLinkAttributes(url)
         newNode = $createLinkNode(url, { target, rel })
-          .append($createTextNode(displayText || url))
+          .append($createTextNode(displayText || url).setFormat(node.getFormat()))
       } else {
         // other mention types become plain text
         // cursor will land on the text node triggering mentions menu

--- a/lib/lexical/commands/links.js
+++ b/lib/lexical/commands/links.js
@@ -45,7 +45,7 @@ export function $toggleLink (editor, url) {
     } else if ($isItemMentionNode(firstChild)) {
       // if the first child is an ItemMentionNode, replace it with a text node
       const text = firstChild.getText()
-      const textNode = $createTextNode(text)
+      const textNode = $createTextNode(text).setFormat(firstChild.getFormat())
       firstChild.replace(textNode)
       return true
     } else {

--- a/lib/lexical/mdast/mention-format.js
+++ b/lib/lexical/mdast/mention-format.js
@@ -1,0 +1,13 @@
+import { IS_BOLD, IS_HIGHLIGHT, IS_ITALIC, IS_STRIKETHROUGH } from './format-constants'
+
+const FORMAT_BY_TYPE = {
+  strong: IS_BOLD,
+  emphasis: IS_ITALIC,
+  delete: IS_STRIKETHROUGH,
+  highlight: IS_HIGHLIGHT
+}
+
+export function getLinkTextFormat (node) {
+  return (FORMAT_BY_TYPE[node.type] || 0) |
+    (node.children || []).reduce((format, child) => format | getLinkTextFormat(child), 0)
+}

--- a/lib/lexical/mdast/mention-format.test.js
+++ b/lib/lexical/mdast/mention-format.test.js
@@ -1,0 +1,36 @@
+/* eslint-env jest */
+
+import { getLinkTextFormat } from './mention-format'
+import { IS_BOLD, IS_ITALIC } from './format-constants'
+
+describe('getLinkTextFormat', () => {
+  it('reads italic formatting from an internal link label', () => {
+    expect(getLinkTextFormat({
+      type: 'link',
+      children: [{
+        type: 'emphasis',
+        children: [{ type: 'text', value: 'High Risk, Low Reward' }]
+      }]
+    })).toBe(IS_ITALIC)
+  })
+
+  it('combines nested formatting flags', () => {
+    expect(getLinkTextFormat({
+      type: 'link',
+      children: [{
+        type: 'strong',
+        children: [{
+          type: 'emphasis',
+          children: [{ type: 'text', value: 'formatted' }]
+        }]
+      }]
+    })).toBe(IS_BOLD | IS_ITALIC)
+  })
+
+  it('returns the default format for plain link text', () => {
+    expect(getLinkTextFormat({
+      type: 'link',
+      children: [{ type: 'text', value: 'plain' }]
+    })).toBe(0)
+  })
+})

--- a/lib/lexical/mdast/transforms/mentions.js
+++ b/lib/lexical/mdast/transforms/mentions.js
@@ -3,6 +3,7 @@ import { visit } from 'unist-util-visit'
 import { toString } from 'mdast-util-to-string'
 import { parseInternalLinks } from '@/lib/url'
 import { isImageOnlyLink } from '@/lib/lexical/mdast/shared'
+import { getLinkTextFormat } from '@/lib/lexical/mdast/mention-format'
 
 // regexes from rehype-sn.js
 const userGroup = '[\\w_]+'
@@ -64,7 +65,8 @@ export function itemMentionTransform (tree) {
           value: {
             id: commentId || itemId,
             text,
-            url: node.url
+            url: node.url,
+            format: getLinkTextFormat(node)
           }
         }
       }

--- a/lib/lexical/mdast/visitors/mentions.js
+++ b/lib/lexical/mdast/visitors/mentions.js
@@ -4,6 +4,7 @@ import {
   $isItemMentionNode
 } from '@/lib/lexical/nodes/decorative/mentions'
 import { $createItemMentionNode, isCustomText } from '@/lib/lexical/nodes/decorative/mentions/item'
+import { IS_BOLD, IS_HIGHLIGHT, IS_ITALIC, IS_STRIKETHROUGH } from '../format-constants'
 
 // user mentions (@user, @user/path)
 // uses transforms to parse mentions
@@ -71,7 +72,8 @@ export const MdastItemMentionVisitor = {
     const node = $createItemMentionNode({
       id: mdastNode.value.id,
       text: mdastNode.value.text,
-      url: mdastNode.value.url
+      url: mdastNode.value.url,
+      format: mdastNode.value.format
     })
     actions.addAndStepInto(node)
   }
@@ -84,15 +86,25 @@ export const LexicalItemMentionVisitor = {
     const url = lexicalNode.getURL()
     const text = lexicalNode.getText()
     const id = lexicalNode.getItemMentionId()
+    const format = lexicalNode.getFormat()
 
     // check if custom text
     if (isCustomText(text, id)) {
       // export as a LinkNode
-      actions.appendToParent(mdastParent, {
+      let node = {
         type: 'link',
         url,
         children: [{ type: 'text', value: text }]
-      })
+      }
+      for (const [flag, type] of [
+        [IS_BOLD, 'strong'],
+        [IS_ITALIC, 'emphasis'],
+        [IS_STRIKETHROUGH, 'delete'],
+        [IS_HIGHLIGHT, 'highlight']
+      ]) {
+        if (format & flag) node = { type, children: [node] }
+      }
+      actions.appendToParent(mdastParent, node)
     } else {
       // export as text node
       actions.appendToParent(mdastParent, {

--- a/lib/lexical/nodes/decorative/mentions/item.jsx
+++ b/lib/lexical/nodes/decorative/mentions/item.jsx
@@ -1,17 +1,48 @@
 import { DecoratorNode, $applyNodeReplacement } from 'lexical'
 import { parseItemUrl } from '@/lib/url'
+import {
+  IS_BOLD,
+  IS_CODE,
+  IS_HIGHLIGHT,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_SUBSCRIPT,
+  IS_SUPERSCRIPT,
+  IS_UNDERLINE
+} from '@/lib/lexical/mdast/format-constants'
 
 function $convertItemMentionElement (domNode) {
   const id = domNode.getAttribute('data-lexical-item-mention-id')
   const text = domNode.getAttribute('data-lexical-item-mention-text') ?? domNode.querySelector('a')?.textContent
   const url = domNode.getAttribute('data-lexical-item-mention-url') ?? domNode.querySelector('a')?.getAttribute('href')
+  const format = Number(domNode.getAttribute('data-lexical-item-mention-format')) || 0
 
   if (id) {
-    const node = $createItemMentionNode({ id, text, url })
+    const node = $createItemMentionNode({ id, text, url, format })
     return { node }
   }
 
   return null
+}
+
+function wrapFormattedElement (element, format) {
+  let content = element
+  for (const [flag, tag] of [
+    [IS_CODE, 'code'],
+    [IS_HIGHLIGHT, 'mark'],
+    [IS_STRIKETHROUGH, 's'],
+    [IS_BOLD, 'strong'],
+    [IS_ITALIC, 'em'],
+    [IS_UNDERLINE, 'u'],
+    [IS_SUBSCRIPT, 'sub'],
+    [IS_SUPERSCRIPT, 'sup']
+  ]) {
+    if (!(format & flag)) continue
+    const wrapper = document.createElement(tag)
+    wrapper.appendChild(content)
+    content = wrapper
+  }
+  return content
 }
 
 export function isCustomText (text, id) {
@@ -22,6 +53,7 @@ export class ItemMentionNode extends DecoratorNode {
   __itemMentionId
   __text
   __url
+  __format
 
   static getType () {
     return 'item-mention'
@@ -39,6 +71,10 @@ export class ItemMentionNode extends DecoratorNode {
     return this.__url
   }
 
+  getFormat () {
+    return this.__format
+  }
+
   getDisplayText () {
     if (this.__text) return this.__text
     try {
@@ -50,18 +86,19 @@ export class ItemMentionNode extends DecoratorNode {
   }
 
   static clone (node) {
-    return new ItemMentionNode(node.__itemMentionId, node.__text, node.__url, node.__key)
+    return new ItemMentionNode(node.__itemMentionId, node.__text, node.__url, node.__format, node.__key)
   }
 
   static importJSON (serializedNode) {
-    return $createItemMentionNode({ id: serializedNode.itemMentionId, text: serializedNode.text, url: serializedNode.url })
+    return $createItemMentionNode({ id: serializedNode.itemMentionId, text: serializedNode.text, url: serializedNode.url, format: serializedNode.format })
   }
 
-  constructor (itemMentionId, text, url, key) {
+  constructor (itemMentionId, text, url, format = 0, key) {
     super(key)
     this.__itemMentionId = itemMentionId
     this.__text = text
     this.__url = url
+    this.__format = format
   }
 
   exportJSON () {
@@ -70,7 +107,8 @@ export class ItemMentionNode extends DecoratorNode {
       version: 1,
       itemMentionId: this.__itemMentionId,
       text: this.__text,
-      url: this.__url
+      url: this.__url,
+      format: this.__format
     }
   }
 
@@ -86,6 +124,7 @@ export class ItemMentionNode extends DecoratorNode {
     // text/url aren't derivable from id alone, so serialize them for hydration
     this.__text && domNode.setAttribute('data-lexical-item-mention-text', this.__text)
     this.__url && domNode.setAttribute('data-lexical-item-mention-url', this.__url)
+    if (this.__format) domNode.setAttribute('data-lexical-item-mention-format', this.__format)
     return domNode
   }
 
@@ -99,10 +138,11 @@ export class ItemMentionNode extends DecoratorNode {
       wrapper.className = className
     }
     wrapper.setAttribute('data-lexical-item-mention-id', this.__itemMentionId)
+    if (this.__format) wrapper.setAttribute('data-lexical-item-mention-format', this.__format)
     const a = document.createElement('a')
     a.setAttribute('href', this.__url)
     a.textContent = this.getDisplayText()
-    wrapper.appendChild(a)
+    wrapper.appendChild(wrapFormattedElement(a, this.__format))
     return { element: wrapper }
   }
 
@@ -130,19 +170,22 @@ export class ItemMentionNode extends DecoratorNode {
   decorate () {
     const ItemPopover = require('@/components/item-popover').default
     const MentionsComponent = require('@/components/editor/nodes/mentions').default
+    const MentionFormat = require('@/components/editor/nodes/mention-format').default
     const id = this.__itemMentionId
     const href = this.__url
     const text = this.getDisplayText()
     return (
       <ItemPopover id={id}>
-        <MentionsComponent nodeKey={this.getKey()} href={href} text={text} />
+        <MentionFormat format={this.__format}>
+          <MentionsComponent nodeKey={this.getKey()} href={href} text={text} />
+        </MentionFormat>
       </ItemPopover>
     )
   }
 }
 
-export function $createItemMentionNode ({ id, text, url }) {
-  return $applyNodeReplacement(new ItemMentionNode(id, text, url))
+export function $createItemMentionNode ({ id, text, url, format = 0 }) {
+  return $applyNodeReplacement(new ItemMentionNode(id, text, url, format))
 }
 
 export function $isItemMentionNode (node) {


### PR DESCRIPTION
Fixes #2767.

## What changed

Internal item links converted to `ItemMentionNode` now retain the text-format flags found in their Markdown label. The format is preserved through node cloning, JSON serialization, DOM hydration, Lexical-to-MDAST export, editor rendering, generated HTML, and double-click conversion back to a normal link.

A small `MentionFormat` renderer applies the same semantic elements used by the supported text formats. The reported italic case now renders as `<em>` independently of whether the link is internal or external; combined formats are preserved as bit flags.

## Verification

- `DATABASE_URL=postgresql://postgres:postgres@localhost:5431/stackernews NODE_OPTIONS='--experimental-vm-modules' npx jest components/editor/nodes/mention-format.test.jsx lib/lexical/mdast/mention-format.test.js --runInBand` — PASS (2 suites, 6 tests)
- `npx standard` on all eight changed JS/JSX files — PASS
- `git diff --check` — PASS

The tests cover the exact italic internal-link label from the issue, nested bold+italic flag extraction, plain labels, semantic italic rendering, combined rendering, and unformatted rendering.

## Compatibility

Existing serialized item mentions without `format` default to `0`. No API, database, or environment-variable changes.

## AI use

Implemented and validated with AI assistance.