### PR TITLE
items: add deleteItemsOlderThan mutation (#3200)

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -19,7 +19,7 @@ import {
 import { msatsToSats } from '@/lib/format'
 import uu from 'url-unshort'
 import { actSchema, bountySchema, commentSchema, discussionSchema, jobSchema, linkSchema, pollSchema, validateSchema } from '@/lib/validate'
-import { defaultCommentSort, isJob, deleteItemByAuthor } from '@/lib/item'
+import { defaultCommentSort, isJob, deleteItemByAuthor, bulkDeleteItemsOlderThan } from '@/lib/item'
 import { datePivot, whenRange } from '@/lib/time'
 import { uploadIdsFromText } from './upload'
 import assertGofacYourself from './ofac'
@@ -820,6 +820,15 @@ export default {
       }
 
       return await deleteItemByAuthor({ models, id, item: old })
+    },
+    deleteItemsOlderThan: async (parent, { olderThanDays, kind }, { me, models }) => {
+      if (!me) {
+        throw new GqlInputError('you must be logged in')
+      }
+      if (!Number.isInteger(olderThanDays) || olderThanDays < 1) {
+        throw new GqlInputError('olderThanDays must be a positive integer')
+      }
+      return await bulkDeleteItemsOlderThan(models, { userId: me.id, olderThanDays, kind })
     },
     upsertLink: async (parent, { id, ...item }, { me, models, lnd }) => {
       await validateSchema(linkSchema, item, { models, me })

--- a/api/typeDefs/item.js
+++ b/api/typeDefs/item.js
@@ -18,11 +18,17 @@ export default gql`
     unshorted: String
   }
 
+  enum ItemsOlderThanKind {
+    POSTS
+    COMMENTS
+  }
+
   extend type Mutation {
     bookmarkItem(id: ID): Item
     pinItem(id: ID): Item
     subscribeItem(id: ID): Item
     deleteItem(id: ID): Item
+    deleteItemsOlderThan(olderThanDays: Int!, kind: ItemsOlderThanKind): Int!
     upsertLink(
       id: ID, subNames: [String!], title: String!, url: String!, text: String, forward: [ItemForwardInput],
       hash: String, hmac: String, sendProtocolId: Int): PayIn!

--- a/lib/__tests__/bulkDeleteItemsOlderThan.test.js
+++ b/lib/__tests__/bulkDeleteItemsOlderThan.test.js
@@ -1,0 +1,82 @@
+/* eslint-env jest */
+
+import { bulkDeleteItemsOlderThan, DELETE_OLDER_THAN_BATCH_LIMIT } from '@/lib/item'
+
+const mockModels = () => {
+  const models = {
+    item: { findMany: jest.fn().mockResolvedValue([]), update: jest.fn().mockResolvedValue({}) },
+    reminder: { deleteMany: jest.fn().mockResolvedValue({}) },
+    $queryRaw: jest.fn().mockResolvedValue(undefined)
+  }
+  return models
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('bulkDeleteItemsOlderThan', () => {
+  test('targets only the user\'s own, not-yet-deleted, non-bio items older than the cutoff', async () => {
+    const models = mockModels()
+    await bulkDeleteItemsOlderThan(models, { userId: '42', olderThanDays: 30 })
+    const { where } = models.item.findMany.mock.calls[0][0]
+    expect(where.userId).toBe(42)
+    expect(where.deletedAt).toBeNull()
+    expect(where.bio).toBe(false)
+    const ageMs = Date.now() - where.createdAt.lt.getTime()
+    // 30 days +/- a few seconds of test execution
+    expect(ageMs).toBeGreaterThan(29 * 24 * 60 * 60 * 1000)
+    expect(ageMs).toBeLessThan(31 * 24 * 60 * 60 * 1000)
+  })
+
+  test('never processes more than DELETE_OLDER_THAN_BATCH_LIMIT items per call', async () => {
+    const models = mockModels()
+    await bulkDeleteItemsOlderThan(models, { userId: 1, olderThanDays: 7 })
+    expect(models.item.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: DELETE_OLDER_THAN_BATCH_LIMIT })
+    )
+    expect(DELETE_OLDER_THAN_BATCH_LIMIT).toBe(500)
+  })
+
+  test('kind=POSTS matches parentId null, kind=COMMENTS matches parentId not null', async () => {
+    const models = mockModels()
+    await bulkDeleteItemsOlderThan(models, { userId: 1, olderThanDays: 7, kind: 'POSTS' })
+    expect(models.item.findMany.mock.calls[0][0].where.parentId).toBeNull()
+    await bulkDeleteItemsOlderThan(models, { userId: 1, olderThanDays: 7, kind: 'COMMENTS' })
+    expect(models.item.findMany.mock.calls[1][0].where.parentId).toEqual({ not: null })
+  })
+
+  test('scrubs text, title, url and poll cost like a single delete does', async () => {
+    const models = mockModels()
+    models.item.findMany.mockResolvedValue([
+      { id: 1, text: 'foo', title: null, url: null, pollCost: null, userId: 7 },
+      { id: 2, text: null, title: 't', url: 'https://x.co', pollCost: 100, userId: 7 }
+    ])
+    const count = await bulkDeleteItemsOlderThan(models, { userId: 7, olderThanDays: 1 })
+    expect(count).toBe(2)
+    expect(models.item.update).toHaveBeenCalledTimes(2)
+
+    const firstUpdate = models.item.update.mock.calls[0][0]
+    expect(firstUpdate.where).toEqual({ id: 1 })
+    expect(firstUpdate.data.deletedAt).toBeInstanceOf(Date)
+    expect(firstUpdate.data.text).toBe('*deleted by author*')
+    // fields that were empty stay untouched
+    expect(firstUpdate.data).not.toHaveProperty('title')
+    expect(firstUpdate.data).not.toHaveProperty('url')
+
+    const secondUpdate = models.item.update.mock.calls[1][0]
+    expect(secondUpdate.data.title).toBe('deleted by author')
+    expect(secondUpdate.data.url).toBeNull()
+    expect(secondUpdate.data.pollCost).toBeNull()
+  })
+
+  test('clears pending reminders for every deleted item', async () => {
+    const models = mockModels()
+    models.item.findMany.mockResolvedValue([{ id: 9, text: 'x', title: null, url: null, pollCost: null, userId: 7 }])
+    await bulkDeleteItemsOlderThan(models, { userId: 7, olderThanDays: 1 })
+    expect(models.$queryRaw).toHaveBeenCalled()
+    expect(models.reminder.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ itemId: 9, userId: 7 }) })
+    )
+  })
+})

--- a/lib/item.js
+++ b/lib/item.js
@@ -113,3 +113,32 @@ export const commentSubTreeRootId = (item, root) => {
   }
   return path.slice(-(COMMENT_DEPTH_LIMIT - 1))[0]
 }
+
+// safety rail for bulk deletion: one batch per call so a misclick (or a bug)
+// can never wipe more than DELETE_OLDER_THAN_BATCH_LIMIT items at once
+export const DELETE_OLDER_THAN_BATCH_LIMIT = 500
+
+// soft-deletes the user's own posts/comments older than `olderThanDays` days,
+// reusing deleteItemByAuthor so scrubbing semantics stay identical to single deletes
+export const bulkDeleteItemsOlderThan = async (models, { userId, olderThanDays, kind }) => {
+  const cutoff = new Date(Date.now() - olderThanDays * 24 * 60 * 60 * 1000)
+  const where = {
+    userId: Number(userId),
+    deletedAt: null,
+    bio: false,
+    createdAt: { lt: cutoff }
+  }
+  if (kind === 'POSTS') where.parentId = null
+  if (kind === 'COMMENTS') where.parentId = { not: null }
+
+  const items = await models.item.findMany({
+    where,
+    orderBy: { id: 'asc' },
+    take: DELETE_OLDER_THAN_BATCH_LIMIT,
+    select: { id: true, text: true, title: true, url: true, pollCost: true, userId: true }
+  })
+  for (const item of items) {
+    await deleteItemByAuthor({ models, id: item.id, item })
+  }
+  return items.length
+}


### PR DESCRIPTION
Implements #3200

## What
Adds `deleteItemsOlderThan(olderThanDays: Int!, kind: ItemsOlderThanKind): Int!`
so users can bulk-delete their own posts and/or comments older than a given age
instead of clicking delete on every item.

- `kind: POSTS | COMMENTS` (omit for both), matching the issue's request
- returns the number of deleted items

## Safety choices (please check these match your intent)

1. **Identical scrub semantics to single delete** — reuses `deleteItemByAuthor`, so bulk deletion is exactly N single deletes: sets `deletedAt`, replaces text/title with the standard `*deleted by author*` markers, clears url/pollCost, cleans up pending reminders. No new deletion behavior was invented.
2. **Hard cap of 500 items per call** (`DELETE_OLDER_THAN_BATCH_LIMIT`) — a misclick or UI bug can never wipe an entire account history in one shot; running the action again deletes the next batch. Happy to adjust the cap.
3. **Same eligibility rules as today**: bio items are excluded, only the caller's own items, items already deleted are skipped.
4. API-first PR: no settings UI yet. I can add a settings page section (age input + posts/comments toggle + confirmation dialog with the count) as a follow-up once the mutation looks right.

## Tests
`lib/__tests__/bulkDeleteItemsOlderThan.test.js` (5 tests):
where-clause scoping (own items, non-bio, not-yet-deleted, age cutoff), batch-limit enforcement, kind filtering, scrub parity with single delete, reminder cleanup. `npx jest` → 10/10 pass (incl. the lnurlp suite from #3205). `npx standard` clean. GraphQL SDL validated.

(Disclosure: implemented with AI assistance, all code reviewed and tested locally.)

---
<sub>Stacker News nym: **@dacdoyx**</sub>