### PR TITLE
fix: keep long posts expanded across back/forward navigation

### DIFF
--- a/components/text.js
+++ b/components/text.js
@@ -25,13 +25,17 @@ export function useOverflow ({ containerRef, truncated = false }) {
   const [overflowing, setOverflowing] = useState(false)
   // should we show the full text?
   const [show, setShow] = useState(false)
-  const showOverflow = useCallback(() => setShow(true), [setShow])
+  // persist the expanded state in the URL so it survives back/forward navigation
+  const showOverflow = useCallback(() => {
+    setShow(true)
+    router.replace({ pathname: router.pathname, query: { ...router.query, full: '1' } }, undefined, { shallow: true })
+  }, [router])
 
-  // if we are navigating to a hash, show the full text
+  // if we are navigating to a hash or the full param is set, show the full text
   useEffect(() => {
-    setShow(router.asPath.includes('#'))
+    setShow(router.asPath.includes('#') || router.query.full === '1')
     const handleRouteChange = (url, { shallow }) => {
-      setShow(url.includes('#'))
+      setShow(url.includes('#') || url.includes('full=1'))
     }
 
     router.events.on('hashChangeStart', handleRouteChange)
@@ -39,7 +43,7 @@ export function useOverflow ({ containerRef, truncated = false }) {
     return () => {
       router.events.off('hashChangeStart', handleRouteChange)
     }
-  }, [router.asPath, router.events])
+  }, [router.asPath, router.query.full, router.events])
 
   // clip item and give it a`show full text` button if we are overflowing
   useEffect(() => {


### PR DESCRIPTION
## Description

Expanding a long post via "show full text" only set React state (`show`), which is lost when you navigate to another page and press back. The post re-collapses, and the browser's restored scroll position lands in the wrong place because the page height shrank.

Fixes #2818 using the approach suggested in the issue: add a hidden GET param via `router.replace` when the post is expanded.

## Changes

In `useOverflow` (`components/text.js`):
- When the user clicks "show full text", also do a shallow `router.replace` to add `full=1` to the URL (no re-fetch, no new history entry).
- Derive the `show` state from `full=1` in addition to the existing hash (`#`) check, so back/forward navigation restores the expanded post.

The `full` param is passed through `...router.query` to the GraphQL query like the existing `commentId` param, and is ignored by the schema (verified `ITEM_FULL` tolerates extra variables the same way it already tolerates `commentId`).

## Testing

- Expand a long post -> URL gains `?full=1` without a re-render/re-fetch
- Click an internal link, press back -> post stays expanded, scroll position correct
- Direct load of a `?full=1` URL -> post renders expanded
- Hash navigation behavior unchanged