### PR TITLE
respect mutes in newComments resolver (live comments)

### DIFF
--- a/api/resolvers/item.js
+++ b/api/resolvers/item.js
@@ -694,6 +694,7 @@ export default {
             )`,
             paidItemSql(me),
             activeOrMineSql(me),
+            muteSql(me),
             Prisma.sql`"Item"."created_at" > ${after}::TIMESTAMP`
           )}
           ORDER BY "Item"."created_at" ASC`


### PR DESCRIPTION
Fixes #2842

## Description

Live comment polling was delivering replies from muted users. The `newComments` resolver (api/resolvers/item.js) never applied `muteSql(me)`, while every other feed-style query in the codebase (search, related, user feeds, notifications) filters muted authors server-side with it, and webPush also excludes muted authors server-side. This adds the same clause to the existing `whereSql` args — one line.

Note on #2846 (open PR against the same issue): that one handles the client side (don't outline/track already-cached muted comments). This prevents muted replies from being delivered by the poll at all, so there is nothing to outline or track in the first place. If both land they don't conflict; happy to defer to whatever approach maintainers prefer.

## Verification

Ran the full dev environment (`./sndev start`) and exercised the resolver as an authenticated viewer against a fresh root item with two commenters:

1. mute viewer -> author A, insert replies from authors A and B
2. `newComments(itemId, after)` returns B's reply only; A's reply absent
3. delete the mute -> same query now returns both replies
4. logged-out request unaffected (no clause applied, no errors)

`standard` passes on the touched file.