### PR TITLE
feat(editor): remember last mode and toolbar visibility

### DIFF
--- a/components/editor/contexts/mode.js
+++ b/components/editor/contexts/mode.js
@@ -1,18 +1,30 @@
-import { createContext, useState, useMemo, useContext, useCallback } from 'react'
+import { createContext, useState, useMemo, useContext, useCallback, useEffect } from 'react'
 
 export const MARKDOWN_MODE = 'markdown'
 export const RICH_MODE = 'rich'
+
+// remember the last used mode across editors and sessions (#2858)
+const MODE_STORAGE_KEY = 'editorMode'
 
 const EditorModeContext = createContext()
 
 export function EditorModeProvider ({ children }) {
   const [mode, setMode] = useState(MARKDOWN_MODE)
 
+  // restored after mount so SSR markup (markdown mode) stays consistent during hydration
+  useEffect(() => {
+    const stored = window.localStorage.getItem(MODE_STORAGE_KEY)
+    if (stored === MARKDOWN_MODE || stored === RICH_MODE) {
+      setMode(stored)
+    }
+  }, [])
+
   const changeMode = useCallback((newMode) => {
     if (newMode !== MARKDOWN_MODE && newMode !== RICH_MODE) {
       throw new Error(`Invalid mode: ${newMode}`)
     }
     setMode(newMode)
+    window.localStorage.setItem(MODE_STORAGE_KEY, newMode)
   }, [])
 
   const toggleMode = useCallback(() => {

--- a/components/editor/contexts/toolbar.js
+++ b/components/editor/contexts/toolbar.js
@@ -1,4 +1,7 @@
-import { createContext, useContext, useMemo, useState, useCallback } from 'react'
+import { createContext, useContext, useMemo, useState, useCallback, useEffect } from 'react'
+
+// remember the toolbar visibility preference across editors and sessions (#2858)
+const TOOLBAR_STORAGE_KEY = 'editorToolbar'
 
 export const INITIAL_FORMAT_STATE = {
   blockType: 'paragraph',
@@ -28,11 +31,23 @@ const ToolbarContext = createContext()
 export function ToolbarContextProvider ({ topLevel, children }) {
   const [toolbarState, setToolbarState] = useState({ ...INITIAL_STATE, showToolbar: !!topLevel })
 
+  // restore the toolbar visibility preference after mount so SSR markup
+  // (default visibility) stays consistent during hydration
+  useEffect(() => {
+    const stored = window.localStorage.getItem(TOOLBAR_STORAGE_KEY)
+    if (stored === 'shown' || stored === 'hidden') {
+      setToolbarState((prev) => ({ ...prev, showToolbar: stored === 'shown' }))
+    }
+  }, [])
+
   const batchUpdateToolbarState = useCallback((updates) => {
     setToolbarState((prev) => ({ ...prev, ...updates }))
   }, [])
 
   const updateToolbarState = useCallback((key, value) => {
+    if (key === 'showToolbar') {
+      window.localStorage.setItem(TOOLBAR_STORAGE_KEY, value ? 'shown' : 'hidden')
+    }
     setToolbarState((prev) => ({
       ...prev,
       [key]: value


### PR DESCRIPTION
Closes #2858

## Description

Remember the editor's last settings in `localStorage`:

- **editor mode** (`editorMode`): `markdown` | `rich` — restored by `EditorModeProvider` after mount so SSR markup stays consistent during hydration. Both `changeMode` and `toggleMode` persist.
- **toolbar visibility** (`editorToolbar`): `shown` | `hidden` — restored by `ToolbarContextProvider` after mount; an explicit user choice now overrides the `topLevel` default in all editors.

Editors therefore open the way you left them instead of always starting in markdown mode with the formatting toolbar expanded. Each comment editor still has its own provider instance, but they all share the same persisted preference.

## Screenshots

n/a (behavioral change, no visual redesign)

## Additional Context

Mode is restored right after mount which remounts the Lexical composer with the stored mode; initial state is rebuilt from the formik field value as usual, so draft content is unaffected.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. New localStorage keys only; no API/schema changes. Defaults are unchanged for first-time users (markdown mode, toolbar shown on top-level editors).

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7. Verified lint passes and traced the mode-switch/remount path (`LexicalExtensionComposer key={modeConfig.name}`) to confirm content re-initializes from the formik field when mode restores at mount. Did not manually test in a browser environment here.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

No visual/CSS changes, so light/dark/mobile rendering is unaffected.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes — fully AI-assisted (issue triage, implementation, and QA reasoning were done with an AI agent).