### PR TITLE
fix: use YouTube oEmbed API for title autopopulation

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -548,21 +548,27 @@ export default {
     pageTitleAndUnshorted: async (parent, { url }, { models }) => {
       const res = {}
       try {
-        const response = await snFetch(url, { protocol: 'http', redirect: 'follow', size: 2 * 1024 * 1024 })
-        const html = await response.text()
-        const doc = domino.createWindow(html).document
-        const titleRuleSet = {
-          rules: [
-            ['h1 > yt-formatted-string.ytd-watch-metadata', el => el.getAttribute('title')],
-            ...metadataRuleSets.title.rules
-          ]
-        }
-        const metadata = getMetadata(doc, url, { title: titleRuleSet, publicationDate: publicationDateRuleSet })
-        const dateHint = ` (${metadata.publicationDate?.getFullYear()})`
-        const moreThanOneYearAgo = metadata.publicationDate && metadata.publicationDate < datePivot(new Date(), { years: -1 })
+        const urlObj = new URL(ensureProtocol(url))
+        const { hostname, pathname } = urlObj
+        const isYoutube = (hostname.endsWith('youtube.com') && (pathname === '/watch' || pathname.startsWith('/shorts/'))) ||
+          hostname.endsWith('youtu.be')
 
-        res.title = metadata?.title
-        if (moreThanOneYearAgo) res.title += dateHint
+        if (isYoutube) {
+          const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(urlObj.toString())}&format=json`
+          const oembedRes = await snFetch(oembedUrl, { protocol: 'http' })
+          const oembed = await oembedRes.json()
+          res.title = oembed.title
+        } else {
+          const response = await snFetch(url, { protocol: 'http', redirect: 'follow', size: 2 * 1024 * 1024 })
+          const html = await response.text()
+          const doc = domino.createWindow(html).document
+          const metadata = getMetadata(doc, url, { title: metadataRuleSets.title, publicationDate: publicationDateRuleSet })
+          const dateHint = ` (${metadata.publicationDate?.getFullYear()})`
+          const moreThanOneYearAgo = metadata.publicationDate && metadata.publicationDate < datePivot(new Date(), { years: -1 })
+
+          res.title = metadata?.title
+          if (moreThanOneYearAgo) res.title += dateHint
+        }
       } catch { }
 
       try {


### PR DESCRIPTION
Fixes #2164

## Problem
When posting a YouTube link, the title field autopopulates with "- YouTube" instead of the actual video title. This happens because YouTube's server-rendered HTML doesn't include the video title — it's rendered client-side via JavaScript. The existing `h1 > yt-formatted-string.ytd-watch-metadata` selector never matches in a server-side fetch.

## Fix
Use YouTube's oEmbed API (`https://www.youtube.com/oembed`) which reliably returns the video title without needing client-side JS execution. This handles `/watch`, `/shorts/`, and `youtu.be` URLs.

Non-YouTube URLs continue to use the existing HTML metadata scraping path.