### PR TITLE
fix: validate embed provider hosts against lookalike domains

### DIFF
--- a/lib/url.js
+++ b/lib/url.js
@@ -137,6 +137,12 @@ export function parseYoutubeStart (t) {
   return r.toString()
 }
 
+// exact match or proper dot-separated subdomain match,
+// so 'notrumble.com' does not match 'rumble.com'
+function hostIs (hostname, domain) {
+  return hostname === domain || hostname.endsWith(`.${domain}`)
+}
+
 export function parseEmbedUrl (href) {
   if (!href) return null
 
@@ -171,20 +177,20 @@ export function parseEmbedUrl (href) {
     }
 
     // https://wavlake.com/track/c0aaeff8-5a26-49cf-8dad-2b6909e4aed1
-    if (hostname.endsWith('wavlake.com') && pathname.startsWith('/track')) {
+    if (hostIs(hostname, 'wavlake.com') && pathname.startsWith('/track')) {
       return {
         provider: 'wavlake',
         id: pathname.split('/')?.[2]
       }
     }
 
-    if (hostname.endsWith('spotify.com') && (pathname.startsWith('/track') || pathname.startsWith('/episode'))) {
+    if (hostIs(hostname, 'spotify.com') && (pathname.startsWith('/track') || pathname.startsWith('/episode'))) {
       return {
         provider: 'spotify'
       }
     }
 
-    if (hostname.endsWith('youtube.com')) {
+    if (hostIs(hostname, 'youtube.com')) {
       if (pathname.includes('/watch')) {
         return {
           provider: 'youtube',
@@ -205,7 +211,7 @@ export function parseEmbedUrl (href) {
       }
     }
 
-    if (hostname.endsWith('youtu.be') && pathname.length > 1) {
+    if (hostIs(hostname, 'youtu.be') && pathname.length > 1) {
       return {
         provider: 'youtube',
         id: pathname.slice(1), // remove leading slash
@@ -216,7 +222,7 @@ export function parseEmbedUrl (href) {
       }
     }
 
-    if (hostname.endsWith('rumble.com') && pathname.includes('/embed')) {
+    if (hostIs(hostname, 'rumble.com') && pathname.includes('/embed')) {
       return {
         provider: 'rumble',
         id: null, // not required
@@ -226,7 +232,7 @@ export function parseEmbedUrl (href) {
       }
     }
 
-    if (hostname.endsWith('peertube.tv') || hostname.endsWith('bitcointv.com')) {
+    if (hostIs(hostname, 'peertube.tv') || hostIs(hostname, 'bitcointv.com')) {
       return {
         provider: 'peertube',
         id: null,

--- a/lib/url.spec.js
+++ b/lib/url.spec.js
@@ -86,3 +86,53 @@ describe('embed nostr links', () => {
     }
   )
 })
+
+// lookalike hosts must not be treated as the real embed providers,
+// otherwise we would render attacker-controlled iframes on our pages
+const lookalikeEmbedUrlCases = [
+  // suffix of 'rumble.com'
+  ['https://notrumble.com/embed/v1xjnyv'],
+  // suffix of 'youtube.com'
+  ['https://fakeyoutube.com/watch?v=xyz'],
+  // suffix of 'youtu.be'
+  ['https://evilyoutu.be/xyz'],
+  // suffix of 'peertube.tv'
+  ['https://xpeertube.tv/w/xyz'],
+  // suffix of 'bitcointv.com'
+  ['https://notbitcointv.com/w/xyz'],
+  // suffix of 'wavlake.com'
+  ['https://evilwavlake.com/track/c0aaeff8-5a26-49cf-8dad-2b6909e4aed1'],
+  // suffix of 'spotify.com'
+  ['https://notspotify.com/track/1KFxcj3MZrpBGiGA8ZWriv']
+]
+
+describe('embed lookalike hosts are not embedded', () => {
+  test.each(lookalikeEmbedUrlCases)(
+    'does not embed %p',
+    (url) => {
+      expect(parseEmbedUrl(url)).toBeNull()
+    }
+  )
+})
+
+const legitEmbedUrlCases = [
+  ['https://rumble.com/embed/v1xjnyv.defi', { provider: 'rumble' }],
+  // proper subdomains of the real providers still work
+  ['https://www.rumble.com/embed/v1xjnyv.defi', { provider: 'rumble' }],
+  ['https://www.youtube.com/watch?v=dQw4w9WgXcQ', { provider: 'youtube' }],
+  ['https://music.youtube.com/watch?v=dQw4w9WgXcQ', { provider: 'youtube' }],
+  ['https://youtu.be/dQw4w9WgXcQ', { provider: 'youtube' }],
+  ['https://peertube.tv/w/b8Zf9HmnYcmM', { provider: 'peertube' }],
+  ['https://bitcointv.com/w/b8Zf9HmnYcmM', { provider: 'peertube' }],
+  ['https://wavlake.com/track/c0aaeff8-5a26-49cf-8dad-2b6909e4aed1', { provider: 'wavlake' }],
+  ['https://open.spotify.com/track/1KFxcj3MZrpBGiGA8ZWriv', { provider: 'spotify' }]
+]
+
+describe('embed legit hosts are still embedded', () => {
+  test.each(legitEmbedUrlCases)(
+    'embeds %p as %p',
+    (url, expected) => {
+      expect(parseEmbedUrl(url)).toMatchObject(expected)
+    }
+  )
+})


### PR DESCRIPTION
## Problem

`parseEmbedUrl` in `lib/url.js` matched embed provider hosts with `String.prototype.endsWith`, which also matches any host merely *ending* in the provider domain:

```js
'notrumble.com'.endsWith('rumble.com')   // true
'fakeyoutube.com'.endsWith('youtube.com') // true
'xpeertube.tv'.endsWith('peertube.tv')    // true
```

Anyone can register such a lookalike domain and post its URL, and the post would render an embedded player pointing at attacker-controlled content:

- `https://notrumble.com/embed/x` -> `<iframe src="https://notrumble.com/embed/x">` (the rumble branch renders `meta.href` directly)
- same for the peertube branch (`meta.href`) and the id-based branches (wavlake/spotify/youtube)

This is content/iframe injection into item pages, which is especially unfortunate on a site where users are used to trusting embedded players.

## Fix

Add a `hostIs(hostname, domain)` helper that only accepts exact matches or proper dot-separated subdomains (`host === domain || host.endsWith('.' + domain)`), and use it for all provider checks (`wavlake.com`, `spotify.com`, `youtube.com`, `youtu.be`, `rumble.com`, `peertube.tv`, `bitcointv.com`).

## Before / after

```
OLD: VULN iframe="https://notrumble.com/embed/v1xjnyv" <- https://notrumble.com/embed/v1xjnyv
OLD: VULN iframe="https://fakeyoutube.com/watch?v=xyz" <- https://fakeyoutube.com/watch?v=xyz
OLD: VULN iframe="https://evilyoutu.be/x"              <- https://evilyoutu.be/x
OLD: VULN iframe="https://xpeertube.tv/videos/embed/y" <- https://xpeertube.tv/w/y

NEW: safe <- https://notrumble.com/embed/v1xjnyv
NEW: safe <- https://fakeyoutube.com/watch?v=xyz
NEW: safe <- https://evilyoutu.be/x
NEW: safe <- https://xpeertube.tv/w/y
```

Legit URLs (including real subdomains like `www.rumble.com`, `music.youtube.com`) still embed as before.

## Tests

Extended `lib/url.spec.js`:
- 7 lookalike-host cases must not be embedded
- 9 legit-host cases (incl. proper subdomains) must still be embedded

`npx jest lib/url.spec.js --runInBand`: **45 passed**
whole `lib/` suite: **238 passed** (9 suites)
`npx standard lib/url.js lib/url.spec.js`: clean