### PR TITLE
fix: show bounty pay button on top-level comment permalink view

### DIFF
--- a/components/reply.js
+++ b/components/reply.js
@@ -105,7 +105,7 @@ export default forwardRef(function Reply ({
   return (
     <div>
       {replyOpen
-        ? <div className='p-3' />
+        ? (children ? <div className={styles.replyButtons}>{children}</div> : <div className='p-3' />)
         : (
           <div className={styles.replyButtons}>
             <div


### PR DESCRIPTION
## Problem

Fixes #2635.

The bounty "pay" button (`<PayBounty>`) never appeared when a bountied comment was viewed on its own permalink page (i.e. as a top-level item, e.g. navigating directly to `/items/<commentId>`), even though the same button correctly appears when the comment is rendered nested inside its parent thread.

## Root cause

`components/comment.js` passes `<PayBounty item={item} />` as `children` into `<Reply>`. But `components/reply.js` had:

```jsx
{replyOpen
  ? <div className='p-3' />
  : (
    <div className={styles.replyButtons}>
      ...{children}
    </div>
  )}
```

`item-full.js` always sets `replyOpen` for the top-level comment view (`<Comment topLevel item={item} replyOpen includeParent noComments />`). When `replyOpen` is true, `Reply` rendered only an empty spacer div and dropped `children` entirely — so `PayBounty` was silently never rendered on that view, regardless of whether the viewer was eligible to pay the bounty.

## Fix

One-line change in `components/reply.js`: when `replyOpen` is true and `children` exist, render them inside the same `styles.replyButtons` container used by the non-`replyOpen` branch, so `PayBounty` renders and is styled consistently. When there are no children (the common case — `replyOpen` used for the normal reply-box flow), behavior is unchanged (still the empty spacer div).

```diff
 {replyOpen
-  ? <div className='p-3' />
+  ? (children ? <div className={styles.replyButtons}>{children}</div> : <div className='p-3' />)
   : (
```

## Testing

Verified locally with `sndev` (minimal profile) + a headless browser, comparing the same top-level comment permalink page before/after the fix:

- Created a bountied post as one seeded dev user, commented on it as a second seeded user (so `PayBounty`'s eligibility check — viewer is bounty OP, target isn't the OP itself — is satisfied).
- **Before fix**: visiting the comment's own permalink page shows no bounty-related UI at all below the comment body.
- **After fix**: the same page shows the bounty action beneath the comment. In this dev environment the test account had no receive wallet configured, so `PayBounty` renders its "no receive wallet" fallback state rather than the "pay bounty" button itself — but this confirms `children` is now reaching the DOM via the same code path that renders `PayBounty` in every other view (nested thread view, feed view, etc.), which was the actual bug.

Payout address for this bounty (BTC, native segwit): `bc1qmg6klfq6rpf9wz8fmax7jj3mprxerxwt9dnvgz`