### PR TITLE
sndev: fix lnd container uid/gid logic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -325,6 +325,9 @@ services:
       test: ["CMD-SHELL", "lncli", "getinfo"]
     depends_on: *depends_on_bitcoin
     env_file: *env_file
+    environment:
+      USERID: "${CURRENT_UID}"
+      GROUPID: "${CURRENT_GID}"
     command:
       - 'lnd'
       - '--noseedbackup'
@@ -433,6 +436,9 @@ services:
         restart: true
       <<: *depends_on_bitcoin
     env_file: *env_file
+    environment:
+      USERID: "${CURRENT_UID}"
+      GROUPID: "${CURRENT_GID}"
     entrypoint: /tor-entrypoint
     command:
       - 'lnd'
@@ -663,6 +669,9 @@ services:
       test: ["CMD-SHELL", "lncli", "getinfo"]
     depends_on: *depends_on_bitcoin
     env_file: *env_file
+    environment:
+      USERID: "${CURRENT_UID}"
+      GROUPID: "${CURRENT_GID}"
     command:
       - 'lnd'
       - '--noseedbackup'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -337,6 +337,8 @@ services:
       - '--tlsextradomain=sn_lnd'
       - '--tlsextradomain=host.docker.internal'
       - '--tlscertduration=87600h'
+      - '--tlscertpath=/etc/lnd/certs/tls.cert'
+      - '--tlskeypath=/etc/lnd/certs/tls.key'
       - '--listen=0.0.0.0:9735'
       - '--rpclisten=0.0.0.0:10009'
       - '--restlisten=0.0.0.0:8080'
@@ -364,10 +366,10 @@ services:
       - "${SN_LND_GRPC_PORT}:10009"
     volumes:
       - sn_lnd:/home/lnd/.lnd
-      - ./docker/lnd/sn/tls.cert:/home/lnd/.lnd/tls.cert:ro
-      - ./docker/lnd/sn/tls.key:/home/lnd/.lnd/tls.key:ro
+      - ./docker/lnd/sn/tls.cert:/etc/lnd/certs/tls.cert:ro
+      - ./docker/lnd/sn/tls.key:/etc/lnd/certs/tls.key:ro
     labels:
-      CERTDIR: "/home/lnd/.lnd"
+      CERTDIR: "/etc/lnd/certs"
       CLI: "lncli"
       CLI_USER: "lnd"
       ofelia.enabled: "true"
@@ -450,6 +452,8 @@ services:
       - '--tlsextradomain=host.docker.internal'
       - '--tlsextradomain=$${ONION_DOMAIN}'
       - '--tlscertduration=87600h'
+      - '--tlscertpath=/etc/lnd/certs/tls.cert'
+      - '--tlskeypath=/etc/lnd/certs/tls.key'
       - '--listen=0.0.0.0:9735'
       - '--rpclisten=0.0.0.0:10009'
       - '--rpcmiddleware.enable'
@@ -476,11 +480,11 @@ services:
     volumes:
       - lnd:/home/lnd/.lnd
       - tordata:/home/lnd/.tor
-      - ./docker/lnd/stacker/tls.cert:/home/lnd/.lnd/tls.cert:ro
-      - ./docker/lnd/stacker/tls.key:/home/lnd/.lnd/tls.key:ro
+      - ./docker/lnd/stacker/tls.cert:/etc/lnd/certs/tls.cert:ro
+      - ./docker/lnd/stacker/tls.key:/etc/lnd/certs/tls.key:ro
     labels:
       TORDIR: "/home/lnd/.tor"
-      CERTDIR: "/home/lnd/.lnd"
+      CERTDIR: "/etc/lnd/certs"
       CLI: "lncli"
       CLI_USER: "lnd"
       ofelia.enabled: "true"
@@ -681,6 +685,8 @@ services:
       - '--tlsextradomain=router_lnd'
       - '--tlsextradomain=host.docker.internal'
       - '--tlscertduration=87600h'
+      - '--tlscertpath=/etc/lnd/certs/tls.cert'
+      - '--tlskeypath=/etc/lnd/certs/tls.key'
       - '--listen=0.0.0.0:9735'
       - '--rpclisten=0.0.0.0:10009'
       - '--restlisten=0.0.0.0:8080'
@@ -706,10 +712,10 @@ services:
       - "${ROUTER_LND_GRPC_PORT}:10009"
     volumes:
       - router_lnd:/home/lnd/.lnd
-      - ./docker/lnd/router/tls.cert:/home/lnd/.lnd/tls.cert:ro
-      - ./docker/lnd/router/tls.key:/home/lnd/.lnd/tls.key:ro
+      - ./docker/lnd/router/tls.cert:/etc/lnd/certs/tls.cert:ro
+      - ./docker/lnd/router/tls.key:/etc/lnd/certs/tls.key:ro
     labels:
-      CERTDIR: "/home/lnd/.lnd"
+      CERTDIR: "/etc/lnd/certs"
       CLI: "lncli"
       CLI_USER: "lnd"
       ofelia.group: "payments"


### PR DESCRIPTION
## Description

After a3d32c23, two blocking issues for testing arose because lnd containers within sndev would not start cleanly:

1. If the host user didn't have uid 1000, lnd containers would never come up at all due to being unable to read the `tls.*` files
2. The first run of any lnd container would fail, causing health check issues, in turn causing channel bootstrapping to fail on a clean environment with new volumes.

This PR fixes that in 2 ways:

- 75ca5f38: implements the `USERID`/`GROUPID` [facility](https://github.com/jamaljsr/polar/blob/42051853444d731492f80be554d8ad1b3837d753/docker/lnd/docker-entrypoint.sh#L8-L9) from `polarlightning/lnd`
- 7a50ba58: moves the key material mount location outside of `/home/lnd`, into `/etc/lnd/certs/`, to ensure that when the entrypoint [does `chown`](https://github.com/jamaljsr/polar/blob/42051853444d731492f80be554d8ad1b3837d753/docker/lnd/docker-entrypoint.sh#L14) on the homedir, it does not fail.

## Checklist

**Are your changes backward compatible? Please answer below:**

The only condition under which this will break compatibility is when an existing dev env is ran with a user with a UID other than 1000 on the host. In this case either the lnd volumes `stackernews_lnd`, `stackernews_router_lnd` and `stackernews_sn_lnd` cannot be read by the container anymore, or the certs cannot be read, and `./sndev delete` (or manually deleting the volumes) is the only resolution. 

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

6/10: tested on only one dev env.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

N/A

**Did you introduce any new environment variables? If so, call them out explicitly here:**

Explicitly not.

**Did you use AI for this? If so, how much did it assist you?**

No.