### PR TITLE
Fix #3150: clear new-comments bubble when a reply is seen in notifications

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -957,13 +957,19 @@ export default {
         throw new GqlAuthenticationError()
       }
 
-      const result = await models.commentsViewAt.upsert({
-        where: {
-          userId_itemId: { userId: Number(me.id), itemId: Number(id) }
-        },
-        update: { lastViewedAt: new Date(meCommentsViewedAt) },
-        create: { userId: Number(me.id), itemId: Number(id), lastViewedAt: new Date(meCommentsViewedAt) }
-      })
+      const userId = Number(me.id)
+      const itemId = Number(id)
+      const viewedAt = new Date(meCommentsViewedAt)
+      const where = { userId_itemId: { userId, itemId } }
+
+      const existing = await models.commentsViewAt.findUnique({ where })
+
+      // never move the viewed timestamp backwards
+      if (existing && existing.lastViewedAt >= viewedAt) return existing.lastViewedAt
+
+      const result = existing
+        ? await models.commentsViewAt.update({ where, data: { lastViewedAt: viewedAt } })
+        : await models.commentsViewAt.create({ data: { userId, itemId, lastViewedAt: viewedAt } })
 
       return result.lastViewedAt
     }

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -1,10 +1,11 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { gql } from '@apollo/client'
-import { useQuery, useApolloClient } from '@apollo/client/react'
+import { useQuery, useMutation, useApolloClient } from '@apollo/client/react'
 import Comment, { CommentSkeleton } from './comment'
 import Item from './item'
 import ItemJob from './item-job'
 import { NOTIFICATIONS } from '@/fragments/notifications'
+import { UPDATE_ITEM_USER_VIEW } from '@/fragments/items'
 import MoreFooter from './more-footer'
 import Invite from './invite'
 import { dayMonthYear, timeSince } from '@/lib/time'
@@ -839,6 +840,16 @@ export default function Notifications ({ ssrData }) {
   const router = useRouter()
   const dat = useData(data, ssrData)
 
+  const [updateCommentsViewAt] = useMutation(UPDATE_ITEM_USER_VIEW, {
+    update (cache, { data: { updateCommentsViewAt }, variables }) {
+      const id = String(variables.id)
+      cache.modify({
+        id: `Item:${id}`,
+        fields: { meCommentsViewedAt: () => updateCommentsViewAt }
+      })
+    }
+  })
+
   // a failed pay-in optimistically bumped an item's counters; its PayInification notification
   // carries the server's truth. reconcile here (not in an ApolloLink) because the feed arrives
   // via SSR + cache-first, so no client-link request ever fires. covers the SSR first page and
@@ -857,6 +868,32 @@ export default function Notifications ({ ssrData }) {
     }
     return retDat
   }, [dat])
+
+  // reply/mention notifications render the comment inline, so reading them in the
+  // notifications list is viewing the thread: mark the root item's comments as
+  // viewed so the front-page "new comments" bubble clears (see #3150). The server
+  // never moves meCommentsViewedAt backwards, so stale/repeated notifications are safe.
+  useEffect(() => {
+    if (!notifications?.length || !lastChecked) return
+
+    const rootViewedAt = new Map()
+    notifications.forEach(n => {
+      if (!n.item?.parentId || !n.item.path) return
+      // only newly-seen notifications need marking
+      if (new Date(n.sortTime).getTime() <= new Date(lastChecked).getTime()) return
+
+      const rootId = Number(n.item.path.split('.')[0])
+      const sortTime = new Date(n.sortTime).getTime()
+      const prev = rootViewedAt.get(rootId)
+      if (!prev || sortTime > prev) rootViewedAt.set(rootId, sortTime)
+    })
+
+    rootViewedAt.forEach((sortTime, rootId) => {
+      updateCommentsViewAt({
+        variables: { id: rootId, meCommentsViewedAt: new Date(sortTime).toISOString() }
+      })
+    })
+  }, [notifications, lastChecked, updateCommentsViewAt])
 
   useEffect(() => {
     if (lastChecked && !router?.query?.checkedAt) {


### PR DESCRIPTION
# Fix #3150: clear "new comments" bubble when a reply is seen in notifications

## Description

The front-page "new comments" blue bubble (shown next to a thread title when
`meCommentsViewedAt < lastCommentAt`) is only cleared when the thread page is
opened, because `markItemViewed` in `components/item-full.js` is the only
caller of the `updateCommentsViewAt` mutation.

Reply notifications render the comment inline in the notifications list, so a
stacker can read (and even zap) a comment there without ever opening the
thread. In that case `meCommentsViewedAt` is never advanced and the bubble
persists on the front page.

This PR:

1. Marks the root item's comments as viewed when reply/mention notifications
   are seen in the notifications list (client, `components/notifications.js`).
   Only notifications newer than the previous `lastChecked` are considered,
   and roots are deduplicated (the latest `sortTime` wins).
2. Makes the `updateCommentsViewAt` resolver monotonic
   (`api/resolvers/item.js`): the viewed timestamp never moves backwards, so
   stale or repeated notification-driven updates can't regress a thread that
   was already read at a later time.

## Checklist

**Are your changes backward compatible?**

Yes. Data shape and GraphQL fields are unchanged. The resolver keeps the same
return type and semantics except that it refuses to move the timestamp
backwards. The client change only fires the existing mutation.

**On a scale of 1-10 how well and how have you QA'd this change?**

6. Verified the freshness semantics against the notifications resolver
(`lastChecked` is the pre-visit `checkedNotesAt`, so `sortTime > lastChecked`
correctly identifies newly-seen notifications). Patch verified to apply
cleanly against current `master`; JSX/syntax checked with esbuild and `node
--check`. Full app runtime testing (docker compose) not performed.

**For frontend changes: Tested on mobile, light and dark mode?**

No. Change is logic-only; no styling touched.

**Did you introduce any new environment variables?**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes. Codex traced the view-state flow (item-full → use-comments-view →
updateCommentsViewAt), designed the fix, and produced the patch; I reviewed
the change before submitting.
