### PR TITLE
WIP: Don't convert sats to CCs (if not asked ?)

### DIFF
--- a/api/payIn/__tests__/fixtures/testUtils.js
+++ b/api/payIn/__tests__/fixtures/testUtils.js
@@ -34,7 +34,6 @@ export async function createTestUser (models, {
   name = `test_user_${Date.now()}_${Math.random()}`,
   msats = 0n,
   mcredits = 0n,
-  trust = 0,
   withLNbitsWallet = false,
   ...otherFields
 } = {}) {
@@ -53,7 +52,6 @@ export async function createTestUser (models, {
       mcredits,
       stackedMsats: 0n,
       stackedMcredits: 0n,
-      trust,
       ...otherFields
     }
   })

--- a/api/payIn/__tests__/integration/payInTypes.test.js
+++ b/api/payIn/__tests__/integration/payInTypes.test.js
@@ -7,7 +7,9 @@ import {
   cleanupPrisma,
   createTestUser,
   createTestItem,
-  cleanupTestData
+  cleanupTestData,
+  assertUserBalance,
+  assertPayInCustodialTokens
 } from '../fixtures/testUtils.js'
 
 describe('Specific PayIn Types', () => {
@@ -383,6 +385,59 @@ describe('Specific PayIn Types', () => {
 
       // Should create invoice since user has no funds
       expect(['PENDING', 'PENDING_INVOICE_CREATION', 'PENDING_HELD']).toContain(result.payInState)
+    })
+
+    it('should not spend the sats balance unless asked to', async () => {
+      const buyer = await createTestUser(models, {
+        msats: satsToMsats(90000),
+        mcredits: 0n
+      })
+      testUsers.push(buyer)
+
+      const result = await pay('BUY_CREDITS', {
+        credits: 150000
+      }, {
+        models,
+        me: buyer
+      })
+
+      expect(result.payInType).toBe('BUY_CREDITS')
+      expect(['PENDING', 'PENDING_INVOICE_CREATION', 'PENDING_HELD']).toContain(result.payInState)
+
+      // sats are only converted into credits on request, so the whole cost is invoiced
+      await assertUserBalance(models, buyer.id, {
+        msats: satsToMsats(90000),
+        mcredits: 0n
+      })
+      await assertPayInCustodialTokens(models, result.id, [])
+    })
+
+    it('should spend the sats balance when asked to', async () => {
+      const buyer = await createTestUser(models, {
+        msats: satsToMsats(90000),
+        mcredits: 0n
+      })
+      testUsers.push(buyer)
+
+      const result = await pay('BUY_CREDITS', {
+        credits: 150000,
+        useRewardSats: true
+      }, {
+        models,
+        me: buyer
+      })
+
+      expect(result.payInType).toBe('BUY_CREDITS')
+      expect(['PENDING', 'PENDING_INVOICE_CREATION', 'PENDING_HELD']).toContain(result.payInState)
+
+      // the balance covers 90k of the 150k, the rest is invoiced
+      await assertUserBalance(models, buyer.id, {
+        msats: 0n,
+        mcredits: 0n
+      })
+      await assertPayInCustodialTokens(models, result.id, [
+        { custodialTokenType: 'SATS', mtokens: satsToMsats(90000) }
+      ])
     })
   })
 

--- a/api/payIn/__tests__/jest.config.js
+++ b/api/payIn/__tests__/jest.config.js
@@ -1,11 +1,23 @@
 // Load environment variables FIRST before anything else
 const { loadEnvConfig } = require('@next/env')
 const path = require('path')
+
+// jest sets NODE_ENV=test, and @next/env keys the files it reads off NODE_ENV, not off
+// its `dev` argument — so it would look for a .env.test that this repo doesn't have.
+// pretend to be development for the duration of the load so .env.development/.env.local are read.
+const nodeEnv = process.env.NODE_ENV
+process.env.NODE_ENV = 'development'
 loadEnvConfig('./', true) // Load .env.development and .env.local
+process.env.NODE_ENV = nodeEnv
+
+// container names only resolve inside the docker network, so the rewrites below apply
+// when the suite runs on the host — but the same suite can also be run inside the app
+// container (docker compose exec app npm test -- --config ...), where they must not.
+const onHost = !require('fs').existsSync('/.dockerenv')
 
 // Override DATABASE_URL for tests running on host machine
 // docker-compose exposes db on port 5431, but internally it's db:5432
