### PR TITLE
fix: analytics area chart tooltip obscured by zIndex: -1

### DIFF
--- a/components/charts.js
+++ b/components/charts.js
@@ -107,7 +107,7 @@ export function WhenAreaChart ({ data }) {
           tick={{ fill: 'var(--theme-grey)' }}
         />
         <YAxis tickFormatter={abbrNum} tick={{ fill: 'var(--theme-grey)' }} />
-        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)', opacity: 1, zIndex: -1 }} />
+        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)' }} />
         <Legend />
         {Object.keys(data[0]).filter(v => v !== 'time' && v !== '__typename').map((v, i) =>
           <Area key={v} type='monotone' dataKey={v} name={v} stackId='1' stroke={getColor(i)} fill={getColor(i)} />)}


### PR DESCRIPTION
## Summary

The analytics area chart tooltip is obscured by other analytics elements when hovering, exactly as reported in #3122.

## Root cause

Commit `bac055c79e` (#2084) added `opacity: 1, zIndex: -1` to the `WhenAreaChart` `Tooltip` `contentStyle`. A negative `z-index` places the tooltip *behind* the chart's other stacking contexts, so with multiple data series the tooltip renders under the legend / other analytics content. The line and composed chart tooltips do not carry this style.

## Fix

Remove `opacity: 1, zIndex: -1` from the area chart tooltip `contentStyle`, matching the `WhenLineChart` and `WhenComposedChart` tooltips. Recharts renders the tooltip above the chart when it is not explicitly z-fighting.

```diff
- <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)', opacity: 1, zIndex: -1 }} />
+ <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)' }} />
```

Closes #3122
