### PR TITLE
fix(search): @nym matches the author exactly, not a substring

### DIFF
--- a/api/resolvers/search.js
+++ b/api/resolvers/search.js
@@ -3,6 +3,7 @@ import { whenToFrom } from '@/lib/time'
 import { getItem, itemQueryWithMeta, SELECT } from './item'
 import { parse } from 'tldts'
 import { searchSchema, validateSchema } from '@/lib/validate'
+import { nymClauses } from '@/lib/search-nym'
 import { DEFAULT_POSTS_SATS_FILTER, DEFAULT_COMMENTS_SATS_FILTER, HOMEPAGE_POSTS_SATS_FILTER } from '@/lib/constants'
 import { resolveOpensearchModelId } from '../search/model-id'
 import removeMd from 'remove-markdown'
@@ -187,19 +188,6 @@ async function loadSatsFilters (me, userLoader) {
 // ---- Query-part builders ----
 // Each returns { filters: [...], queries: [...] } for spreading into
 // the filter and termQuery arrays.
-
-function nymClauses (nym) {
-  if (!nym) return { filters: [], queries: [] }
-  const name = nym.slice(1).toLowerCase()
-  if (!name) return { filters: [], queries: [] } // guard: bare "@" with no name
-  const pattern = `*${name}*`
-  // Strict author-only filter for @nym searches.
-  // case_insensitive: keyword field stores original case; queries are lowercased
-  return {
-    filters: [{ wildcard: { 'user.name': { value: pattern, case_insensitive: true } } }],
-    queries: []
-  }
-}
 
 function territoryClauses (territory) {
   if (!territory) return { filters: [], queries: [] }

--- a/lib/search-nym.js
+++ b/lib/search-nym.js
@@ -1,0 +1,12 @@
+// @nym is an exact author filter. A wildcard *name* match lets
+// @ek also return @hynek / @gkrizek, which is obvious when sorting by sats.
+
+export function nymClauses (nym) {
+  if (!nym) return { filters: [], queries: [] }
+  const name = nym.slice(1)
+  if (!name) return { filters: [], queries: [] }
+  return {
+    filters: [{ term: { 'user.name': { value: name, case_insensitive: true } } }],
+    queries: []
+  }
+}

--- a/lib/search-nym.spec.js
+++ b/lib/search-nym.spec.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+
+import { nymClauses } from './search-nym'
+
+describe('nymClauses', () => {
+  test('returns no clauses when nym is missing', () => {
+    expect(nymClauses()).toEqual({ filters: [], queries: [] })
+    expect(nymClauses('')).toEqual({ filters: [], queries: [] })
+    expect(nymClauses('@')).toEqual({ filters: [], queries: [] })
+  })
+
+  test('filters on the exact author, not a substring wildcard', () => {
+    expect(nymClauses('@ek')).toEqual({
+      filters: [{ term: { 'user.name': { value: 'ek', case_insensitive: true } } }],
+      queries: []
+    })
+    const clause = nymClauses('@ek').filters[0]
+    expect(JSON.stringify(clause)).not.toContain('*ek*')
+  })
+
+  test('preserves the nym spelling and relies on case_insensitive', () => {
+    expect(nymClauses('@K00b').filters[0].term['user.name'].value).toBe('K00b')
+  })
+})


### PR DESCRIPTION
## Description

Fixes #3210.

`@nym` search is documented as author-only. `nymClauses` used a wildcard `*name*` on `user.name`, so `@ek` also matched `@hynek`, `@gkrizek`, `@billytheked`, etc. That is easy to miss on relevance/new and obvious when sorting by sats.

Live check 2026-09-09:

- https://stacker.news/search?q=@ek&sort=sats also listed `@hynek` `@gkrizek` `@itsTomekK` `@hn` `@unpaywall` `@maciek` `@derekross`
- https://stacker.news/search?q=@ek&sort=new also listed `@billytheked` `@i_am_a_seeker`
- https://stacker.news/search?q=@k00b&sort=sats stayed on `@k00b` (no substring collision)

Fix: exact `term` on `user.name` with `case_insensitive: true`. Helper + Jest in `lib/search-nym.js`.

Please apply `difficulty:*` on #3210. Proposing `difficulty:easy`.

## Screenshots

N/A (search API filter). Reproduction URLs above.

## Additional Context

Did not change `~territory` or `url:` wildcards.

## Checklist

**Are your changes backward compatible? Please answer below:**

Yes for unique nyms. `@ek`-style substrings stop leaking other authors, which matches the help text.

**On a scale of 1-10 how well and how have you QA'd this change and any features it might affect? Please answer below:**

7/10. Reproduced on production search. Helper unit-tested. No local OpenSearch.

**For frontend changes: Tested on mobile, light and dark mode? Please answer below:**

N/A.

**Did you introduce any new environment variables? If so, call them out explicitly here:**

No.

**Did you use AI for this? If so, how much did it assist you?**

Yes. An AI assistant reproduced the live leak and extracted the helper. I verified the `@ek` / `@k00b` result sets on stacker.news.
