### PR TITLE
index poll options so related posts can match on them

### DIFF
--- a/worker/search.js
+++ b/worker/search.js
@@ -26,6 +26,11 @@ const ITEM_SEARCH_FIELDS = gql`
         name
       }
     }
+    poll {
+      options {
+        option
+      }
+    }
     status
     company
     location
@@ -54,6 +59,14 @@ async function _indexItem (item, { models, updatedAt }) {
   }
   if (item.text) {
     itemcp.text = removeMd(item.text)
+  }
+
+  // make poll options searchable/highlightable alongside the title and body
+  if (item.poll?.options?.length) {
+    const options = item.poll.options.map(({ option }) => option).filter(Boolean).join('\n')
+    if (options) {
+      itemcp.text = itemcp.text ? `${itemcp.text}\n\n${options}` : options
+    }
   }
 
   // Keep territory metadata in a flat array because ingest processing can


### PR DESCRIPTION
Fixes #1149

Related posts are driven by the indexed document: more_like_this (and the semantic/sparse legs) all read title_text, which the ingest pipeline builds from title + text. Poll items only contributed title/body, so poll choices were invisible to related-posts matching.

This fetches poll options in ITEM_SEARCH_FIELDS and folds each option into the indexed text (after markdown stripping, before the pipeline computes title_text/embeddings/content hash - no pipeline changes needed).

## Verification
- standard passes
- opensearch bootstrap couldn't run in this sandbox (memory); verified by code-path review: init-opensearch.sh concatenates ctx.title + ctx.text into title_text read by more_like_this; poll resolver works unauthenticated; non-poll items unchanged