### PR TITLE
Fix quote toggling around code blocks

### DIFF
--- a/lib/lexical/commands/formatting/blocks.js
+++ b/lib/lexical/commands/formatting/blocks.js
@@ -16,6 +16,7 @@ import { $createSNHeadingNode } from '@/lib/lexical/nodes/misc/heading'
 import { USE_TRANSFORMER_BRIDGE } from '@/components/editor/plugins/core/transformer-bridge'
 import { MD_INSERT_BLOCK_COMMAND } from '@/lib/lexical/commands/formatting/markdown'
 import { $splitParagraphsByLineBreaks } from '@/lib/lexical/nodes/utils'
+import { $unwrapSelectedQuotes } from '@/lib/lexical/commands/formatting/quote'
 
 /** command to format blocks (headings, lists, quotes, etc.)
  * @param {string} block - block type ('paragraph', 'h1', 'bullet', 'quote', etc.)
@@ -48,8 +49,9 @@ const $formatCheckList = (editor, activeBlock, block, selection) => {
 }
 
 const $formatBlockQuote = (activeBlock, block, selection) => {
-  if (activeBlock === block) return $formatParagraph(selection)
   if (!selection) return
+  if (activeBlock === block && $unwrapSelectedQuotes(selection)) return
+  if (activeBlock === block) return $formatParagraph(selection)
   $setBlocksType(selection, () => $createQuoteNode())
 }
 

--- a/lib/lexical/commands/formatting/blocks.test.js
+++ b/lib/lexical/commands/formatting/blocks.test.js
@@ -1,0 +1,60 @@
+/* eslint-env jest */
+
+import { createHeadlessEditor } from '@lexical/headless'
+import { CodeNode, $createCodeNode, $isCodeNode } from '@lexical/code-core'
+import { QuoteNode, $createQuoteNode, $isQuoteNode } from '@lexical/rich-text'
+import { $createParagraphNode, $createTextNode, $getRoot, $isParagraphNode } from 'lexical'
+import { $unwrapSelectedQuotes } from './quote'
+
+function createEditor () {
+  return createHeadlessEditor({
+    namespace: 'sn-rich',
+    nodes: [CodeNode, QuoteNode],
+    onError: error => { throw error }
+  })
+}
+
+describe('$formatBlock quote', () => {
+  test('unwraps a quoted code block without converting the code block', () => {
+    const editor = createEditor()
+
+    editor.update(() => {
+      const text = $createTextNode('console.log("hello")')
+      const code = $createCodeNode().append(text)
+      $getRoot().append($createQuoteNode().append(code))
+      text.select(0, 0)
+
+      $unwrapSelectedQuotes(text.getLatest().select(0, 0))
+    }, { discrete: true })
+
+    editor.getEditorState().read(() => {
+      const children = $getRoot().getChildren()
+      expect(children).toHaveLength(1)
+      expect($isCodeNode(children[0])).toBe(true)
+      expect(children[0].getTextContent()).toBe('console.log("hello")')
+    })
+  })
+
+  test('preserves the order and types of all blocks when unwrapping a quote', () => {
+    const editor = createEditor()
+
+    editor.update(() => {
+      const codeText = $createTextNode('const answer = 42')
+      const code = $createCodeNode().append(codeText)
+      const paragraph = $createParagraphNode().append($createTextNode('explanation'))
+      $getRoot().append($createQuoteNode().append(code, paragraph))
+      codeText.select(0, 0)
+
+      $unwrapSelectedQuotes(codeText.getLatest().select(0, 0))
+    }, { discrete: true })
+
+    editor.getEditorState().read(() => {
+      const children = $getRoot().getChildren()
+      expect(children).toHaveLength(2)
+      expect($isCodeNode(children[0])).toBe(true)
+      expect($isParagraphNode(children[1])).toBe(true)
+      expect(children.map(node => node.getTextContent())).toEqual(['const answer = 42', 'explanation'])
+      expect(children.some($isQuoteNode)).toBe(false)
+    })
+  })
+})

--- a/lib/lexical/commands/formatting/quote.js
+++ b/lib/lexical/commands/formatting/quote.js
@@ -1,0 +1,20 @@
+import { $isRangeSelection } from 'lexical'
+import { $isQuoteNode } from '@lexical/rich-text'
+import { $findTopLevelElement } from '@/lib/lexical/commands/utils'
+
+export function $unwrapSelectedQuotes (selection) {
+  if (!$isRangeSelection(selection)) return false
+
+  const quotes = new Set()
+  for (const node of selection.getNodes()) {
+    const topLevelElement = $findTopLevelElement(node)
+    if ($isQuoteNode(topLevelElement)) quotes.add(topLevelElement)
+  }
+
+  for (const quote of quotes) {
+    for (const child of quote.getChildren()) quote.insertBefore(child)
+    quote.remove()
+  }
+
+  return quotes.size > 0
+}


### PR DESCRIPTION
Fixes #2862

## What changed

When quote formatting is toggled off, unwrap selected top-level quote nodes instead of converting their nested blocks to paragraphs. This preserves nested code blocks and any other child block types while maintaining their order.

## Tests

- `npx jest lib/lexical/commands/formatting/blocks.test.js --runInBand` (2 passing)
- `npx standard lib/lexical/commands/formatting/blocks.js lib/lexical/commands/formatting/quote.js lib/lexical/commands/formatting/blocks.test.js`
- `git diff --check`

The regression tests cover the quoted-code reproduction and a mixed code/paragraph quote to ensure unwrapping preserves both type and order.