-if (process.env.DATABASE_URL && process.env.DATABASE_URL.includes('@db:5432')) {
+if (onHost && process.env.DATABASE_URL && process.env.DATABASE_URL.includes('@db:5432')) {
   // Running tests from host machine, need to use localhost:5431
   process.env.DATABASE_URL = process.env.DATABASE_URL.replace('@db:5432', '@localhost:5431')
   console.log('📝 Adjusted DATABASE_URL for host machine:', process.env.DATABASE_URL.split('@')[1])
@@ -13,7 +25,7 @@ if (process.env.DATABASE_URL && process.env.DATABASE_URL.includes('@db:5432')) {
 
 // Override LND_SOCKET for tests running on host machine
 // docker-compose exposes sn_lnd on port 10009, but internally it's sn_lnd:10009
-if (process.env.LND_SOCKET && process.env.LND_SOCKET === 'sn_lnd:10009') {
+if (onHost && process.env.LND_SOCKET && process.env.LND_SOCKET === 'sn_lnd:10009') {
   process.env.LND_SOCKET = 'localhost:10009'
   console.log('📝 Adjusted LND_SOCKET for host machine:', process.env.LND_SOCKET)
 }

--- a/api/payIn/__tests__/jest.setup.js
+++ b/api/payIn/__tests__/jest.setup.js
@@ -28,6 +28,29 @@ jest.mock('@shocknet/clink-sdk', () => ({
   default: jest.fn()
 }))
 
+// wallets/lib/preimage.js reaches this through the wallet protocols; it's ESM only,
+// so back it with node's crypto rather than stubbing preimage verification itself.
+jest.mock('@noble/hashes/sha2.js', () => ({
+  __esModule: true,
+  sha256: (data) => new Uint8Array(require('crypto').createHash('sha256').update(Buffer.from(data)).digest())
+}))
+
+// itemCreate pulls this in, and its unified/micromark/mdast deps ship ESM only.
+// no payIn test asserts on mention extraction, so stub it out.
+// the path is relative because the @/ alias is resolved by SWC at transform time,
+// and jest.mock's specifier isn't rewritten by it.
+jest.mock('../../../lib/lexical/server/mentions', () => ({
+  __esModule: true,
+  extractMentions: jest.fn(() => ({ userNames: [], itemIds: [] }))
+}))
+
+// same for the other lexical entry point the payIn engine drags in through api/resolvers/item.js.
+// lexicalHTMLGenerator only ever runs in `html` field resolvers, never in a payIn write path.
+jest.mock('../../../lib/lexical/server/html', () => ({
+  __esModule: true,
+  lexicalHTMLGenerator: jest.fn(() => '')
+}))
+
 // Counter for guaranteed unique invoice hashes
 let invoiceCounter = 0
 let hodlCounter = 0

--- a/api/payIn/__tests__/resolvers/buyCredits.test.js
+++ b/api/payIn/__tests__/resolvers/buyCredits.test.js
@@ -1,0 +1,58 @@
+/* eslint-env jest */
+
+// this lives under the payIn suite rather than beside api/resolvers because only this
+// config carries the ESM mocks (lexical, @noble/hashes, ln-service) that importing the
+// whole resolver tree needs.
+
+import { makeExecutableSchema } from '@graphql-tools/schema'
+import { graphql } from 'graphql'
+import pay from '../../index.js'
+import typeDefs from '../../../typeDefs/index.js'
+import resolvers from '../../../resolvers/index.js'
+
+jest.mock('../../index.js', () => ({
+  __esModule: true,
+  default: jest.fn(async () => ({ id: 1 }))
+}))
+
+const BUY_CREDITS = `
+  mutation buyCredits($credits: Int!) {
+    buyCredits(credits: $credits) {
+      id
+    }
+  }`
+
+const BUY_CREDITS_WITH_REWARD_SATS = `
+  mutation buyCredits($credits: Int!, $useRewardSats: Boolean) {
+    buyCredits(credits: $credits, useRewardSats: $useRewardSats) {
+      id
+    }
+  }`
+
+describe('buyCredits mutation', () => {
+  const schema = makeExecutableSchema({ typeDefs, resolvers })
+  const me = { id: 123 }
+
+  const buyCredits = (source, variableValues) =>
+    graphql({ schema, source, variableValues, contextValue: { me, models: {} } })
+
+  it('forwards useRewardSats to the payIn as an arg', async () => {
+    const { errors } = await buyCredits(BUY_CREDITS_WITH_REWARD_SATS, { credits: 1000, useRewardSats: true })
+
+    expect(errors).toBeUndefined()
+    expect(pay).toHaveBeenCalledWith(
+      'BUY_CREDITS',
+      expect.objectContaining({ credits: 1000, useRewardSats: true }),
+      expect.anything())
+  })
+
+  it('leaves useRewardSats unset when the buyer does not ask for it', async () => {
+    const { errors } = await buyCredits(BUY_CREDITS, { credits: 1000 })
+
+    expect(errors).toBeUndefined()
+    expect(pay).toHaveBeenCalledWith(
+      'BUY_CREDITS',
+      expect.not.objectContaining({ useRewardSats: true }),
+      expect.anything())
+  })
+})

--- a/api/payIn/lib/is.js
+++ b/api/payIn/lib/is.js
@@ -17,6 +17,14 @@ export function isPayableWithCredits (payIn) {
   return payInModule.paymentMethods.includes(PAID_ACTION_PAYMENT_METHODS.FEE_CREDIT)
 }
 
+export function isPayableWithRewardSats (payIn, payInArgs) {
+  const payInModule = payInTypeModules[payIn.payInType]
+  return payInModule.paymentMethods.includes(PAID_ACTION_PAYMENT_METHODS.REWARD_SATS) &&
+    // some payIns turn sats into something that can't be withdrawn, so they only spend
+    // the sats balance when the payer asks for it
+    (!payInModule.rewardSatsOptIn || payInArgs?.useRewardSats === true)
+}
+
 export function isInvoiceable (payIn) {
   const payInModule = payInTypeModules[payIn.payInType]
   return payInModule.paymentMethods.includes(PAID_ACTION_PAYMENT_METHODS.OPTIMISTIC) ||

--- a/api/payIn/lib/payInCreate.js
+++ b/api/payIn/lib/payInCreate.js
@@ -14,7 +14,7 @@ export const PAY_IN_INCLUDE = {
 }
 
 export async function payInCreate (tx, payInProspect, payInArgs, { me }) {
-  const { mCostRemaining, mP2PCost, payInCustodialTokens } = await getPayInCosts(tx, payInProspect, { me })
+  const { mCostRemaining, mP2PCost, payInCustodialTokens } = await getPayInCosts(tx, payInProspect, payInArgs, { me })
   const payInState = await getPayInState(payInProspect, { mCostRemaining, mP2PCost })
   const payOutCustodialTokens = payInProspect.payOutCustodialTokens
   const fullProspect = {
@@ -44,9 +44,9 @@ export async function payInCreate (tx, payInProspect, payInArgs, { me }) {
   return { payIn, mCostRemaining }
 }
 
-async function getPayInCosts (tx, payIn, { me }) {
+async function getPayInCosts (tx, payIn, payInArgs, { me }) {
   const { mP2PCost, mCustodialCost } = getCostBreakdown(payIn)
-  const payInCustodialTokens = await getPayInCustodialTokens(tx, mCustodialCost, payIn, { me })
+  const payInCustodialTokens = await getPayInCustodialTokens(tx, mCustodialCost, payIn, payInArgs, { me })
   const mCustodialPaid = payInCustodialTokens.reduce((acc, token) => acc + token.mtokens, 0n)
 
   return {

--- a/api/payIn/lib/payInCustodialTokens.js
+++ b/api/payIn/lib/payInCustodialTokens.js
@@ -1,8 +1,8 @@
 import { ceilBigInt } from '@/lib/format'
-import { isP2P, isP2POnly, isPayableWithCredits, isSystemOnly, isWithdrawal } from './is'
+import { isP2P, isP2POnly, isPayableWithCredits, isPayableWithRewardSats, isSystemOnly, isWithdrawal } from './is'
 import { USER_ID } from '@/lib/constants'
 
-export async function getPayInCustodialTokens (tx, mCustodialCost, payIn, { me }) {
+export async function getPayInCustodialTokens (tx, mCustodialCost, payIn, payInArgs, { me }) {
   const payInCustodialTokens = []
 
   if (!me || me.id === USER_ID.anon || mCustodialCost <= 0n) {
@@ -14,6 +14,7 @@ export async function getPayInCustodialTokens (tx, mCustodialCost, payIn, { me }
   }
 
   const mCreditPayable = isPayableWithCredits(payIn) ? mCustodialCost : 0n
+  const mSatsPayable = isPayableWithRewardSats(payIn, payInArgs) ? mCustodialCost : 0n
 
   // Calculate optimal spending to maximize custodial usage, preferring to spend mcredits,
   // while keeping any remainder as multiple of 1000 for invoice creation
@@ -21,7 +22,7 @@ export async function getPayInCustodialTokens (tx, mCustodialCost, payIn, { me }
     WITH payer AS (
       SELECT
         id,
-        msats,
+        LEAST(msats, ${mSatsPayable}) as max_msats,
         LEAST(mcredits, ${mCreditPayable}) as max_mcredits,
         (${mCustodialCost} - LEAST(mcredits, ${mCreditPayable})) % 1000 as max_mcredits_modulo_1000
       FROM users
@@ -35,19 +36,19 @@ export async function getPayInCustodialTokens (tx, mCustodialCost, payIn, { me }
         id,
         (CASE
           -- Strategy 1: Can we pay everything custodially?
-          WHEN max_mcredits + msats >= ${mCustodialCost} THEN
+          WHEN max_mcredits + max_msats >= ${mCustodialCost} THEN
             -- [min(the mcredits we have, the mcost that can be paid with credits), what's left to pay with msats].sum() = mCustodialCost
             ARRAY[max_mcredits, ${mCustodialCost} - max_mcredits]
           -- Strategy 2: Can we spend all mcredits and maximize msats spending, but leaving a remainder of a multiple of 1000?
-          WHEN msats >= max_mcredits_modulo_1000 THEN
+          WHEN max_msats >= max_mcredits_modulo_1000 THEN
             -- [min(the mcredits we have, the mcost that can be paid with credits), the max msats we can spend that bring the remainder to a multiple of 1000].sum() < mCustodialCost
             ARRAY[max_mcredits,
                 max_mcredits_modulo_1000 +
-                  ((GREATEST(0, msats - max_mcredits_modulo_1000) / 1000) * 1000)]
+                  ((GREATEST(0, max_msats - max_mcredits_modulo_1000) / 1000) * 1000)]
           -- Strategy 3: Spend multiples of 1000 only for both mcredits and msats
           ELSE
             -- [mcredits floored to a multiple of 1000, msats floored to a multiple of 1000].sum() < mCustodialCost
-            ARRAY[(max_mcredits / 1000) * 1000, (msats / 1000) * 1000]
+            ARRAY[(max_mcredits / 1000) * 1000, (max_msats / 1000) * 1000]
         END)::BIGINT[] AS spending
       FROM payer
     )

--- a/api/payIn/types/buyCredits.js
+++ b/api/payIn/types/buyCredits.js
@@ -8,6 +8,10 @@ export const paymentMethods = [
   PAID_ACTION_PAYMENT_METHODS.PESSIMISTIC
 ]
 
+// buying credits with the sats balance converts withdrawable sats into credits,
+// so we only do it when the buyer explicitly asks for it
+export const rewardSatsOptIn = true
+
 export async function getInitial (models, { credits }, { me }) {
   return {
     payInType: 'BUY_CREDITS',

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -100,8 +100,8 @@ const resolvers = {
       await dropBolt11({ userId: me.id, hash }, { models, lnd })
       return true
     },
-    buyCredits: async (parent, { credits, sendProtocolId }, { me, models }) => {
-      return await pay('BUY_CREDITS', { credits }, { models, me, sendProtocolId })
+    buyCredits: async (parent, { credits, sendProtocolId, useRewardSats }, { me, models }) => {
+      return await pay('BUY_CREDITS', { credits, useRewardSats }, { models, me, sendProtocolId })
     }
   }
 }

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -17,7 +17,7 @@ const typeDefs = gql`
     reportExternalSendObservation(input: ExternalSendObservationInput!): Boolean!
     sendToLnAddr(addr: String!, amount: Int!, maxFee: Int!, comment: String, identifier: Boolean, name: String, email: String): PayIn!
     dropBolt11(hash: String!): Boolean
-    buyCredits(credits: Int!, sendProtocolId: Int): PayIn!
+    buyCredits(credits: Int!, sendProtocolId: Int, useRewardSats: Boolean): PayIn!
 
     # test a receive protocol by asking it to mint a probe invoice
     testWalletRecvProtocol(config: WalletRecvProtocolTestInput!): Boolean!


### PR DESCRIPTION
## Description
fix #3151

### RED phase
It seems that payIn type's `paymentMethods` only means anything if `api/payIn/lib/is.js` has a predicate for it. There's one for every paying method but none for `REWARD_SATS`. So 17 types declare it and nothing reads it, and `getPayInCustodialTokens` reaches for your sats balance on any payIn with a custodial cost, no matter what the module says.
## Screenshots

## Additional Context

_Was anything unclear during your work on this PR? Anything we should definitely take a closer look at?_

## Checklist

**Are your changes backward compatible? Please answer below:**

_For example, a change is not backward compatible if you removed a GraphQL field or dropped a database column._

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**


**Did you introduce any new environment variables? If so, call them out explicitly here:**


**Did you use AI for this? If so, how much did it assist you?**
