### PR TITLE
Disallow URI schemes in post titles

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -56,7 +56,11 @@ export function truncateToCharLength (value, maxLength) {
 const titleValidator = string().required('required').trim().max(
   MAX_TITLE_LENGTH,
   ({ max, value }) => `-${Math.abs(max - value.length)} characters remaining`
-).min(MIN_TITLE_LENGTH, `must be at least ${MIN_TITLE_LENGTH} characters`)
+).min(MIN_TITLE_LENGTH, `must be at least ${MIN_TITLE_LENGTH} characters`).test(
+  'no-uri-scheme',
+  'remove URI scheme from title',
+  value => !value || !/\b[a-z][a-z\d+.-]*:\/\//i.test(value)
+)
 
 const textValidator = (max) => string().trim().max(
   max,

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -1,6 +1,26 @@
 /* eslint-env jest */
 
-import { pollSchema } from './validate'
+import { discussionSchema, pollSchema } from './validate'
+
+describe('post title validation', () => {
+  test.each([
+    'Read https://stacker.news/items/13221',
+    'HTTPS://stacker.news should not be a title',
+    'Open ipfs://bafyexample'
+  ])('rejects URI schemes in titles: %s', async title => {
+    await expect(discussionSchema({}).validateAt('title', { title }))
+      .rejects.toThrow('remove URI scheme from title')
+  })
+
+  test.each([
+    'Crypto.com stadium hosts big game',
+    'What happened at stacker.news today?',
+    'A title with a colon: but no URI'
+  ])('allows domains and ordinary title punctuation: %s', async title => {
+    await expect(discussionSchema({}).validateAt('title', { title }))
+      .resolves.toBe(title)
+  })
+})
 
 describe('pollSchema', () => {
   afterEach(() => {

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -1,10 +1,23 @@
 /* eslint-env jest */
 
-import { discussionSchema, pollSchema } from './validate'
+import { bountySchema, discussionSchema, jobSchema, linkSchema, pollSchema } from './validate'
+
+const titledPostSchemas = [
+  ['bounty', () => bountySchema({})],
+  ['discussion', () => discussionSchema({})],
+  ['job', () => jobSchema({})],
+  ['link', () => linkSchema({})],
+  ['poll', () => pollSchema({})]
+]
 
 describe('post title validation', () => {
+  test.each(titledPostSchemas)('rejects URI schemes in %s titles', async (name, createSchema) => {
+    const title = 'Read https://stacker.news/items/13221'
+    await expect(createSchema().validateAt('title', { title }))
+      .rejects.toThrow('remove URI scheme from title')
+  })
+
   test.each([
-    'Read https://stacker.news/items/13221',
     'HTTPS://stacker.news should not be a title',
     'Open ipfs://bafyexample'
   ])('rejects URI schemes in titles: %s', async title => {


### PR DESCRIPTION
Fixes #117

## What changed

The shared post title validator now rejects URI schemes written as `scheme://`, case-insensitively. Because bounty, discussion, link, poll, and job post schemas all use this validator, the rule applies consistently across titled post types.

Ordinary domains such as `Crypto.com` and normal colon punctuation remain valid.

## Tests

- `npx jest lib/validate.spec.js --runInBand` (10 passing)
- `npx standard lib/validate.js lib/validate.spec.js`
- `git diff --check`

The new parameterized tests cover HTTP, mixed-case HTTPS, another URI scheme, bare domains, ordinary host text, and normal colon punctuation.