### PR TITLE
fix: confirm before discarding comment edit changes (fixes #2568)

### DIFF
--- a/components/comment-edit.js
+++ b/components/comment-edit.js
@@ -5,8 +5,21 @@ import { FeeButtonProvider } from './fee-button'
 import { ItemButtonBar } from './post'
 import { UPDATE_COMMENT } from '@/fragments/payIn'
 import useItemSubmit from './use-item-submit'
+import { useFormikContext } from 'formik'
+import { useEffect } from 'react'
 
-export default function CommentEdit ({ comment, editThreshold, onSuccess, onCancel }) {
+function DirtyTracker ({ original, onDirtyChange }) {
+  const { values } = useFormikContext()
+  const dirty = values.text?.trim() !== (original ?? '').trim()
+
+  useEffect(() => {
+    onDirtyChange?.(dirty)
+  }, [dirty, onDirtyChange])
+
+  return null
+}
+
+export default function CommentEdit ({ comment, editThreshold, onSuccess, onCancel, onDirtyChange }) {
   const onSubmit = useItemSubmit(UPDATE_COMMENT, {
     payInMutationOptions: {
       cachePhases: {
@@ -64,6 +77,7 @@ export default function CommentEdit ({ comment, editThreshold, onSuccess, onCanc
             autoFocus
             required
           />
+          <DirtyTracker original={comment.text} onDirtyChange={onDirtyChange} />
           <ItemButtonBar itemId={comment.id} onDelete={onSuccess} hasCancel={false} />
         </Form>
       </FeeButtonProvider>

--- a/components/comment.js
+++ b/components/comment.js
@@ -29,6 +29,8 @@ import { gql } from '@apollo/client'
 import { useApolloClient } from '@apollo/client/react'
 import classNames from 'classnames'
 import useCallbackRef from './use-callback-ref'
+import { useShowModal } from './modal'
+import { ObstacleButtons } from './obstacle'
 
 function Parent ({ item, rootText }) {
   const root = useRoot()
@@ -104,6 +106,8 @@ export default function Comment ({
   navigator, ...props
 }) {
   const [edit, setEdit] = useState()
+  const [dirty, setDirty] = useState(false)
+  const showModal = useShowModal()
   const { me } = useMe()
   // Collapse comments that don't meet the viewer's commentsSatsFilter threshold
   const commentsSatsFilter = me ? me.privates?.commentsSatsFilter : DEFAULT_COMMENTS_SATS_FILTER
@@ -263,7 +267,27 @@ export default function Comment ({
                     </>
                   }
                   edit={edit}
-                  toggleEdit={e => { setEdit(!edit) }}
+                  toggleEdit={() => {
+                    if (edit && dirty) {
+                      showModal(onClose => (
+                        <div>
+                          <p className='fw-bolder'>Discard your changes?</p>
+                          <ObstacleButtons
+                            onClose={onClose}
+                            onConfirm={() => {
+                              onClose()
+                              setEdit(false)
+                              setDirty(false)
+                            }}
+                            confirmText='discard'
+                            confirmVariant='danger'
+                          />
+                        </div>
+                      ))
+                      return
+                    }
+                    setEdit(!edit)
+                  }}
                   editText={edit ? 'cancel' : 'edit'}
                 />}
 
@@ -290,8 +314,10 @@ export default function Comment ({
             ? (
               <CommentEdit
                 comment={item}
+                onDirtyChange={setDirty}
                 onSuccess={() => {
                   setEdit(!edit)
+                  setDirty(false)
                 }}
               />
               )


### PR DESCRIPTION
**Problem:** Clicking "cancel" while editing a comment silently discards unsaved changes.

**Fix:** While editing, a DirtyTracker inside the comment edit form compares the current editor content against the original comment text. When clicking "cancel" with unsaved changes, a confirmation modal ("Discard your changes?") is shown instead of immediately closing the editor. Cancel without changes behaves exactly as before (no prompt).

Implementation notes:
- The comparison is against the original comment text (not the empty string), so untouched edits never trigger a prompt and the modal disappears again if the user reverts to the original content.
- The editor flushes its formik value on blur (BLUR_COMMAND), which fires before the cancel click, so even debounced rich-mode saves are captured.
- DirtyTracker lives inside the Form so it has access to formik values via useFormikContext.