### PR TITLE
fix: preserve nested blocks when toggling quote formatting (fixes #2862)

### DIFF
--- a/lib/lexical/commands/formatting/blocks.js
+++ b/lib/lexical/commands/formatting/blocks.js
@@ -11,11 +11,11 @@ import {
   COMMAND_PRIORITY_EDITOR, $createParagraphNode
 } from 'lexical'
 import { $setBlocksType } from '@lexical/selection'
-import { $createQuoteNode } from '@lexical/rich-text'
 import { $createSNHeadingNode } from '@/lib/lexical/nodes/misc/heading'
 import { USE_TRANSFORMER_BRIDGE } from '@/components/editor/plugins/core/transformer-bridge'
 import { MD_INSERT_BLOCK_COMMAND } from '@/lib/lexical/commands/formatting/markdown'
 import { $splitParagraphsByLineBreaks } from '@/lib/lexical/nodes/utils'
+import { $unwrapSelectedQuotes, $wrapSelectedInQuote } from '@/lib/lexical/commands/formatting/quote'
 
 /** command to format blocks (headings, lists, quotes, etc.)
  * @param {string} block - block type ('paragraph', 'h1', 'bullet', 'quote', etc.)
@@ -48,9 +48,14 @@ const $formatCheckList = (editor, activeBlock, block, selection) => {
 }
 
 const $formatBlockQuote = (activeBlock, block, selection) => {
-  if (activeBlock === block) return $formatParagraph(selection)
   if (!selection) return
-  $setBlocksType(selection, () => $createQuoteNode())
+  if (activeBlock === block) {
+    // toggling quote off: unwrap quotes while preserving any nested blocks
+    if ($unwrapSelectedQuotes(selection)) return
+    return $formatParagraph(selection)
+  }
+  // toggling quote on: wrap blocks, preserving non-paragraph blocks (eg code blocks)
+  $wrapSelectedInQuote(selection)
 }
 
 const $formatCodeBlock = (activeBlock, block, selection) => {

--- a/lib/lexical/commands/formatting/blocks.test.js
+++ b/lib/lexical/commands/formatting/blocks.test.js
@@ -1,0 +1,140 @@
+/* eslint-env jest */
+
+import { createHeadlessEditor } from '@lexical/headless'
+import { CodeNode, CodeHighlightNode, $createCodeNode, $createCodeHighlightNode } from '@lexical/code-core'
+import { QuoteNode, $createQuoteNode, $isQuoteNode } from '@lexical/rich-text'
+import {
+  $createParagraphNode, $createTextNode, $createRangeSelection,
+  $getRoot, $isParagraphNode, $setSelection
+} from 'lexical'
+
+// mock modules that drag ESM-only deps (github-slugger, micromark, mdast) into
+// the test environment; they're only used by formatting paths this suite doesn't exercise
+jest.mock('../../../lexical/nodes/misc/heading.jsx', () => ({
+  $createSNHeadingNode: () => { throw new Error('heading formatting not exercised in this suite') }
+}))
+jest.mock('../../../../components/editor/plugins/core/transformer-bridge.js', () => ({
+  USE_TRANSFORMER_BRIDGE: {}
+}))
+jest.mock('./markdown.js', () => ({
+  MD_INSERT_BLOCK_COMMAND: {},
+  MD_FORMAT_COMMAND: {}
+}))
+
+// eslint-disable-next-line import/first
+import { $formatBlock } from './blocks'
+
+/** creates a headless editor with the nodes needed for the block format tests */
+const createQuoteEditor = () => createHeadlessEditor({
+  nodes: [CodeNode, CodeHighlightNode, QuoteNode]
+})
+
+/** sets a range selection between the given text nodes and offsets */
+const $selectRange = (anchorNode, anchorOffset, focusNode = anchorNode, focusOffset = anchorOffset) => {
+  const selection = $createRangeSelection()
+  selection.anchor.set(anchorNode.getKey(), anchorOffset, 'text')
+  selection.focus.set(focusNode.getKey(), focusOffset, 'text')
+  $setSelection(selection)
+}
+
+describe('quote block formatting', () => {
+  test('toggles a paragraph into a quote', () => {
+    const editor = createQuoteEditor()
+    editor.update(() => {
+      const paragraph = $createParagraphNode()
+      const text = $createTextNode('hello')
+      paragraph.append(text)
+      $getRoot().append(paragraph)
+      $selectRange(text, 1, text, 4)
+      $formatBlock(editor, 'quote')
+    })
+
+    editor.read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1)
+      const child = $getRoot().getFirstChild()
+      expect($isQuoteNode(child)).toBe(true)
+      expect(child.getTextContent()).toBe('hello')
+    })
+  })
+
+  test('removing a quote preserves a nested code block instead of destroying it', () => {
+    const editor = createQuoteEditor()
+    editor.update(() => {
+      const quote = $createQuoteNode()
+      const code = $createCodeNode()
+      const codeText = $createCodeHighlightNode('const x = 1')
+      code.append(codeText)
+      quote.append(code)
+      $getRoot().append(quote)
+      $selectRange(codeText, 3, codeText, 3)
+      $formatBlock(editor, 'quote')
+    })
+
+    editor.read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1)
+      const child = $getRoot().getFirstChild()
+      expect(child.getType()).toBe('code')
+      expect(child.getTextContent()).toBe('const x = 1')
+    })
+  })
+
+  test('removing a quote on plain text turns it into a paragraph', () => {
+    const editor = createQuoteEditor()
+    editor.update(() => {
+      const quote = $createQuoteNode()
+      const text = $createTextNode('hello')
+      quote.append(text)
+      $getRoot().append(quote)
+      $selectRange(text, 1, text, 4)
+      $formatBlock(editor, 'quote')
+    })
+
+    editor.read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1)
+      const child = $getRoot().getFirstChild()
+      expect($isParagraphNode(child)).toBe(true)
+      expect(child.getTextContent()).toBe('hello')
+    })
+  })
+
+  test('adding a quote around a code block keeps the code block', () => {
+    const editor = createQuoteEditor()
+    editor.update(() => {
+      const code = $createCodeNode()
+      const codeText = $createCodeHighlightNode('const x = 1')
+      code.append(codeText)
+      $getRoot().append(code)
+      $selectRange(codeText, 2, codeText, 2)
+      $formatBlock(editor, 'quote')
+    })
+
+    editor.read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1)
+      const quote = $getRoot().getFirstChild()
+      expect($isQuoteNode(quote)).toBe(true)
+      expect(quote.getFirstChild().getType()).toBe('code')
+      expect(quote.getTextContent()).toBe('const x = 1')
+    })
+  })
+
+  test('removing a quote around another quote keeps the inner quote', () => {
+    const editor = createQuoteEditor()
+    editor.update(() => {
+      const outerQuote = $createQuoteNode()
+      const innerQuote = $createQuoteNode()
+      const text = $createTextNode('nested')
+      innerQuote.append(text)
+      outerQuote.append(innerQuote)
+      $getRoot().append(outerQuote)
+      $selectRange(text, 2, text, 2)
+      $formatBlock(editor, 'quote')
+    })
+
+    editor.read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1)
+      const child = $getRoot().getFirstChild()
+      expect($isQuoteNode(child)).toBe(true)
+      expect(child.getTextContent()).toBe('nested')
+    })
+  })
+})

