### PR TITLE
fix: locale-aware formatting of sankey amounts (fixes #2942)

### DIFF
--- a/components/payIn/sankey/index.js
+++ b/components/payIn/sankey/index.js
@@ -43,10 +43,10 @@ export function PayInSankeySkeleton () {
 }
 
 function assetFormatted (msats, type) {
-  if (type === 'CREDITS') {
-    return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'CC', unitPlural: 'CCs', abbreviate: false })
-  }
-  return numWithUnits(msatsToSatsDecimal(msats), { unitSingular: 'sat', unitPlural: 'sats', abbreviate: false })
+  const opts = type === 'CREDITS'
+    ? { unitSingular: 'CC', unitPlural: 'CCs' }
+    : { unitSingular: 'sat', unitPlural: 'sats' }
+  return numWithUnits(Number(msats) / 1000, { ...opts, abbreviate: false })
 }
 
 function Tooltip ({ node, link }) {


### PR DESCRIPTION
**Problem:** Sankey diagram amounts are not rendered with locale-aware number formatting (see thread referenced in the issue, e.g. 1.500 shown instead of 1,5 for European viewers).

**Root cause:** \ssetFormatted\ in \components/payIn/sankey/index.js\ passed the output of \msatsToSatsDecimal\ - a string from \Number.parseFloat(n).toFixed(3)\ (e.g. \"1.500"\) - into \
umWithUnits\. \Intl.NumberFormat\ never received a real number, defeating its fraction-digit handling and producing forced trailing zeros.

**Fix:** Pass the numeric value (\Number(msats) / 1000\) into \
umWithUnits\, which already formats via \
ew Intl.NumberFormat().format(n)\ (browser locale, no new i18n dependency). Result:
- \1000\ msats ? \1 sat\ (singular preserved)
- \1500\ msats ? \1,5 sats\ in a comma-locale (no forced \.000\)
- \1000000\ msats ? \1.000 sats\ / \1,000 sats\ grouped per locale
- \CREDITS\ branch identical, only the unit label differs
- No behaviour change for any other caller of \
umWithUnits\ / \msatsToSatsDecimal\ (both still used elsewhere; \msatsToSatsDecimal\ remains for \link.value\)