### PR TITLE
remove njump.me embeds, switch nostr links to damus.io

### DIFF
--- a/components/embed.js
+++ b/components/embed.js
@@ -21,59 +21,6 @@ function TweetSkeleton ({ className }) {
   )
 }
 
-export const NostrEmbed = memo(function NostrEmbed ({ className, darkMode, id }) {
-  const [show, setShow] = useState(false)
-  const iframeRef = useRef(null)
-
-  useEffect(() => {
-    if (!iframeRef.current) return
-
-    const setHeightFromIframe = (e) => {
-      if (e.origin !== 'https://njump.me' || !e?.data?.height || e.source !== iframeRef.current.contentWindow) return
-      iframeRef.current.height = `${e.data.height}px`
-    }
-
-    window?.addEventListener('message', setHeightFromIframe)
-
-    const handleIframeLoad = () => {
-      iframeRef.current.contentWindow.postMessage({ setDarkMode: darkMode }, '*')
-    }
-
-    if (iframeRef.current.complete) {
-      handleIframeLoad()
-    } else {
-      iframeRef.current.addEventListener('load', handleIframeLoad)
-    }
-
-    // https://github.com/vercel/next.js/issues/39451
-    iframeRef.current.src = `https://njump.me/${id}?embed=yes`
-
-    return () => {
-      window?.removeEventListener('message', setHeightFromIframe)
-      iframeRef.current?.removeEventListener('load', handleIframeLoad)
-    }
-  }, [iframeRef.current, darkMode])
-
-  return (
-    <div className={classNames('sn-nostr-container', !show && 'sn-embed-contained', className)}>
-      <iframe
-        ref={iframeRef}
-        width='100%'
-        style={{ maxWidth: '100%' }}
-        height={iframeRef.current?.height || '100%'}
-        frameBorder='0'
-        sandbox='allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox'
-        allow=''
-      />
-      {!show &&
-        <Button size='md' variant='info' className='sn-embed-show-full' onClick={() => setShow(true)}>
-          <div>show full note</div>
-          <small className='fw-normal fst-italic'>or other stuff</small>
-        </Button>}
-    </div>
-  )
-})
-
 const SpotifyEmbed = function SpotifyEmbed ({ src, className }) {
   const iframeRef = useRef(null)
 
@@ -140,12 +87,6 @@ const Embed = memo(function Embed ({ src, provider, id, meta, className, topLeve
             </Button>}
         </div>
       </>
-    )
-  }
-
-  if (provider === 'nostr') {
-    return (
-      <NostrEmbed src={src} className={embedClass} id={id} darkMode={darkMode} />
     )
   }
 

--- a/components/footer.js
+++ b/components/footer.js
@@ -58,7 +58,7 @@ const SocialsPopover = (
     <Popover.Body style={{ fontWeight: 500, fontSize: '.9rem' }}>
       <div className='d-flex justify-content-center'>
         <a
-          href='https://njump.me/npub1jfujw6llhq7wuvu5detycdsq5v5yqf56sgrdq8wlgrryx2a2p09svwm0gx' className='nav-link p-0 d-inline-flex'
+          href='https://damus.io/npub1jfujw6llhq7wuvu5detycdsq5v5yqf56sgrdq8wlgrryx2a2p09svwm0gx' className='nav-link p-0 d-inline-flex'
           target='_blank' rel='noreferrer'
         >
           nostr

--- a/components/item-info.js
+++ b/components/item-info.js
@@ -210,7 +210,7 @@ export default function ItemInfo ({
                   opentimestamp
                 </Link>}
               {item?.noteId && (
-                <Dropdown.Item onClick={() => window.open(`https://njump.me/${item.noteId}`, '_blank', 'noopener,noreferrer,nofollow')}>
+                <Dropdown.Item onClick={() => window.open(`https://damus.io/${item.noteId}`, '_blank', 'noopener,noreferrer,nofollow')}>
                   nostr note
                 </Dropdown.Item>
               )}

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -363,14 +363,14 @@ function NostrZap ({ n }) {
     <div className='fw-bold text-nostr'>
       <NostrIcon width={24} height={24} className='fill-nostr me-1' />{numWithUnits(n.earnedSats)} zap from
       {// eslint-disable-next-line
-        <Link className='mx-1 text-reset text-underline' target='_blank' href={`https://njump.me/${npub}`} rel={UNKNOWN_LINK_REL}>
+        <Link className='mx-1 text-reset text-underline' target='_blank' href={`https://damus.io/${npub}`} rel={UNKNOWN_LINK_REL}>
           {npub.slice(0, 10)}...
         </Link>
         }
       on {note
           ? (
             // eslint-disable-next-line
-            <Link className='mx-1 text-reset text-underline' target='_blank' href={`https://njump.me/${note}`} rel={UNKNOWN_LINK_REL}>
+            <Link className='mx-1 text-reset text-underline' target='_blank' href={`https://damus.io/${note}`} rel={UNKNOWN_LINK_REL}>
               {note.slice(0, 12)}...
             </Link>)
           : 'nostr'}

--- a/components/payIn/bolt11-info.js
+++ b/components/payIn/bolt11-info.js
@@ -164,13 +164,13 @@ function NostrZapRequest ({ zap }) {
     <ExpandableDetailPill label='Nostr zap request' icon={<NostrIcon width={16} height={16} className='fill-nostr' />}>
       <div className='fw-bold text-nostr small'>
         from{' '}
-        <Link className='text-reset text-underline' target='_blank' href={`https://njump.me/${npub}`} rel='noreferrer nofollow noopener'>
+        <Link className='text-reset text-underline' target='_blank' href={`https://damus.io/${npub}`} rel='noreferrer nofollow noopener'>
           {npub.slice(0, 10)}...
         </Link>
         {note && (
           <>
             {' '}on{' '}
-            <Link className='text-reset text-underline' target='_blank' href={`https://njump.me/${note}`} rel='noreferrer nofollow noopener'>
+            <Link className='text-reset text-underline' target='_blank' href={`https://damus.io/${note}`} rel='noreferrer nofollow noopener'>
               {note.slice(0, 12)}...
             </Link>
           </>

--- a/components/user-header.js
+++ b/components/user-header.js
@@ -216,7 +216,7 @@ function SocialLink ({ name, id }) {
     const npub = hexToBech32(id)
     return (
       // eslint-disable-next-line
-      <Link className={className} target='_blank' href={`https://njump.me/${npub}`} rel={UNKNOWN_LINK_REL}>
+      <Link className={className} target='_blank' href={`https://damus.io/${npub}`} rel={UNKNOWN_LINK_REL}>
         <NostrIcon width={20} height={20} className='me-1' />
         {npub.slice(0, 10)}...{npub.slice(-10)}
       </Link>

--- a/lib/lexical/mdast/visitors/nostr.js
+++ b/lib/lexical/mdast/visitors/nostr.js
@@ -2,7 +2,9 @@ import { $createTextNode } from 'lexical'
 import { $createLinkNode, $isLinkNode, $isAutoLinkNode } from '@lexical/link'
 
 const NOSTR_ID_PATTERN = /^((npub1|nevent1|nprofile1|note1|naddr1)[02-9ac-hj-np-z]+)$/
-const NJUMP_ORIGIN = 'https://njump.me'
+const DAMUS_ORIGIN = 'https://damus.io'
+// njump.me links are no longer created but must still round-trip for old posts
+const NOSTR_LINK_ORIGINS = [DAMUS_ORIGIN, 'https://njump.me']
 
 function isNostrIdLink (lexicalNode) {
   const url = lexicalNode.getURL?.()
@@ -10,7 +12,7 @@ function isNostrIdLink (lexicalNode) {
 
   try {
     const u = new URL(url)
-    if (u.origin !== NJUMP_ORIGIN) return null
+    if (!NOSTR_LINK_ORIGINS.includes(u.origin)) return null
     if (u.search || u.hash) return null
     const id = u.pathname.replace(/^\//, '')
     if (!id) return null
@@ -30,7 +32,7 @@ function isNostrIdLink (lexicalNode) {
 export const MdastNostrIdVisitor = {
   testNode: 'nostrId',
   visitNode ({ mdastNode, actions }) {
-    const url = `${NJUMP_ORIGIN}/${mdastNode.value}`
+    const url = `${DAMUS_ORIGIN}/${mdastNode.value}`
     const link = $createLinkNode(url, {
       target: '_blank',
       rel: 'noopener nofollow noreferrer'

--- a/lib/lexical/nodes/content/embed.jsx
+++ b/lib/lexical/nodes/content/embed.jsx
@@ -118,8 +118,8 @@ export class EmbedNode extends DecoratorBlockNode {
       providerClasses?.container,
       providerClasses?.embed
     ]
-    // only twitter and nostr have a contained state
-    if (this.__provider === 'twitter' || this.__provider === 'nostr') {
+    // only twitter has a contained state
+    if (this.__provider === 'twitter') {
       classes.push(providerClasses?.contained)
     }
     container.classList.add(...classes.filter(Boolean))

--- a/lib/lexical/theme/index.js
+++ b/lib/lexical/theme/index.js
@@ -27,11 +27,6 @@ const theme = {
       contained: 'sn-embed-contained',
       embed: 'sn-embed--twitter'
     },
-    nostr: {
-      container: 'sn-nostr-container',
-      contained: 'sn-embed-contained',
-      embed: 'sn-embed--nostr'
-    },
     wavlake: {
       container: 'sn-wavlake-wrapper',
       embed: 'sn-embed--wavlake'

--- a/lib/url.js
+++ b/lib/url.js
@@ -1,6 +1,3 @@
-import { nip19 } from 'nostr-tools'
-import { DEFAULT_CROSSPOSTING_RELAYS } from './nostr'
-
 export function ensureProtocol (value) {
   if (!value) return value
   value = value.trim()
@@ -125,25 +122,6 @@ export function parseEmbedUrl (href) {
     }
 
     const { hostname, pathname, searchParams } = new URL(href)
-
-    // nostr prefixes: [npub1, nevent1, nprofile1, note1]
-    const nostr = pathname.match(/\/(?<id>(?<type>npub1|nevent1|nprofile1|note1|naddr1)[02-9ac-hj-np-z]+)/)
-    if (nostr?.groups?.id) {
-      let id = nostr.groups.id
-      if (nostr.groups.type === 'npub1') {
-        const { data } = nip19.decode(id)
-        id = nip19.nprofileEncode({ pubkey: data })
-      }
-      if (nostr.groups.type === 'note1') {
-        const { data } = nip19.decode(id)
-        // njump needs relays to embed
-        id = nip19.neventEncode({ id: data, relays: DEFAULT_CROSSPOSTING_RELAYS, author: '' })
-      }
-      return {
-        provider: 'nostr',
-        id
-      }
-    }
 
     // https://wavlake.com/track/c0aaeff8-5a26-49cf-8dad-2b6909e4aed1
     if (hostname.endsWith('wavlake.com') && pathname.startsWith('/track')) {

--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { parseInternalLinks, isMisleadingLink, parseEmbedUrl } from './url.js'
+import { parseInternalLinks, isMisleadingLink } from './url.js'
 
 const internalLinkCases = [
   ['https://stacker.news/items/123', '#123'],
@@ -61,28 +61,6 @@ describe('misleading links', () => {
     (text, href, expected) => {
       const actual = isMisleadingLink(text, href)
       expect(actual).toBe(expected)
-    }
-  )
-})
-
-const nostrEmbedUrlCases = [
-  ['https://njump.me/nprofile1qqsfy7f8d0lms08wxw2xu4jvxcq2x2zqy6dgypksrh05p3jr9w4qhjc2xjd74', true],
-  ['https://yakihonne.com/note/nevent1qgsfy7f8d0lms08wxw2xu4jvxcq2x2zqy6dgypksrh05p3jr9w4qhjcppemhxue69uhkummn9ekx7mp0qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qpqa56frq6ljgdeh85rntn50yv3c9u5ffkd26nzs698h9xuljtezljs98kq07', true],
-  ['https://npub1nsyte9neefm3jle7dg5gw6mhchxyk75a6f5dng70l4l3a2mx0nashqv2jk.nsite.lol/', false],
-  ['https://njump.me/nevent1qgsfy7f8d0lms08wxw2xu4jvxcq2x2zqy6dgypksrh05p3jr9w4qhjcppemhxue69uhkummn9ekx7mp0qy2hwumn8ghj7un9d3shjtnyv9kh2uewd9hj7qpqa56frq6ljgdeh85rntn50yv3c9u5ffkd26nzs698h9xuljtezljs98kq07', true],
-  ['https://primal.net/p/npub1jfujw6llhq7wuvu5detycdsq5v5yqf56sgrdq8wlgrryx2a2p09svwm0gx', true]
-]
-
-describe('embed nostr links', () => {
-  test.each(nostrEmbedUrlCases)(
-    'identifies %p as embed: %p',
-    (url, expectedEmbed) => {
-      const actual = parseEmbedUrl(url)
-      if (expectedEmbed) {
-        expect(actual).toMatchObject({ provider: 'nostr' })
-      } else {
-        expect(actual).toBeNull()
-      }
     }
   )
 })

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -464,7 +464,6 @@ export default function Settings ({ ssrData }) {
                     <li>if checked and a link is an image, video or can be embedded in another way, we will do it</li>
                     <li>we support embeds from following sites:</li>
                     <ul>
-                      <li>njump.me</li>
                       <li>youtube.com</li>
                       <li>twitter.com</li>
                       <li>spotify.com</li>

--- a/proxy.js
+++ b/proxy.js
@@ -220,7 +220,7 @@ function applySecurityHeaders (resp) {
     // unsafe-inline for styles is not ideal but okay if script-src is using nonces
     "style-src 'self' a.stacker.news 'unsafe-inline'",
     "manifest-src 'self'",
-    'frame-src www.youtube.com www.youtube-nocookie.com platform.twitter.com njump.me open.spotify.com rumble.com embed.wavlake.com bitcointv.com peertube.tv',
+    'frame-src www.youtube.com www.youtube-nocookie.com platform.twitter.com open.spotify.com rumble.com embed.wavlake.com bitcointv.com peertube.tv',
     "connect-src 'self' https: wss:" + devSrc,
     // disable dangerous plugins like Flash
     "object-src 'none'",

--- a/styles/text.scss
+++ b/styles/text.scss
@@ -407,7 +407,6 @@ span + .sn-link {
 
 // embed containers
 .sn-twitter-container,
-.sn-nostr-container,
 .sn-video-wrapper,
 .sn-wavlake-wrapper,
 .sn-spotify-wrapper {
@@ -416,20 +415,14 @@ span + .sn-link {
   background-color: var(--theme-bg);
 }
 
-// twitter and nostr
-.sn-twitter-container,
-.sn-nostr-container {
+// twitter
+.sn-twitter-container {
   position: relative;
   overflow: hidden;
 }
 
-.sn-twitter-container iframe,
-.sn-nostr-container iframe {
+.sn-twitter-container iframe {
   border-radius: 13px;
-}
-
-.sn-nostr-container {
-  margin-right: 15px;
 }
 
 /* Contained state (collapsed) */
@@ -437,13 +430,11 @@ span + .sn-link {
   overflow: hidden;
 }
 
-.sn-embed-contained.sn-embed--twitter,
-.sn-embed-contained.sn-embed--nostr {
+.sn-embed-contained.sn-embed--twitter {
   height: 150px;
 }
 
-.topLevel .sn-embed-contained.sn-embed--twitter,
-.topLevel .sn-embed-contained.sn-embed--nostr {
+.topLevel .sn-embed-contained.sn-embed--twitter {
   height: 200px;
 }
 
@@ -561,16 +552,6 @@ span + .sn-link {
 }
 
 .topLevel .sn-embed--twitter {
-  max-width: 550px;
-}
-
-// nostr embed
-.sn-embed--nostr {
-  width: 100%;
-  max-width: 350px;
-}
-
-.topLevel .sn-embed--nostr {
   max-width: 550px;
 }
 


### PR DESCRIPTION
## Description

Closes #2813.

njump.me embeds no longer load promptly, so this removes the nostr embed pipeline and switches all njump.me links to damus.io (which is fast and supports npub/nevent/nprofile/note/naddr paths — verified live: valid entity paths return 200, invalid paths 404).

## Embed removal

- `parseEmbedUrl` no longer returns a `nostr` provider (nostr URLs fall through to regular links/media)
- Removed the `NostrEmbed` iframe component and the `provider === 'nostr'` branch
- Removed `njump.me` from the CSP `frame-src`, the settings embed list, the Lexical theme, and the `.sn-nostr-container`/`.sn-embed--nostr` CSS
- Removed the now-unused nostr embed tests and `nip19`/`DEFAULT_CROSSPOSTING_RELAYS` imports

Note: existing posts with nostr embed nodes in their lexical state will render nothing (those embeds were already broken/slow). New nostr links render as plain links.

## Link switch (njump.me -> damus.io)

- Footer nostr profile link
- User header nostr profile link
- Nostr zap notifications (profile + note)
- Bolt11 zap-request detail (profile + note)
- Item dropdown "nostr note" link
- The mdast `nostrId` visitor now creates damus.io links for new content, but still recognizes njump.me origins so existing posts round-trip back to raw nostr IDs unchanged

## Testing

- `node --check` passes on all modified non-JSX files
- Verified damus.io routing for npub/nevent/nprofile (200) vs invalid paths (404)