### PR TITLE
Protect reward sats when buying credits

### DIFF
--- a/api/payIn/__tests__/integration/payInTypes.test.js
+++ b/api/payIn/__tests__/integration/payInTypes.test.js
@@ -367,7 +367,7 @@ describe('Specific PayIn Types', () => {
   describe('BUY_CREDITS', () => {
     it('should purchase credits', async () => {
       const buyer = await createTestUser(models, {
-        msats: 0n,
+        msats: satsToMsats(2000),
         mcredits: 0n
       })
       testUsers.push(buyer)
@@ -381,8 +381,11 @@ describe('Specific PayIn Types', () => {
 
       expect(result.payInType).toBe('BUY_CREDITS')
 
-      // Should create invoice since user has no funds
+      // Buying credits must not spend reward sats; it should create an invoice instead.
       expect(['PENDING', 'PENDING_INVOICE_CREATION', 'PENDING_HELD']).toContain(result.payInState)
+      const updatedBuyer = await models.user.findUnique({ where: { id: buyer.id } })
+      expect(updatedBuyer.msats).toBe(satsToMsats(2000))
+      expect(await models.payInCustodialToken.count({ where: { payInId: result.id } })).toBe(0)
     })
   })
 

--- a/api/payIn/lib/is.js
+++ b/api/payIn/lib/is.js
@@ -17,6 +17,11 @@ export function isPayableWithCredits (payIn) {
   return payInModule.paymentMethods.includes(PAID_ACTION_PAYMENT_METHODS.FEE_CREDIT)
 }
 
+export function isPayableWithRewardSats (payIn) {
+  const payInModule = payInTypeModules[payIn.payInType]
+  return payInModule.paymentMethods.includes(PAID_ACTION_PAYMENT_METHODS.REWARD_SATS)
+}
+
 export function isInvoiceable (payIn) {
   const payInModule = payInTypeModules[payIn.payInType]
   return payInModule.paymentMethods.includes(PAID_ACTION_PAYMENT_METHODS.OPTIMISTIC) ||

--- a/api/payIn/lib/payInCustodialTokens.js
+++ b/api/payIn/lib/payInCustodialTokens.js
@@ -1,5 +1,5 @@
 import { ceilBigInt } from '@/lib/format'
-import { isP2P, isP2POnly, isPayableWithCredits, isSystemOnly, isWithdrawal } from './is'
+import { isP2P, isP2POnly, isPayableWithCredits, isPayableWithRewardSats, isSystemOnly, isWithdrawal } from './is'
 import { USER_ID } from '@/lib/constants'
 
 export async function getPayInCustodialTokens (tx, mCustodialCost, payIn, { me }) {
@@ -14,6 +14,7 @@ export async function getPayInCustodialTokens (tx, mCustodialCost, payIn, { me }
   }
 
   const mCreditPayable = isPayableWithCredits(payIn) ? mCustodialCost : 0n
+  const mRewardSatsPayable = isPayableWithRewardSats(payIn) ? mCustodialCost : 0n
 
   // Calculate optimal spending to maximize custodial usage, preferring to spend mcredits,
   // while keeping any remainder as multiple of 1000 for invoice creation
@@ -22,6 +23,7 @@ export async function getPayInCustodialTokens (tx, mCustodialCost, payIn, { me }
       SELECT
         id,
         msats,
+        LEAST(msats, ${mRewardSatsPayable}) as max_msats,
         LEAST(mcredits, ${mCreditPayable}) as max_mcredits,
         (${mCustodialCost} - LEAST(mcredits, ${mCreditPayable})) % 1000 as max_mcredits_modulo_1000
       FROM users
@@ -35,19 +37,19 @@ export async function getPayInCustodialTokens (tx, mCustodialCost, payIn, { me }
         id,
         (CASE
           -- Strategy 1: Can we pay everything custodially?
-          WHEN max_mcredits + msats >= ${mCustodialCost} THEN
+          WHEN max_mcredits + max_msats >= ${mCustodialCost} THEN
             -- [min(the mcredits we have, the mcost that can be paid with credits), what's left to pay with msats].sum() = mCustodialCost
             ARRAY[max_mcredits, ${mCustodialCost} - max_mcredits]
           -- Strategy 2: Can we spend all mcredits and maximize msats spending, but leaving a remainder of a multiple of 1000?
-          WHEN msats >= max_mcredits_modulo_1000 THEN
+          WHEN max_msats >= max_mcredits_modulo_1000 THEN
             -- [min(the mcredits we have, the mcost that can be paid with credits), the max msats we can spend that bring the remainder to a multiple of 1000].sum() < mCustodialCost
             ARRAY[max_mcredits,
                 max_mcredits_modulo_1000 +
-                  ((GREATEST(0, msats - max_mcredits_modulo_1000) / 1000) * 1000)]
+                  ((GREATEST(0, max_msats - max_mcredits_modulo_1000) / 1000) * 1000)]
           -- Strategy 3: Spend multiples of 1000 only for both mcredits and msats
           ELSE
             -- [mcredits floored to a multiple of 1000, msats floored to a multiple of 1000].sum() < mCustodialCost
-            ARRAY[(max_mcredits / 1000) * 1000, (msats / 1000) * 1000]
+            ARRAY[(max_mcredits / 1000) * 1000, (max_msats / 1000) * 1000]
         END)::BIGINT[] AS spending
       FROM payer
     )

--- a/api/payIn/types/buyCredits.js
+++ b/api/payIn/types/buyCredits.js
@@ -4,7 +4,6 @@ import { numWithUnits, satsToMsats, msatsToSats } from '@/lib/format'
 export const anonable = false
 
 export const paymentMethods = [
-  PAID_ACTION_PAYMENT_METHODS.REWARD_SATS,
   PAID_ACTION_PAYMENT_METHODS.PESSIMISTIC
 ]
 

--- a/docs/user/faq.md
+++ b/docs/user/faq.md
@@ -158,7 +158,7 @@ No. Even if you have CCs, we will only try to pay with sats from your wallet whe
 
 ### Can I pay only the remainder with sats?
 
-Yes. Anytime you pay Stacker News for something, we will spend the less desirable CCs first, and pay any remainder with Reward Sats, and pay any remainder of that with an attached wallet.
+Yes. For payments to Stacker News, we spend the less desirable CCs first, then Reward Sats, and then any remainder from an attached wallet. Buying CCs is the exception: it always uses an attached wallet and never spends your existing CCs or Reward Sats.
 
 ### Which wallet is used if I attached multiple wallets for send or receive?
 


### PR DESCRIPTION
Fixes #3151

BUY_CREDITS currently consumes reward sats before creating the invoice, converting withdrawable rewards into non-withdrawable credits. This change makes the pay-in selector honor each payment type's declared methods, removes REWARD_SATS from BUY_CREDITS, preserves the user's reward sats, and documents the exception in the FAQ.

Added a regression assertion that reward sats remain unchanged and no custodial token is created. Standard lint passes. The integration test requires the repository's database environment, which is not configured in this workspace.