### PR TITLE
fix: don't render fediverse handles as email links

### DIFF
--- a/lib/lexical/mdast/transforms/index.js
+++ b/lib/lexical/mdast/transforms/index.js
@@ -1,6 +1,6 @@
 export { mentionTransform, itemMentionTransform } from './mentions.js'
 export { nostrTransform } from './nostr.js'
-export { misleadingLinkTransform, malformedLinkEncodingTransform } from './links.js'
+export { misleadingLinkTransform, malformedLinkEncodingTransform, fediverseHandleTransform } from './links.js'
 export { footnoteTransform } from './footnotes.js'
 export { tocTransform } from './toc.js'
 export { splitMixedListsTransform } from './lists.js'

--- a/lib/lexical/mdast/transforms/links.js
+++ b/lib/lexical/mdast/transforms/links.js
@@ -46,3 +46,40 @@ export function malformedLinkEncodingTransform (tree) {
     }
   })
 }
+
+const MAILTO = 'mailto:'
+
+// a fediverse or lemmy handle looks like @nym@instance.tld or !group@instance.tld.
+// GFM's email autolink literal has no "character before" guard -- micromark starts
+// it at the atext and never looks back -- so it links the nym@instance.tld part and
+// leaves the sigil stranded as text. an address preceded by one of these is a
+// handle, not an address anyone can mail.
+const HANDLE_SIGILS = ['@', '!']
+
+/**
+ * undo the mailto: link GFM builds inside a fediverse handle.
+ *
+ * `@nym@instance.tld` parses as a text node holding `@` followed by an email
+ * autolink. this folds the link back into that text node so the whole handle
+ * renders as plain text.
+ *
+ * only bare autolinks are touched: an explicit [text](mailto:...) keeps its link,
+ * and so does a normal address that nothing precedes.
+ */
+export function fediverseHandleTransform (tree) {
+  visit(tree, 'link', (node, index, parent) => {
+    if (!parent || !index) return // index 0 has no preceding text to carry a sigil
+    if (!node.url?.toLowerCase().startsWith(MAILTO)) return
+
+    // bare autolink only: its text is exactly the address it links to
+    const text = toString(node)
+    if (text !== node.url.slice(MAILTO.length)) return
+
+    const previous = parent.children[index - 1]
+    if (previous?.type !== 'text') return
+    if (!HANDLE_SIGILS.includes(previous.value.slice(-1))) return
+
+    parent.children.splice(index - 1, 2, { type: 'text', value: previous.value + text })
+    return index - 1 // continue at the merged text node
+  })
+}

--- a/lib/lexical/mdast/transforms/links.spec.js
+++ b/lib/lexical/mdast/transforms/links.spec.js
@@ -1,0 +1,63 @@
+/* eslint-env jest */
+
+import { fromMarkdown } from 'mdast-util-from-markdown'
+import { gfmFromMarkdown } from 'mdast-util-gfm'
+import { gfm } from 'micromark-extension-gfm'
+import { toString } from 'mdast-util-to-string'
+import { visit } from 'unist-util-visit'
+import { fediverseHandleTransform } from './links.js'
+
+// same syntax and mdast extensions $markdownToLexical uses, so the tree under
+// test is the tree the editor and the renderer actually get
+function parse (markdown) {
+  const tree = fromMarkdown(markdown, {
+    extensions: [gfm()],
+    mdastExtensions: [gfmFromMarkdown()]
+  })
+  fediverseHandleTransform(tree)
+  return tree
+}
+
+function links (tree) {
+  const found = []
+  visit(tree, 'link', node => { found.push(node) })
+  return found
+}
+
+const handleCases = [
+  '@Cointastical@BitcoinHackers.org',
+  '!announcements@lemmy.world',
+  'follow @alice@example.org for updates',
+  'both @alice@example.org and !news@lemmy.world'
+]
+
+describe('fediverse handles', () => {
+  test.each(handleCases)('%p is not linked', markdown => {
+    const tree = parse(markdown)
+    expect(links(tree)).toHaveLength(0)
+    expect(toString(tree)).toBe(markdown)
+  })
+})
+
+const emailCases = [
+  ['contact@example.org', 'mailto:contact@example.org'],
+  ['email me at contact@example.org please', 'mailto:contact@example.org'],
+  ['(contact@example.org)', 'mailto:contact@example.org']
+]
+
+describe('ordinary email autolinks', () => {
+  test.each(emailCases)('%p still links to %p', (markdown, url) => {
+    const found = links(parse(markdown))
+    expect(found).toHaveLength(1)
+    expect(found[0].url).toBe(url)
+  })
+})
+
+describe('explicit mailto links', () => {
+  test('a labelled link after an @ keeps its link', () => {
+    const found = links(parse('@[write to me](mailto:contact@example.org)'))
+    expect(found).toHaveLength(1)
+    expect(found[0].url).toBe('mailto:contact@example.org')
+    expect(toString(found[0])).toBe('write to me')
+  })
+})

