### PR TITLE
Proxy receive toggle

### DIFF
--- a/api/payIn/index.js
+++ b/api/payIn/index.js
@@ -209,10 +209,12 @@ async function afterBegin (models, { payIn, result, mCostRemaining }, { me, send
         payInBolt11
       })
     } else if (payIn.payInState === 'PENDING_INVOICE_WRAP') {
+      const description = payInArgs?.description ??
+        await payInTypeModules[payIn.payInType].describe(models, payIn.id)
       const payInBolt11 = await payInBolt11WrapProspect(models, payIn,
         {
           msats: mCostRemaining,
-          description: await payInTypeModules[payIn.payInType].describe(models, payIn.id),
+          description,
           descriptionHash: payInArgs?.descriptionHash
         })
       return await afterInvoiceCreation({

--- a/api/payIn/lib/payInBolt11.js
+++ b/api/payIn/lib/payInBolt11.js
@@ -44,11 +44,12 @@ export async function payInBolt11WrapProspect (models, payIn, { msats, descripti
   assertLndAvailable()
   try {
     const { mtokens: maxRoutingFeeMsats } = payIn.payOutCustodialTokens.find(t => t.payOutType === 'ROUTING_FEE')
+    description = payIn.user.hideInvoiceDesc ? undefined : description
     const bolt11 = await wrapBolt11({
       msats,
       maxRoutingFeeMsats,
       bolt11: payIn.payOutBolt11.bolt11,
-      hideInvoiceDesc: payIn.user.hideInvoiceDesc,
+      hideInvoiceDesc: !description,
       description,
       descriptionHash
     })

--- a/api/payIn/lib/payOutBolt11.js
+++ b/api/payIn/lib/payOutBolt11.js
@@ -1,6 +1,7 @@
 import { PAY_IN_RECEIVER_FAILURE_REASONS } from '@/lib/pay-in'
 import { createBolt11FromWalletProtocols } from '@/wallets/server/receive'
 import { payInFailureReasonsSql } from './sql'
+import { Prisma } from '@prisma/client'
 
 // returns the least failed, highest priority wallet protocols
 async function getLeastFailedWalletProtocols (models, { genesisId, userId }) {
@@ -22,12 +23,14 @@ async function getLeastFailedWalletProtocols (models, { genesisId, userId }) {
     ORDER BY "failedWallets"."failedCount" ASC NULLS FIRST, "Wallet"."priority" ASC`
 }
 
-async function getWalletProtocols (models, { userId }) {
+async function getWalletProtocols (models, { userId, walletId }) {
+  const walletFilter = walletId == null ? Prisma.empty : Prisma.sql`AND "Wallet"."id" = ${Number(walletId)}`
   return await models.$queryRaw`
     SELECT "WalletProtocol".*, "Wallet"."userId" as "userId"
     FROM "WalletProtocol"
     JOIN "Wallet" ON "Wallet"."id" = "WalletProtocol"."walletId"
     WHERE "Wallet"."userId" = ${userId} AND "WalletProtocol"."enabled" = true AND "WalletProtocol"."send" = false
+    ${walletFilter}
     ORDER BY "Wallet"."priority" ASC`
 }
 
@@ -75,7 +78,7 @@ export async function payOutBolt11Replacement (models, genesisId, { payOutType, 
   return await createPayOutBolt11FromWalletProtocols(candidateWalletProtocols, { msats }, { payOutType, userId }, { models }, testBolt11)
 }
 
-export async function payOutBolt11Prospect (models, bolt11Args, { payOutType, userId }, testBolt11) {
-  const walletProtocols = await getWalletProtocols(models, { userId })
+export async function payOutBolt11Prospect (models, bolt11Args, { payOutType, userId, walletId }, testBolt11) {
+  const walletProtocols = await getWalletProtocols(models, { userId, walletId })
   return await createPayOutBolt11FromWalletProtocols(walletProtocols, bolt11Args, { payOutType, userId }, { models }, testBolt11)
 }

--- a/api/payIn/lib/payOutBolt11.js
+++ b/api/payIn/lib/payOutBolt11.js
@@ -42,7 +42,7 @@ export class NoReceiveWalletError extends Error {
 }
 
 async function createPayOutBolt11FromWalletProtocols (walletProtocols, bolt11Args, { payOutType, userId }, { models }, testBolt11) {
-  for await (const { bolt11, invoice, protocol } of createBolt11FromWalletProtocols(walletProtocols, bolt11Args, { models })) {
+  for await (const { bolt11, invoice, protocol } of createBolt11FromWalletProtocols(walletProtocols, bolt11Args, { models, userId })) {
     try {
       if (testBolt11 && !(await testBolt11(bolt11))) {
         continue

--- a/api/payIn/types/proxyPayment.js
+++ b/api/payIn/types/proxyPayment.js
@@ -1,4 +1,5 @@
 import { PAID_ACTION_PAYMENT_METHODS, PROXY_RECEIVE_FEE_PERCENT } from '@/lib/constants'
+import { bolt11Description } from '@/lib/bolt11'
 import { toPositiveBigInt } from '@/lib/format'
 import { notifyDeposit } from '@/lib/webPush'
 import { payOutBolt11Prospect } from '../lib/payOutBolt11'
@@ -9,16 +10,17 @@ export const paymentMethods = [
   PAID_ACTION_PAYMENT_METHODS.P2P
 ]
 
-export async function getInitial (models, { msats, description, descriptionHash, expiry, walletId }, { me }) {
+export async function getInitial (models, { msats, description, expiry, walletId }, { me }) {
   const mcost = toPositiveBigInt(msats)
   const proxyPaymentMtokens = mcost * (100n - PROXY_RECEIVE_FEE_PERCENT) / 100n
   const routingFeeMtokens = mcost - proxyPaymentMtokens
 
   // payInBolt11 and payOutBolt11 belong to the same user
+  // The wrapped pay-in applies payer-facing description hashes; the attached
+  // wallet only receives the readable description.
   const payOutBolt11 = await payOutBolt11Prospect(models, {
     msats: proxyPaymentMtokens,
     description,
-    descriptionHash,
     expiry
   }, { payOutType: 'PROXY_PAYMENT', userId: me.id, walletId })
 
@@ -74,9 +76,9 @@ export async function onPaidSideEffects (models, payInId) {
 }
 
 export async function describe (models, payInId) {
-  const { user } = await models.payIn.findUnique({
+  const { user, payOutBolt11 } = await models.payIn.findUnique({
     where: { id: payInId },
-    include: { user: true }
+    include: { user: true, payOutBolt11: true }
   })
-  return `pay ${user.name}@stacker.news`
+  return bolt11Description(payOutBolt11.bolt11) || `pay ${user.name}@stacker.news`
 }

--- a/api/payIn/types/proxyPayment.js
+++ b/api/payIn/types/proxyPayment.js
@@ -1,4 +1,4 @@
-import { PAID_ACTION_PAYMENT_METHODS } from '@/lib/constants'
+import { PAID_ACTION_PAYMENT_METHODS, PROXY_RECEIVE_FEE_PERCENT } from '@/lib/constants'
 import { toPositiveBigInt } from '@/lib/format'
 import { notifyDeposit } from '@/lib/webPush'
 import { payOutBolt11Prospect } from '../lib/payOutBolt11'
@@ -9,11 +9,10 @@ export const paymentMethods = [
   PAID_ACTION_PAYMENT_METHODS.P2P
 ]
 
-// 3% to routing fee, 7% to rewards pool, 90% to invoice
-export async function getInitial (models, { msats, description, descriptionHash, expiry }, { me }) {
+export async function getInitial (models, { msats, description, descriptionHash, expiry, walletId }, { me }) {
   const mcost = toPositiveBigInt(msats)
-  const proxyPaymentMtokens = mcost * 90n / 100n
-  const routingFeeMtokens = mcost * 3n / 100n
+  const proxyPaymentMtokens = mcost * (100n - PROXY_RECEIVE_FEE_PERCENT) / 100n
+  const routingFeeMtokens = mcost - proxyPaymentMtokens
 
   // payInBolt11 and payOutBolt11 belong to the same user
   const payOutBolt11 = await payOutBolt11Prospect(models, {
@@ -21,7 +20,7 @@ export async function getInitial (models, { msats, description, descriptionHash,
     description,
     descriptionHash,
     expiry
-  }, { payOutType: 'PROXY_PAYMENT', userId: me.id })
+  }, { payOutType: 'PROXY_PAYMENT', userId: me.id, walletId })
 
   const payOutCustodialTokens = getRedistributedPayOutCustodialTokens({
     sub: null,
@@ -41,19 +40,14 @@ export async function getInitial (models, { msats, description, descriptionHash,
   }
 }
 
-export async function onBegin (tx, payInId, { comment, lud18Data, noteStr }) {
-  let note = null
-  if (noteStr) {
-    try {
-      note = JSON.parse(noteStr)
-    } catch (e) {
-      console.error('invalid noteStr', noteStr)
-    }
+export async function onBegin (tx, payInId, { comment, descriptionHashPreimage, lud18Data, note }) {
+  if (note && typeof descriptionHashPreimage !== 'string') {
+    throw new Error('NIP-57 request is missing its description hash preimage')
   }
 
   const data = {
     ...(lud18Data && { lud18Data: { create: lud18Data } }),
-    ...(note && { nostrNote: { create: { note } } }),
+    ...(note && { nostrNote: { create: { note, rawRequest: descriptionHashPreimage } } }),
     ...(comment && { comment: { create: { comment } } })
   }
 

--- a/api/resolvers/notifications.js
+++ b/api/resolvers/notifications.js
@@ -8,6 +8,7 @@ import { getPayIn } from './payIn'
 import { PAY_IN_NOTIFICATION_TYPES, WALLET_RETRY_BEFORE_MS, WALLET_MAX_RETRIES } from '@/lib/constants'
 import { lexicalHTMLGenerator } from '@/lib/lexical/server/html'
 import { Prisma } from '@prisma/client'
+import { EXTERNAL_TRANSACTION_INCLUDE } from '@/wallets/server/external-transactions'
 
 const PAY_IN_NOTIFICATION_TYPES_SQL = Prisma.join(
   PAY_IN_NOTIFICATION_TYPES.map(type => Prisma.sql`${type}::"PayInType"`)
@@ -271,6 +272,18 @@ export default {
             AND "PayIn"."payInStateChangedAt" < ${decodedCursor.time}::TIMESTAMP
             AND "PayIn"."mcost" > 1000
             AND "PayIn"."payInType" = 'PROXY_PAYMENT'
+            ORDER BY "sortTime" DESC
+            LIMIT ${LIMIT}::INTEGER)`
+        )
+        queries.push(
+          Prisma.sql`(SELECT "ExternalTransaction".id::text, "ExternalTransaction".updated_at AS "sortTime",
+            COALESCE(FLOOR(COALESCE("ExternalTransaction"."settledMsats", "ExternalTransaction"."amountMsats") / 1000), 0)::INTEGER AS "earnedSats",
+            ${'ExternalReceiveNotification'}::TEXT AS type
+            FROM "ExternalTransaction"
+            WHERE "ExternalTransaction"."userId" = ${me.id}::INTEGER
+            AND "ExternalTransaction"."direction" = 'RECEIVE'
+            AND "ExternalTransaction"."outcome" = 'SETTLED'
+            AND "ExternalTransaction".updated_at < ${decodedCursor.time}::TIMESTAMP
             ORDER BY "sortTime" DESC
             LIMIT ${LIMIT}::INTEGER)`
         )
@@ -649,6 +662,17 @@ export default {
         return null
       }
       return await getItem(n, { id: itemPayIn.itemId }, { models, me })
+    }
+  },
+  ExternalReceiveNotification: {
+    transaction: async (n, args, { me, models }) => {
+      return await models.externalTransaction.findFirst({
+        where: {
+          id: Number(n.id),
+          userId: me.id
+        },
+        include: EXTERNAL_TRANSACTION_INCLUDE
+      })
     }
   },
   Invitification: {

--- a/api/resolvers/user.js
+++ b/api/resolvers/user.js
@@ -464,6 +464,21 @@ export default {
           foundNotes()
           return true
         }
+
+        const externalReceive = await models.externalTransaction.findFirst({
+          where: {
+            userId: me.id,
+            direction: 'RECEIVE',
+            outcome: 'SETTLED',
+            updatedAt: {
+              gt: lastChecked
+            }
+          }
+        })
+        if (externalReceive) {
+          foundNotes()
+          return true
+        }
       }
 
       if (user.noteWithdrawals) {

--- a/api/resolvers/wallet.js
+++ b/api/resolvers/wallet.js
@@ -1,7 +1,6 @@
 import crypto, { timingSafeEqual } from 'crypto'
 import { validateSchema, withdrawlSchema, walletInvoiceSchema } from '@/lib/validate'
 import { satsToMsats } from '@/lib/format'
-import { WALLET_MAX_PENDING_EXTERNAL_RECEIVES } from '@/lib/constants'
 import assertGofacYourself from './ofac'
 import assertApiKeyNotPermitted from './apiKey'
 import { fetchLnAddrInvoice } from '@/lib/lnurl'
@@ -11,10 +10,9 @@ import { parseWalletId } from '@/wallets/server/resolvers/util'
 import { decodePaymentRequest, getNodeSockets } from '../lnd'
 import pay from '../payIn'
 import { dropBolt11 } from '@/worker/autoDropBolt11'
-import { createBolt11FromWalletProtocols } from '@/wallets/server/receive'
+import { createExternalReceiveInvoice } from '@/wallets/server/receive'
 import {
   acceptClientExternalSendObservation,
-  createExternalReceiveTransaction,
   createExternalSendTransaction,
   EXTERNAL_TRANSACTION_INCLUDE
 } from '@/wallets/server/external-transactions'
@@ -173,7 +171,7 @@ export async function createWithdrawal (parent, { invoice, maxFee }, { me, model
   return await pay('WITHDRAWAL', { bolt11: invoice, maxFee, protocolId: protocol?.id }, { me, models })
 }
 
-async function createWalletInvoice (parent, { walletId, amount, description }, { me, models }) {
+async function createWalletInvoice (parent, { walletId, amount, description, proxyReceive = false }, { me, models }) {
   if (!me) {
     throw new GqlAuthenticationError()
   }
@@ -181,74 +179,23 @@ async function createWalletInvoice (parent, { walletId, amount, description }, {
 
   const walletIdNumber = parseWalletId(walletId)
 
-  // Check before asking a provider to mint another real invoice. Count invoices
-  // created in the last hour that are still payable and not known settled/failed;
-  // this includes a checkless receive born UNKNOWN until its invoice expires.
-  const now = new Date()
-  const recentUnpaidReceives = await models.externalTransaction.count({
-    where: {
-      userId: me.id,
-      direction: 'RECEIVE',
-      createdAt: { gt: new Date(now.getTime() - 60 * 60_000) },
-      invoiceExpiresAt: { gt: now },
-      OR: [
-        { outcome: null },
-        { outcome: 'UNKNOWN' }
-      ]
-    }
-  })
-  if (recentUnpaidReceives >= WALLET_MAX_PENDING_EXTERNAL_RECEIVES) {
-    throw new GqlInputError('too many unpaid invoices created recently; try again later')
-  }
-
-  const validated = await validateSchema(walletInvoiceSchema, { amount, description })
+  const validated = await validateSchema(walletInvoiceSchema, { amount, description, proxyReceive })
 
   const sats = Number(validated.amount)
-
-  const protocols = await models.walletProtocol.findMany({
-    where: {
-      walletId: walletIdNumber,
-      send: false,
-      enabled: true,
-      wallet: {
-        userId: me.id
-      }
-    },
-    orderBy: {
-      id: 'asc'
-    }
-  })
-
-  if (protocols.length === 0) {
-    throw new GqlInputError('wallet cannot receive')
-  }
-
-  const walletProtocols = protocols.map(protocol => ({
-    ...protocol,
-    userId: me.id
-  }))
-
-  const invoices = createBolt11FromWalletProtocols(
-    walletProtocols,
-    {
+  if (validated.proxyReceive) {
+    const payIn = await pay('PROXY_PAYMENT', {
       msats: satsToMsats(sats),
-      description: validated.description
-    },
-    { models, limitPending: false }
-  )
-  const { value } = await invoices.next()
-
-  if (!value) {
-    throw new GqlInputError('wallet could not create a receive invoice')
+      description: validated.description,
+      walletId: walletIdNumber
+    }, { models, me })
+    return payIn.id
   }
 
-  const transaction = await createExternalReceiveTransaction(models, {
+  const { transaction } = await createExternalReceiveInvoice(models, {
     userId: me.id,
-    protocol: value.protocol,
-    bolt11: value.bolt11,
-    invoice: value.invoice,
-    lnurlVerifyUrl: value.lnurlVerifyUrl,
-    providerRequestId: value.providerRequestId
+    walletId: walletIdNumber,
+    msats: satsToMsats(sats),
+    description: validated.description
   })
   return transaction.id
 }

--- a/api/typeDefs/notifications.js
+++ b/api/typeDefs/notifications.js
@@ -88,6 +88,13 @@ export default gql`
     payInItem: Item
   }
 
+  type ExternalReceiveNotification {
+    id: ID!
+    transaction: ExternalTransaction!
+    earnedSats: Int!
+    sortTime: Date!
+  }
+
   type JobChanged {
     id: ID!
     item: Item!
@@ -193,7 +200,7 @@ export default gql`
     | FollowActivity | ForwardedVotification | Revenue | SubStatus
     | TerritoryPost | TerritoryTransfer | Reminder | ItemMention | PayInification
     | ReferralReward | CowboyHat | NewHorse | LostHorse | NewGun | LostGun
-    | Bulletinification
+    | Bulletinification | ExternalReceiveNotification
 
   type Notifications {
     lastChecked: Date

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -78,6 +78,24 @@ const typeDefs = gql`
     RETENTION
   }
 
+  type ExternalTransactionLud18 {
+    id: Int!
+    name: String
+    identifier: String
+    email: String
+    pubkey: String
+  }
+
+  type ExternalTransactionNostrNote {
+    id: Int!
+    note: JSONObject!
+  }
+
+  type ExternalTransactionComment {
+    id: Int!
+    comment: String!
+  }
+
   type ExternalTransaction {
     id: Int!
     createdAt: Date!
@@ -97,6 +115,9 @@ const typeDefs = gql`
     sourceValue: String
     providerRequestId: String
     walletInfo: PayInWalletInfo
+    lud18Data: ExternalTransactionLud18
+    nostrNote: ExternalTransactionNostrNote
+    comment: ExternalTransactionComment
   }
 
   input ExternalSendCreateInput {

--- a/api/typeDefs/wallet.js
+++ b/api/typeDefs/wallet.js
@@ -12,7 +12,7 @@ const typeDefs = gql`
 
   extend type Mutation {
     createWithdrawl(invoice: String!, maxFee: Int!): PayIn!
-    createWalletInvoice(walletId: ID!, amount: Int!, description: String): Int!
+    createWalletInvoice(walletId: ID!, amount: Int!, description: String, proxyReceive: Boolean): Int!
     createExternalSend(input: ExternalSendCreateInput!): Int!
     reportExternalSendObservation(input: ExternalSendObservationInput!): Boolean!
     sendToLnAddr(addr: String!, amount: Int!, maxFee: Int!, comment: String, identifier: Boolean, name: String, email: String): PayIn!
@@ -203,6 +203,7 @@ const typeDefs = gql`
     | WalletRecvSpark
 
   type WalletSettings {
+    proxyReceive: Boolean!
     receiveCreditsBelowSats: Int!
     sendCreditsBelowSats: Int!
     autoWithdrawThreshold: Int
@@ -211,6 +212,7 @@ const typeDefs = gql`
   }
 
   input WalletSettingsInput {
+    proxyReceive: Boolean
     receiveCreditsBelowSats: Int!
     sendCreditsBelowSats: Int!
     autoWithdrawThreshold: Int!

--- a/components/notifications.js
+++ b/components/notifications.js
@@ -77,6 +77,7 @@ function Notification ({ n, fresh }) {
           ((n.payIn.payInType === 'WITHDRAWAL' || n.payIn.payInType === 'AUTO_WITHDRAWAL') && <PayInWithdrawal n={n} />) ||
             <PayInFailed n={n} />
         )) ||
+        (type === 'ExternalReceiveNotification' && <ExternalReceiveNotification n={n} />) ||
         (type === 'ReferralReward' && <ReferralReward n={n} />) ||
         (type === 'Bulletinification' && <Bulletinification n={n} />)
       }
@@ -169,6 +170,7 @@ const defaultOnClick = n => {
   if (type === 'SubStatus') return { href: `/~${n.sub.name}` }
   if (type === 'Invitification') return { href: '/invites' }
   if (type === 'PayInification') return { href: `/transactions/${n.payIn.id}` }
+  if (type === 'ExternalReceiveNotification') return { href: `/wallets/transactions/${n.transaction.id}` }
   if (['CowboyHat', 'NewHorse', 'LostHorse', 'NewGun', 'LostGun'].includes(type)) return {}
   if (type === 'TerritoryTransfer') return { href: `/~${n.sub.name}` }
 
@@ -355,13 +357,12 @@ function Invitification ({ n }) {
   )
 }
 
-function NostrZap ({ n }) {
-  const { nostrNote } = n.payIn.payerPrivates.payInBolt11
+function NostrZap ({ nostrNote, earnedSats, sortTime }) {
   const { npub, content, note } = nostrZapDetails(nostrNote.note)
 
   return (
     <div className='fw-bold text-nostr'>
-      <NostrIcon width={24} height={24} className='fill-nostr me-1' />{numWithUnits(n.earnedSats)} zap from
+      <NostrIcon width={24} height={24} className='fill-nostr me-1' />{numWithUnits(earnedSats)} zap from
       {// eslint-disable-next-line
         <Link className='mx-1 text-reset text-underline' target='_blank' href={`https://njump.me/${npub}`} rel={UNKNOWN_LINK_REL}>
           {npub.slice(0, 10)}...
@@ -374,7 +375,7 @@ function NostrZap ({ n }) {
               {note.slice(0, 12)}...
             </Link>)
           : 'nostr'}
-      <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.sortTime))}</small>
+      <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(sortTime))}</small>
       {content && <small className='d-block ms-4 ps-1 mt-1 mb-1 text-muted fw-normal'><Text>{content}</Text></small>}
     </div>
   )
@@ -396,26 +397,38 @@ function getPayerSig (lud18Data) {
   return payerSig
 }
 
-function PayInProxyPayment ({ n }) {
-  if (n.payIn.payerPrivates.payInBolt11.nostrNote) {
-    return <NostrZap n={n} />
+function WalletReceiveNotification ({ n, metadata, action }) {
+  if (metadata.nostrNote) {
+    return <NostrZap nostrNote={metadata.nostrNote} earnedSats={n.earnedSats} sortTime={n.sortTime} />
   }
 
-  const payerSig = getPayerSig(n.payIn.payerPrivates.payInBolt11.lud18Data)
-  const sats = n.earnedSats
-  const actionString = 'proxied to your attached wallet'
+  const payerSig = getPayerSig(metadata.lud18Data)
 
   return (
     <div className='fw-bold text-info'>
-      <Check className='fill-info me-1' />{numWithUnits(sats, { abbreviate: false, unitSingular: 'sat was', unitPlural: 'sats were' })} {actionString}
+      <Check className='fill-info me-1' />{numWithUnits(n.earnedSats, { abbreviate: false, unitSingular: 'sat was', unitPlural: 'sats were' })} {action}
       <small className='text-muted ms-1 fw-normal' suppressHydrationWarning>{timeSince(new Date(n.sortTime))}</small>
-      {n.payIn.payerPrivates.payInBolt11.comment &&
+      {(metadata.comment || payerSig) &&
         <small className='d-block ms-4 ps-1 mt-1 mb-1 text-muted fw-normal'>
-          <Text>{n.payIn.payerPrivates.payInBolt11.comment.comment}</Text>
+          {metadata.comment && <Text>{metadata.comment.comment}</Text>}
           {payerSig}
         </small>}
     </div>
   )
+}
+
+function PayInProxyPayment ({ n }) {
+  return (
+    <WalletReceiveNotification
+      n={n}
+      metadata={n.payIn.payerPrivates.payInBolt11}
+      action='proxied to your attached wallet'
+    />
+  )
+}
+
+function ExternalReceiveNotification ({ n }) {
+  return <WalletReceiveNotification n={n} metadata={n.transaction} action='received by your attached wallet' />
 }
 
 function PayInFailed ({ n }) {

--- a/fragments/notifications.js
+++ b/fragments/notifications.js
@@ -226,6 +226,29 @@ export const NOTIFICATIONS = gql`
         ... on PayInification {
           ...PayInificationFields
         }
+        ... on ExternalReceiveNotification {
+          id
+          sortTime
+          earnedSats
+          transaction {
+            id
+            lud18Data {
+              id
+              name
+              identifier
+              email
+              pubkey
+            }
+            nostrNote {
+              id
+              note
+            }
+            comment {
+              id
+              comment
+            }
+          }
+        }
         ... on Reminder {
           id
           sortTime

--- a/lib/cln.js
+++ b/lib/cln.js
@@ -5,7 +5,7 @@ import { snFetch } from './fetch'
 import { WALLET_CREATE_INVOICE_TIMEOUT_MS } from './constants'
 import { walletAmountToMsats, walletAmountToMsatsOrUndefined } from '@/wallets/lib/amount'
 
-export const createInvoice = async ({ msats, description, expiry }, { socket, rune, cert }, { signal }) => {
+export const createInvoice = async ({ msats, description, deschashonly, expiry }, { socket, rune, cert }, { signal }) => {
   const method = 'POST'
   return await clnFetchJson(socket, {
     path: '/v1/invoice',
@@ -16,6 +16,7 @@ export const createInvoice = async ({ msats, description, expiry }, { socket, ru
       // see https://docs.corelightning.org/reference/lightning-invoice
       label: crypto.randomBytes(16).toString('hex'),
       description,
+      ...(deschashonly && { deschashonly: true }),
       amount_msat: msats,
       expiry
     },

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -105,7 +105,7 @@ export const MAX_WALLET_INVOICE_SATS = 99_999_999
 export const RESERVED_MAX_USER_ID = 615
 export const GLOBAL_SEED = USER_ID.k00b
 export const FREEBIE_BASE_COST_THRESHOLD = 10
-export const PROXY_RECEIVE_FEE_PERCENT = 10n
+export const PROXY_RECEIVE_FEE_PERCENT = 3n
 // the smallest amount a sat-only receive provider can mint (1 sat)
 export const MIN_RECEIVE_MSATS = 1000n
 // the maximum msats we'll allow for the outgoing (wrapped) invoice

--- a/lib/lnurl.js
+++ b/lib/lnurl.js
@@ -2,7 +2,13 @@ import { createHash } from 'crypto'
 import { bech32 } from 'bech32'
 import { lightningAddressValidator, lnAddrSchema, lud18PayerDataSchema, validateSchema } from './validate'
 import { snFetch } from './fetch'
-import { WALLET_CREATE_INVOICE_TIMEOUT_MS } from './constants'
+import {
+  MAX_WALLET_INVOICE_SATS,
+  MIN_RECEIVE_MSATS,
+  PROXY_PAYER_MAX_MSATS,
+  PROXY_PAYER_MIN_MSATS,
+  WALLET_CREATE_INVOICE_TIMEOUT_MS
+} from './constants'
 import { satsToMsats } from './format'
 import { isAbortLike } from './time'
 import { assertContentTypeJson, assertResponseOk } from './url'
@@ -18,7 +24,7 @@ export function encodeLnurl (url) {
 }
 
 export function lnurlPayMetadata (username) {
-  const description = `Proxied payment to ${username}@stacker.news`
+  const description = `Payment to ${username}@stacker.news`
   const metadata = JSON.stringify([
     ['text/plain', description],
     ['text/identifier', `${username}@stacker.news`]
@@ -28,6 +34,18 @@ export function lnurlPayMetadata (username) {
     description,
     descriptionHash: createHash('sha256').update(metadata).digest('hex')
   }
+}
+
+export function lnurlPayLimits ({ proxyReceive }) {
+  return proxyReceive
+    ? {
+        minSendable: PROXY_PAYER_MIN_MSATS,
+        maxSendable: PROXY_PAYER_MAX_MSATS
+      }
+    : {
+        minSendable: MIN_RECEIVE_MSATS,
+        maxSendable: satsToMsats(MAX_WALLET_INVOICE_SATS)
+      }
 }
 
 // The LUD-16 well-known path for a name, shared by the provider URL builder

--- a/lib/lnurl.js
+++ b/lib/lnurl.js
@@ -93,6 +93,29 @@ export async function sanitizeLud18PayerData (payerData) {
 // providers that mandate it before we ever build a payer payload.
 export const SUPPORTED_PAYER_DATA_FIELDS = ['identifier', 'name', 'email']
 
+export function lnurlFetchUrl (url, {
+  isServer = typeof window === 'undefined',
+  nodeEnv = process.env.NODE_ENV,
+  publicUrl = process.env.NEXT_PUBLIC_URL,
+  selfUrl = process.env.SELF_URL
+} = {}) {
+  const original = url.toString()
+  if (!isServer || nodeEnv !== 'development' || !publicUrl || !selfUrl) return original
+
+  try {
+    const target = new URL(original)
+    if (target.origin !== new URL(publicUrl).origin) return original
+
+    const transport = new URL(selfUrl)
+    transport.pathname = target.pathname
+    transport.search = target.search
+    transport.hash = target.hash
+    return transport.toString()
+  } catch {
+    return original
+  }
+}
+
 // --- resolve an address to the provider's pay service ----------------------
 
 export async function fetchLnAddrService (addr, { signal } = {}) {
@@ -110,7 +133,7 @@ export async function fetchLnAddrService (addr, { signal } = {}) {
   let url = `${protocol}://${domain}`
   try {
     url = new URL(lnurlpWellKnownPath(name), url).toString()
-    res = await snFetch(url, { method, signal, timeout: WALLET_CREATE_INVOICE_TIMEOUT_MS })
+    res = await snFetch(lnurlFetchUrl(url), { method, signal, timeout: WALLET_CREATE_INVOICE_TIMEOUT_MS })
   } catch (err) {
     if (isAbortLike(err)) throw err
     // Preserve the original error as `cause` so callers can distinguish DNS,
@@ -220,9 +243,10 @@ export function lnAddrInvoiceUrl (service, { msats, comment, payer }) {
 
 export async function fetchInvoiceFromCallback (url, { signal } = {}) {
   const method = 'GET'
-  const res = await snFetch(url.toString(), { method, signal, timeout: WALLET_CREATE_INVOICE_TIMEOUT_MS })
+  const logicalUrl = url.toString()
+  const res = await snFetch(lnurlFetchUrl(logicalUrl), { method, signal, timeout: WALLET_CREATE_INVOICE_TIMEOUT_MS })
 
-  const body = await parseLnurlBody(res, { method, url: url.toString(), requiredField: 'pr' })
+  const body = await parseLnurlBody(res, { method, url: logicalUrl, requiredField: 'pr' })
   if (body.status === 'ERROR') {
     throw new Error(body.reason ?? 'lightning address failed')
   }
@@ -233,9 +257,10 @@ export async function fetchInvoiceFromCallback (url, { signal } = {}) {
 // ERROR means verification unavailable here; callers interpret it.
 export async function fetchLnAddrVerify (url, { signal } = {}) {
   const method = 'GET'
-  const res = await snFetch(url.toString(), { method, signal })
+  const logicalUrl = url.toString()
+  const res = await snFetch(lnurlFetchUrl(logicalUrl), { method, signal })
 
-  return await parseLnurlBody(res, { method, url: url.toString(), requiredField: 'settled' })
+  return await parseLnurlBody(res, { method, url: logicalUrl, requiredField: 'settled' })
 }
 
 // LUD-01 says ignore status/content-type and parse the body first:

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -76,7 +76,7 @@ const floatValidator = number().typeError('must be a number')
 // string is a lightning address — used both to classify destinations
 // (isLightningAddress) and to validate them (lightningAddressValidator).
 const LIGHTNING_ADDRESS_REGEX = /^[A-Za-z0-9._+-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*\.[A-Za-z]{2,}$/
-const LOCAL_DEV_ADDRESS_REGEX = /^[A-Za-z0-9._+-]+@(?:localhost|app)(?::\d+)?$/
+const LOCAL_DEV_ADDRESS_REGEX = /^[A-Za-z0-9._+-]+@localhost(?::\d+)?$/
 
 export function isLightningAddress (value) {
   if (typeof value !== 'string') return false

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -5,6 +5,7 @@ import {
   TERRITORY_BILLING_TYPES, MAX_COMMENT_TEXT_LENGTH, MAX_POST_TEXT_LENGTH, MIN_TITLE_LENGTH, BOUNTY_MIN,
   RESERVED_SUB_NAMES,
   BOOST_MAX, MAX_INVOICE_DESCRIPTION_LENGTH, MAX_WALLET_INVOICE_SATS, MAX_ZAP_SATS, MAX_BOUNTY_SATS,
+  PROXY_PAYER_MIN_MSATS, PROXY_PAYER_MAX_MSATS,
   SSR,
   BOOST_MIN,
   MAX_SEO_TITLE_LENGTH,
@@ -459,8 +460,17 @@ export const amountSchema = object({
 })
 
 export const walletInvoiceSchema = object({
+  proxyReceive: boolean(),
   amount: intValidator.required('required').positive('must be positive')
-    .max(MAX_WALLET_INVOICE_SATS, `must be at most ${numWithUnits(MAX_WALLET_INVOICE_SATS, { abbreviate: false })}`),
+    .when(['proxyReceive'], ([proxyReceive], schema) => {
+      const min = Number(PROXY_PAYER_MIN_MSATS / 1000n)
+      const max = Number(PROXY_PAYER_MAX_MSATS / 1000n)
+      return proxyReceive
+        ? schema
+          .min(min, `must be at least ${numWithUnits(min, { abbreviate: false })}`)
+          .max(max, `must be at most ${numWithUnits(max, { abbreviate: false })}`)
+        : schema.max(MAX_WALLET_INVOICE_SATS, `must be at most ${numWithUnits(MAX_WALLET_INVOICE_SATS, { abbreviate: false })}`)
+    }),
   description: string().trim().test({
     name: 'max-bytes',
     message: 'description is too long',
@@ -534,6 +544,7 @@ export const settingsSchema = object().shape({
 }, [['tipRandomMax', 'tipRandomMin']])
 
 export const walletSettingsSchema = object({
+  proxyReceive: boolean(),
   autoWithdrawThreshold: intValidator.required('required').min(0, 'must be at least 0').max(10000, 'must be at most 10000').transform(Number),
   autoWithdrawMaxFeePercent: floatValidator.required('required').min(0, 'must be at least 0').max(50, 'must not exceed 50').transform(Number),
   autoWithdrawMaxFeeTotal: intValidator.required('required').min(0, 'must be at least 0').max(1_000, 'must not exceed 1000').transform(Number),

--- a/lib/webPush.js
+++ b/lib/webPush.js
@@ -554,6 +554,18 @@ export async function notifyDeposit (userId, invoice) {
   }
 }
 
+export async function notifyExternalReceive (userId, receive) {
+  try {
+    await sendUserNotification(userId, {
+      title: `${numWithUnits(msatsToSats(receive.msatsReceived), { abbreviate: false, unitSingular: 'sat was', unitPlural: 'sats were' })} received by your attached wallet`,
+      body: receive.comment || undefined,
+      setting: 'noteDeposits'
+    })
+  } catch (err) {
+    log('error sending external receive notification:', err)
+  }
+}
+
 export async function notifyWithdrawal (payOutBolt11) {
   try {
     if (payOutBolt11.msats > 1000) {

--- a/pages/api/lnurlp/[username]/index.js
+++ b/pages/api/lnurlp/[username]/index.js
@@ -1,8 +1,9 @@
 import { getPublicKey } from 'nostr'
 import models from '@/api/models'
-import { lnurlPayMetadata, lnurlpCallbackUrl } from '@/lib/lnurl'
-import { LNURLP_COMMENT_MAX_LENGTH, PROXY_PAYER_MIN_MSATS, PROXY_PAYER_MAX_MSATS } from '@/lib/constants'
+import { lnurlPayLimits, lnurlPayMetadata, lnurlpCallbackUrl } from '@/lib/lnurl'
+import { LNURLP_COMMENT_MAX_LENGTH } from '@/lib/constants'
 import { isLndMaintenance, LND_MAINTENANCE_MESSAGE } from '@/api/lnd/maintenance'
+import { protocolSupportsDescriptionHash } from '@/wallets/server/protocols'
 
 export default async ({ query: { username } }, res) => {
   if (isLndMaintenance()) {
@@ -16,10 +17,23 @@ export default async ({ query: { username } }, res) => {
 
   const url = process.env.NODE_ENV === 'development' ? process.env.SELF_URL : process.env.NEXT_PUBLIC_URL
   const { metadata } = lnurlPayMetadata(username)
+  const { minSendable, maxSendable } = lnurlPayLimits({ proxyReceive: user.proxyReceive })
+  const receiveProtocols = await models.walletProtocol.findMany({
+    where: {
+      send: false,
+      enabled: true,
+      wallet: { userId: user.id }
+    },
+    select: { name: true }
+  })
+  const nostrPrivateKey = process.env.NOSTR_PRIVATE_KEY
+  const allowsNostr = !!nostrPrivateKey && receiveProtocols.length > 0 &&
+    (user.proxyReceive || receiveProtocols.some(protocolSupportsDescriptionHash))
+
   return res.status(200).json({
     callback: lnurlpCallbackUrl(username, url), // The URL from LN SERVICE which will accept the pay request parameters
-    minSendable: Number(PROXY_PAYER_MIN_MSATS), // Min amount LN SERVICE is willing to receive, can not be less than 1 or more than `maxSendable`
-    maxSendable: Number(PROXY_PAYER_MAX_MSATS), // Max amount LN SERVICE is willing to receive: the largest payer amount whose post-fee payout the wrap pipeline accepts
+    minSendable: Number(minSendable), // Min amount LN SERVICE is willing to receive, can not be less than 1 or more than `maxSendable`
+    maxSendable: Number(maxSendable), // Max amount LN SERVICE is willing to receive
     metadata, // Metadata json which must be presented as raw string here, this is required to pass signature verification at a later step
     commentAllowed: LNURLP_COMMENT_MAX_LENGTH, // LUD-12 Comments for payRequests https://github.com/lnurl/luds/blob/luds/12.md
     payerData: { // LUD-18 payer data for payRequests https://github.com/lnurl/luds/blob/luds/18.md
@@ -29,7 +43,7 @@ export default async ({ query: { username } }, res) => {
       email: { mandatory: false }
     },
     tag: 'payRequest', // Type of LNURL
-    nostrPubkey: process.env.NOSTR_PRIVATE_KEY ? getPublicKey(process.env.NOSTR_PRIVATE_KEY) : undefined,
-    allowsNostr: !!process.env.NOSTR_PRIVATE_KEY
+    nostrPubkey: allowsNostr ? getPublicKey(nostrPrivateKey) : undefined,
+    allowsNostr
   })
 }

--- a/pages/api/lnurlp/[username]/index.js
+++ b/pages/api/lnurlp/[username]/index.js
@@ -15,7 +15,6 @@ export default async ({ query: { username } }, res) => {
     return res.status(400).json({ status: 'ERROR', reason: `user @${username} does not exist` })
   }
 
-  const url = process.env.NODE_ENV === 'development' ? process.env.SELF_URL : process.env.NEXT_PUBLIC_URL
   const { metadata } = lnurlPayMetadata(username)
   const { minSendable, maxSendable } = lnurlPayLimits({ proxyReceive: user.proxyReceive })
   const receiveProtocols = await models.walletProtocol.findMany({
@@ -31,7 +30,7 @@ export default async ({ query: { username } }, res) => {
     (user.proxyReceive || receiveProtocols.some(protocolSupportsDescriptionHash))
 
   return res.status(200).json({
-    callback: lnurlpCallbackUrl(username, url), // The URL from LN SERVICE which will accept the pay request parameters
+    callback: lnurlpCallbackUrl(username), // The URL from LN SERVICE which will accept the pay request parameters
     minSendable: Number(minSendable), // Min amount LN SERVICE is willing to receive, can not be less than 1 or more than `maxSendable`
     maxSendable: Number(maxSendable), // Max amount LN SERVICE is willing to receive
     metadata, // Metadata json which must be presented as raw string here, this is required to pass signature verification at a later step

--- a/pages/api/lnurlp/[username]/pay.js
+++ b/pages/api/lnurlp/[username]/pay.js
@@ -1,14 +1,15 @@
 import models from '@/api/models'
-import { lnurlPayMetadata, lnurlpVerifyUrl, sanitizeLud18PayerData } from '@/lib/lnurl'
+import { lnurlPayLimits, lnurlPayMetadata, lnurlpVerifyUrl, sanitizeLud18PayerData } from '@/lib/lnurl'
 import { schnorr } from '@noble/curves/secp256k1'
 import { createHash } from 'crypto'
-import { LNURLP_COMMENT_MAX_LENGTH, PROXY_PAYER_MIN_MSATS, PROXY_PAYER_MAX_MSATS } from '@/lib/constants'
+import { LNURLP_COMMENT_MAX_LENGTH } from '@/lib/constants'
 import { formatMsats, toPositiveBigInt } from '@/lib/format'
 import assertGofacYourself from '@/api/resolvers/ofac'
 import { characterLength } from '@/lib/validate'
 import { walletLogger } from '@/wallets/server'
 import pay from '@/api/payIn'
 import { isLndMaintenance, LND_MAINTENANCE_MESSAGE } from '@/api/lnd/maintenance'
+import { createExternalReceiveInvoice } from '@/wallets/server/receive'
 
 export default async ({ query: { username, amount, nostr, comment, payerdata: payerData }, headers }, res) => {
   if (isLndMaintenance()) {
@@ -20,12 +21,13 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
     return res.status(400).json({ status: 'ERROR', reason: `user @${username} does not exist` })
   }
 
+  const { minSendable, maxSendable } = lnurlPayLimits({ proxyReceive: user.proxyReceive })
   const amountMsats = Number(amount)
-  if (!Number.isFinite(amountMsats) || amountMsats < Number(PROXY_PAYER_MIN_MSATS)) {
-    return res.status(400).json({ status: 'ERROR', reason: `amount must be >= ${PROXY_PAYER_MIN_MSATS} msats` })
+  if (!Number.isFinite(amountMsats) || amountMsats < Number(minSendable)) {
+    return res.status(400).json({ status: 'ERROR', reason: `amount must be >= ${minSendable} msats` })
   }
-  if (amountMsats > Number(PROXY_PAYER_MAX_MSATS)) {
-    return res.status(400).json({ status: 'ERROR', reason: `amount must be <= ${PROXY_PAYER_MAX_MSATS} msats` })
+  if (amountMsats > Number(maxSendable)) {
+    return res.status(400).json({ status: 'ERROR', reason: `amount must be <= ${maxSendable} msats` })
   }
   if (amountMsats % 1000 !== 0) {
     return res.status(400).json({ status: 'ERROR', reason: 'amount must be a whole number of sats' })
@@ -38,12 +40,14 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
   try {
     await assertGofacYourself({ models, headers })
     // if nostr, decode, validate sig, check tags, set description hash
-    let { description, descriptionHash } = lnurlPayMetadata(username)
-    let noteStr
+    const { metadata, description, descriptionHash: metadataDescriptionHash } = lnurlPayMetadata(username)
+    let descriptionHash = metadataDescriptionHash
+    let descriptionHashPreimage = metadata
+    let note
     let lud18Data
     if (nostr) {
-      noteStr = decodeURIComponent(nostr)
-      const note = JSON.parse(noteStr)
+      descriptionHashPreimage = decodeURIComponent(nostr)
+      note = JSON.parse(descriptionHashPreimage)
       // It MUST have only one p tag
       const hasPTag = note.tags?.filter(t => t[0] === 'p').length === 1
       // It MUST have 0 or 1 e tags
@@ -52,7 +56,7 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
       const eventAmount = note.tags?.find(t => t[0] === 'amount')?.[1]
       if (schnorr.verify(note.sig, note.id, note.pubkey) && hasPTag && hasETag && (!eventAmount || Number(eventAmount) === Number(amount))) {
         // override description hash
-        descriptionHash = createHash('sha256').update(noteStr).digest('hex')
+        descriptionHash = createHash('sha256').update(descriptionHashPreimage).digest('hex')
       } else {
         res.status(400).json({ status: 'ERROR', reason: 'invalid NIP-57 note' })
         return
@@ -76,7 +80,8 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
         return res.status(400).json({ status: 'ERROR', reason: err.toString() })
       }
 
-      descriptionHash = createHash('sha256').update(lnurlPayMetadata(username).metadata + payerData).digest('hex')
+      descriptionHashPreimage = metadata + payerData
+      descriptionHash = createHash('sha256').update(descriptionHashPreimage).digest('hex')
     }
 
     if (comment && characterLength(comment) > LNURLP_COMMENT_MAX_LENGTH) {
@@ -86,22 +91,45 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
       })
     }
 
-    // generate invoice
-    const { payInBolt11 } = await pay('PROXY_PAYMENT', {
-      msats: toPositiveBigInt(amount),
-      description,
-      descriptionHash,
-      comment: comment || '',
-      lud18Data,
-      noteStr
-    }, { models, me: user })
+    let bolt11
+    let hash
+    let canVerify = user.proxyReceive
+    if (user.proxyReceive) {
+      const { payInBolt11 } = await pay('PROXY_PAYMENT', {
+        msats: toPositiveBigInt(amount),
+        description,
+        descriptionHash,
+        comment: comment || '',
+        lud18Data,
+        ...(note && { descriptionHashPreimage, note })
+      }, { models, me: user })
 
-    if (!payInBolt11) throw new Error('could not generate invoice')
+      if (!payInBolt11) throw new Error('could not generate invoice')
+      bolt11 = payInBolt11.bolt11
+      hash = payInBolt11.hash
+    } else {
+      const direct = await createExternalReceiveInvoice(models, {
+        userId: user.id,
+        msats: toPositiveBigInt(amount),
+        description,
+        descriptionHash,
+        descriptionHashPreimage,
+        requireDescriptionHash: !!nostr,
+        sourceType: 'LN_ADDR',
+        sourceValue: `${username}@stacker.news`,
+        comment: comment || '',
+        lud18Data,
+        note
+      })
+      bolt11 = direct.bolt11
+      hash = direct.invoice.id
+      canVerify = direct.transaction.nextCheckAt != null
+    }
 
     return res.status(200).json({
-      pr: payInBolt11.bolt11,
+      pr: bolt11,
       routes: [],
-      verify: lnurlpVerifyUrl(username, payInBolt11.hash)
+      ...(canVerify && { verify: lnurlpVerifyUrl(username, hash) })
     })
   } catch (error) {
     console.log(error)

--- a/pages/api/lnurlp/[username]/verify/[hash].js
+++ b/pages/api/lnurlp/[username]/verify/[hash].js
@@ -3,15 +3,28 @@ import models from '@/api/models'
 export default async ({ query: { hash } }, res) => {
   try {
     const payInBolt11 = await models.payInBolt11.findUnique({ where: { hash } })
-    if (!payInBolt11) {
+    if (payInBolt11) {
+      const settled = !!payInBolt11.confirmedAt
+      return res.status(200).json({
+        status: 'OK',
+        settled,
+        preimage: settled ? payInBolt11.preimage : null,
+        pr: payInBolt11.bolt11
+      })
+    }
+
+    const externalTransaction = await models.externalTransaction.findFirst({
+      where: { hash, direction: 'RECEIVE' }
+    })
+    if (!externalTransaction) {
       return res.status(404).json({ status: 'ERROR', reason: 'not found' })
     }
-    const settled = !!payInBolt11.confirmedAt
+    const settled = externalTransaction.outcome === 'SETTLED'
     return res.status(200).json({
       status: 'OK',
       settled,
-      preimage: settled ? payInBolt11.preimage : null,
-      pr: payInBolt11.bolt11
+      preimage: settled ? externalTransaction.preimage : null,
+      pr: externalTransaction.bolt11
     })
   } catch (err) {
     console.log('error', err)

--- a/pages/settings/index.js
+++ b/pages/settings/index.js
@@ -260,7 +260,7 @@ export default function Settings ({ ssrData }) {
             groupClassName='mb-0'
           />
           <Checkbox
-            label='sats are proxied to my attached wallet'
+            label='sats are received by my attached wallet'
             name='noteDeposits'
             groupClassName='mb-0'
           />

--- a/pages/settings/wallets.js
+++ b/pages/settings/wallets.js
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 import InputGroup from 'react-bootstrap/InputGroup'
 import { useField } from 'formik'
 import { useMutation, useQuery } from '@apollo/client/react'
-import { Form, Input, SubmitButton } from '@/components/form'
+import { Checkbox, Form, Input, SubmitButton } from '@/components/form'
 import Info from '@/components/info'
 import { useToast } from '@/components/toast'
 import { isNumber } from '@/lib/format'
@@ -48,6 +48,7 @@ export default function WalletSettings ({ ssrData }) {
   }, [setSettings, toaster])
 
   const initial = {
+    proxyReceive: settings?.proxyReceive ?? false,
     receiveCreditsBelowSats: settings?.receiveCreditsBelowSats ?? 10,
     sendCreditsBelowSats: settings?.sendCreditsBelowSats ?? 10,
     autoWithdrawThreshold: settings?.autoWithdrawThreshold ?? 10000,
@@ -66,6 +67,7 @@ export default function WalletSettings ({ ssrData }) {
           schema={walletSettingsSchema}
           onSubmit={onSubmit}
         >
+          <ReceiveSettings />
           <AutowithdrawSettings />
           <CowboyCreditsSettings />
           <div className='d-flex mt-4'>
@@ -74,6 +76,29 @@ export default function WalletSettings ({ ssrData }) {
         </Form>
       </div>
     </Layout>
+  )
+}
+
+function ReceiveSettings () {
+  return (
+    <>
+      <h4 className='mb-3'>Receive Settings</h4>
+      <Checkbox
+        name='proxyReceive'
+        label={
+          <div className='d-flex align-items-center'>
+            proxy receives for enhanced privacy by default
+            <Info>
+              <ul>
+                <li>payments to your Stacker News lightning address are wrapped by the SN node</li>
+                <li>new external wallet invoices will start with proxying enabled, but you can turn it off for each invoice</li>
+                <li>proxying hides your external wallet from the payer. The fee is about 3% and can be higher for small payments.</li>
+              </ul>
+            </Info>
+          </div>
+        }
+      />
+    </>
   )
 }
 

--- a/pages/wallets/[id]/receive.js
+++ b/pages/wallets/[id]/receive.js
@@ -1,32 +1,41 @@
 import { getGetServerSideProps } from '@/api/ssrApollo'
-import { Form, Input, SubmitButton } from '@/components/form'
+import { Checkbox, Form, Input, SubmitButton } from '@/components/form'
+import Info from '@/components/info'
+import { useData } from '@/components/use-data'
 import { utf8ByteLength, walletInvoiceSchema } from '@/lib/validate'
-import { CREATE_WALLET_INVOICE } from '@/wallets/client/fragments'
+import { CREATE_WALLET_INVOICE, WALLET_SETTINGS } from '@/wallets/client/fragments'
 import { WalletActionEmpty, WalletActionShell, WalletBottomBar, WalletRoutePage } from '@/wallets/client/components'
 import { useRouteWallet, useWalletCapabilities } from '@/wallets/client/hooks'
-import { MAX_INVOICE_DESCRIPTION_LENGTH, MAX_WALLET_INVOICE_SATS } from '@/lib/constants'
+import {
+  MAX_INVOICE_DESCRIPTION_LENGTH,
+  MAX_WALLET_INVOICE_SATS,
+  PROXY_PAYER_MAX_MSATS,
+  PROXY_PAYER_MIN_MSATS
+} from '@/lib/constants'
 import sharedStyles from '@/wallets/client/components/wallet.module.css'
 import sendStyles from '@/wallets/client/components/send/send.module.css'
 import classNames from 'classnames'
-import { useMutation } from '@apollo/client/react'
+import { useMutation, useQuery } from '@apollo/client/react'
 import { InputGroup } from 'react-bootstrap'
 import { useRouter } from 'next/router'
 import { FormikConsumer } from 'formik'
 const styles = { ...sharedStyles, ...sendStyles }
 
-export const getServerSideProps = getGetServerSideProps({ authRequired: true })
+export const getServerSideProps = getGetServerSideProps({ query: WALLET_SETTINGS, authRequired: true })
 
-export default function WalletReceivePage () {
+export default function WalletReceivePage ({ ssrData }) {
   const { wallet, ready } = useRouteWallet()
+  const { data } = useQuery(WALLET_SETTINGS)
+  const settings = useData(data, ssrData)?.walletSettings
 
   return (
     <WalletRoutePage ready={ready} resource={wallet}>
-      {wallet => <WalletReceive wallet={wallet} />}
+      {wallet => <WalletReceive wallet={wallet} defaultProxyReceive={settings?.proxyReceive ?? false} />}
     </WalletRoutePage>
   )
 }
 
-function WalletReceive ({ wallet }) {
+function WalletReceive ({ wallet, defaultProxyReceive }) {
   const { canReceive } = useWalletCapabilities(wallet)
   const [createWalletInvoice] = useMutation(CREATE_WALLET_INVOICE)
   const router = useRouter()
@@ -45,53 +54,78 @@ function WalletReceive ({ wallet }) {
   return (
     <WalletActionShell wallet={wallet} title='receive'>
       <Form
+        enableReinitialize
         initial={{
           amount: 10000,
-          description: ''
+          description: '',
+          proxyReceive: defaultProxyReceive
         }}
         schema={walletInvoiceSchema}
-        onSubmit={async ({ amount, description }) => {
+        onSubmit={async ({ amount, description, proxyReceive }) => {
           const normalizedDescription = (description || '').trim()
           const { data } = await createWalletInvoice({
             variables: {
               walletId: wallet.id,
               amount: Number(amount),
-              description: normalizedDescription || undefined
+              description: normalizedDescription || undefined,
+              proxyReceive
             }
           })
           // the QR + live settlement status now live on the transaction page
-          await router.push(`/wallets/transactions/${data.createWalletInvoice}`)
+          await router.push(proxyReceive
+            ? `/transactions/${data.createWalletInvoice}`
+            : `/wallets/transactions/${data.createWalletInvoice}`)
         }}
       >
         <div className={classNames(styles.fields, styles.formResponsiveReset, 'd-flex flex-column')}>
-          <Input
-            label='amount'
-            name='amount'
-            type='number'
-            step={10}
-            max={MAX_WALLET_INVOICE_SATS}
-            required
-            autoFocus
-            append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
-          />
           <FormikConsumer>
             {({ values }) => {
               const bytes = utf8ByteLength((values.description || '').trim())
               const remaining = MAX_INVOICE_DESCRIPTION_LENGTH - bytes
+              const min = values.proxyReceive ? Number(PROXY_PAYER_MIN_MSATS / 1000n) : 1
+              const max = values.proxyReceive ? Number(PROXY_PAYER_MAX_MSATS / 1000n) : MAX_WALLET_INVOICE_SATS
               return (
-                <Input
-                  label='memo'
-                  name='description'
-                  as='textarea'
-                  rows={3}
-                  hint={
-                    <span className={remaining < 0 ? 'text-danger' : 'text-muted'}>
-                      {remaining < 0
-                        ? 'description is too long'
-                        : `${remaining} memo space remaining`}
-                    </span>
-                  }
-                />
+                <>
+                  <Input
+                    label='amount'
+                    name='amount'
+                    type='number'
+                    step={1}
+                    min={min}
+                    max={max}
+                    required
+                    autoFocus
+                    append={<InputGroup.Text className='text-monospace'>sats</InputGroup.Text>}
+                  />
+                  <Input
+                    label='memo'
+                    name='description'
+                    as='textarea'
+                    rows={3}
+                    hint={
+                      <span className={remaining < 0 ? 'text-danger' : 'text-muted'}>
+                        {remaining < 0
+                          ? 'description is too long'
+                          : `${remaining} memo space remaining`}
+                      </span>
+                    }
+                  />
+                  <Checkbox
+                    name='proxyReceive'
+                    label={
+                      <span className='d-flex align-items-center'>
+                        proxy receive for enhanced privacy
+                        <Info>
+                          <ul>
+                            <li>Stacker News wraps the invoice so the payer cannot identify your external wallet</li>
+                            <li>your wallet receives about 97%; small payments may receive less due to rounding</li>
+                            <li>if proxying fails, we will not expose your wallet by falling back to a direct invoice</li>
+                          </ul>
+                        </Info>
+                      </span>
+                    }
+                  />
+                </>
               )
             }}
           </FormikConsumer>

--- a/prisma/migrations/20260817000000_restore_proxy_receive/migration.sql
+++ b/prisma/migrations/20260817000000_restore_proxy_receive/migration.sql
@@ -47,6 +47,11 @@ ON "ExternalTransactionNostrNote"("externalTransactionId");
 CREATE UNIQUE INDEX "ExternalTransactionComment_externalTransactionId_key"
 ON "ExternalTransactionComment"("externalTransactionId");
 
+CREATE INDEX "ExternalTransaction_settled_receive_notifications_idx"
+ON "ExternalTransaction"("userId", "updated_at" DESC)
+WHERE "direction" = 'RECEIVE'::"ExternalTransactionDirection"
+AND "outcome" = 'SETTLED'::"ExternalTransactionOutcome";
+
 ALTER TABLE "ExternalTransactionLud18"
 ADD CONSTRAINT "ExternalTransactionLud18_externalTransactionId_fkey"
 FOREIGN KEY ("externalTransactionId") REFERENCES "ExternalTransaction"("id")

--- a/prisma/migrations/20260817000000_restore_proxy_receive/migration.sql
+++ b/prisma/migrations/20260817000000_restore_proxy_receive/migration.sql
@@ -1,0 +1,63 @@
+ALTER TABLE "users"
+ADD COLUMN "proxyReceive" BOOLEAN NOT NULL DEFAULT true;
+
+-- Preserve the privacy-first behavior existing users had before this setting
+-- was removed without updating user rows and firing their update triggers.
+-- Accounts created after this migration use the new false default.
+ALTER TABLE "users"
+ALTER COLUMN "proxyReceive" SET DEFAULT false;
+
+ALTER TABLE "PayInBolt11NostrNote"
+ADD COLUMN "rawRequest" TEXT;
+
+CREATE TABLE "ExternalTransactionLud18" (
+    "id" SERIAL NOT NULL,
+    "externalTransactionId" INTEGER NOT NULL,
+    "name" TEXT,
+    "identifier" TEXT,
+    "email" TEXT,
+    "pubkey" TEXT,
+
+    CONSTRAINT "ExternalTransactionLud18_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "ExternalTransactionNostrNote" (
+    "id" SERIAL NOT NULL,
+    "externalTransactionId" INTEGER NOT NULL,
+    "note" JSONB NOT NULL,
+    "rawRequest" TEXT NOT NULL,
+
+    CONSTRAINT "ExternalTransactionNostrNote_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "ExternalTransactionComment" (
+    "id" SERIAL NOT NULL,
+    "externalTransactionId" INTEGER NOT NULL,
+    "comment" TEXT NOT NULL,
+
+    CONSTRAINT "ExternalTransactionComment_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ExternalTransactionLud18_externalTransactionId_key"
+ON "ExternalTransactionLud18"("externalTransactionId");
+
+CREATE UNIQUE INDEX "ExternalTransactionNostrNote_externalTransactionId_key"
+ON "ExternalTransactionNostrNote"("externalTransactionId");
+
+CREATE UNIQUE INDEX "ExternalTransactionComment_externalTransactionId_key"
+ON "ExternalTransactionComment"("externalTransactionId");
+
+ALTER TABLE "ExternalTransactionLud18"
+ADD CONSTRAINT "ExternalTransactionLud18_externalTransactionId_fkey"
+FOREIGN KEY ("externalTransactionId") REFERENCES "ExternalTransaction"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ExternalTransactionNostrNote"
+ADD CONSTRAINT "ExternalTransactionNostrNote_externalTransactionId_fkey"
+FOREIGN KEY ("externalTransactionId") REFERENCES "ExternalTransaction"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "ExternalTransactionComment"
+ADD CONSTRAINT "ExternalTransactionComment_externalTransactionId_fkey"
+FOREIGN KEY ("externalTransactionId") REFERENCES "ExternalTransaction"("id")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -108,6 +108,7 @@ model User {
   mcredits                  BigInt                 @default(0)
   receiveCreditsBelowSats   Int                    @default(10)
   sendCreditsBelowSats      Int                    @default(10)
+  proxyReceive              Boolean                @default(false)
   muters                    Mute[]                 @relation("muter")
   muteds                    Mute[]                 @relation("muted")
   Sub                       Sub[]
@@ -1500,11 +1501,40 @@ model ExternalTransaction {
   sourceValue         String?
   verificationContext Json?                         @db.JsonB
   walletLogs          WalletLog[]
+  lud18Data           ExternalTransactionLud18?
+  nostrNote           ExternalTransactionNostrNote?
+  comment             ExternalTransactionComment?
 
   @@index([userId, createdAt, id])
   @@index([walletId, createdAt, id])
   @@index([protocolId])
   @@index([hash])
+}
+
+model ExternalTransactionLud18 {
+  id                    Int                 @id @default(autoincrement())
+  externalTransactionId Int                 @unique
+  externalTransaction   ExternalTransaction @relation(fields: [externalTransactionId], references: [id], onDelete: Cascade)
+
+  name       String?
+  identifier String?
+  email      String?
+  pubkey     String?
+}
+
+model ExternalTransactionNostrNote {
+  id                    Int                 @id @default(autoincrement())
+  externalTransactionId Int                 @unique
+  externalTransaction   ExternalTransaction @relation(fields: [externalTransactionId], references: [id], onDelete: Cascade)
+  note                  Json
+  rawRequest            String
+}
+
+model ExternalTransactionComment {
+  id                    Int                 @id @default(autoincrement())
+  externalTransactionId Int                 @unique
+  externalTransaction   ExternalTransaction @relation(fields: [externalTransactionId], references: [id], onDelete: Cascade)
+  comment               String
 }
 
 // payIn playground
@@ -1831,6 +1861,7 @@ model PayInBolt11NostrNote {
   payInBolt11Id Int         @unique
   payInBolt11   PayInBolt11 @relation(fields: [payInBolt11Id], references: [id])
   note          Json
+  rawRequest    String?
 }
 
 model PayInBolt11Comment {

--- a/wallets/client/fragments/wallet.js
+++ b/wallets/client/fragments/wallet.js
@@ -273,8 +273,8 @@ export const CREATE_EMBEDDED_SPARK_WALLET = gql`
 `
 
 export const CREATE_WALLET_INVOICE = gql`
-  mutation createWalletInvoice($walletId: ID!, $amount: Int!, $description: String) {
-    createWalletInvoice(walletId: $walletId, amount: $amount, description: $description)
+  mutation createWalletInvoice($walletId: ID!, $amount: Int!, $description: String, $proxyReceive: Boolean) {
+    createWalletInvoice(walletId: $walletId, amount: $amount, description: $description, proxyReceive: $proxyReceive)
   }`
 
 export const GET_EXTERNAL_TRANSACTION = gql`
@@ -307,6 +307,7 @@ export const DISABLE_PASSPHRASE_EXPORT = gql`
 export const WALLET_SETTINGS = gql`
   query WalletSettings {
     walletSettings {
+      proxyReceive
       receiveCreditsBelowSats
       sendCreditsBelowSats
       autoWithdrawMaxFeePercent
@@ -319,6 +320,7 @@ export const WALLET_SETTINGS = gql`
 export const SET_WALLET_SETTINGS = gql`
   mutation SetWalletSettings($settings: WalletSettingsInput!) {
     setWalletSettings(settings: $settings) {
+      proxyReceive
       receiveCreditsBelowSats
       sendCreditsBelowSats
       autoWithdrawMaxFeePercent

--- a/wallets/lib/protocols/docs/dev/lnAddr.md
+++ b/wallets/lib/protocols/docs/dev/lnAddr.md
@@ -1,6 +1,6 @@
-For testing lightning address autowithdraw, you'll need to reference a host reachable by the worker, e.g. `app:3000`.
-
-You'll want to deposit in another nym's account using an address like: `nym@app:3000`.
+Use an address like `nym@localhost:3000` from browser-based attached wallets.
+LNURL requests to the public development origin are translated to `SELF_URL`
+server-side, so the app and worker can reach the same address internally.
 
 ## Proof/status
 

--- a/wallets/server/external-transactions.js
+++ b/wallets/server/external-transactions.js
@@ -20,7 +20,7 @@ import { truncateToCharLength } from '@/lib/validate'
 import { TOR_REGEXP } from '@/lib/url'
 import { walletLogger } from './logger'
 import { requireExternalSendConfirmationIfNeeded } from './external-transaction-duplicates'
-import { notifyDeposit } from '@/lib/webPush'
+import { notifyExternalReceive } from '@/lib/webPush'
 
 const EXTERNAL_TX_CHECK_BATCH_SIZE = 25
 
@@ -394,7 +394,7 @@ export async function recordExternalTransactionObservation (
 async function externalReceiveSettledSideEffects (transaction, metadata) {
   if (transaction.direction !== 'RECEIVE' || transaction.outcome !== 'SETTLED') return
 
-  await notifyDeposit(transaction.userId, {
+  await notifyExternalReceive(transaction.userId, {
     msatsReceived: transaction.settledMsats ?? transaction.amountMsats,
     comment: metadata?.comment?.comment
   })

--- a/wallets/server/external-transactions.js
+++ b/wallets/server/external-transactions.js
@@ -20,6 +20,7 @@ import { truncateToCharLength } from '@/lib/validate'
 import { TOR_REGEXP } from '@/lib/url'
 import { walletLogger } from './logger'
 import { requireExternalSendConfirmationIfNeeded } from './external-transaction-duplicates'
+import { notifyDeposit } from '@/lib/webPush'
 
 const EXTERNAL_TX_CHECK_BATCH_SIZE = 25
 
@@ -176,6 +177,9 @@ export async function createExternalReceiveTransaction (models, args) {
   const { userId, protocol, bolt11, invoice } = args
   const lnurlVerifyUrl = sanitizeLnurlVerifyUrl(args.lnurlVerifyUrl)
   const providerRequestId = sanitizeProviderRequestId(args.providerRequestId)
+  const sourceValue = args.sourceType === 'LN_ADDR' && args.sourceValue
+    ? truncateToCharLength(args.sourceValue, 320)
+    : null
   const verificationContext = {
     ...(lnurlVerifyUrl && { lnurlVerifyUrl }),
     ...(providerRequestId && { providerRequestId })
@@ -197,7 +201,14 @@ export async function createExternalReceiveTransaction (models, args) {
       userId,
       walletId: protocol.walletId,
       protocolId: protocol.id,
-      verificationContext: Object.keys(verificationContext).length > 0 ? verificationContext : Prisma.DbNull
+      sourceType: args.sourceType ?? null,
+      sourceValue,
+      verificationContext: Object.keys(verificationContext).length > 0 ? verificationContext : Prisma.DbNull,
+      lud18Data: args.lud18Data ? { create: args.lud18Data } : undefined,
+      nostrNote: args.note
+        ? { create: { note: args.note, rawRequest: args.descriptionHashPreimage } }
+        : undefined,
+      comment: args.comment ? { create: { comment: args.comment } } : undefined
     }
   })
 
@@ -346,17 +357,47 @@ export async function recordExternalTransactionObservation (
       actualFeeMsats: outcome.actualFeeMsats ?? null
     })
   }
-  const { count } = await models.externalTransaction.updateMany({
-    where: { id: transaction.id, outcome: null },
-    data
-  })
-  if (count === 0) return transaction
+  const result = await models.$transaction(async tx => {
+    const { count } = await tx.externalTransaction.updateMany({
+      where: { id: transaction.id, outcome: null },
+      data
+    })
+    if (count === 0) return null
 
-  const updated = { ...transaction, ...data }
+    const updated = { ...transaction, ...data }
+    let metadata
+    if (updated.direction === 'RECEIVE' && updated.outcome === 'SETTLED') {
+      metadata = await tx.externalTransaction.findUnique({
+        where: { id: updated.id },
+        include: { comment: true, nostrNote: true }
+      })
+
+      if (metadata?.nostrNote && updated.preimage) {
+        await tx.$executeRaw`
+          INSERT INTO pgboss.job (name, data)
+          VALUES ('nip57', jsonb_build_object('hash', ${updated.hash}))`
+      }
+    }
+
+    return { updated, metadata }
+  })
+  if (!result) return transaction
+
+  const { updated, metadata } = result
   await logExternalTransactionTransition(models, updated, {
     detail: observation.detail
   })
+  await externalReceiveSettledSideEffects(updated, metadata)
   return updated
+}
+
+async function externalReceiveSettledSideEffects (transaction, metadata) {
+  if (transaction.direction !== 'RECEIVE' || transaction.outcome !== 'SETTLED') return
+
+  await notifyDeposit(transaction.userId, {
+    msatsReceived: transaction.settledMsats ?? transaction.amountMsats,
+    comment: metadata?.comment?.comment
+  })
 }
 
 async function logExternalTransactionTransition (models, after, { detail } = {}) {
@@ -402,6 +443,9 @@ async function logExternalTransactionTransition (models, after, { detail } = {})
 }
 
 export const EXTERNAL_TRANSACTION_INCLUDE = {
+  lud18Data: true,
+  nostrNote: true,
+  comment: true,
   protocol: {
     include: {
       wallet: {

--- a/wallets/server/protocols/clnRest.js
+++ b/wallets/server/protocols/clnRest.js
@@ -2,16 +2,22 @@ import { createInvoice as clnCreateInvoice, getInvoice as clnGetInvoice, runeMay
 import { WalletPermissionsError } from '@/wallets/lib/errors'
 
 export const name = 'CLN_REST'
+export const supportsDescriptionHash = true
 
 export const createInvoice = async (
-  { msats, description, expiry },
+  { msats, description, descriptionHash, descriptionHashPreimage, expiry },
   { socket, rune, cert },
   { signal }
 ) => {
+  if (descriptionHash && descriptionHashPreimage == null) {
+    throw new Error('description hash preimage required')
+  }
+
   const inv = await clnCreateInvoice(
     {
       msats,
-      description,
+      description: descriptionHash ? descriptionHashPreimage : description,
+      deschashonly: !!descriptionHash,
       expiry
     },
     {

--- a/wallets/server/protocols/index.js
+++ b/wallets/server/protocols/index.js
@@ -19,6 +19,7 @@ export * from './util'
  * @typedef {Object} ServerWalletProtocol
  * @property {ProtocolName} name - must match a protocol name in the database
  * @property {ProtocolCreateInvoice} createInvoice - create a new invoice
+ * @property {boolean} [supportsDescriptionHash] - can create BOLT11 invoices with a caller-supplied description hash
  * @property {ProtocolCheckInvoice} [checkInvoice] - checks a created invoice without creating another one
  * @property {ProtocolTestCreateInvoice} testCreateInvoice - create a test invoice
  */
@@ -44,6 +45,7 @@ export * from './util'
  * @property {number} msats - payment amount in millisatoshis
  * @property {string} description - payment description
  * @property {string} [descriptionHash] - optional description hash (BOLT11 `h` tag)
+ * @property {string} [descriptionHashPreimage] - exact source string whose SHA-256 digest is `descriptionHash`
  * @property {number} expiry - expiry time in seconds
  */
 

--- a/wallets/server/protocols/lndGrpc.js
+++ b/wallets/server/protocols/lndGrpc.js
@@ -5,6 +5,7 @@ import { TOR_REGEXP } from '@/lib/url'
 import { WalletPermissionsError } from '@/wallets/lib/errors'
 
 export const name = 'LND_GRPC'
+export const supportsDescriptionHash = true
 
 export const createInvoice = async (
   { msats, description, descriptionHash, expiry },
@@ -23,8 +24,7 @@ export const createInvoice = async (
     const invoice = await raceAbort(
       lndCreateInvoice({
         lnd,
-        description,
-        description_hash: descriptionHash,
+        ...(descriptionHash ? { description_hash: descriptionHash } : { description }),
         mtokens: String(msats),
         expires_at: datePivot(new Date(), { seconds: expiry })
       }),

--- a/wallets/server/protocols/nwc.js
+++ b/wallets/server/protocols/nwc.js
@@ -10,13 +10,18 @@ import {
 import { msatsSatsFloor } from '@/lib/format'
 
 export const name = 'NWC'
+export const supportsDescriptionHash = true
 
 // AlbyHub's NWC only invoices whole sats as of https://github.com/getAlby/hub/commit/64afc2227f128cf4cd90daf0d844af48e3513166
 export const receivableMsats = msatsSatsFloor
 
-export async function createInvoice ({ msats, description, expiry }, { url }, { signal }) {
+export async function createInvoice ({ msats, description, descriptionHash, expiry }, { url }, { signal }) {
   const result = await nwcTryRun(
-    nwc => nwc.req('make_invoice', { amount: msats, description, expiry }),
+    nwc => nwc.req('make_invoice', {
+      amount: msats,
+      expiry,
+      ...(descriptionHash ? { description_hash: descriptionHash } : { description })
+    }),
     { url },
     { signal }
   )

--- a/wallets/server/protocols/spark.js
+++ b/wallets/server/protocols/spark.js
@@ -7,6 +7,7 @@ import {
 } from '@/wallets/lib/protocols/spark'
 
 export const name = 'SPARK'
+export const supportsDescriptionHash = true
 
 const SPARK_RECEIVE_FAILURE_STATUSES = new Set([
   'TRANSFER_CREATION_FAILED',

--- a/wallets/server/protocols/util.js
+++ b/wallets/server/protocols/util.js
@@ -10,6 +10,10 @@ export function protocolCreateInvoice ({ name }, args, config, opts) {
   return normalizeCreateInvoiceResult(protocol(name).createInvoice(args, config, opts))
 }
 
+export function protocolSupportsDescriptionHash ({ name }) {
+  return protocol(name)?.supportsDescriptionHash === true
+}
+
 export function protocolCheckInvoice (walletProtocol, transaction, config, opts) {
   const checkInvoice = invoiceChecker(walletProtocol, transaction)
   if (!checkInvoice) {

--- a/wallets/server/receive.js
+++ b/wallets/server/receive.js
@@ -20,9 +20,14 @@ export async function * createBolt11FromWalletProtocols (walletProtocols, {
   descriptionHashPreimage,
   requireDescriptionHash = false,
   expiry = 360
-}, { models, limitPending = true }) {
+}, { models, userId, limitPending = true }) {
   msats = toPositiveNumber(msats)
-  description ||= ''
+  const user = await models.user.findUnique({
+    where: { id: userId },
+    select: { hideInvoiceDesc: true }
+  })
+  if (!user) throw new GqlInputError('user not found')
+  description = user.hideInvoiceDesc ? '' : description || ''
 
   if (requireDescriptionHash) {
     const expectedDescriptionHash = typeof descriptionHashPreimage === 'string'
@@ -180,7 +185,7 @@ export async function createExternalReceiveInvoice (models, {
   const invoices = createBolt11FromWalletProtocols(
     protocols.map(protocol => ({ ...protocol, userId })),
     { msats, description, descriptionHash, descriptionHashPreimage, requireDescriptionHash, expiry },
-    { models, limitPending: false }
+    { models, userId, limitPending: false }
   )
   const { value } = await invoices.next()
   if (!value) throw new GqlInputError('wallet could not create a receive invoice')

--- a/wallets/server/receive.js
+++ b/wallets/server/receive.js
@@ -1,20 +1,41 @@
 import { decodePaymentRequest } from '@/api/lnd'
-import { errorMessage } from '@/lib/error'
+import { createHash } from 'crypto'
+import { errorMessage, GqlInputError } from '@/lib/error'
 import { formatMsats, formatSats, msatsToSats, msatsSatsFloor, toPositiveNumber } from '@/lib/format'
-import { WALLET_MAX_PENDING_PAYOUT_INVOICES, MIN_RECEIVE_MSATS, WALLET_CREATE_INVOICE_TIMEOUT_MS } from '@/lib/constants'
+import { WALLET_MAX_PENDING_EXTERNAL_RECEIVES, WALLET_MAX_PENDING_PAYOUT_INVOICES, MIN_RECEIVE_MSATS, WALLET_CREATE_INVOICE_TIMEOUT_MS } from '@/lib/constants'
 import { withTimeoutSignal } from '@/lib/time'
 import { walletLogger } from '@/wallets/server/logger'
+import { createExternalReceiveTransaction } from '@/wallets/server/external-transactions'
 import {
   protocolCreateInvoice,
   protocolReceivableDescription,
-  protocolReceivableMsats
+  protocolReceivableMsats,
+  protocolSupportsDescriptionHash
 } from '@/wallets/server/protocols'
 
-export async function * createBolt11FromWalletProtocols (walletProtocols, { msats, description, descriptionHash, expiry = 360 }, { models, limitPending = true }) {
+export async function * createBolt11FromWalletProtocols (walletProtocols, {
+  msats,
+  description,
+  descriptionHash,
+  descriptionHashPreimage,
+  requireDescriptionHash = false,
+  expiry = 360
+}, { models, limitPending = true }) {
   msats = toPositiveNumber(msats)
   description ||= ''
 
+  if (requireDescriptionHash) {
+    const expectedDescriptionHash = typeof descriptionHashPreimage === 'string'
+      ? createHash('sha256').update(descriptionHashPreimage).digest('hex')
+      : undefined
+    if (typeof descriptionHash !== 'string' || expectedDescriptionHash !== descriptionHash.toLowerCase()) {
+      throw new Error('description hash does not match its preimage')
+    }
+  }
+
   for (const protocol of walletProtocols) {
+    if (requireDescriptionHash && !protocolSupportsDescriptionHash(protocol)) continue
+
     // snap the request onto what this provider can actually invoice
     const receivableMsats = protocolReceivableMsats(protocol, msats)
     if (receivableMsats < MIN_RECEIVE_MSATS) continue
@@ -54,7 +75,13 @@ export async function * createBolt11FromWalletProtocols (walletProtocols, { msat
         const result = await withTimeoutSignal(WALLET_CREATE_INVOICE_TIMEOUT_MS, signal =>
           protocolCreateInvoice(
             protocol,
-            { msats: receivableMsatsNum, description: receivableDescription, descriptionHash, expiry },
+            {
+              msats: receivableMsatsNum,
+              description: receivableDescription,
+              descriptionHash,
+              descriptionHashPreimage,
+              expiry
+            },
             protocol.config,
             { signal }))
         bolt11 = result.bolt11
@@ -78,6 +105,9 @@ export async function * createBolt11FromWalletProtocols (walletProtocols, { msat
       if (invoiceMsats > receivableMsats || invoiceMsats < minInvoiceMsats) {
         throw new Error(`invoice invalid: provider minted ${invoiceMsats} msats, expected ${minInvoiceMsats} to ${receivableMsats}`)
       }
+      if (requireDescriptionHash && invoice.description_hash?.toLowerCase() !== descriptionHash.toLowerCase()) {
+        throw new Error('wallet returned invoice with an incorrect description hash')
+      }
 
       logger.ok(`created invoice for ${formatSats(msatsToSats(invoice.mtokens))}`, {
         bolt11,
@@ -90,4 +120,85 @@ export async function * createBolt11FromWalletProtocols (walletProtocols, { msat
       logger.error(errorMessage(err), { updateStatus: true })
     }
   }
+}
+
+export async function createExternalReceiveInvoice (models, {
+  userId,
+  walletId,
+  msats,
+  description,
+  descriptionHash,
+  descriptionHashPreimage,
+  requireDescriptionHash,
+  expiry,
+  sourceType,
+  sourceValue,
+  comment,
+  lud18Data,
+  note
+}) {
+  if (note && typeof descriptionHashPreimage !== 'string') {
+    throw new GqlInputError('NIP-57 request is missing its description hash preimage')
+  }
+
+  const now = new Date()
+  const recentUnpaidReceives = await models.externalTransaction.count({
+    where: {
+      userId,
+      direction: 'RECEIVE',
+      createdAt: { gt: new Date(now.getTime() - 60 * 60_000) },
+      invoiceExpiresAt: { gt: now },
+      OR: [
+        { outcome: null },
+        { outcome: 'UNKNOWN' }
+      ]
+    }
+  })
+  if (recentUnpaidReceives >= WALLET_MAX_PENDING_EXTERNAL_RECEIVES) {
+    throw new GqlInputError('too many unpaid invoices created recently; try again later')
+  }
+
+  const protocols = await models.walletProtocol.findMany({
+    where: {
+      send: false,
+      enabled: true,
+      wallet: {
+        userId,
+        ...(walletId != null && { id: Number(walletId) })
+      }
+    },
+    orderBy: [
+      { wallet: { priority: 'asc' } },
+      { id: 'asc' }
+    ]
+  })
+
+  if (protocols.length === 0) {
+    throw new GqlInputError(walletId == null ? 'no wallet can receive' : 'wallet cannot receive')
+  }
+
+  const invoices = createBolt11FromWalletProtocols(
+    protocols.map(protocol => ({ ...protocol, userId })),
+    { msats, description, descriptionHash, descriptionHashPreimage, requireDescriptionHash, expiry },
+    { models, limitPending: false }
+  )
+  const { value } = await invoices.next()
+  if (!value) throw new GqlInputError('wallet could not create a receive invoice')
+
+  const transaction = await createExternalReceiveTransaction(models, {
+    userId,
+    protocol: value.protocol,
+    bolt11: value.bolt11,
+    invoice: value.invoice,
+    lnurlVerifyUrl: value.lnurlVerifyUrl,
+    providerRequestId: value.providerRequestId,
+    sourceType,
+    sourceValue,
+    comment,
+    descriptionHashPreimage,
+    lud18Data,
+    note
+  })
+
+  return { ...value, transaction }
 }

--- a/wallets/server/resolvers/wallet.js
+++ b/wallets/server/resolvers/wallet.js
@@ -236,9 +236,7 @@ async function setWalletPriorities (parent, { priorities }, { me, models }) {
 async function setWalletSettings (parent, { settings }, { me, models }) {
   if (!me) throw new GqlAuthenticationError()
 
-  await validateSchema(walletSettingsSchema, settings)
+  const validated = await validateSchema(walletSettingsSchema, settings)
 
-  await models.user.update({ where: { id: me.id }, data: settings })
-
-  return settings
+  return await models.user.update({ where: { id: me.id }, data: validated })
 }

--- a/worker/nostr.js
+++ b/worker/nostr.js
@@ -1,4 +1,5 @@
 import Nostr from '@/lib/nostr'
+import { createHash } from 'crypto'
 import { parsePaymentRequest } from 'ln-service'
 
 export async function nip57 ({ data: { hash }, boss, lnd, models }) {
@@ -6,6 +7,7 @@ export async function nip57 ({ data: { hash }, boss, lnd, models }) {
     where: {
       hash,
       confirmedAt: { not: null },
+      preimage: { not: null },
       nostrNote: { isNot: null },
       payIn: {
         payInType: 'PROXY_PAYMENT',
@@ -17,27 +19,59 @@ export async function nip57 ({ data: { hash }, boss, lnd, models }) {
     }
   })
 
-  // check if invoice still exists since JIT invoices get deleted after usage
-  if (!payInBolt11) return
+  const externalTransaction = payInBolt11
+    ? null
+    : await models.externalTransaction.findFirst({
+      where: {
+        hash,
+        direction: 'RECEIVE',
+        outcome: 'SETTLED',
+        preimage: { not: null }
+      },
+      include: { nostrNote: true }
+    })
+  const directNostrNote = externalTransaction?.nostrNote
 
-  const note = payInBolt11.nostrNote.note
+  // check if invoice still exists since JIT invoices get deleted after usage
+  if (!payInBolt11 && !directNostrNote) return
+
+  const nostrNote = payInBolt11?.nostrNote ?? directNostrNote
+  const { note, rawRequest } = nostrNote
+  const bolt11 = payInBolt11 ? payInBolt11.bolt11 : externalTransaction.bolt11
+  const preimage = payInBolt11 ? payInBolt11.preimage : externalTransaction.preimage
+  const confirmedAt = payInBolt11
+    ? payInBolt11.confirmedAt
+    : externalTransaction.settledAt ?? externalTransaction.updatedAt
 
   try {
-    const ptag = note.tags.filter(t => t?.length >= 2 && t[0] === 'p')[0]
-    const etag = note.tags.filter(t => t?.length >= 2 && t[0] === 'e')[0]
-    const atag = note.tags.filter(t => t?.length >= 2 && t[0] === 'a')[0]
+    if (!preimage) throw new Error('cannot publish NIP-57 receipt without a preimage')
+    if (typeof rawRequest !== 'string') throw new Error('cannot publish NIP-57 receipt without its raw request')
+
+    const invoice = parsePaymentRequest({ request: bolt11 })
+    const requestHash = createHash('sha256').update(rawRequest).digest('hex')
+    if (invoice.description_hash?.toLowerCase() !== requestHash) {
+      throw new Error('NIP-57 request does not match the invoice description hash')
+    }
+
+    const recipientTag = note.tags.filter(t => t?.length >= 2 && t[0] === 'p')[0]
+    const eventTag = note.tags.filter(t => t?.length >= 2 && t[0] === 'e')[0]
+    const addressTag = note.tags.filter(t => t?.length >= 2 && t[0] === 'a')[0]
+    const senderTag = typeof note.pubkey === 'string' ? ['P', note.pubkey] : null
+    const kindTag = note.tags.filter(t => t?.length >= 2 && t[0] === 'k')[0]
     const relays = note.tags.find(t => t?.length >= 2 && t[0] === 'relays').slice(1)
 
-    const tags = [ptag]
-    if (etag) tags.push(etag)
-    if (atag) tags.push(atag)
-    tags.push(['bolt11', payInBolt11.bolt11])
-    tags.push(['description', parsePaymentRequest({ request: payInBolt11.bolt11 }).description])
-    tags.push(['preimage', payInBolt11.preimage])
+    const tags = [recipientTag]
+    if (eventTag) tags.push(eventTag)
+    if (addressTag) tags.push(addressTag)
+    if (senderTag) tags.push(senderTag)
+    if (kindTag) tags.push(kindTag)
+    tags.push(['bolt11', bolt11])
+    tags.push(['description', rawRequest])
+    tags.push(['preimage', preimage])
 
     const e = {
       kind: 9735,
-      created_at: Math.floor(new Date(payInBolt11.confirmedAt).getTime() / 1000),
+      created_at: Math.floor(new Date(confirmedAt).getTime() / 1000),
       content: '',
       tags
     }
@@ -50,6 +84,6 @@ export async function nip57 ({ data: { hash }, boss, lnd, models }) {
       timeout: 1000
     })
   } catch (e) {
-    console.log(e)
+    console.error('failed to publish NIP-57 receipt:', e)
   }
 }


### PR DESCRIPTION
This reintroduces the proxy toggle for receives. It applies to lnurl/lnaddr payments to nyms and serves as the default value in external transaction receive forms where it can be enabled/disabled on a case by case basis.

This branch also allows settled external transaction receives that are not proxied to appear in notifications and adds support for nip57, lnurl comments, and lud18 to external transaction receive lnurl/lnaddr payments.

Oh and it reduces the proxy fee to 3% from 10%.

For nip57/lnurl-verify, while we check the adapter for verification support on direct receives, we don't check the wallet's permissions to confirm we'll be able to verify payment but still communicate, optimistically, that we'll be able to. I decided this was okay.

Additionally, the branch fixes:

- some cases where `hideInvoiceDesc` wasn't used
- paying to a `localhost` lightning address
- `nip57` needs the original request, `rawRequest`, which we hadn't been including since `PayIn` was introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Lightning receive routing (proxy vs direct) and LNURL pay/verify behavior; mistakes could affect invoice amounts, description hashes, or payer privacy expectations, though validation and protocol capability checks are expanded alongside the new paths.
> 
> **Overview**
> Reintroduces a **proxy receive** user setting (wallet settings + per-invoice checkbox) that chooses whether lightning-address/LNURL payments and wallet receive flows wrap invoices through the SN node (~**3%** fee, down from 10%) or mint **direct** invoices on the attached wallet.
> 
> When proxying is off, `createWalletInvoice` and the LNURL pay callback use **`createExternalReceiveInvoice`** instead of `PROXY_PAYMENT`, with amount limits driven by **`lnurlPayLimits`**. Direct receives now support **NIP-57**, **LUD-18**, and **LNURL comments**, persisted on **`ExternalTransaction`** (new related tables) and wired through wallet adapters that declare **`supportsDescriptionHash`**.
> 
> **Notifications** and deposit push alerts cover settled direct external receives via **`ExternalReceiveNotification`**. LNURL **verify** resolves both proxied `PayInBolt11` and external receive hashes. **`nip57`** publishing and **`rawRequest`** storage fix receipt validation for zaps on both paths.
> 
> Smaller fixes: **`hideInvoiceDesc`** on wrap invoices, optional **`walletId`** for proxy payouts, dev **`lnurlFetchUrl`** for `localhost` addresses, and invoice wrap description overrides from pay-in args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96995b88edc4f93fab6a984602c1fdd0b8682699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->