### PR TITLE
fix: avoid saving local draft if formik's text field hasn't changed

### DIFF
--- a/components/editor/plugins/core/local-draft.js
+++ b/components/editor/plugins/core/local-draft.js
@@ -1,5 +1,5 @@
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
-import { useContext, useCallback, useEffect } from 'react'
+import { useContext, useCallback, useEffect, useRef } from 'react'
 import { StorageKeyPrefixContext } from '@/components/form'
 import { $setText } from '@/lib/lexical/utils'
 import { $markdownToLexical } from '@/lib/lexical/utils/mdast'
@@ -14,6 +14,7 @@ import { useField } from 'formik'
 export default function LocalDraftPlugin ({ name }) {
   const [editor] = useLexicalComposerContext()
   const [text] = useField({ name })
+  const prevText = useRef(text.value)
 
   // local storage keys, e.g. 'reply-123456-text'
   const storageKeyPrefix = useContext(StorageKeyPrefixContext)
@@ -56,6 +57,11 @@ export default function LocalDraftPlugin ({ name }) {
 
   // save the draft to local storage
   useEffect(() => {
+    // avoid saving the draft if the text hasn't changed
+    // this also keeps the saving from depending on components lifecycle
+    if (prevText.current === text.value) return
+    prevText.current = text.value
+
     upsertDraft(text.value)
   }, [upsertDraft, text.value])
 


### PR DESCRIPTION
## Description

Fixes #3193 
Local drafts are based on the current Formik's `text.value`, and content is restored the moment the Lexical editor is mounted. Since editor updates are scheduled, there's a tiny window in which the `LocalDraftPlugin` can remove the local draft if the initial `text.value` is `''`.

Normally, the editor recovers from this by syncing Formik with the new state (after the draft editor update executes). However, in cases where the editor can remount, and this remount occurs while the draft editor update is still in the queue, the local draft is permanently lost.
This is the case for the link form, where the editor lives inside of a collapsed `AccordianItem`. 

https://github.com/stackernews/stacker.news/blob/fc91e8ba58ef99a46993c06bbe15895dd39c5e06/components/accordian-item.js#L37-L39

When the accordion changes `activeKey` from `undefined` to `null`, the editor gets destroyed and recreated because the body of the accordion is keyed on `activeKey`. The destroyed editor never finishes synchronizing its restored content, and the draft is lost.

---

This PR makes draft persistence react only to actual Formik value changes. Mounting with an initial value is not a content change, so it no longer writes or removes anything from local storage. If restoration is interrupted by a remount, the stored draft remains available for the next editor to load.

## Screenshots


https://github.com/user-attachments/assets/960c095f-668d-48d5-87ed-46c9a9b2d125



## Additional Context

This was _fixed_ at the `AccordianItem` level in #3187 by transitioning to a better Base UI primitive analog that won't remount, but the real fix is all about not letting `LocalDraftPlugin` save initial values.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7, works great now

**Did you use AI for this? If so, how much did it assist you?**

No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to draft persistence timing with no auth or data-model impact; main risk is edge cases around empty vs restored text syncing.
> 
> **Overview**
> **Fixes draft loss when the Lexical editor remounts** (e.g. link form inside a keyed accordion) by not treating mount-time Formik values as edits.
> 
> `LocalDraftPlugin` now tracks the previous `text.value` in a ref and **skips** `upsertDraft` when the value is unchanged. That stops an empty initial `text.value` from clearing local storage before a queued restore finishes, so a remounted editor can still load the stored draft.
> 
> Mount still **loads** from local storage when Formik is empty; only the **save** path is gated on real value changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 814abf592a823c2dc5ac485aceae6eda39c9288a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->