### PR TITLE
fix: demote MediaNode to LinkNode on media check non-ok responses

### DIFF
--- a/components/editor/nodes/media.js
+++ b/components/editor/nodes/media.js
@@ -355,7 +355,11 @@ export const useMediaHelper = ({ src, srcSet, srcSetIntital, bestResSrc, width, 
     const checkMedia = async () => {
       try {
         const res = await fetch(`${PUBLIC_MEDIA_CHECK_URL}/${encodeURIComponent(src)}`, { signal: controller.signal })
-        if (!res.ok) return
+        // non-ok response: transform media into LinkNode
+        if (!res.ok) {
+          setKind?.('unknown')
+          return
+        }
 
         const data = await res.json()
 


### PR DESCRIPTION
## Description

When our media check microservice responds with `400` or any other non-ok response, `MediaNode`s get stuck on the `loading` state, never resolving to a `LinkNode`.
This PR adds "non-ok" handling to media type checks.

## Screenshots


https://github.com/user-attachments/assets/e32524c7-4560-4726-9131-42c425adf6a9



## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7, media that got non-ok responses should always result in `LinkNode`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in editor media autolink handling with no auth or data changes; aligns failure paths with the existing unknown-kind link fallback.
> 
> **Overview**
> Fixes **MediaNode**s that never leave the loading state when the media check service returns non-ok responses (e.g. **400**).
> 
> Previously `checkMedia` in `useMediaHelper` returned early on `!res.ok` without updating kind, so autolinked media with unknown type kept spinning. The change sets **`setKind('unknown')`** on non-ok responses, which matches the existing branch that already calls **`$replaceWithLink()`** and turns the node into a **LinkNode**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fd3429f4b96825085b3d84898775d0d29077edd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->