### PR TITLE
fix: show analytics tooltip above other chart elements (fixes #3122)

### DIFF
--- a/components/charts.js
+++ b/components/charts.js
@@ -107,7 +107,7 @@ export function WhenAreaChart ({ data }) {
           tick={{ fill: 'var(--theme-grey)' }}
         />
         <YAxis tickFormatter={abbrNum} tick={{ fill: 'var(--theme-grey)' }} />
-        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)', opacity: 1, zIndex: -1 }} />
+        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)' }} />
         <Legend />
         {Object.keys(data[0]).filter(v => v !== 'time' && v !== '__typename').map((v, i) =>
           <Area key={v} type='monotone' dataKey={v} name={v} stackId='1' stroke={getColor(i)} fill={getColor(i)} />)}


### PR DESCRIPTION
**Problem:** The analytics tooltip on hover is obscured by other chart elements, so it is hard to read.

**Root cause:** The \WhenAreaChart\ tooltip in components/charts.js set \zIndex: -1\ in its \contentStyle\, which renders it behind the adjacent chart columns (and their backgrounds) instead of on top. The other charts (\WhenLineChart\, \WhenComposedChart\) do not set \zIndex\ and are not affected.

**Fix:** Remove the \zIndex: -1\ so the tooltip matches the other charts' tooltip styling and renders above the surrounding elements.

**Testing:** Standard lint passes. Visual check: the affected charts are used on the analytics page (pages/stackers/[sub]/[when].js) and the satistics graphs page (pages/satistics/graphs/[when].js); the area-chart tooltip now appears above adjacent elements on hover.