--- a/lib/lexical/commands/formatting/quote.js
+++ b/lib/lexical/commands/formatting/quote.js
@@ -1,0 +1,77 @@
+import { $createParagraphNode, $isRangeSelection, $isRootNode } from 'lexical'
+import { $createQuoteNode, $isQuoteNode } from '@lexical/rich-text'
+import { $setBlocksType } from '@lexical/selection'
+import { $findTopLevelElement } from '@/lib/lexical/commands/utils'
+import { $isBlockElement } from '@/lib/lexical/nodes/utils'
+
+/** moves a quote's children out of it, wrapping loose inline children in paragraphs
+ * this preserves nested blocks (eg code blocks inside quotes) which a plain
+ * paragraph conversion would destroy
+ * @param {Object} quote - quote node to unwrap
+ */
+const $unwrapQuote = (quote) => {
+  let insertionPoint = quote
+  for (const child of quote.getChildren()) {
+    if ($isBlockElement(child)) {
+      insertionPoint.insertAfter(child)
+      insertionPoint = child
+    } else {
+      const paragraph = $createParagraphNode()
+      insertionPoint.insertAfter(paragraph)
+      paragraph.append(child)
+      insertionPoint = paragraph
+    }
+  }
+  quote.remove()
+}
+
+/** unwraps the top-level quote nodes touched by a selection
+ * @param {Object} selection - lexical selection
+ * @returns {boolean} true if any quote was unwrapped
+ */
+export function $unwrapSelectedQuotes (selection) {
+  if (!$isRangeSelection(selection)) return false
+
+  const quotes = new Set()
+  for (const node of selection.getNodes()) {
+    const topLevelElement = $findTopLevelElement(node)
+    if ($isQuoteNode(topLevelElement)) quotes.add(topLevelElement)
+  }
+
+  for (const quote of quotes) {
+    $unwrapQuote(quote)
+  }
+
+  return quotes.size > 0
+}
+
+/** wraps the top-level elements touched by a selection in quote nodes
+ * all-paragraph selections keep the previous block-conversion behavior,
+ * anything else is wrapped so the original block (eg a code block) is preserved
+ * @param {Object} selection - lexical selection
+ * @returns {boolean} true if elements were wrapped
+ */
+export function $wrapSelectedInQuote (selection) {
+  if (!$isRangeSelection(selection)) return false
+
+  const topLevelElements = new Set()
+  for (const node of selection.getNodes()) {
+    const element = $findTopLevelElement(node)
+    if (!$isRootNode(element)) topLevelElements.add(element)
+  }
+
+  if (topLevelElements.size === 0) return false
+
+  if ([...topLevelElements].every(node => node.getType() === 'paragraph')) {
+    $setBlocksType(selection, () => $createQuoteNode())
+    return true
+  }
+
+  for (const element of topLevelElements) {
+    const quote = $createQuoteNode()
+    element.replace(quote)
+    quote.append(element)
+  }
+
+  return true
+}


### PR DESCRIPTION
## Description

Fixes #2862. Toggling block quote formatting used $setBlocksType, which replaced the quote block and moved all of its children into the new block. When a quote contained a nested block (e.g. a code block produced by Markdown like `> code`), toggling the quote destroyed the nested block's structure.

## Changes
- New `lib/lexical/commands/formatting/quote.js` with:
  - ``: unwraps quotes while preserving nested blocks (block children stay blocks, loose inline children are wrapped in paragraphs)
  - ``: wraps a selection in quotes; all-paragraph selections keep the previous conversion behavior, non-paragraph blocks (like code blocks) are wrapped instead of flattened
- `` now uses the new helpers
- New headless editor tests in `lib/lexical/commands/formatting/blocks.test.js` covering toggle on/off for paragraphs, code blocks, and nested quotes

## Verification
- `jest` passes (10 suites / 227 tests)
- `standard` lint is clean