### PR TITLE
fix: disallow URI schemes (e.g. https://) in post titles

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -57,6 +57,11 @@ const titleValidator = string().required('required').trim().max(
   MAX_TITLE_LENGTH,
   ({ max, value }) => `-${Math.abs(max - value.length)} characters remaining`
 ).min(MIN_TITLE_LENGTH, `must be at least ${MIN_TITLE_LENGTH} characters`)
+  .test({
+    name: 'no-uri-scheme',
+    test: value => !/[a-z][a-z0-9+.-]*:\/\//i.test(value ?? ''),
+    message: 'must not contain a URI scheme, e.g. https://'
+  })
 
 const textValidator = (max) => string().trim().max(
   max,


### PR DESCRIPTION
## Problem

Fixes #117.

A post title containing a full URI scheme (e.g. `https://`) provides no value over the bare domain/URL text, and messes with downstream character-count assumptions (the issue mentions automated Tweeting via Zapier breaking because of it).

## Fix

Added a `.test()` to the shared `titleValidator` in `lib/validate.js` that rejects any title containing a `scheme://` pattern (`/[a-z][a-z0-9+.-]*:\/\//i`). This validator is the single source used by `discussionSchema`, `linkSchema`, `bountySchema`, `pollSchema`, and `jobSchema` (see `api/resolvers/item.js`), and is also used by the client-side post form, so this is enforced both client-side (immediate inline error) and server-side (via `validateSchema(...Schema, ...)` in the GraphQL resolver).

The regex only matches an actual `scheme://` (two slashes), not a bare colon, so titles like `"A title with a colon: like this"` or `"Crypto.com stadium hosts big game"` are unaffected — only literal URI schemes such as `http://`, `https://`, `ftp://` are rejected.

## Testing

Verified locally with `sndev` + a headless browser against the live post form (`/post?type=discussion`):

- Submitting a title containing `https://` shows the inline validation error "must not contain a URI scheme, e.g. https://" and the post is not created.
- Submitting a normal title with no scheme (and titles containing domains/colons without `//`) submits normally, unaffected.

Also spot-checked the regex against edge cases (`Crypto.com stadium hosts big game`, `A title with a colon: like this`, `ftp://old-school transfer`, etc.) to confirm no false positives on ordinary titles.
