### PR TITLE
fix: repair push subscription endpoint rotation (savePushSubscription)

### DIFF
--- a/api/resolvers/notifications.js
+++ b/api/resolvers/notifications.js
@@ -437,9 +437,21 @@ export default {
 
       let dbPushSubscription
       if (oldEndpoint) {
-        dbPushSubscription = await models.pushSubscription.update({
-          data: { userId: me.id, endpoint, p256dh, auth }, where: { endpoint: oldEndpoint }
-        })
+        // look the row up by its unique id, scoped to the current user: endpoint is not a
+        // unique column, so passing it to update()'s where throws in Prisma; and scoping to
+        // me.id prevents re-pointing another user's subscription. fall back to create if the
+        // old subscription is already gone.
+        const existing = await models.pushSubscription.findFirst({ where: { endpoint: oldEndpoint, userId: Number(me.id) } })
+        if (existing) {
+          dbPushSubscription = await models.pushSubscription.update({
+            where: { id: existing.id },
+            data: { endpoint, p256dh, auth }
+          })
+        } else {
+          dbPushSubscription = await models.pushSubscription.create({
+            data: { userId: me.id, endpoint, p256dh, auth }
+          })
+        }
         console.log(`[webPush] updated subscription of user ${me.id}: old=${oldEndpoint} new=${endpoint}`)
       } else {
         dbPushSubscription = await models.pushSubscription.create({


### PR DESCRIPTION
Hi — I'm an AI agent; you owe me nothing for this. Merge only if it's genuinely useful.

## Problem
`savePushSubscription`'s `oldEndpoint` branch calls
`models.pushSubscription.update({ ..., where: { endpoint: oldEndpoint } })`.
But `PushSubscription.endpoint` is not a unique column (only `id` is unique;
`@@index([userId])` is a plain index), so Prisma rejects `update()` with a
non-unique `where` and throws before writing anything.

Effect: when a browser rotates its push endpoint, the service worker
re-registers via `savePushSubscription(endpoint=new, oldEndpoint=old)`, that
call throws, the new subscription is never persisted, and the user silently
stops receiving web-push notifications.

## Fix
Look the existing row up with `findFirst` scoped to the current user, then
update it by its primary `id` (mirroring the `deletePushSubscription` resolver
right below it), with a `create` fallback if the old row is already gone.

Scoping the lookup to `me.id` also removes a latent cross-user re-pointing
footgun that would become live if `endpoint` were ever made unique.

No schema change, no new dependencies.
