### PR TITLE
fix: prevent iOS viewport jump when deleting text in the editor

### DIFF
--- a/components/editor/editor.js
+++ b/components/editor/editor.js
@@ -24,6 +24,7 @@ import { EditorRefPlugin } from '@lexical/react/LexicalEditorRefPlugin'
 import { ApplePatchExtension } from '@/lib/lexical/exts/apple'
 import { SoftkeyUnborkerPlugin } from '@/components/editor/plugins/patch/softkey-unborker'
 import { SoftkeyEmptyGuardPlugin } from '@/components/editor/plugins/patch/softkey-emptyguard'
+import { IOSDeleteScrollGuardPlugin } from '@/components/editor/plugins/patch/ios-delete-scroll-guard'
 import { MarkdownTextExtension } from '@/lib/lexical/exts/markdown'
 import AppendValuePlugin from '@/components/editor/plugins/core/append-value'
 import TransformerBridgePlugin from '@/components/editor/plugins/core/transformer-bridge'
@@ -180,6 +181,7 @@ function EditorContent ({
       <MaxLengthPlugin lengthOptions={lengthOptions} />
       <SoftkeyUnborkerPlugin />
       <SoftkeyEmptyGuardPlugin />
+      <IOSDeleteScrollGuardPlugin />
       {!isMarkdown && (
         <>
           <CodeThemePlugin />

--- a/components/editor/plugins/patch/ios-delete-scroll-guard.js
+++ b/components/editor/plugins/patch/ios-delete-scroll-guard.js
@@ -1,0 +1,59 @@
+import { useEffect } from 'react'
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { CAN_USE_BEFORE_INPUT, IS_IOS } from '@lexical/utils'
+
+/**
+ * Workaround for iOS Safari (and the PWA): after a native deleteContentBackward,
+ * WebKit may restore focus to the editor root while syncing the DOM selection.
+ * Programmatic focus() scrolls the focused element into view and WebKit ignores
+ * preventScroll, so when the editor is taller than the viewport the browser jumps
+ * to the top of the editor instead of keeping the caret in view.
+ *
+ * We snapshot the scroll offset while a native delete event is dispatched and
+ * restore it right after the browser settles, unless the user scrolled themselves
+ * within that window.
+ */
+
+// how long after a delete event the scroll correction stays armed
+const guardWindowMs = 150
+
+// jumps smaller than this are treated as regular caret-keeping adjustments
+const minJumpPx = 40
+
+// a single guard serves every editor on the page
+let installed = false
+let anchorY = null
+let armedUntil = 0
+
+function onBeforeInput (e) {
+  if (!e.inputType || !e.inputType.startsWith('delete')) return
+  anchorY = window.scrollY
+  armedUntil = Date.now() + guardWindowMs
+}
+
+function onScroll () {
+  if (anchorY === null) return
+  if (Date.now() > armedUntil || Math.abs(window.scrollY - anchorY) < minJumpPx) return
+  const y = anchorY
+  anchorY = null
+  window.scrollTo({ top: y, behavior: 'instant' })
+}
+
+function install () {
+  if (installed) return
+  installed = true
+  // capture phase: arm before the native deletion mutates the DOM
+  document.addEventListener('beforeinput', onBeforeInput, true)
+  window.addEventListener('scroll', onScroll, { passive: true })
+}
+
+export function IOSDeleteScrollGuardPlugin () {
+  const [editor] = useLexicalComposerContext()
+
+  useEffect(() => {
+    if (!IS_IOS || !CAN_USE_BEFORE_INPUT) return // only apply on Apple webkit with native beforeinput
+    install()
+  }, [editor])
+
+  return null
+}


### PR DESCRIPTION
## Summary

Pressing backspace in an editor that is taller than the viewport on iOS (Safari / PWA) causes WebKit to refocus the editor root and scroll it into view at the wrong position — usually jumping to the top of the editor instead of keeping the caret in view ([reported by `BlokchainB`](https://stacker.news/items/1524058)).

On Apple platforms our `apple-patch` extension intentionally lets native `deleteContentBackward` run so autocorrect, autocompletion, and hold-to-delete keep working (see facebook/lexical#7994). While syncing the DOM selection after such a native deletion, Lexical can restore focus to the root element (`rootElement.focus({ preventScroll: true })` in Lexical's `$updateDOMSelection`) — but WebKit ignores `preventScroll`, and focus-scrolling targets the element's start edge rather than the caret. Plain typing doesn't hit this path because `insertText` doesn't trigger the same focus restoration.

## Changes

- add an iOS-only patch plugin (`IOSDeleteScrollGuardPlugin`) following the existing Android patch-plugin pattern:
  - snapshots `window.scrollY` (capture phase) while a native delete is dispatched
  - if the browser scrolls more than 40px within a short window afterwards, restores the snapshot once
  - one shared guard instance serves all editors on the page and is inert outside Apple WebKit

## Testing

- `standard` lint passes on the touched files
- desktop browsers are unaffected: the plugin returns early unless `IS_IOS && CAN_USE_BEFORE_INPUT`
- verification steps for iOS Safari / PWA:
  1. open a reply editor and write until it overflows the viewport
  2. press backspace
  3. before: viewport jumps toward the top of the editor; after: viewport stays anchored at the caret

Fixes #3130
