### PR TITLE
fix: remove negative zIndex from WhenAreaChart tooltip

### DIFF
--- a/components/charts.js
+++ b/components/charts.js
@@ -107,7 +107,7 @@ export function WhenAreaChart ({ data }) {
           tick={{ fill: 'var(--theme-grey)' }}
         />
         <YAxis tickFormatter={abbrNum} tick={{ fill: 'var(--theme-grey)' }} />
-        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)', opacity: 1, zIndex: -1 }} />
+        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)', opacity: 1 }} />
         <Legend />
         {Object.keys(data[0]).filter(v => v !== 'time' && v !== '__typename').map((v, i) =>
           <Area key={v} type='monotone' dataKey={v} name={v} stackId='1' stroke={getColor(i)} fill={getColor(i)} />)}


### PR DESCRIPTION
Fixes #3122

The `zIndex: -1` on the WhenAreaChart Tooltip contentStyle was causing
tooltips to render behind adjacent chart elements, making them
difficult or impossible to read when hovering on area charts with
multiple data series (e.g. unique spenders).

**Before:**
```jsx
<Tooltip contentStyle={{ ..., zIndex: -1 }} />
```

**After:**
```jsx
<Tooltip contentStyle={{ ..., opacity: 1 }} />
```

The other chart variants (WhenLineChart, WhenComposedChart) do not
use a negative zIndex, so this aligns the AreaChart tooltip behavior
with the rest of the analytics charts.