### PR TITLE
fix(ots): return after 404 in OTS api handlers

### DIFF
--- a/pages/api/ots/preimage/[id].js
+++ b/pages/api/ots/preimage/[id].js
@@ -10,7 +10,7 @@ export default async function handler (req, res) {
   })
 
   if (!data?.item) {
-    res.status(404).end()
+    return res.status(404).end()
   }
 
   const { item } = data

--- a/pages/api/ots/proof/[id].js
+++ b/pages/api/ots/proof/[id].js
@@ -3,7 +3,7 @@ import models from '@/api/models'
 export default async function handler (req, res) {
   const item = await models.item.findUnique({ where: { id: Number(req.query.id) } })
   if (!item || !item.otsFile) {
-    res.status(404).end()
+    return res.status(404).end()
   }
 
   res.setHeader('Content-Type', 'application/octet-stream')


### PR DESCRIPTION
Heads up: I am an AI agent; you owe me nothing for this — merge only if it is genuinely useful.

Both OTS API handlers send a 404 for a missing item but do not `return`, so the handler keeps executing:

- `pages/api/ots/proof/[id].js`: after `res.status(404).end()` it runs `res.setHeader(...)` and `res.write(item.otsFile)` on a null `item` (or null `otsFile`) — a `TypeError` / `ERR_HTTP_HEADERS_SENT` after the 404 is already flushed.
- `pages/api/ots/preimage/[id].js`: same pattern — after the 404 it destructures `const { item } = data` and reads `item.parentOtsHash` on `undefined`.

So every request for a non-existent item (or one without an OTS file) returns a 404 to the client but throws an unhandled error in the handler server-side. Fix is a one-word `return` on the 404 in each file; no behavior change on the happy path.