### PR TITLE
Fix @nym filter for sats/comments search sorts

### DIFF
--- a/api/resolvers/search.js
+++ b/api/resolvers/search.js
@@ -192,11 +192,9 @@ function nymClauses (nym) {
   if (!nym) return { filters: [], queries: [] }
   const name = nym.slice(1).toLowerCase()
   if (!name) return { filters: [], queries: [] } // guard: bare "@" with no name
-  const pattern = `*${name}*`
-  // Strict author-only filter for @nym searches.
-  // case_insensitive: keyword field stores original case; queries are lowercased
+  // Exact author match: *nym* substring lets "@hn" match "John".
   return {
-    filters: [{ wildcard: { 'user.name': { value: pattern, case_insensitive: true } } }],
+    filters: [{ term: { 'user.name': { value: name, case_insensitive: true } } }],
     queries: []
   }
 }


### PR DESCRIPTION
Fixes #3210

## Root cause
`@nym` is applied on every sort path (`nymClauses` → OpenSearch `filter`). It was a case-insensitive **infix wildcard** (`*hn*`), so `@hn` also matched `John*`, `Schnitzel`, `THNDRGAMES`, etc.

Relevance/new still *looked* filtered because `hn` posts a lot and fills the first page. Sats/comments rank other substring matches first, so the nym looks dropped. Same query; different ranking.

## Change
Exact case-insensitive `term` on `user.name` so `@nym` is author-only for all sorts.

## Test
- `@hn` + relevance/new/sats/comments → only `hn`
- `@k00b` + sats still only `k00b` (already unique under the old wildcard)