### PR TITLE
Onboard flow

### DIFF
--- a/api/payIn/lib/freebie.js
+++ b/api/payIn/lib/freebie.js
@@ -20,13 +20,13 @@ export function canCreateFreeComment (user) {
 /**
  * Check if the item qualifies as a freebie
  * @param {Object} models - Prisma models
- * @param {Object} params - { mcost, baseMcost, parentId, bio }
+ * @param {Object} params - { mcost, baseMcost, parentId, useFreebie }
  * @param {Object} context - { me } with me.id
  * @returns {Promise<boolean>} - true if item should be free
  */
-export async function checkFreebieEligibility (models, { mcost, baseMcost, parentId, bio }, { me }) {
-  // Only comments and bios can be freebies
-  if (!parentId && !bio) return false
+export async function checkFreebieEligibility (models, { mcost, baseMcost, parentId, useFreebie = false }, { me }) {
+  // Only comments can be freebies
+  if (!parentId) return false
 
   // Cost must not exceed base cost (no spam multiplier)
   if (mcost > baseMcost) return false
@@ -44,11 +44,10 @@ export async function checkFreebieEligibility (models, { mcost, baseMcost, paren
   const cantAfford = user.msats + user.mcredits < mcost
   if (!cantAfford) return false
 
-  // Can't have a send wallet attached
-  if (user.hasSendWallet) return false
+  // Users with send wallets must explicitly opt in
+  if (user.hasSendWallet && !useFreebie) return false
 
-  // For comments (not bio), check monthly limit
-  if (!bio && !canCreateFreeComment(user)) return false
+  if (!canCreateFreeComment(user)) return false
 
   return true
 }

--- a/api/payIn/types/itemCreate.js
+++ b/api/payIn/types/itemCreate.js
@@ -22,9 +22,7 @@ export const paymentMethods = [
 
 const DEFAULT_ITEM_MCOST = 1000n
 
-async function getBaseMcost (models, { bio, parentId, subNames }) {
-  if (bio) return DEFAULT_ITEM_MCOST
-
+async function getBaseMcost (models, { parentId, subNames }) {
   const subs = await getSubs(models, { subNames, parentId })
 
   if (parentId) {
@@ -51,17 +49,19 @@ async function getBaseMcost (models, { bio, parentId, subNames }) {
   return baseMcost > 0n ? baseMcost : DEFAULT_ITEM_MCOST
 }
 
-async function getMcost (models, { subNames, parentId, uploadIds, bio }, { me }) {
-  const baseMcost = await getBaseMcost(models, { bio, parentId, subNames })
+async function getMcost (models, { subNames, parentId, uploadIds, bio, useFreebie }, { me }) {
+  if (bio) return 0n
+
+  const baseMcost = await getBaseMcost(models, { parentId, subNames })
 
   // mcost = baseMcost * 10^num_items_in_10m * 100 (anon) or 1 (user) + upload fees
   const [{ mcost }] = await models.$queryRaw`
     SELECT ${baseMcost}::INTEGER
       * POWER(10, item_spam(${parseInt(parentId)}::INTEGER, ${me.id}::INTEGER,
-          ${me.id !== USER_ID.anon && !bio ? ITEM_SPAM_INTERVAL : ANON_ITEM_SPAM_INTERVAL}::INTERVAL))
+          ${me.id !== USER_ID.anon ? ITEM_SPAM_INTERVAL : ANON_ITEM_SPAM_INTERVAL}::INTERVAL))
       * ${me.id !== USER_ID.anon ? 1 : ANON_FEE_MULTIPLIER}::INTEGER  as mcost`
 
-  const isFreebie = await checkFreebieEligibility(models, { mcost, baseMcost, parentId, bio }, { me })
+  const isFreebie = await checkFreebieEligibility(models, { mcost, baseMcost, parentId, useFreebie }, { me })
   return isFreebie ? BigInt(0) : BigInt(mcost)
 }
 
@@ -123,6 +123,7 @@ export async function validateBeforeCreate (tx, payInProspect, payInArgs, { me }
 
 export async function onBegin (tx, payInId, args) {
   const { parentId, uploadIds = [], forwardUsers = [], options: pollOptions = [], subNames = [], ...data } = args
+  delete data.useFreebie
   const payIn = await tx.payIn.findUnique({ where: { id: payInId } })
 
   const { userNames, itemIds } = extractMentions(args.text)

--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -884,13 +884,13 @@ export default {
         return await createItem(parent, item, { me, models, lnd })
       }
     },
-    upsertComment: async (parent, { id, ...item }, { me, models, lnd }) => {
+    upsertComment: async (parent, { id, useFreebie, ...item }, { me, models, lnd }) => {
       await validateSchema(commentSchema, item)
 
       if (id) {
         return await updateItem(parent, { id, ...item }, { me, models, lnd })
       } else {
-        return await createItem(parent, item, { me, models, lnd })
+        return await createItem(parent, { ...item, useFreebie }, { me, models, lnd })
       }
     },
     updateNoteId: async (parent, { id, noteId }, { me, models }) => {

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -39,7 +39,7 @@ export default gql`
       id: ID, subNames: [String!], title: String!, text: String, options: [String!]!, forward: [ItemForwardInput], pollExpiresAt: Date,
       randPollOptions: Boolean, hash: String, hmac: String, sendProtocolId: Int): PayIn!
     updateNoteId(id: ID!, noteId: String!): Item!
-    upsertComment(id: ID, text: String!, parentId: ID, hash: String, hmac: String, sendProtocolId: Int): PayIn!
+    upsertComment(id: ID, text: String!, parentId: ID, hash: String, hmac: String, useFreebie: Boolean, sendProtocolId: Int): PayIn!
     act(id: ID!, sats: Int, act: String, hasSendWallet: Boolean, sendProtocolId: Int): PayIn!
     payBounty(id: ID!, sendProtocolId: Int): PayIn!
     pollVote(id: ID!, sendProtocolId: Int): PayIn!

--- a/api/typeDefs/user.js
+++ b/api/typeDefs/user.js
@@ -130,6 +130,7 @@ export default gql`
     freeCommentCount: Int!
     freeCommentsLeft: Int!
     hasSendWallet: Boolean!
+    hasRecvWallet: Boolean!
 
     """
     only relevant to user

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -21,6 +21,7 @@ const typeDefs = gql`
 
     # test a receive protocol by asking it to mint a probe invoice
     testWalletRecvProtocol(config: WalletRecvProtocolTestInput!): Boolean!
+    createEmbeddedSparkWallet(input: EmbeddedSparkWalletInput!): Wallet!
 
     # delete
     deleteWallet(id: ID!): Boolean
@@ -404,6 +405,10 @@ const typeDefs = gql`
   input WalletRecvClinkConfigInput { noffer: String! }
   input WalletSendSparkConfigInput { mnemonic: VaultEntryInput! }
   input WalletRecvSparkConfigInput { identityPubkey: String! }
+  input EmbeddedSparkWalletInput {
+    mnemonic: VaultEntryInput!
+    identityPubkey: String!
+  }
 
   type WalletLogs {
     logs: [WalletLogEntry!]!

--- a/components/fee-button.js
+++ b/components/fee-button.js
@@ -1,5 +1,6 @@
-import { useEffect, useContext, createContext, useState, useCallback, useMemo } from 'react'
+import { useEffect, useContext, createContext, useState, useCallback, useId, useMemo } from 'react'
 import Table from 'react-bootstrap/Table'
+import BootstrapForm from 'react-bootstrap/Form'
 import ActionTooltip from './action-tooltip'
 import Info from './info'
 import styles from './fee-button.module.css'
@@ -12,6 +13,7 @@ import AnonIcon from '@/svgs/spy-fill.svg'
 import { useShowModal } from './modal'
 import Link from 'next/link'
 import { SubmitButton } from './form'
+import { useFormikContext } from 'formik'
 
 const FeeButtonContext = createContext()
 
@@ -151,21 +153,16 @@ export function FeeButtonProvider ({ baseLineItems = DEFAULT_BASE_LINE_ITEMS, us
   const value = useMemo(() => {
     const lines = { ...baseLineItems, ...lineItems, ...remoteLineItems }
     const total = Object.values(lines).sort(sortHelper).reduce((acc, { modifier }) => modifier(acc), 0)
-
-    // Find base cost line item (could be 'baseCost' or '*-baseCost' for territories)
     const baseCostLine = Object.values(lines).find(line => line.op === '_' && line.allowFreebies !== undefined)
 
-    // freebies: there's only a base cost, we don't have enough sats/credits,
-    // no send wallet attached, and have free comments left (for comments only)
     const cantAfford = (me?.privates?.sats ?? 0) + (me?.privates?.credits ?? 0) < total
     const hasSendWallet = me?.privates?.hasSendWallet
     const freeCommentsLeft = me?.privates?.freeCommentsLeft ?? 0
     const isComment = baseCostLine?.isComment
-    const free = me &&
+    const canBeFree = me &&
       total === baseCostLine?.modifier(0) &&
       baseCostLine?.allowFreebies &&
       cantAfford &&
-      !hasSendWallet &&
       (!isComment || freeCommentsLeft > 0)
     return {
       lines,
@@ -174,7 +171,8 @@ export function FeeButtonProvider ({ baseLineItems = DEFAULT_BASE_LINE_ITEMS, us
       disabled: disabledReasons.size > 0,
       disabledReasons,
       setDisabled,
-      free,
+      free: canBeFree && !hasSendWallet,
+      freebieAvailable: canBeFree && hasSendWallet && isComment,
       freeCommentsLeft: isComment ? freeCommentsLeft : null
     }
   }, [me, me?.privates?.sats, me?.privates?.credits, me?.privates?.freeCommentsLeft, me?.privates?.hasSendWallet, baseLineItems, lineItems, remoteLineItems, mergeLineItems, disabledReasons, setDisabled])
@@ -191,10 +189,34 @@ export function useFeeButton () {
   return context
 }
 
+export function FreebieCheckbox () {
+  const { freebieAvailable } = useFeeButton()
+  const { setFieldValue, values } = useFormikContext()
+  const id = useId()
+  const checked = Boolean(values.useFreebie)
+
+  useEffect(() => {
+    if (checked && !freebieAvailable) setFieldValue('useFreebie', false, false)
+  }, [checked, freebieAvailable, setFieldValue])
+
+  if (!freebieAvailable) return null
+
+  return (
+    <BootstrapForm.Check
+      type='checkbox'
+      id={id}
+      className={styles.freebieCheckbox}
+      label='use free comment'
+      checked={checked}
+      onChange={e => setFieldValue('useFreebie', e.target.checked, false)}
+    />
+  )
+}
+
 function FreebieDialog ({ freeCommentsLeft }) {
   return (
     <>
-      <div className='fw-bold'>you don't have enough sats, so this one is on us</div>
+      <div className='fw-bold'>if you don't have enough sats, this one is on us</div>
       <ul className='mt-2'>
         <li>Free items have limited visibility and can only earn cowboy credits.</li>
         {freeCommentsLeft !== null && (
@@ -208,7 +230,11 @@ function FreebieDialog ({ freeCommentsLeft }) {
 
 export default function FeeButton ({ ChildButton = SubmitButton, variant, text, disabled }) {
   const { me } = useMe()
-  const { lines, total, disabled: ctxDisabled, free, freeCommentsLeft } = useFeeButton()
+  const { lines, total, disabled: ctxDisabled, free: automaticFree, freebieAvailable, freeCommentsLeft } = useFeeButton()
+  const { values } = useFormikContext()
+  const requestedFreebie = Boolean(values.useFreebie)
+  const free = automaticFree || (freebieAvailable && requestedFreebie)
+
   const feeText = free
     ? 'free'
     : total > 1

--- a/components/fee-button.module.css
+++ b/components/fee-button.module.css
@@ -15,6 +15,19 @@
     font-weight: 400;
 }
 
+.freebieCheckbox {
+    margin: 0;
+    white-space: nowrap;
+}
+
+.freebieCheckbox label {
+    color: var(--theme-grey);
+}
+
+.freebieCheckbox:focus-within label {
+    color: var(--theme-color);
+}
+
 .receipt td {
     padding: .25rem .1rem;
     background-color: var(--theme-inputBg);

--- a/components/post.js
+++ b/components/post.js
@@ -11,7 +11,7 @@ import { PollForm } from './poll-form'
 import { BountyForm } from './bounty-form'
 import { SubMultiSelect } from './sub-select'
 import { useCallback, useState } from 'react'
-import FeeButton, { FeeButtonProvider, postCommentBaseLineItems, postCommentUseRemoteLineItems } from './fee-button'
+import FeeButton, { FeeButtonProvider, FreebieCheckbox, postCommentBaseLineItems, postCommentUseRemoteLineItems } from './fee-button'
 import Delete from './delete'
 import CancelButton from './cancel-button'
 import { subNames, subsPostPrefix, subsAllSupport } from '@/lib/subs'
@@ -191,6 +191,7 @@ export function ItemButtonBar ({
   return (
     <div className={`mt-3 ${className}`}>
       <div className='d-flex justify-content-between'>
+        <FreebieCheckbox />
         {itemId && canDelete &&
           <Delete
             itemId={itemId}

--- a/fragments/payIn.js
+++ b/fragments/payIn.js
@@ -405,8 +405,8 @@ export const UPSERT_BIO = gql`
 
 export const CREATE_COMMENT = gql`
   ${PAY_IN_FIELDS}
-  mutation upsertComment($text: String!, $parentId: ID!, $sendProtocolId: Int) {
-    upsertComment(text: $text, parentId: $parentId, sendProtocolId: $sendProtocolId) {
+  mutation upsertComment($text: String!, $parentId: ID!, $useFreebie: Boolean, $sendProtocolId: Int) {
+    upsertComment(text: $text, parentId: $parentId, useFreebie: $useFreebie, sendProtocolId: $sendProtocolId) {
       ...PayInFields
     }
   }`

--- a/fragments/users.js
+++ b/fragments/users.js
@@ -36,6 +36,7 @@ ${STREAK_FIELDS}
       credits
       freeCommentsLeft
       hasSendWallet
+      hasRecvWallet
       tipDefault
       tipRandom
       tipRandomMin

--- a/lib/safe-url.js
+++ b/lib/safe-url.js
@@ -87,6 +87,21 @@ export function safeRedirectPath (uri, allowedHost) {
   return '/'
 }
 
+export function walletOnboardingPath (callbackUrl, allowedHost) {
+  const returnTo = safeRedirectPath(callbackUrl, allowedHost)
+  if (returnTo === '/') return '/onboarding/wallet'
+
+  const url = new URL(returnTo, 'https://stacker.news')
+  const { pathname } = url
+  if (/^\/invites\/[^/]+\/?$/.test(pathname)) {
+    url.searchParams.set('onboarding', '1')
+    return url.pathname + url.search + url.hash
+  }
+  if (pathname === '/onboarding/wallet') return returnTo
+
+  return `/onboarding/wallet?${new URLSearchParams({ returnTo })}`
+}
+
 export function getRequestOrigin (req) {
   const parsed = parseSafeHost(req?.headers?.host)
   if (!parsed) return null

--- a/pages/api/auth/domains/begin.js
+++ b/pages/api/auth/domains/begin.js
@@ -1,5 +1,5 @@
 import { DOMAINS_AUTH_VERIFIER_COOKIE, deriveChallenge, isValidHex64, safeEqual } from '@/lib/domains/auth'
-import { parseSafeHost, formatHost, safeRedirectPath } from '@/lib/safe-url'
+import { parseSafeHost, formatHost, safeRedirectPath, walletOnboardingPath } from '@/lib/safe-url'
 import { getDomainMapping, SN_MAIN_DOMAIN } from '@/lib/domains'
 
 /**
@@ -25,7 +25,9 @@ export default async function handler (req, res) {
   const canonicalDomain = formatHost(parsedDomain)
   // redirectUri is the path the user will be redirected to after authentication
   // distinguishes between login flow (callbackUrl) and domains auth flow (redirectUri)
-  const redirectUri = safeRedirectPath(callbackUrl, canonicalDomain)
+  const redirectUri = signup
+    ? walletOnboardingPath(callbackUrl, canonicalDomain)
+    : safeRedirectPath(callbackUrl, canonicalDomain)
   // multi-auth is the "add existing account" intent. it never makes sense to
   // pair it with signup, which always creates a fresh user.
   const wantsMultiAuth = !signup && multiAuth === 'true'

--- a/pages/invites/[id].js
+++ b/pages/invites/[id].js
@@ -10,7 +10,7 @@ import { CenterLayout } from '@/components/layout'
 import { getAuthOptions } from '@/pages/api/auth/[...nextauth]'
 import pay from '@/api/payIn'
 
-export async function getServerSideProps ({ req, res, query: { id, error = null } }) {
+export async function getServerSideProps ({ req, res, query: { id, error = null, onboarding = null } }) {
   const session = await getServerSession(req, res, getAuthOptions(req))
 
   const client = await getSSRApolloClient({ req, res })
@@ -44,15 +44,18 @@ export async function getServerSideProps ({ req, res, query: { id, error = null 
     }
 
     res.writeHead(302, {
-      Location: '/'
+      Location: onboarding === '1' ? '/onboarding/wallet' : '/'
     }).end()
     return { props: {} }
   }
 
+  const callbackUrl = new URL(req.url, process.env.NEXT_PUBLIC_URL)
+  callbackUrl.searchParams.set('onboarding', '1')
+
   return {
     props: {
       providers: await getProviders(),
-      callbackUrl: process.env.NEXT_PUBLIC_URL + req.url,
+      callbackUrl: callbackUrl.toString(),
       invite: data.invite,
       error
     }

--- a/pages/onboarding/wallet.js
+++ b/pages/onboarding/wallet.js
@@ -1,0 +1,8 @@
+import { getGetServerSideProps } from '@/api/ssrApollo'
+import { WalletOnboarding } from '@/wallets/client/components/onboarding'
+
+export const getServerSideProps = getGetServerSideProps({ authRequired: true })
+
+export default function WalletOnboardingPage () {
+  return <WalletOnboarding />
+}

--- a/pages/signup.js
+++ b/pages/signup.js
@@ -1,7 +1,16 @@
 import Link from 'next/link'
 import { StaticLayout } from '@/components/layout'
 import Login from '@/components/login'
-export { getServerSideProps } from './login'
+import { walletOnboardingPath } from '@/lib/safe-url'
+import { getServerSideProps as getLoginServerSideProps } from './login'
+
+export async function getServerSideProps (context) {
+  const result = await getLoginServerSideProps(context)
+  if (result.props && !result.props.domainData) {
+    result.props.callbackUrl = walletOnboardingPath(result.props.callbackUrl, context.req.headers.host)
+  }
+  return result
+}
 
 function SignUpHeader ({ domainData }) {
   return (

--- a/wallets/client/components/form/index.js
+++ b/wallets/client/components/form/index.js
@@ -23,6 +23,7 @@ import { useToast } from '@/components/toast'
 import { useShowModal } from '@/components/modal'
 import { useRouter } from 'next/router'
 import { WalletStaleConfigError } from '@/wallets/client/errors'
+import { isSafeRedirectPath } from '@/lib/safe-url'
 const styles = { ...sharedStyles, ...configureStyles }
 
 export function WalletConfigureForm ({ wallet }) {
@@ -57,6 +58,10 @@ function WalletConfigureFormLayout ({ protocols }) {
   const toaster = useToast()
   const router = useRouter()
   const showModal = useShowModal()
+  const onboarding = isTemplate(wallet) && router.query.onboarding === '1'
+  const returnTo = onboarding && typeof router.query.returnTo === 'string' && isSafeRedirectPath(router.query.returnTo)
+    ? router.query.returnTo
+    : null
   const selection = useProtocolSelection({ sendProtocols: primarySendProtocols, receiveProtocols, sharedNames: sharedProtocolNames })
   const onNwcLud16 = useNwcLightningAddressBridge({ receiveProtocols, forceReceiveLnAddr: selection.forceReceiveLnAddr })
 
@@ -76,12 +81,19 @@ function WalletConfigureFormLayout ({ protocols }) {
     }
 
     try {
-      await router.push(walletId && !saveState.willDeleteWallet ? `/wallets/${walletId}` : '/wallets')
+      if (onboarding && walletId && !saveState.willDeleteWallet) {
+        await router.replace({
+          pathname: '/onboarding/wallet',
+          query: { walletId, ...(returnTo && { returnTo }) }
+        })
+      } else {
+        await router.push(walletId && !saveState.willDeleteWallet ? `/wallets/${walletId}` : '/wallets')
+      }
     } catch {
       // cancelled/aborted navigation; the save already succeeded
     }
     return true
-  }, [canSave, saveState.willDeleteWallet, saveWallet, formik.values, allProtocols, toaster, router])
+  }, [canSave, saveState.willDeleteWallet, saveWallet, formik.values, allProtocols, toaster, onboarding, returnTo, router])
 
   const [onSave, inFlight] = useSingleFlight(onSaveWalletSubmit)
 

--- a/wallets/client/components/home/add.js
+++ b/wallets/client/components/home/add.js
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import classNames from 'classnames'
 import { useWalletSupport } from '@/wallets/client/hooks'
 import { fuzzySearch, WalletSearch } from '@/wallets/client/components/search'
@@ -15,6 +16,13 @@ const styles = { ...sharedStyles, ...rowsStyles, ...addStyles }
 
 export function AddWalletPanel ({ templates }) {
   const [query, setQuery] = useState('')
+  const router = useRouter()
+  const templateQuery = router.query.onboarding === '1'
+    ? {
+        onboarding: '1',
+        ...(typeof router.query.returnTo === 'string' && { returnTo: router.query.returnTo })
+      }
+    : undefined
 
   const searchFilter = fuzzySearch(query)
   const templateMatches = templates.map(template => ({
@@ -32,7 +40,10 @@ export function AddWalletPanel ({ templates }) {
         {templateMatches.map(({ template, visible }) => (
           <Link
             key={template.name}
-            href={addWalletTemplateRoute(templateNameToPathSegment(template.name))}
+            href={{
+              pathname: addWalletTemplateRoute(templateNameToPathSegment(template.name)),
+              query: templateQuery
+            }}
             className={classNames(styles.surfaceRow, styles.surfaceRowHover, styles.row)}
             hidden={!visible}
           >

--- a/wallets/client/components/onboarding.js
+++ b/wallets/client/components/onboarding.js
@@ -16,7 +16,7 @@ import { useEncryption } from '@/wallets/client/hooks/crypto'
 import { protocolTestSendPayment } from '@/wallets/client/protocols'
 import { clearWalletBalanceCache } from '@/wallets/client/balance'
 import {
-  SAVE_WALLET_PROTOCOLS,
+  CREATE_EMBEDDED_SPARK_WALLET,
   TEST_WALLET_RECV_PROTOCOL,
   WALLETS
 } from '@/wallets/client/fragments'
@@ -119,7 +119,7 @@ function EmbeddedSparkProvision ({ onSuccess }) {
   const client = useApolloClient()
   const { encrypt } = useEncryption()
   const [testReceive] = useMutation(TEST_WALLET_RECV_PROTOCOL)
-  const [saveWallet] = useMutation(SAVE_WALLET_PROTOCOLS)
+  const [createWallet] = useMutation(CREATE_EMBEDDED_SPARK_WALLET)
   const abortController = useRef(null)
   const [error, setError] = useState(null)
 
@@ -141,24 +141,21 @@ function EmbeddedSparkProvision ({ onSuccess }) {
         context: { fetchOptions: { signal: controller.signal } }
       })
       const encryptedMnemonic = await encrypt(mnemonic)
-      const { data } = await saveWallet({
+      const { data } = await createWallet({
         variables: {
-          templateName: 'SPARK',
-          upserts: [
-            { enabled: true, config: { walletSendSpark: { mnemonic: encryptedMnemonic } } },
-            { enabled: true, config: { walletRecvSpark: { identityPubkey } } }
-          ],
-          removeIds: []
+          input: { mnemonic: encryptedMnemonic, identityPubkey }
         },
         context: { fetchOptions: { signal: controller.signal } }
       })
-      const walletId = data?.saveWalletProtocols?.id
+      const walletId = data?.createEmbeddedSparkWallet?.id
       if (!walletId) throw new Error('wallet saved without an id')
 
       requestPersistentStorage()
       clearWalletBalanceCache()
-      await client.refetchQueries({ include: [ME, WALLETS] })
       onSuccess(walletId)
+      client.refetchQueries({ include: [ME, WALLETS] }).catch(err => {
+        console.error('failed to refresh wallet state:', err)
+      })
     } catch (err) {
       if (controller.signal.aborted) return
       console.error('failed to create embedded wallet:', err)
@@ -166,7 +163,7 @@ function EmbeddedSparkProvision ({ onSuccess }) {
     } finally {
       if (abortController.current === controller) abortController.current = null
     }
-  }, [client, encrypt, onSuccess, saveWallet, testReceive])
+  }, [client, createWallet, encrypt, onSuccess, testReceive])
 
   useEffect(() => {
     provision()

--- a/wallets/client/components/onboarding.js
+++ b/wallets/client/components/onboarding.js
@@ -1,0 +1,224 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useApolloClient, useMutation } from '@apollo/client/react'
+import { Button } from 'react-bootstrap'
+import classNames from 'classnames'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { useMe } from '@/components/me'
+import { requestPersistentStorage } from '@/components/use-indexeddb'
+import { withTimeoutSignal } from '@/lib/time'
+import { WALLET_SEND_PAYMENT_TIMEOUT_MS } from '@/lib/constants'
+import { ME } from '@/fragments/users'
+import { WalletShellMain } from './layout'
+import { WalletLoadingShell, WalletRouteGate } from './page-shells'
+import { WalletLogo } from './wallet-logo'
+import { useEncryption } from '@/wallets/client/hooks/crypto'
+import { protocolTestSendPayment } from '@/wallets/client/protocols'
+import { clearWalletBalanceCache } from '@/wallets/client/balance'
+import {
+  SAVE_WALLET_PROTOCOLS,
+  TEST_WALLET_RECV_PROTOCOL,
+  WALLETS
+} from '@/wallets/client/fragments'
+import Moon from '@/svgs/moon-fill.svg'
+import ArrowRight from '@/svgs/arrow-right-line.svg'
+import CheckCircle from '@/svgs/checkbox-circle-fill.svg'
+import { selectedWalletRoute } from '@/wallets/lib/routes'
+import { isSafeRedirectPath } from '@/lib/safe-url'
+import sharedStyles from './wallet.module.css'
+import onboardingStyles from './onboarding.module.css'
+const styles = { ...sharedStyles, ...onboardingStyles }
+
+export function WalletOnboarding () {
+  const { me } = useMe()
+  const router = useRouter()
+  const [path, setPath] = useState(null)
+  const [completedWalletId, setCompletedWalletId] = useState(null)
+  const returnedWalletId = typeof router.query.walletId === 'string' && /^[1-9]\d*$/.test(router.query.walletId)
+    ? router.query.walletId
+    : null
+  const returnTo = typeof router.query.returnTo === 'string' &&
+    isSafeRedirectPath(router.query.returnTo) &&
+    !router.query.returnTo.startsWith('/onboarding/wallet')
+    ? router.query.returnTo
+    : null
+  const setupComplete = completedWalletId || returnedWalletId
+  const alreadyHasWallet = me?.privates?.hasSendWallet || me?.privates?.hasRecvWallet
+
+  useEffect(() => {
+    if (alreadyHasWallet && !setupComplete) router.replace(returnTo || '/')
+  }, [alreadyHasWallet, returnTo, router, setupComplete])
+
+  useEffect(() => {
+    if (path === 'external' && me?.privates?.showPassphrase === false) {
+      router.push({
+        pathname: '/wallets/add',
+        query: { onboarding: '1', ...(returnTo && { returnTo }) }
+      })
+    }
+  }, [me?.privates?.showPassphrase, path, returnTo, router])
+
+  if (!me || (alreadyHasWallet && !setupComplete)) {
+    return <WalletLoadingShell message='loading wallet setup' />
+  }
+
+  if (setupComplete) {
+    return <WalletOnboardingSuccess walletId={setupComplete} returnTo={returnTo} />
+  }
+
+  if (!path) {
+    return (
+      <OnboardingShell>
+        <div className={styles.heading}>
+          <div className={styles.eyebrow}>Step 1 of 3</div>
+          <h1>Do you need a lightning wallet?</h1>
+          <p>A lightning wallet lets you receive bitcoin for your posts and comments.</p>
+        </div>
+
+        <div className={styles.choices}>
+          <button type='button' className={classNames(styles.surfaceRow, styles.surfaceRowHover, styles.choice)} onClick={() => setPath('embedded')}>
+            <div className={styles.choiceHeader}>
+              <span className={styles.choiceTitle}>Yes, create one</span>
+              <WalletLogo name='SPARK' fallback='name' height={18} className={styles.sparkLogo} fallbackClassName={styles.sparkName} />
+            </div>
+            <span>
+              <strong>Treat it like a custodial wallet:</strong> Spark can see your IP address and wallet activity, and access to this wallet depends on Spark.
+            </span>
+            <ArrowRight className={styles.choiceArrow} width={20} height={20} />
+          </button>
+          <button type='button' className={classNames(styles.surfaceRow, styles.surfaceRowHover, styles.choice)} onClick={() => setPath('external')}>
+            <span className={styles.choiceTitle}>No, I have one</span>
+            <span>Connect Alby, Blink, Coinos, LNbits, Phoenixd, and other wallets.</span>
+            <ArrowRight className={styles.choiceArrow} width={20} height={20} />
+          </button>
+        </div>
+
+        <button type='button' className={classNames(styles.textButton, styles.skip)} onClick={() => router.replace(returnTo || '/')}>
+          <span>Skip for now</span>
+          <small>You can create or connect a wallet anytime.</small>
+        </button>
+      </OnboardingShell>
+    )
+  }
+
+  return (
+    <WalletRouteGate
+      passphraseSetupProps={{
+        onBack: () => setPath(null),
+        confirmText: 'Continue'
+      }}
+    >
+      {path === 'embedded'
+        ? <EmbeddedSparkProvision onSuccess={setCompletedWalletId} />
+        : <WalletLoadingShell message='opening wallet setup' />}
+    </WalletRouteGate>
+  )
+}
+
+function EmbeddedSparkProvision ({ onSuccess }) {
+  const client = useApolloClient()
+  const { encrypt } = useEncryption()
+  const [testReceive] = useMutation(TEST_WALLET_RECV_PROTOCOL)
+  const [saveWallet] = useMutation(SAVE_WALLET_PROTOCOLS)
+  const abortController = useRef(null)
+  const [error, setError] = useState(null)
+
+  const provision = useCallback(async () => {
+    abortController.current?.abort()
+    setError(null)
+    const controller = new AbortController()
+    abortController.current = controller
+
+    try {
+      const { mnemonic, identityPubkey } = await withTimeoutSignal(
+        WALLET_SEND_PAYMENT_TIMEOUT_MS,
+        signal => protocolTestSendPayment({ name: 'SPARK' }, {}, { signal }),
+        { parentSignal: controller.signal }
+      )
+
+      await testReceive({
+        variables: { config: { walletRecvSpark: { identityPubkey } } },
+        context: { fetchOptions: { signal: controller.signal } }
+      })
+      const encryptedMnemonic = await encrypt(mnemonic)
+      const { data } = await saveWallet({
+        variables: {
+          templateName: 'SPARK',
+          upserts: [
+            { enabled: true, config: { walletSendSpark: { mnemonic: encryptedMnemonic } } },
+            { enabled: true, config: { walletRecvSpark: { identityPubkey } } }
+          ],
+          removeIds: []
+        },
+        context: { fetchOptions: { signal: controller.signal } }
+      })
+      const walletId = data?.saveWalletProtocols?.id
+      if (!walletId) throw new Error('wallet saved without an id')
+
+      requestPersistentStorage()
+      clearWalletBalanceCache()
+      await client.refetchQueries({ include: [ME, WALLETS] })
+      onSuccess(walletId)
+    } catch (err) {
+      if (controller.signal.aborted) return
+      console.error('failed to create embedded wallet:', err)
+      setError(err.message || 'failed to create wallet')
+    } finally {
+      if (abortController.current === controller) abortController.current = null
+    }
+  }, [client, encrypt, onSuccess, saveWallet, testReceive])
+
+  useEffect(() => {
+    provision()
+    return () => abortController.current?.abort()
+  }, [provision])
+
+  return (
+    <OnboardingShell narrow>
+      <div className={classNames(styles.heading, 'text-center')}>
+        <div className={styles.eyebrow}>Finishing setup</div>
+        <Moon className='spin fill-grey mb-3' height={32} width={32} />
+        <h1>Creating your wallet</h1>
+        <p>Your recovery secret is being generated and encrypted on this device.</p>
+      </div>
+      {error && (
+        <div className='text-center'>
+          <p className='text-danger'>{error}</p>
+          <Button variant='primary' onClick={provision}>try again</Button>
+        </div>
+      )}
+    </OnboardingShell>
+  )
+}
+
+function WalletOnboardingSuccess ({ walletId, returnTo }) {
+  const safeReturnTo = typeof returnTo === 'string' && isSafeRedirectPath(returnTo) && returnTo !== '/'
+    ? returnTo
+    : null
+
+  return (
+    <OnboardingShell narrow>
+      <div className={styles.success}>
+        <CheckCircle className={styles.successIcon} width={48} height={48} />
+        <div className={styles.heading}>
+          <h1>Your wallet is ready</h1>
+          <p>Your wallet is set up and ready to use on SN.</p>
+        </div>
+        <div className={styles.successActions}>
+          <Button as={Link} href={selectedWalletRoute(walletId)}>Go to wallet</Button>
+          <Button as={Link} href={safeReturnTo || '/'} variant='link'>
+            {safeReturnTo ? 'Continue' : 'Go to homepage'}
+          </Button>
+        </div>
+      </div>
+    </OnboardingShell>
+  )
+}
+
+function OnboardingShell ({ children, narrow = false }) {
+  return (
+    <WalletShellMain mobileTopBar={false}>
+      <div className={classNames(styles.page, narrow && styles.pageNarrow)}>{children}</div>
+    </WalletShellMain>
+  )
+}

--- a/wallets/client/components/onboarding.module.css
+++ b/wallets/client/components/onboarding.module.css
@@ -1,0 +1,162 @@
+.page {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2.75rem;
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+}
+
+.pageNarrow {
+  max-width: 680px;
+}
+
+.heading {
+  max-width: 680px;
+}
+
+.heading h1 {
+  margin-bottom: 0.75rem;
+  font-size: clamp(1.8rem, 5vw, 2.5rem);
+  font-weight: 800;
+  letter-spacing: -0.035em;
+}
+
+.heading p {
+  margin: 0;
+  color: var(--theme-grey);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.eyebrow {
+  margin-bottom: 0.8rem;
+  color: var(--theme-grey);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+}
+
+.choices {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.choice {
+  --surface-row-padding: 2rem;
+  --surface-row-border: 0;
+  --surface-row-radius: 0.75rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 240px;
+  text-align: left;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.choice:focus-visible {
+  border-color: var(--bs-primary);
+  box-shadow: inset 0 0 0 1px var(--bs-primary);
+  outline: 0;
+}
+
+.choiceTitle {
+  font-size: 1.2rem;
+  font-weight: 800;
+}
+
+.choiceHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+}
+
+.sparkLogo {
+  flex: 0 0 auto;
+  max-width: 72px;
+}
+
+.sparkName {
+  flex: 0 0 auto;
+  font-weight: 800;
+}
+
+.choice > span:not(.choiceTitle) {
+  color: var(--theme-grey);
+  line-height: 1.55;
+}
+
+.choiceArrow {
+  align-self: flex-end;
+  margin-top: auto;
+  fill: currentColor;
+}
+
+.skip {
+  align-self: center;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+  padding: 0.5rem 1rem;
+  text-align: center;
+}
+
+.skip span {
+  color: var(--bs-body-color);
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.skip small {
+  max-width: 24rem;
+  font-size: 0.8rem;
+  line-height: 1.45;
+}
+
+.success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  text-align: center;
+}
+
+.successIcon {
+  fill: var(--bs-success);
+}
+
+.successActions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+@media (max-width: 767px) {
+  .page {
+    justify-content: flex-start;
+    gap: 2rem;
+    padding: 2.5rem 0.25rem;
+  }
+
+  .choices {
+    grid-template-columns: 1fr;
+  }
+
+  .choice {
+    --surface-row-padding: 1.5rem;
+    min-height: 185px;
+  }
+
+  .successActions {
+    flex-direction: column;
+    width: 100%;
+  }
+}

--- a/wallets/client/components/page-shells.js
+++ b/wallets/client/components/page-shells.js
@@ -76,7 +76,7 @@ export function WalletDetailRoutePage ({ ready, resource, title, notFoundMessage
   )
 }
 
-export function WalletRouteGate ({ children, walletsRequired = true }) {
+export function WalletRouteGate ({ children, walletsRequired = true, passphraseSetupProps }) {
   const { me } = useMe()
   const [justUnlocked, setJustUnlocked] = useState(false)
   const key = useKey()
@@ -100,6 +100,7 @@ export function WalletRouteGate ({ children, walletsRequired = true }) {
   const wrongKey = keyError === WRONG_KEY
   const showPassphrase = me?.privates?.showPassphrase
   const canRecoverReceiveOnlyPassphrase = wrongKey && showPassphrase && !me?.privates?.hasSendWallet
+  const passphraseSetup = <CenteredPrompt><WalletPassphraseSetup {...passphraseSetupProps} /></CenteredPrompt>
 
   if (keyError === KEY_STORAGE_UNAVAILABLE) {
     const insecureContext = typeof window !== 'undefined' && window.isSecureContext === false
@@ -114,7 +115,7 @@ export function WalletRouteGate ({ children, walletsRequired = true }) {
   }
 
   if (canRecoverReceiveOnlyPassphrase && walletSendReady) {
-    return <CenteredPrompt><WalletPassphraseSetup /></CenteredPrompt>
+    return passphraseSetup
   }
 
   if (wrongKey) {
@@ -142,7 +143,7 @@ export function WalletRouteGate ({ children, walletsRequired = true }) {
   }
 
   if (showPassphrase && !justUnlocked) {
-    return <CenteredPrompt><WalletPassphraseSetup /></CenteredPrompt>
+    return passphraseSetup
   }
 
   return children

--- a/wallets/client/components/passphrase.js
+++ b/wallets/client/components/passphrase.js
@@ -70,7 +70,13 @@ function ResetPassphraseDialog ({ onCancel, onConfirm }) {
   )
 }
 
-function PassphraseConfirmation ({ words, onBack, onConfirm, saving }) {
+function PassphraseConfirmation ({
+  words,
+  onBack,
+  onConfirm,
+  saving,
+  confirmText = 'Open my wallets'
+}) {
   const [challenge] = useState(() => buildChallenge(words))
   const [confirmed, setConfirmed] = useState(0)
   const [confirmErrorCount, setConfirmErrorCount] = useState(0)
@@ -168,7 +174,7 @@ function PassphraseConfirmation ({ words, onBack, onConfirm, saving }) {
         >
           {saving
             ? 'opening your wallets...'
-            : <>Open my wallets <ForwardArrow className={styles.actionIcon} width={20} height={20} /></>}
+            : <>{confirmText} <ForwardArrow className={styles.actionIcon} width={20} height={20} /></>}
         </Button>
       </WalletBottomBar>
     </div>
@@ -270,7 +276,7 @@ export function WalletPassphrasePrompt ({ onSuccess }) {
     if (e.key === ' ') {
       e.preventDefault()
       if (words[i] && i < WORD_COUNT - 1) focusSlot(i + 1, 'start')
-    } else if (e.key === 'Enter') {
+    } else if (e.key === 'Enter' && !complete) {
       e.preventDefault()
       if (words[i] && i < WORD_COUNT - 1) {
         focusSlot(i + 1, 'start')
@@ -403,7 +409,10 @@ export function WalletPassphrasePrompt ({ onSuccess }) {
   )
 }
 
-export function WalletPassphraseSetup () {
+export function WalletPassphraseSetup ({
+  onBack,
+  confirmText = 'Open my wallets'
+} = {}) {
   const generateRandomKey = useGenerateRandomKey()
   const updateWalletEncryption = useWalletEncryptionUpdate()
   const toaster = useToast()
@@ -473,6 +482,7 @@ export function WalletPassphraseSetup () {
         onBack={() => setConfirming(false)}
         onConfirm={savePassphrase}
         saving={savingPassphrase}
+        confirmText={confirmText}
       />
     )
   }
@@ -511,11 +521,21 @@ export function WalletPassphraseSetup () {
         </div>
       </div>
 
-      <div className='d-flex justify-content-center'>
-        <Button type='button' variant='primary' onClick={() => setConfirming(true)}>
-          I've saved them - continue
-        </Button>
-      </div>
+      {onBack
+        ? (
+          <WalletBottomBar onBack={onBack} backText='back'>
+            <Button type='button' variant='primary' onClick={() => setConfirming(true)}>
+              I've saved them - continue
+            </Button>
+          </WalletBottomBar>
+          )
+        : (
+          <div className='d-flex justify-content-center'>
+            <Button type='button' variant='primary' onClick={() => setConfirming(true)}>
+              I've saved them - continue
+            </Button>
+          </div>
+          )}
 
       <p className={styles.footnote}>You'll confirm 3 of the 12 next.</p>
     </div>

--- a/wallets/client/fragments/wallet.js
+++ b/wallets/client/fragments/wallet.js
@@ -264,6 +264,14 @@ export const SAVE_WALLET_PROTOCOLS = gql`
   }
 `
 
+export const CREATE_EMBEDDED_SPARK_WALLET = gql`
+  mutation CreateEmbeddedSparkWallet($input: EmbeddedSparkWalletInput!) {
+    createEmbeddedSparkWallet(input: $input) {
+      id
+    }
+  }
+`
+
 export const CREATE_WALLET_INVOICE = gql`
   mutation createWalletInvoice($walletId: ID!, $amount: Int!, $description: String) {
     createWalletInvoice(walletId: $walletId, amount: $amount, description: $description)

--- a/wallets/lib/protocols/docs/dev/spark.md
+++ b/wallets/lib/protocols/docs/dev/spark.md
@@ -35,4 +35,8 @@ The command generates temporary service and receiver wallets and refuses to run 
 
 ## Production
 
-Spark receive requires `SPARK_SERVICE_MNEMONIC` in both web and worker environments. Spark is restricted to `SN_ADMIN_IDS` in production until the integration is ready for wider use.
+Spark is available to all users. Receive support requires the same funded
+`SPARK_SERVICE_MNEMONIC` secret in both the web and worker environments; treat
+it as a required production deployment secret. The web process uses it for
+invoice creation and connection probes, while workers use it to reconcile
+incoming transfers.

--- a/wallets/server/resolvers/protocol.js
+++ b/wallets/server/resolvers/protocol.js
@@ -33,6 +33,7 @@ export const resolvers = {
   },
   Mutation: {
     addWalletLog,
+    createEmbeddedSparkWallet,
     saveWalletProtocols,
     testWalletRecvProtocol,
     deleteWalletLogs
@@ -71,6 +72,72 @@ export async function testWalletRecvProtocol (parent, { config: wrapper }, { me 
   }
 
   return true
+}
+
+// Embedded onboarding means "ensure this user has a Spark wallet." Serializing
+// on the user row makes concurrent requests and retries after a lost response
+// converge on the same wallet without restricting normal multi-wallet saves.
+export async function createEmbeddedSparkWallet (parent, { input }, { me, models }) {
+  if (!me) throw new GqlAuthenticationError()
+
+  const send = decodeProtocolConfig({ walletSendSpark: { mnemonic: input.mnemonic } })
+  const receive = decodeProtocolConfig({ walletRecvSpark: { identityPubkey: input.identityPubkey } })
+  await validateProtocolConfig(send.protocol, send.config, { keyHash: input.mnemonic.keyHash })
+  await validateProtocolConfig(receive.protocol, receive.config)
+
+  const savedWalletId = await commitWithBadgeNotifications(models, async tx => {
+    const [user] = await tx.$queryRaw`
+      SELECT "vaultKeyHash" FROM users WHERE id = ${me.id} FOR NO KEY UPDATE`
+    if (!user) throw new GqlAuthenticationError()
+
+    const existing = await tx.wallet.findFirst({
+      where: { userId: me.id, templateName: 'SPARK' },
+      select: { id: true }
+    })
+    if (existing) {
+      return { value: existing.id, notifications: [] }
+    }
+
+    if (!user.vaultKeyHash || user.vaultKeyHash !== input.mnemonic.keyHash) {
+      throw new GqlInputError('passphrase changed, please retry')
+    }
+
+    const wallet = await tx.wallet.create({
+      data: { userId: me.id, templateName: 'SPARK' },
+      select: { id: true }
+    })
+    await upsertProtocolInTransaction({
+      tx,
+      walletId: wallet.id,
+      userId: me.id,
+      protocol: send.protocol,
+      enabled: true,
+      config: send.config
+    })
+    await upsertProtocolInTransaction({
+      tx,
+      walletId: wallet.id,
+      userId: me.id,
+      protocol: receive.protocol,
+      enabled: true,
+      config: receive.config
+    })
+
+    return {
+      value: wallet.id,
+      notifications: await updateWalletBadges({ userId: me.id, tx })
+    }
+  })
+
+  const wallet = await models.wallet.findUnique({
+    where: { id: savedWalletId, userId: me.id },
+    include: {
+      template: true,
+      protocols: { orderBy: { id: 'asc' } }
+    }
+  })
+  if (!wallet) throw new GqlInputError('wallet not found')
+  return mapWalletResolveTypes(wallet)
 }
 
 // Atomic configure-save: validate every upsert, then apply upserts + removes

--- a/wallets/server/resolvers/protocol.js
+++ b/wallets/server/resolvers/protocol.js
@@ -14,7 +14,7 @@ import {
   validateProtocolConfig
 } from '@/wallets/server/persist'
 import { withTimeoutSignal } from '@/lib/time'
-import { SN_ADMIN_IDS, WALLET_CREATE_INVOICE_TIMEOUT_MS } from '@/lib/constants'
+import { WALLET_CREATE_INVOICE_TIMEOUT_MS } from '@/lib/constants'
 import { decodeCursor, LIMIT, nextCursorEncoded } from '@/lib/cursor'
 import { writeWalletLog } from '@/wallets/server/logger'
 import { WalletValidationError } from '@/wallets/lib/errors'
@@ -47,9 +47,6 @@ export async function testWalletRecvProtocol (parent, { config: wrapper }, { me 
   if (!me) throw new GqlAuthenticationError()
 
   const { protocol, config } = decodeProtocolConfig(wrapper)
-  if (process.env.NODE_ENV === 'production' && protocol.name === 'SPARK' && !SN_ADMIN_IDS.includes(me.id)) {
-    throw new GqlInputError('spark wallet is in limited beta')
-  }
   await validateProtocolConfig(protocol, config)
 
   let invoice
@@ -102,11 +99,6 @@ export async function saveWalletProtocols (parent, { walletId, templateName, ups
     const { protocol, config } = decodeProtocolConfig(wrapper)
     return { protocol, enabled, config }
   })
-  if (process.env.NODE_ENV === 'production' &&
-      (templateName === 'SPARK' || validatedUpserts.some(({ protocol }) => protocol.name === 'SPARK')) &&
-      !SN_ADMIN_IDS.includes(me.id)) {
-    throw new GqlInputError('spark wallet is in limited beta')
-  }
   if (templateName === 'SPARK') {
     const sparkProtocols = validatedUpserts.filter(({ protocol }) => protocol.name === 'SPARK')
     if (!sparkProtocols.some(({ protocol }) => protocol.send) ||
@@ -124,6 +116,10 @@ export async function saveWalletProtocols (parent, { walletId, templateName, ups
   const removeIdNumbers = removeIds.map(Number)
 
   const savedWalletId = await commitWithBadgeNotifications(models, async (tx) => {
+    // Lock the vault key before writing any encrypted configuration. The lock
+    // is held until commit, so a passphrase rotation cannot race this save.
+    if (usesVaultKey) await assertVaultKeyUnchanged(tx, me.id, vaultKeyHash)
+
     const wallet = await resolveWalletForSave(tx, {
       walletId,
       templateName,
@@ -138,9 +134,6 @@ export async function saveWalletProtocols (parent, { walletId, templateName, ups
       await upsertProtocolInTransaction({ tx, walletId: resolvedWalletId, userId: me.id, protocol, enabled, config })
     }
     await applyRemoves(tx, { removeIds: removeIdNumbers, walletId: resolvedWalletId, userId: me.id })
-
-    // Guard against a passphrase rotation committing mid-save.
-    if (usesVaultKey) await assertVaultKeyUnchanged(tx, me.id, vaultKeyHash)
 
     const deleted = await deleteWalletIfEmpty(tx, resolvedWalletId)
     return {

--- a/wallets/server/resolvers/wallet.js
+++ b/wallets/server/resolvers/wallet.js
@@ -1,5 +1,4 @@
 import { GqlAuthenticationError, GqlInputError } from '@/lib/error'
-import { SN_ADMIN_IDS } from '@/lib/constants'
 import { mapWalletResolveTypes } from '@/wallets/server/resolvers/util'
 import { decodeProtocolConfig, updateExistingProtocolConfigInTransaction } from '@/wallets/server/persist'
 import { assertRotationPayloadCoversSendProtocols, getVaultMetadata, initializeVaultKeyHash, setVaultShowPassphrase, updateVaultMetadata } from '@/wallets/server/vault'
@@ -68,7 +67,7 @@ async function wallets (parent, args, { me, models }) {
     throw new GqlAuthenticationError()
   }
 
-  let wallets = await models.wallet.findMany({
+  const wallets = (await models.wallet.findMany({
     where: {
       userId: me.id
     },
@@ -77,16 +76,9 @@ async function wallets (parent, args, { me, models }) {
       { priority: 'asc' },
       { id: 'asc' }
     ]
-  })
+  })).map(mapWalletResolveTypes)
 
-  let walletTemplates = await models.walletTemplate.findMany()
-
-  if (process.env.NODE_ENV === 'production' && !SN_ADMIN_IDS.includes(me.id)) {
-    walletTemplates = walletTemplates.filter(template => template.name !== 'SPARK')
-  }
-
-  wallets = wallets.map(mapWalletResolveTypes)
-  walletTemplates = walletTemplates.map(t => {
+  const walletTemplates = (await models.walletTemplate.findMany()).map(t => {
     return {
       ...t,
       __resolveType: 'WalletTemplate'


### PR DESCRIPTION
This PR makes wallet creation/adding part of the onboarding flow after sign up. The main bit is this screen with a one-click (+ passphrase flow) generation of an embedded (Spark 🙄) wallet when they click `Yes`.

<img width="833" height="601" alt="Screenshot 2026-08-17 at 4 17 54 PM" src="https://github.com/user-attachments/assets/11b9b30b-1b04-4689-99b2-4249762634f6" />

Assuming more new folks will end up with an unfunded send wallet as a result of this change, I had to modify freebies in b0015c4bd92ab7e008fa5dc0769f6db868886e22:

- when a comment is eligible and the stacker has a send wallet, a `use free comment` checkbox will appear
- bios have a `0` base fee now so that they are free (absent other cost modifiers) by default now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes signup/auth redirect targets and payment eligibility for comments, plus a new server mutation that persists encrypted Spark credentials with user-row locking.
> 
> **Overview**
> Adds a **post-signup wallet onboarding** path at `/onboarding/wallet`: new users are steered there from signup, invite links, and custom-domain signup via `walletOnboardingPath`, with safe `returnTo` handling through connect-wallet and add-wallet flows.
> 
> The onboarding UI lets users **create an embedded Spark wallet** in one flow (mnemonic generation, receive probe, encrypted save through `createEmbeddedSparkWallet`) or connect an external wallet, with passphrase setup integrated into the same gate. **Spark is no longer admin-only** in production for save, probe, and template listing.
> 
> **Freebies** are tightened for users who already have a send wallet: only **comments** qualify (bios are **0 mcost** by default, not freebie-flagged), and wallet holders must pass **`useFreebie`** on `upsertComment` or check **use free comment** in the fee UI. **`hasRecvWallet`** is exposed on `me.privates` for onboarding skip logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 122ad23f053e99f16ce388bfa3bebce6c4295f39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->