### PR TITLE
fix: fade out carousel nav arrows when idle (fixes #2500)

### DIFF
--- a/components/carousel.js
+++ b/components/carousel.js
@@ -59,6 +59,19 @@ function Carousel ({ close, mediaArr, src, setOptions }) {
     if (index === -1) return [src, false, false]
     return [mediaArr[index][0], index > 0, index < mediaArr.length - 1]
   }, [src, mediaArr, index])
+  const [navHidden, setNavHidden] = useState(false)
+  const navTimeoutRef = useRef()
+
+  const resetNavTimer = useCallback(() => {
+    setNavHidden(false)
+    clearTimeout(navTimeoutRef.current)
+    navTimeoutRef.current = setTimeout(() => setNavHidden(true), 3000)
+  }, [])
+
+  useEffect(() => {
+    resetNavTimer()
+    return () => clearTimeout(navTimeoutRef.current)
+  }, [resetNavTimer])
 
   useEffect(() => {
     if (index === -1) return
@@ -79,9 +92,9 @@ function Carousel ({ close, mediaArr, src, setOptions }) {
   useArrowKeys({ moveLeft, moveRight })
 
   return (
-    <div className={styles.fullScreenContainer} onClick={close}>
+    <div className={styles.fullScreenContainer} onClick={close} onMouseMove={resetNavTimer} onTouchStart={resetNavTimer}>
       <img className={styles.fullScreen} src={currentSrc} />
-      <div className={styles.fullScreenNavContainer}>
+      <div className={classNames(styles.fullScreenNavContainer, navHidden && styles.navHidden)}>
         <div
           className={classNames(styles.fullScreenNav, !canGoLeft && 'invisible', styles.left)}
           onClick={(e) => {

--- a/components/carousel.module.css
+++ b/components/carousel.module.css
@@ -9,6 +9,15 @@ div.fullScreenNavContainer {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    transition: opacity .3s ease-in-out;
+}
+
+div.fullScreenNavContainer.navHidden {
+    opacity: 0;
+}
+
+div.fullScreenNavContainer.navHidden div.fullScreenNav {
+    pointer-events: none;
 }
 
 img.fullScreen {


### PR DESCRIPTION
**Problem:** The fullscreen image carousel nav arrows permanently overlay the image, hiding the part of the image beneath them.

**Fix:** The arrows now fade out after 3 seconds of inactivity and reappear on mouse move or touch. They keep their hover background behavior while visible, and become non-interactive (pointer-events: none) while faded so the invisible area does not capture clicks.

**Testing:** Standard lint passes. The arrows still navigate on click and remain visible while hovering/using them; after 3s idle they fade out and the image is unobstructed.