### PR TITLE
fix: disallow URI schemes in post titles (fixes #117)

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -56,7 +56,11 @@ export function truncateToCharLength (value, maxLength) {
 const titleValidator = string().required('required').trim().max(
   MAX_TITLE_LENGTH,
   ({ max, value }) => `-${Math.abs(max - value.length)} characters remaining`
-).min(MIN_TITLE_LENGTH, `must be at least ${MIN_TITLE_LENGTH} characters`)
+).min(MIN_TITLE_LENGTH, `must be at least ${MIN_TITLE_LENGTH} characters`).test(
+  'no-uri-scheme',
+  'remove URI scheme from title',
+  value => !value || !/\b[a-z][a-z\d+.-]*:\/\//i.test(value)
+)
 
 const textValidator = (max) => string().trim().max(
   max,

--- a/lib/validate.spec.js
+++ b/lib/validate.spec.js
@@ -1,6 +1,37 @@
 /* eslint-env jest */
 
-import { pollSchema } from './validate'
+import { bountySchema, discussionSchema, jobSchema, linkSchema, pollSchema } from './validate'
+
+describe('post title validation', () => {
+  test.each([
+    ['bounty', () => bountySchema({})],
+    ['discussion', () => discussionSchema({})],
+    ['job', () => jobSchema({})],
+    ['link', () => linkSchema({})],
+    ['poll', () => pollSchema({})]
+  ])('rejects URI schemes in %s titles', async (name, createSchema) => {
+    await expect(createSchema().validateAt('title', {
+      title: 'Read https://stacker.news/items/13221'
+    })).rejects.toThrow('remove URI scheme from title')
+  })
+
+  test.each([
+    'HTTPS://stacker.news should not be a title',
+    'Open ipfs://bafyexample'
+  ])('rejects URI schemes in titles: %s', async title => {
+    await expect(discussionSchema({}).validateAt('title', { title }))
+      .rejects.toThrow('remove URI scheme from title')
+  })
+
+  test.each([
+    'Crypto.com stadium hosts big game',
+    'What happened at stacker.news today?',
+    'A title with a colon: but no URI'
+  ])('allows domains and ordinary title punctuation: %s', async title => {
+    await expect(discussionSchema({}).validateAt('title', { title }))
+      .resolves.toBe(title)
+  })
+})
 
 describe('pollSchema', () => {
   afterEach(() => {


### PR DESCRIPTION
Fixes #117

Post titles can currently contain URI schemes (e.g. https://), which breaks character-count calculations for automated crossposting (e.g. Zapier). A scheme like https:// in a title is never meaningful, though plain domains (Crypto.com) should remain allowed.

This adds a 
o-uri-scheme test to the shared 	itleValidator used by all post types (bounty, discussion, job, link, poll), rejecting titles containing a URI scheme while allowing domains and ordinary punctuation.

Changes:
- lib/validate.js: reject URI schemes in 	itleValidator
- lib/validate.spec.js: regression tests for all post types