### PR TITLE
fix: use youtube oEmbed title as fallback for pageTitleAndUnshorted (fixes #2164)

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -1,5 +1,6 @@
 import { ensureProtocol, removeTracking, stripTrailingSlash } from '@/lib/url'
 import { snFetch } from '@/lib/fetch'
+import { isYoutubeUrl, isUsefulYoutubeTitle, fetchYoutubeTitle } from '@/lib/youtube-title'
 import { decodeCursor, nextCursorEncoded } from '@/lib/cursor'
 import { getMetadata, metadataRuleSets } from 'page-metadata-parser'
 import { ruleSet as publicationDateRuleSet } from '@/lib/timedate-scraper'
@@ -562,8 +563,15 @@ export default {
         const moreThanOneYearAgo = metadata.publicationDate && metadata.publicationDate < datePivot(new Date(), { years: -1 })
 
         res.title = metadata?.title
-        if (moreThanOneYearAgo) res.title += dateHint
+        if (res.title && moreThanOneYearAgo) res.title += dateHint
       } catch { }
+
+      // YouTube's server-rendered HTML often only has the generic
+      // "- YouTube" document title, so fall back to the oEmbed endpoint
+      // (no API key required) to get the actual video title.
+      if (isYoutubeUrl(url) && !isUsefulYoutubeTitle(res.title)) {
+        res.title = await fetchYoutubeTitle(url, snFetch)
+      }
 
       try {
         const unshorted = await uu().expand(url)

--- a/lib/youtube-title.js
+++ b/lib/youtube-title.js
@@ -1,0 +1,35 @@
+// NOTE: keep this module free of imports so it can be unit tested in isolation
+
+const YOUTUBE_HOSTS = ['www.youtube.com', 'youtube.com', 'm.youtube.com', 'youtu.be']
+const YOUTUBE_TITLE_PLACEHOLDER = /^- YouTube$/i
+
+function ensureProtocol (url) {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(url) ? url : `https://${url}`
+}
+
+export function isYoutubeUrl (url) {
+  try {
+    return YOUTUBE_HOSTS.includes(new URL(ensureProtocol(url)).hostname)
+  } catch {
+    return false
+  }
+}
+
+// YouTube serves `- YouTube` as the document title when the page is rendered
+// without JS, so we must not treat it as a real title
+export function isUsefulYoutubeTitle (title) {
+  return !!title && !YOUTUBE_TITLE_PLACEHOLDER.test(title.trim())
+}
+
+export async function fetchYoutubeTitle (url, fetchImpl) {
+  if (!isYoutubeUrl(url)) return undefined
+  try {
+    const oembedUrl = `https://www.youtube.com/oembed?url=${encodeURIComponent(ensureProtocol(url))}&format=json`
+    const response = await fetchImpl(oembedUrl)
+    if (!response?.ok) return undefined
+    const oembed = await response.json()
+    return typeof oembed?.title === 'string' ? oembed.title : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/lib/youtube-title.test.js
+++ b/lib/youtube-title.test.js
@@ -1,0 +1,55 @@
+/* eslint-env jest */
+
+import { isYoutubeUrl, isUsefulYoutubeTitle, fetchYoutubeTitle } from './youtube-title'
+
+describe('isYoutubeUrl', () => {
+  it('detects youtube hostnames', () => {
+    expect(isYoutubeUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(true)
+    expect(isYoutubeUrl('https://youtu.be/dQw4w9WgXcQ')).toBe(true)
+    expect(isYoutubeUrl('https://m.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(true)
+  })
+
+  it('rejects non-youtube hostnames', () => {
+    expect(isYoutubeUrl('https://example.com/watch?v=dQw4w9WgXcQ')).toBe(false)
+    expect(isYoutubeUrl('not a url')).toBe(false)
+  })
+})
+
+describe('isUsefulYoutubeTitle', () => {
+  it('rejects the placeholder title', () => {
+    expect(isUsefulYoutubeTitle('- YouTube')).toBe(false)
+    expect(isUsefulYoutubeTitle(' - YouTube ')).toBe(false)
+  })
+
+  it('accepts real titles', () => {
+    expect(isUsefulYoutubeTitle('Happy 4th of July Stackers!')).toBe(true)
+  })
+
+  it('rejects empty titles', () => {
+    expect(isUsefulYoutubeTitle(undefined)).toBe(false)
+    expect(isUsefulYoutubeTitle('')).toBe(false)
+  })
+})
+
+describe('fetchYoutubeTitle', () => {
+  it('returns the oEmbed title', async () => {
+    const fetchImpl = async url => ({
+      ok: true,
+      json: async () => ({ title: 'Stacker News Weekly', author_name: 'Stacker News' })
+    })
+    await expect(fetchYoutubeTitle('https://www.youtube.com/watch?v=dQw4w9WgXcQ', fetchImpl))
+      .resolves.toBe('Stacker News Weekly')
+  })
+
+  it('returns undefined when oEmbed fails', async () => {
+    const fetchImpl = async () => ({ ok: false })
+    await expect(fetchYoutubeTitle('https://www.youtube.com/watch?v=dQw4w9WgXcQ', fetchImpl))
+      .resolves.toBeUndefined()
+  })
+
+  it('returns undefined for non-youtube urls', async () => {
+    const fetchImpl = async () => { throw new Error('should not be called') }
+    await expect(fetchYoutubeTitle('https://example.com/', fetchImpl))
+      .resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
Fixes #2164

YouTube's server-rendered HTML usually only contains the generic '- YouTube' document title, so the title field was autopopulated with that placeholder instead of the real video title.

This adds a fallback to the official YouTube oEmbed endpoint (no API key required) when the scraped title is missing or is the '- YouTube' placeholder.

Changes:
- lib/youtube-title.js: pure, import-free helpers - isYoutubeUrl, isUsefulYoutubeTitle (rejects the '- YouTube' placeholder), fetchYoutubeTitle (oEmbed)
- api/resolvers/item.js: pageTitleAndUnshorted falls back to oEmbed for YouTube URLs
- lib/youtube-title.test.js: 8 unit tests

Verified against the counterexamples from the issue: works for AHRtMxVrP78 and pgNCgJG0vnY (which previously failed).