### PR TITLE
fix: align sticky header with viewport edges (fixes #2346)

### DIFF
--- a/components/header.module.css
+++ b/components/header.module.css
@@ -119,7 +119,8 @@
 .sticky {
     position: fixed;
     border-bottom: 1px solid var(--theme-toolbarActive);
-    width: 100vw;
+    left: 0;
+    right: 0;
     top: -1px;
     padding-top: 1px;
     background-color: var(--bs-body-bg);


### PR DESCRIPTION
**Problem:** The fixed (sticky) header is slightly shifted horizontally relative to the non-sticky header.

**Root cause:** The .sticky element uses position: fixed with width: 100vw but no explicit left/right. Since 100vw includes the scrollbar width, the element spans the viewport width from its static (content-area) position, pushing the inner content out of alignment with the page content.

**Fix:** Replace width: 100vw with left: 0; right: 0 so the fixed header spans exactly the viewport edges, matching the layout of the non-sticky header.

This matches the approach suggested in the issue thread.