### PR TITLE
Remember local editor mode and toolbar visibility

### DIFF
--- a/components/editor/contexts/mode.js
+++ b/components/editor/contexts/mode.js
@@ -1,4 +1,5 @@
-import { createContext, useState, useMemo, useContext, useCallback } from 'react'
+import { createContext, useState, useMemo, useContext, useCallback, useEffect } from 'react'
+import { EDITOR_MODE_STORAGE_KEY, readEditorMode, writeEditorSetting } from '@/lib/editor-settings'
 
 export const MARKDOWN_MODE = 'markdown'
 export const RICH_MODE = 'rich'
@@ -8,15 +9,24 @@ const EditorModeContext = createContext()
 export function EditorModeProvider ({ children }) {
   const [mode, setMode] = useState(MARKDOWN_MODE)
 
+  useEffect(() => {
+    setMode(readEditorMode(window.localStorage, MARKDOWN_MODE))
+  }, [])
+
   const changeMode = useCallback((newMode) => {
     if (newMode !== MARKDOWN_MODE && newMode !== RICH_MODE) {
       throw new Error(`Invalid mode: ${newMode}`)
     }
     setMode(newMode)
+    writeEditorSetting(window.localStorage, EDITOR_MODE_STORAGE_KEY, newMode)
   }, [])
 
   const toggleMode = useCallback(() => {
-    setMode(prev => prev === MARKDOWN_MODE ? RICH_MODE : MARKDOWN_MODE)
+    setMode(prev => {
+      const next = prev === MARKDOWN_MODE ? RICH_MODE : MARKDOWN_MODE
+      writeEditorSetting(window.localStorage, EDITOR_MODE_STORAGE_KEY, next)
+      return next
+    })
   }, [])
 
   const value = useMemo(() => ({

--- a/components/editor/contexts/toolbar.js
+++ b/components/editor/contexts/toolbar.js
@@ -1,4 +1,5 @@
-import { createContext, useContext, useMemo, useState, useCallback } from 'react'
+import { createContext, useContext, useMemo, useState, useCallback, useEffect } from 'react'
+import { EDITOR_TOOLBAR_STORAGE_KEY, readEditorToolbarVisibility, writeEditorSetting } from '@/lib/editor-settings'
 
 export const INITIAL_FORMAT_STATE = {
   blockType: 'paragraph',
@@ -28,11 +29,21 @@ const ToolbarContext = createContext()
 export function ToolbarContextProvider ({ topLevel, children }) {
   const [toolbarState, setToolbarState] = useState({ ...INITIAL_STATE, showToolbar: !!topLevel })
 
+  useEffect(() => {
+    setToolbarState(prev => ({
+      ...prev,
+      showToolbar: readEditorToolbarVisibility(window.localStorage, !!topLevel)
+    }))
+  }, [topLevel])
+
   const batchUpdateToolbarState = useCallback((updates) => {
     setToolbarState((prev) => ({ ...prev, ...updates }))
   }, [])
 
   const updateToolbarState = useCallback((key, value) => {
+    if (key === 'showToolbar') {
+      writeEditorSetting(window.localStorage, EDITOR_TOOLBAR_STORAGE_KEY, value)
+    }
     setToolbarState((prev) => ({
       ...prev,
       [key]: value

--- a/lib/editor-settings.js
+++ b/lib/editor-settings.js
@@ -1,0 +1,30 @@
+export const EDITOR_MODE_STORAGE_KEY = 'editorMode'
+export const EDITOR_TOOLBAR_STORAGE_KEY = 'editorShowToolbar'
+
+const EDITOR_MODES = new Set(['markdown', 'rich'])
+
+export function readEditorMode (storage, fallback = 'markdown') {
+  try {
+    const value = storage?.getItem(EDITOR_MODE_STORAGE_KEY)
+    return EDITOR_MODES.has(value) ? value : fallback
+  } catch {
+    return fallback
+  }
+}
+
+export function readEditorToolbarVisibility (storage, fallback) {
+  try {
+    const value = storage?.getItem(EDITOR_TOOLBAR_STORAGE_KEY)
+    if (value === 'true') return true
+    if (value === 'false') return false
+    return fallback
+  } catch {
+    return fallback
+  }
+}
+
+export function writeEditorSetting (storage, key, value) {
+  try {
+    storage?.setItem(key, String(value))
+  } catch {}
+}

--- a/lib/editor-settings.test.js
+++ b/lib/editor-settings.test.js
@@ -1,0 +1,58 @@
+/* eslint-env jest */
+
+import {
+  EDITOR_MODE_STORAGE_KEY,
+  EDITOR_TOOLBAR_STORAGE_KEY,
+  readEditorMode,
+  readEditorToolbarVisibility,
+  writeEditorSetting
+} from './editor-settings'
+
+function memoryStorage (entries = {}) {
+  const values = new Map(Object.entries(entries))
+  return {
+    getItem: jest.fn(key => values.get(key) ?? null),
+    setItem: jest.fn((key, value) => values.set(key, value))
+  }
+}
+
+describe('editor settings storage', () => {
+  it.each(['markdown', 'rich'])('reads a valid %s mode', mode => {
+    const storage = memoryStorage({ [EDITOR_MODE_STORAGE_KEY]: mode })
+    expect(readEditorMode(storage)).toBe(mode)
+  })
+
+  it('rejects an unknown stored mode', () => {
+    const storage = memoryStorage({ [EDITOR_MODE_STORAGE_KEY]: 'invalid' })
+    expect(readEditorMode(storage, 'markdown')).toBe('markdown')
+  })
+
+  it.each([
+    ['true', true],
+    ['false', false]
+  ])('reads stored toolbar visibility %s', (stored, expected) => {
+    const storage = memoryStorage({ [EDITOR_TOOLBAR_STORAGE_KEY]: stored })
+    expect(readEditorToolbarVisibility(storage, !expected)).toBe(expected)
+  })
+
+  it('uses each editor context default when toolbar visibility is absent', () => {
+    expect(readEditorToolbarVisibility(memoryStorage(), true)).toBe(true)
+    expect(readEditorToolbarVisibility(memoryStorage(), false)).toBe(false)
+  })
+
+  it('serializes setting values', () => {
+    const storage = memoryStorage()
+    writeEditorSetting(storage, EDITOR_TOOLBAR_STORAGE_KEY, false)
+    expect(storage.setItem).toHaveBeenCalledWith(EDITOR_TOOLBAR_STORAGE_KEY, 'false')
+  })
+
+  it('falls back without throwing when storage is unavailable', () => {
+    const storage = {
+      getItem: () => { throw new Error('blocked') },
+      setItem: () => { throw new Error('blocked') }
+    }
+    expect(readEditorMode(storage, 'markdown')).toBe('markdown')
+    expect(readEditorToolbarVisibility(storage, true)).toBe(true)
+    expect(() => writeEditorSetting(storage, EDITOR_MODE_STORAGE_KEY, 'rich')).not.toThrow()
+  })
+})


### PR DESCRIPTION
Fixes #2858.

## What changed

The editor now remembers two local UI preferences across editor mounts and browser sessions:

- the last selected mode (`markdown` or `rich`)
- toolbar visibility (`shown` or `hidden`)

Contexts retain their current SSR-safe defaults for the first render, then hydrate from `localStorage` after mount. Missing or invalid values preserve the existing defaults (top-level toolbar shown, reply toolbar hidden, markdown mode). Storage read/write failures degrade safely instead of breaking the editor.

## Verification

- `DATABASE_URL=postgresql://postgres:postgres@localhost:5431/stackernews NODE_OPTIONS='--experimental-vm-modules' npx jest lib/editor-settings.test.js --runInBand` — PASS (1 suite, 8 tests)
- `npx standard components/editor/contexts/mode.js components/editor/contexts/toolbar.js lib/editor-settings.js lib/editor-settings.test.js` — PASS
- `git diff --check` — PASS

Tests cover both valid modes, invalid-mode fallback, both toolbar values, context-specific fallback, serialization, and unavailable storage.

## Compatibility

No server API, database, environment variable, or account preference changes. Settings remain local to the browser.

## AI use

Implemented and validated with AI assistance.