### PR TITLE
lnurlp: report receiver-wallet unavailability distinctly (#3058)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,4 +4,8 @@ const nextJest = require('next/jest')
 const createJestConfig = nextJest({ dir: './' })
 
 // createJestConfig is exported in this way to ensure that next/jest can load the Next.js configuration, which is async
-module.exports = createJestConfig({ testPathIgnorePatterns: ['/payIn/'] })
+module.exports = createJestConfig({
+  testPathIgnorePatterns: ['/payIn/'],
+  // mirror the jsconfig '@/' path alias so unit tests can run without the Next.js compiler
+  moduleNameMapper: { '^@/(.*)$': '<rootDir>/$1' }
+})

--- a/pages/api/lnurlp/[username]/__tests__/pay.test.js
+++ b/pages/api/lnurlp/[username]/__tests__/pay.test.js
@@ -1,0 +1,82 @@
+/* eslint-env jest */
+
+import handler from '../pay.js'
+import models from '@/api/models'
+import pay from '@/api/payIn'
+
+jest.mock('@/api/models', () => ({
+  __esModule: true,
+  default: { user: { findUnique: jest.fn() } }
+}))
+jest.mock('@/api/payIn', () => ({ __esModule: true, default: jest.fn() }))
+jest.mock('@/api/resolvers/ofac', () => ({ __esModule: true, default: jest.fn(() => Promise.resolve()) }))
+jest.mock('@/wallets/server', () => ({
+  walletLogger: () => ({
+    info: jest.fn(() => Promise.resolve()),
+    error: jest.fn(() => Promise.resolve())
+  })
+}))
+// keep these transitive deps isolated so the suite runs without DB/LND credentials
+jest.mock('@/lib/proxy')
+jest.mock('@/api/lnd')
+
+const callHandler = async (query) => {
+  const res = { status: jest.fn(() => res), json: jest.fn(() => res) }
+  await handler({ query, headers: {} }, res)
+  return res
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('lnurlp pay endpoint', () => {
+  test('returns error if the user does not exist', async () => {
+    models.user.findUnique.mockResolvedValue(null)
+    const res = await callHandler({ username: 'swapmarket', amount: '21000' })
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({
+      status: 'ERROR',
+      reason: 'user @swapmarket does not exist'
+    })
+    expect(pay).not.toHaveBeenCalled()
+  })
+
+  test('passes the requested name through as-is (db citext handles case)', async () => {
+    // users.name is a citext column, so looking up 'SwapMarket' finds @swapmarket
+    models.user.findUnique.mockResolvedValue(null)
+    await callHandler({ username: 'SwapMarket', amount: '21000' })
+    expect(models.user.findUnique).toHaveBeenCalledWith({ where: { name: 'SwapMarket' } })
+  })
+
+  test('rejects amounts below the proxied payment minimum', async () => {
+    models.user.findUnique.mockResolvedValue({ id: 1, name: 'swapmarket' })
+    const res = await callHandler({ username: 'swapmarket', amount: '1000' })
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'ERROR', reason: expect.stringMatching(/^amount must be >=/) })
+    )
+    expect(pay).not.toHaveBeenCalled()
+  })
+
+  test('reports missing receive wallet distinctly so senders are not mislead', async () => {
+    models.user.findUnique.mockResolvedValue({ id: 1, name: 'swapmarket' })
+    pay.mockRejectedValue(Object.assign(new Error('no wallet to receive available'), { name: 'NoReceiveWalletError' }))
+    const res = await callHandler({ username: 'swapmarket', amount: '21000' })
+    expect(pay).toHaveBeenCalledWith('PROXY_PAYMENT', expect.anything(), expect.anything())
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({
+      status: 'ERROR',
+      reason: 'user @swapmarket cannot receive lightning payments right now'
+    })
+  })
+
+  test('keeps the generic reason for other invoice errors', async () => {
+    models.user.findUnique.mockResolvedValue({ id: 1, name: 'swapmarket' })
+    pay.mockRejectedValue(new Error('lnd unavailable'))
+    const res = await callHandler({ username: 'swapmarket', amount: '21000' })
+    expect(res.json).toHaveBeenCalledWith({
+      status: 'ERROR',
+      reason: 'could not generate invoice to customer\'s attached wallet'
+    })
+  })
+})

--- a/pages/api/lnurlp/[username]/pay.js
+++ b/pages/api/lnurlp/[username]/pay.js
@@ -107,6 +107,15 @@ export default async ({ query: { username, amount, nostr, comment, payerdata: pa
     console.log(error)
     logger.error(`${user.name}@stacker.news payment failed: ${error.message}`)
       .catch(err => console.error('failed to write lnurl payment failure log:', err))
+    // the likeliest failure is the receiver having no (working) attached wallet.
+    // report that specifically so senders know the payment can't proceed - the generic
+    // reason is opaque and senders misattribute the failure, e.g. to username case (#3058)
+    if (error?.name === 'NoReceiveWalletError') {
+      return res.status(400).json({
+        status: 'ERROR',
+        reason: `user @${username} cannot receive lightning payments right now`
+      })
+    }
     res.status(400).json({ status: 'ERROR', reason: 'could not generate invoice to customer\'s attached wallet' })
   }
 }


### PR DESCRIPTION
Fixes #3058

## Root cause

The reported failure is not a username-case problem:

- `users.name` is a `citext` column (`prisma/migrations/20210902220036_case_insensitive_names`), so the `findUnique({ where: { name } })` lookups in both lnurlp endpoints already match case-insensitively. There cannot be both a `swapmarket` and a `SwapMarket` user.
- The reporter's log shows the wallet successfully reached `GET /api/lnurlp/swapmarket/pay` — meaning the payRequest lookup (step 1) already succeeded with a lowercased name, and the failure happened at invoice generation (step 2).

Step 2 calls `pay('PROXY_PAYMENT', ...)`, which builds the receiver invoice via `payOutBolt11Prospect` → the recipient's attached wallet protocols. When the recipient has no (working) enabled receive wallet, every protocol is skipped and a `NoReceiveWalletError` is thrown — but the API responded with the generic `could not generate invoice to customer's attached wallet`, which sent the reporter chasing nonexistent causes like capitalization.

## Change

In `pages/api/lnurlp/[username]/pay.js`, when invoice generation fails with `NoReceiveWalletError`, respond with:

```json
{ "status": "ERROR", "reason": "user @swapmarket cannot receive lightning payments right now" }
```

All other errors keep the existing generic response. The receiver can fix the situation by attaching/enabling a receive wallet; the sender now gets a truthful, actionable reason.

## Tests

Added `pages/api/lnurlp/[username]/__tests__/pay.test.js` covering:

1. nonexistent user → existing 400 (unchanged)
2. mixed-case lookup is passed through (db `citext` handles case)
3. amount below minimum rejected before invoice generation (unchanged)
4. `NoReceiveWalletError` → the new distinct reason (**new behavior**)
5. other errors → existing generic reason unchanged (regression guard)

Note: `jest.config.js` gains an explicit `moduleNameMapper` for the `@/` jsconfig alias, since requiring handlers directly in Jest doesn't go through the Next.js webpack alias.

`npx jest 'pages/api/lnurlp'` → 5 passed. `npx standard` → clean.

(Disclosure: implemented with AI assistance, reviewed and tested locally.)

---
<sub>Stacker News nym: **@dacdoyx**</sub>