### PR TITLE
fix: use canonical username from DB in LNURL-pay responses

### DIFF
--- a/pages/api/lnurlp/[username]/index.js
+++ b/pages/api/lnurlp/[username]/index.js
@@ -9,10 +9,12 @@ export default async ({ query: { username } }, res) => {
     return res.status(400).json({ status: 'ERROR', reason: `user @${username} does not exist` })
   }
 
+  // use canonical name from DB since proxies may alter the URL param's casing
+  const name = user.name
   const url = process.env.NODE_ENV === 'development' ? process.env.SELF_URL : process.env.NEXT_PUBLIC_URL
-  const { metadata } = lnurlPayMetadata(username)
+  const { metadata } = lnurlPayMetadata(name)
   return res.status(200).json({
-    callback: lnurlpCallbackUrl(username, url), // The URL from LN SERVICE which will accept the pay request parameters
+    callback: lnurlpCallbackUrl(name, url), // The URL from LN SERVICE which will accept the pay request parameters
     minSendable: Number(PROXY_PAYER_MIN_MSATS), // Min amount LN SERVICE is willing to receive, can not be less than 1 or more than `maxSendable`
     maxSendable: Number(PROXY_PAYER_MAX_MSATS), // Max amount LN SERVICE is willing to receive: the largest payer amount whose post-fee payout the wrap pipeline accepts
     metadata, // Metadata json which must be presented as raw string here, this is required to pass signature verification at a later step

--- a/pages/api/lnurlp/[username]/pay.js
+++ b/pages/api/lnurlp/[username]/pay.js
@@ -15,6 +15,8 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
     return res.status(400).json({ status: 'ERROR', reason: `user @${username} does not exist` })
   }
 
+  // use canonical name from DB since proxies may alter the URL param's casing
+  const name = user.name
   const amountMsats = Number(amount)
   if (!Number.isFinite(amountMsats) || amountMsats < Number(PROXY_PAYER_MIN_MSATS)) {
     return res.status(400).json({ status: 'ERROR', reason: `amount must be >= ${PROXY_PAYER_MIN_MSATS} msats` })
@@ -33,7 +35,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
   try {
     await assertGofacYourself({ models, headers })
     // if nostr, decode, validate sig, check tags, set description hash
-    let { description, descriptionHash } = lnurlPayMetadata(username)
+    let { description, descriptionHash } = lnurlPayMetadata(name)
     let noteStr
     let lud18Data
     if (nostr) {
@@ -71,7 +73,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
         return res.status(400).json({ status: 'ERROR', reason: err.toString() })
       }
 
-      descriptionHash = createHash('sha256').update(lnurlPayMetadata(username).metadata + payerData).digest('hex')
+      descriptionHash = createHash('sha256').update(lnurlPayMetadata(name).metadata + payerData).digest('hex')
     }
 
     if (comment && characterLength(comment) > LNURLP_COMMENT_MAX_LENGTH) {
@@ -96,7 +98,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
     return res.status(200).json({
       pr: payInBolt11.bolt11,
       routes: [],
-      verify: lnurlpVerifyUrl(username, payInBolt11.hash)
+      verify: lnurlpVerifyUrl(name, payInBolt11.hash)
     })
   } catch (error) {
     console.log(error)


### PR DESCRIPTION
## Description

External LNURL proxies (e.g. coinos) may lowercase the username in the URL path when resolving a lightning address like `SwapMarket@stacker.news` → `/api/lnurlp/swapmarket/pay`.

While the Citext DB column handles the user lookup correctly regardless of casing, both the `index` and `pay` endpoints were using the raw URL param (`username`) for:
- `lnurlPayMetadata(username)` — generates the metadata and description hash
- `lnurlpCallbackUrl(username)` — generates the callback URL
- `lnurlpVerifyUrl(username)` — generates the verify URL

This causes a **description hash mismatch**: the wallet resolves `SwapMarket@stacker.news` and gets metadata saying `swapmarket@stacker.news`, then when it verifies the invoice description hash against the original address casing, it fails with a 400.

## Fix

Use `user.name` from the DB (the canonical casing) for all metadata generation and URL construction. The raw URL param is still used for the DB lookup (which Citext handles case-insensitively) and in the error message for non-existent users.

Closes #3058

## Testing

- `GET /.well-known/lnurlp/SwapMarket` → metadata contains `SwapMarket@stacker.news`, callback URL uses `SwapMarket`
- `GET /.well-known/lnurlp/swapmarket` → same response (canonical casing from DB)
- `GET /api/lnurlp/swapmarket/pay?amount=21000` → invoice description hash matches what the index endpoint returned