### PR TITLE
fix: preserve empty tables when leaving rich editor mode (fixes #3109)

### DIFF
--- a/lib/lexical/utils/index.js
+++ b/lib/lexical/utils/index.js
@@ -31,7 +31,11 @@ export function $getTextContent (trimWhitespace = true) {
 }
 
 export function $isTextEmpty () {
-  return $getTextContent().trim() === ''
+  if ($getTextContent().trim() !== '') return false
+  // structural content with no text (e.g. an empty table) is not an empty editor
+  return $getRoot().getChildren().every((child) =>
+    $isElementNode(child) && child.isEmpty() && $isParagraphNode(child)
+  )
 }
 
 /** gets the final markdown content of the editor

--- a/lib/lexical/utils/is-text-empty.test.js
+++ b/lib/lexical/utils/is-text-empty.test.js
@@ -1,0 +1,76 @@
+/* eslint-env jest */
+
+import { createHeadlessEditor } from '@lexical/headless'
+import { TableCellNode, TableNode, TableRowNode, $createTableNodeWithDimensions } from '@lexical/table'
+import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical'
+
+// mdast pulls ESM-only packages (micromark, mdast-util-gfm) that the jest
+// environment cannot load; this suite only exercises $isTextEmpty/$getTextContent
+jest.mock('./mdast', () => ({
+  $markdownToLexical: () => {},
+  $lexicalToMarkdown: () => '',
+  removeZeroWidthSpace: (str) => str
+}))
+
+// eslint-disable-next-line import/first
+import { $isTextEmpty } from './index'
+
+const createEditor = () => createHeadlessEditor({
+  nodes: [TableNode, TableRowNode, TableCellNode]
+})
+
+describe('$isTextEmpty', () => {
+  test('an empty table is not considered empty', () => {
+    const editor = createEditor()
+    editor.update(() => {
+      $getRoot().append($createTableNodeWithDimensions(1, 1))
+    })
+    editor.read(() => {
+      expect($getRoot().getChildrenSize()).toBe(1)
+      expect($isTextEmpty()).toBe(false)
+    })
+  })
+
+  test('a table with text is not considered empty', () => {
+    const editor = createEditor()
+    editor.update(() => {
+      const table = $createTableNodeWithDimensions(1, 1)
+      const cell = table.getFirstChild().getFirstChild()
+      cell.append($createTextNode('hello'))
+      $getRoot().append(table)
+    })
+    editor.read(() => {
+      expect($isTextEmpty()).toBe(false)
+    })
+  })
+
+  test('only empty paragraphs are considered empty', () => {
+    const editor = createEditor()
+    editor.update(() => {
+      $getRoot().append($createParagraphNode())
+      $getRoot().append($createParagraphNode())
+    })
+    editor.read(() => {
+      expect($isTextEmpty()).toBe(true)
+    })
+  })
+
+  test('an empty root is considered empty', () => {
+    const editor = createEditor()
+    editor.read(() => {
+      expect($isTextEmpty()).toBe(true)
+    })
+  })
+
+  test('a paragraph with text is not considered empty', () => {
+    const editor = createEditor()
+    editor.update(() => {
+      const paragraph = $createParagraphNode()
+      paragraph.append($createTextNode('hello'))
+      $getRoot().append(paragraph)
+    })
+    editor.read(() => {
+      expect($isTextEmpty()).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
**Problem:** An empty table (\|   |\n| - |\) gets deleted when switching from rich (compose) mode back to markdown (write) mode. The markdown->lexical direction survives; the lexical->markdown direction loses the table.

**Root cause:** \\()\ (lib/lexical/utils/index.js) treated an empty table as "empty" because \TableNode.getTextContent()\ returns \''\ for a table whose cells have no text. In \FormikBridgePlugin\ (\syncFormik\), the early \\()\ check then ran \setValue('')\ instead of \setValue(\(editor))\, wiping the table's markdown on the first sync after entering rich mode.

**Fix:** \\\ now only reports an empty editor when there is no text AND every top-level child is an empty paragraph. Structural content without text (e.g. an empty table) is preserved.

**Testing:** Added \lib/lexical/utils/is-text-empty.test.js\ covering empty tables, tables with text, only empty paragraphs, an empty root, and a paragraph with text. Full suite passes (232 tests, 11 suites) and standard lint is clean.