### PR TITLE
fix: re-clicking the same zap suggestion amount now updates the input

### DIFF
--- a/components/form.js
+++ b/components/form.js
@@ -312,7 +312,7 @@ function FormGroup ({ className, label, children }) {
 }
 
 function InputInner ({
-  prepend, append, hint, warn, showValid, onChange, onBlur, overrideValue, appendValue,
+  prepend, append, hint, warn, showValid, onChange, onBlur, overrideValue, overrideKey, appendValue,
   innerRef, noForm, clear, onKeyDown, inputGroupClassName, debounce: debounceTime, maxLength, hideError,
   AppendColumn, ...props
 }) {
@@ -367,7 +367,10 @@ function InputInner ({
         onChange && onChange(formik, { target: { value: draft } })
       }
     }
-  }, [overrideValue])
+    // overrideKey is an optional nonce a caller can bump to force this effect to
+    // re-run even when overrideValue is unchanged (e.g. re-selecting the same
+    // preset amount button twice in a row shouldn't be a no-op)
+  }, [overrideValue, overrideKey])
 
   useEffect(() => {
     if (appendValue) {

--- a/components/item-act.js
+++ b/components/item-act.js
@@ -63,6 +63,13 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
   const toaster = useToast()
   const client = useApolloClient()
   const [oValue, setOValue] = useState()
+  // bumped alongside oValue so re-clicking the same preset amount still forces
+  // the amount input to re-sync (see Tips onClick below)
+  const [oValueKey, setOValueKey] = useState(0)
+  const handleOValue = useCallback((v) => {
+    setOValue(v)
+    setOValueKey(k => k + 1)
+  }, [])
 
   useEffect(() => {
     inputRef.current?.focus()
@@ -131,6 +138,7 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
         type='number'
         innerRef={inputRef}
         overrideValue={oValue}
+        overrideKey={oValueKey}
         step={step}
         required
         autoFocus
@@ -138,7 +146,7 @@ export default function ItemAct ({ onClose, item, act = 'TIP', step, children, a
       />
 
       <div className='d-flex flex-wrap gap-2'>
-        <Tips setOValue={setOValue} />
+        <Tips setOValue={handleOValue} />
       </div>
       <div className='d-flex mt-3'>
         <SubmitButton variant={act === 'DONT_LIKE_THIS' ? 'danger' : 'success'} className='ms-auto mt-1 px-4' value={act}>


### PR DESCRIPTION
Fixes #2703.

## Root cause

`ItemAct` (`components/item-act.js`) keeps the last-clicked preset amount in a
plain `useState` (`oValue`), which is passed to `Input` as `overrideValue`.
`Input`'s `InputInner` (`components/form.js`) syncs that into the form field
via a `useEffect` keyed on `[overrideValue]`:

```js
useEffect(() => {
  if (overrideValue) {
    helpers.setValue(overrideValue)
    ...
  }
  ...
}, [overrideValue])
```

Repro from the issue:

1. Click the `100` preset → `oValue` becomes `100`, effect runs, field becomes `100`.
2. Type a different amount, e.g. `4242`, directly into the field.
3. Click `100` again → `setOValue(100)` is called, but `oValue` **is already `100`**
   from step 1, so React bails out the state update (`Object.is` same-value check
   on primitives — no re-render happens at all). The effect's dependency array
   never changes, so it never re-runs, and the field stays at `4242`.

## Fix

Added an optional `overrideKey` prop to `Input`, included alongside
`overrideValue` in the effect's dependency array. A caller can bump this
independently of the value itself to force a re-sync even when the clicked
amount repeats.

`ItemAct` now maintains a companion `oValueKey` counter that increments on
every `Tips` button click (`handleOValue`), regardless of whether the amount
value changed, so the second click on `100` forces the field back to `100`
even though the *value* passed is identical to before.

This is additive and backward compatible: I grepped every other
`overrideValue` consumer in the repo (`search.js`, `top-header.js`,
`sub-select.js`, `multi-select.js`, `link-form.js`, `pages/[name]/[type].js`,
and `Select` in `form.js`) — none of them pass `overrideKey`, so it's
`undefined` for all of them and the effect's dependency array behaves
byte-for-byte the same as before for every other caller.

`ItemAct` backs every zap/tip/boost/downzap surface in the app (long-press
zap in `upvote.js`, `boost-button.js`, `dont-link-this.js`'s downzap), so
this one fix covers the preset-amount buttons everywhere they appear, not
just the specific flow in the original report.

## Verification

- `npx standard components/form.js components/item-act.js` — clean.
- Reproduced the exact bug against **live production stacker.news**, logged
  out (the bolt icon's short-press opens `ItemAct` for anonymous visitors
  too, so no account was needed): click `100` → field `100`; type `4242` →
  field `4242`; click `100` again → field **stays `4242`** on unpatched
  production.
- Ran the identical script against a local instance running this patch
  (`COMPOSE_PROFILES=minimal` sndev stack): after the fix, re-clicking `100`
  correctly resets the field to `100`.
- Screenshots (before/after, patched build):
  - Before re-click (field manually set to 4242): https://raw.githubusercontent.com/agnibina-create/stacker.news/pr-evidence-2703/2703_before_reclick_4242.png
  - After clicking `100` again (fixed — resets to 100): https://raw.githubusercontent.com/agnibina-create/stacker.news/pr-evidence-2703/2703_after_reclick_100.png

If it's helpful for review, the tiny Playwright repro script I used is:

```js
const bolt = page.locator('[class*="upvoteWrapper"], svg[class*="upvote"]').first()
await bolt.click()
const amountInput = page.locator('input[name="amount"]')
await page.getByRole('button', { name: /^100$/ }).click()
await amountInput.fill('4242')
await page.getByRole('button', { name: /^100$/ }).click()
console.log(await amountInput.inputValue()) // '4242' before fix, '100' after
```

Payout target if accepted for a sats award: `bc1qmg6klfq6rpf9wz8fmax7jj3mprxerxwt9dnvgz`.