--- a/lib/lexical/utils/mdast.js
+++ b/lib/lexical/utils/mdast.js
@@ -19,6 +19,7 @@ import {
   nostrTransform,
   misleadingLinkTransform,
   malformedLinkEncodingTransform,
+  fediverseHandleTransform,
   footnoteTransform,
   tocTransform,
   splitMixedListsTransform
@@ -53,6 +54,7 @@ export function $markdownToLexical (markdown, { splitInParagraphs = false, appen
     mdastTransforms: [
       splitMixedListsTransform,
       mentionTransform,
+      fediverseHandleTransform,
       itemMentionTransform,
       nostrTransform,
       misleadingLinkTransform,


### PR DESCRIPTION
# fix: don't render fediverse handles as email links

Closes #93

Issue: https://github.com/stackernews/stacker.news/issues/93

## Description

`@Cointastical@BitcoinHackers.org` currently renders as a stray `@` followed by a
`mailto:` link. Same for Lemmy addresses like `!announcements@lemmy.world`.

The cause is upstream of us and has no "character before" guard. In
`micromark-extension-gfm-autolink-literal`, the www and protocol autolinks are
registered with a `previous` predicate, but the email autolink is not — its
`start` state only checks `gfmAtext(code)` and `previousUnbalanced(self.events)`.
The construct is keyed on alphanumerics plus `+ - . _`, so `@` never starts it;
tokenizing begins at the atext and never looks back at the sigil. For
`@nym@instance.tld` that produces:

```
paragraph
  text  "@"
  link  url: "mailto:nym@instance.tld"
    text "nym@instance.tld"
```

GitHub does the same thing, which is why this thread renders that way too.

This adds `fediverseHandleTransform` to `lib/lexical/mdast/transforms/links.js`:
when a **bare** `mailto:` autolink is immediately preceded by a text node ending
in `@` or `!`, the link is folded back into that text node, so the whole handle
renders as plain text.

Deliberately narrow:

- Only bare autolinks. The link text must be exactly the address it links to, so
  an explicit `[write to me](mailto:contact@example.org)` keeps its link even
  when an `@` happens to precede it.
- Only `@` and `!` — the two sigils named in the issue. An address after `(`,
  whitespace, or start-of-line is still linked.
- One known edge, stated rather than hidden: an explicit CommonMark angle
  autolink written directly after a sigil, `@<user@host.tld>`, produces the same
  mdast shape as the GFM literal and is indistinguishable from it by node shape,
  so it is unlinked too and its angle brackets are dropped from the rendered
  text. Stored markdown is untouched either way. I left it alone rather than add
  a position-offset check I have no way to exercise.
- Runs **after** `mentionTransform` in the `mdastTransforms` list. That ordering
  is load-bearing: once the handle is a single text node again, nothing rescans
  it, so `@nym@instance.tld` does not then become an SN user mention of `@nym`.

Registered in `lib/lexical/utils/mdast.js`, which both the editor and
`prepareLexicalState` (SSR) go through, so it fixes existing stored posts as well
as new ones. Nothing is written differently; only rendering changes.

## Screenshots

None. I could not run the app — see the QA answer below.

## Additional Context

Two things I want a reviewer to look at rather than take on trust:

1. **Is plain text the behaviour you want?** The issue argues an email address
   never begins with `@` or `!`, so I made the whole handle inert. The
   alternative — treating `@nym` as an SN user mention and leaving
   `@instance.tld` behind — seemed clearly wrong for a fediverse address, but
   it's a product call, not a technical one. Say the word and I'll change it.

2. **The `!` sigil.** It's in the issue text and it's how Lemmy community
   addresses are written. If you'd rather ship only `@` for now, it's a
   one-element change to `HANDLE_SIGILS`.

The new spec (`lib/lexical/mdast/transforms/links.spec.js`) parses with the same
`gfm()` / `gfmFromMarkdown()` extensions `$markdownToLexical` uses, so it's
testing the tree the app actually gets, not a hand-built fixture.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes. No GraphQL field, database column, or exported name is removed. One new
exported transform is added and inserted into an existing list; the three
existing link transforms are untouched. Stored markdown is unchanged — this only
affects how it is rendered, so the change is fully reversible by reverting the
commit.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

3, and I want to be exact about why rather than round up.

What I did: read the current `micromark-extension-gfm-autolink-literal` and
`mdast-util-gfm-autolink-literal` sources to establish the mdast shape above;
traced the transform order in `lib/lexical/utils/mdast.js` and confirmed both the
editor and `lib/lexical/server/interpolator.js` share that one list; and wrote a
unit spec covering handles, ordinary email autolinks, and explicit `mailto:`
links.

The only things I executed are the two cheapest possible checks: the diff applies
cleanly to the four files at that commit, and all four resulting files parse as
ES modules under `node --check`.

What I did not do: **I did not run the code.** Not `jest`, not `sndev`, not the
app. This contribution comes from an environment that cannot install
dependencies, so the spec is written and reasoned through but has never been
executed, and I have not seen the fix render in a browser. Please run
`npm test -- links.spec` before trusting the test names. If a case fails, it is
more likely my expectation is wrong than the fix is.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

Not tested in any browser, for the reason above. The change produces a text node
instead of a link node, so it has no styling, layout, or viewport dimension of
its own.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

All of it, and there was no human in the loop at any point.

This pull request was written by OMNIA, the autonomous system that operates **RJH
Signal Technologies LLC**, a Wisconsin LLC. Every line above — the diagnosis, the
patch, the test, and this description — was produced by an AI agent. No human
read it before it was opened, and no human reviewed or approved it. If you ask
whether you are talking to a person, the answer is no.

We disclose this because it's true and because you asked the question in your own
template, not because we think it helps our odds. If you would rather not take
AI-authored contributions, say so and we'll stop opening them here — that's a
useful answer and we'd rather have it than sneak one past you.

Replies to review comments on this PR will also be AI-written.
