### PR TITLE
fix(editor): preserve formatting in internal item links (#2767)

### DIFF
--- a/lib/lexical/mdast/transforms/mentions.js
+++ b/lib/lexical/mdast/transforms/mentions.js
@@ -52,6 +52,14 @@ export function itemMentionTransform (tree) {
     // skip if link wraps only an image
     if (isImageOnlyLink(node)) return
 
+    // links whose children carry formatting (emphasis, strong, ...) cannot be
+    // represented by the plain-text itemMention node without losing it. leave
+    // them untouched so they render as regular links, consistent with how
+    // external links behave (https://github.com/stackernews/stacker.news/issues/2767)
+    const hasPlainText = node.children?.length > 0 &&
+      node.children.every(child => child.type === 'text')
+    if (!hasPlainText) return
+
     try {
       const { itemId, commentId } = parseInternalLinks(node.url)
       if (itemId || commentId) {


### PR DESCRIPTION
## Problem

Closes #2767.

Markdown links pointing to internal items (`https://stacker.news/items/...`) lose their inline formatting when the link text contains emphasis/strong/etc. An external link `[_How to Win Friends_](https://www.goodreads.com/...)` renders italic, but the same syntax with an internal link `[_High Risk, Low Reward_](https://stacker.news/items/778491)` does not.

## Root cause

`itemMentionTransform` flattens every internal item link into a single `itemMention` node whose `text` comes from `mdast-util-to-string`'s `toString(node)` — that collapses the link's children to plain text, dropping any `emphasis`/`strong`. External links are unaffected because they never pass through this transform.

## Solution

Skip the itemMention conversion when the link's children are not all plain `text` nodes, so formatted links fall through to the regular link visitor and render exactly like external links. Bare links and plain-custom-text internal links still become `itemMention` nodes, preserving the popover + `#id` behavior. This is the minimal change matching the issue's expectation: "Text is italic independent of which link was used."

```diff
   // skip if link wraps only an image
   if (isImageOnlyLink(node)) return

+  // links whose children carry formatting (emphasis, strong, ...) cannot be
+  // represented by the plain-text itemMention node without losing it. leave
+  // them untouched so they render as regular links, consistent with how
+  // external links behave (#2767)
+  const hasPlainText = node.children?.length > 0 &&
+    node.children.every(child => child.type === 'text')
+  if (!hasPlainText) return
+
   try {
```

## Test evidence

The mdast pipeline under this path is ESM-only and isn't covered by the project's jest config (no existing spec exercises `itemMentionTransform`). I verified locally with a throwaway spec transforming the ESM-only deps (`npx jest mentions.spec --transformIgnorePatterns 'never-match-anything'`, `NEXT_PUBLIC_URL=https://stacker.news`):

```
PASS lib/lexical/mdast/transforms/mentions.spec.js
  itemMentionTransform
    ✓ converts plain-text internal item links into itemMention
    ✓ keeps bare internal links as itemMention without custom text
    ✓ leaves formatted internal links untouched so formatting survives
    ✓ leaves external formatted links as regular links
Tests: 4 passed, 4 total
```

`npx standard lib/lexical/mdast/transforms/mentions.js` is clean.

I did not include the spec because the project's current jest setup cannot load the ESM-only dependency chain (`mdast-util-find-and-replace` and friends) without a `transformIgnorePatterns` change. Happy to add the spec + the small jest config tweak in a follow-up if you'd like.
