### PR TITLE
fix: empty table content deleted when toggling write/compose

### DIFF
--- a/lib/lexical/utils/index.js
+++ b/lib/lexical/utils/index.js
@@ -1,4 +1,4 @@
-import { $getRoot, $getSelection, $isRangeSelection, $createParagraphNode, $isTextNode, $isElementNode, $isParagraphNode, $createTextNode, $getEditor } from 'lexical'
+import { $getRoot, $getSelection, $isRangeSelection, $createParagraphNode, $isTextNode, $isElementNode, $isParagraphNode, $isLineBreakNode, $createTextNode, $getEditor } from 'lexical'
 import { $markdownToLexical, $lexicalToMarkdown, removeZeroWidthSpace } from '@/lib/lexical/utils/mdast'
 import { isMarkdownMode } from '@/lib/lexical/commands/utils'
 
@@ -31,6 +31,14 @@ export function $getTextContent (trimWhitespace = true) {
 }
 
 export function $isTextEmpty () {
+  const root = $getRoot()
+  for (const child of root.getChildren()) {
+    // structural nodes (tables, code, media, ...) are content even without text
+    if (!$isParagraphNode(child)) return false
+    for (const inline of child.getChildren()) {
+      if (!$isTextNode(inline) && !$isLineBreakNode(inline)) return false
+    }
+  }
   return $getTextContent().trim() === ''
 }
 


### PR DESCRIPTION
Fixes #3109

## Problem
A post whose text is only an empty table loses its content when toggling between write and compose modes:

1. create an empty table in markdown (write mode)
2. switch to compose
3. switch back to write — the text is gone

## Root cause
`$isTextEmpty()` (lib/lexical/utils/index.js) decided emptiness purely from `getTextContent()`. A `TableNode` whose cells are all empty has no text content, so it was considered "empty". `FormikBridgePlugin`'s `syncFormik()` uses `$isTextEmpty()` as a shortcut: when true it calls `textHelpers.setValue('')`, wiping the formik field that carries content across the editor remount on mode toggle. The same heuristic in `$appendMarkdown()` would also clear a root containing an empty table.

The mdast layer round-trips empty tables fine (`|  |  |` parses and serializes correctly), and Lexical keeps empty table cells — the loss was entirely in this emptiness check.

## Fix
`$isTextEmpty()` now treats structural content as non-empty:
- any non-paragraph top-level node (tables, code blocks, media, lists, ...) counts as content
- any non-text/non-linebreak inline node inside a paragraph (e.g. inline decorators) counts as content

Only editors containing nothing but empty paragraphs/whitespace are considered empty, preserving the existing behavior for truly empty editors.

## Verification
Tested the emptiness logic in a headless Lexical editor across cases:

| case | before | after |
| --- | --- | --- |
| empty table | empty (bug) | content |
| empty paragraph | empty | empty |
| whitespace paragraph | empty | empty |
| paragraph with text | content | content |
| table with text | content | content |
| empty root | empty | empty |

Also verified with the repo's mdast library versions that an empty-cell table serializes back to `|   |   |\n| - | - |` via `mdast-util-to-markdown` + `gfmTableToMarkdown`.