### PR TITLE
fix: Sankey chart number formatting crash (string vs number)

### DIFF
--- a/components/payIn/sankey/index.js
+++ b/components/payIn/sankey/index.js
@@ -43,10 +43,11 @@ export function PayInSankeySkeleton () {
 }
 
 function assetFormatted (msats, type) {
+  const sats = Number(msatsToSatsDecimal(msats))
   if (type === 'CREDITS') {
-    return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
+    return numWithUnits(sats, { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
   }
-  return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
+  return numWithUnits(sats, { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
 }
 
 function Tooltip ({ node, link }) {
@@ -213,7 +214,7 @@ function reduceLinksAndNodes ({ links, nodes }) {
   })
 
   reducedLinks.forEach(link => {
-    link.value = msatsToSatsDecimal(link.mtokens)
+    link.value = Number(msatsToSatsDecimal(link.mtokens))
     link.asset = assetFormatted(link.mtokens, link.custodialTokenType)
   })
 


### PR DESCRIPTION
Fixes #2942

## Problem
`msatsToSatsDecimal` returns a string, but the Sankey chart tooltip passes it directly to `Intl.NumberFormat.format()` which expects a number. This causes a TypeError crash.

## Fix
Convert the string result to a number before passing to `Intl.NumberFormat.format()`.