### PR TITLE
fix tooltip position over charts

### DIFF
--- a/components/charts.js
+++ b/components/charts.js
@@ -107,7 +107,7 @@ export function WhenAreaChart ({ data }) {
           tick={{ fill: 'var(--theme-grey)' }}
         />
         <YAxis tickFormatter={abbrNum} tick={{ fill: 'var(--theme-grey)' }} />
-        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)', opacity: 1, zIndex: -1 }} />
+        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)' }} wrapperStyle={{ zIndex: 1 }} />
         <Legend />
         {Object.keys(data[0]).filter(v => v !== 'time' && v !== '__typename').map((v, i) =>
           <Area key={v} type='monotone' dataKey={v} name={v} stackId='1' stroke={getColor(i)} fill={getColor(i)} />)}
@@ -144,7 +144,7 @@ export function WhenLineChart ({ data }) {
           tick={{ fill: 'var(--theme-grey)' }}
         />
         <YAxis tickFormatter={abbrNum} tick={{ fill: 'var(--theme-grey)' }} />
-        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)' }} />
+        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)' }} wrapperStyle={{ zIndex: 1 }} />
         <Legend />
         {Object.keys(data[0]).filter(v => v !== 'time' && v !== '__typename').map((v, i) =>
           <Line key={v} type='monotone' dataKey={v} name={v} stroke={getColor(i)} fill={getColor(i)} />)}
@@ -187,7 +187,7 @@ export function WhenComposedChart ({
         />
         <YAxis yAxisId='left' orientation='left' allowDecimals={false} stroke='var(--theme-grey)' tickFormatter={abbrNum} tick={{ fill: 'var(--theme-grey)' }} />
         <YAxis yAxisId='right' orientation='right' allowDecimals={false} stroke='var(--theme-grey)' tickFormatter={abbrNum} tick={{ fill: 'var(--theme-grey)' }} />
-        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)' }} />
+        <Tooltip labelFormatter={labelFormatter(when, from, to)} contentStyle={{ color: 'var(--bs-body-color)', backgroundColor: 'var(--bs-body-bg)' }} wrapperStyle={{ zIndex: 1 }} />
         <Legend />
         {barNames?.map((v, i) =>
           <Bar yAxisId={barAxis} key={v} stackId={barStackId} type='monotone' dataKey={v} name={v} stroke={getColor(i)} fill={getColor(i)} />)}
@@ -224,7 +224,7 @@ export function GrowthPieChart ({ data }) {
             ))
           }
         </Pie>
-        <Tooltip />
+        <Tooltip wrapperStyle={{ zIndex: 1 }} />
       </PieChart>
     </ResponsiveContainer>
   )


### PR DESCRIPTION
## Description

Fixes #3122.
The analytics tooltip was rendered behind the charts of the rows below it. The fix sets `wrapperStyle={{ zIndex: 1 }}` on the tooltips. A positive z-index moves the tooltip into the layer painted after all `z-index: auto` positioned elements, regardless of DOM order. `1` is enough and stays well below the sticky nav.

## Screenshots
before
<img width="432" height="894" alt="Schermata del 2026-09-07 11-12-26" src="https://github.com/user-attachments/assets/9b1c0494-c54a-42cf-8055-1edc41e57992" />
after
<img width="432" height="894" alt="Schermata del 2026-09-07 11-12-35" src="https://github.com/user-attachments/assets/cc87e6c3-0b9a-4f4f-b731-2074ee555607" />

## Additional Context

Applied to all four charts since they share the same layout and the same latent bug.

## Checklist

**Are your changes backward compatible? Please answer below:**

yes

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**
8/10


**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

yes

**Did you introduce any new environment variables? If so, call them out explicitly here:**

no

**Did you use AI for this? If so, how much did it assist you?**

yes, to locate the bug, study the current behavior and propose a fix.